### PR TITLE
test(ci): add failing PR to validate Discord alerts

### DIFF
--- a/tests/test_ci_fail.py
+++ b/tests/test_ci_fail.py
@@ -1,0 +1,2 @@
+def test_ci_fails():
+    assert False, 'Intentional failure to validate Discord alerts'


### PR DESCRIPTION
## Summary
- What changed & why:

## Checklist
- [ ] Tests added/updated
- [ ] `ruff check .` green locally
- [ ] `pytest -q` green locally
- [ ] No hardcoded params; YAML-driven only
- [ ] Contracts respected (indicator/exit/audit/spread)
- [ ] If backtest logic: smoke sanity run done
