### PR TITLE
ci: remove intentional failing test; pin dev CI deps

### DIFF
--- a/pytest.log
+++ b/pytest.log
@@ -1,0 +1,1 @@
+zsh: command not found: run:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+numpy
+pandas
+pytest
+ruff
+numpy
+pandas
+pytest
+ruff

--- a/smoke.log
+++ b/smoke.log
@@ -1,0 +1,1 @@
+zsh: command not found: run:

--- a/tests/test_ci_notify_fail.py
+++ b/tests/test_ci_notify_fail.py
@@ -1,2 +1,0 @@
-def test_ci_notify_fail():
-    assert False, "Intentional failure to verify Discord notifications"


### PR DESCRIPTION
## Summary
- What changed & why:

## Checklist
- [ ] Tests added/updated
- [ ] `ruff check .` green locally
- [ ] `pytest -q` green locally
- [ ] No hardcoded params; YAML-driven only
- [ ] Contracts respected (indicator/exit/audit/spread)
- [ ] If backtest logic: smoke sanity run done
