### PR TITLE
test(ci): force CI failure to validate Discord webhook

### DIFF
--- a/tests/test_discord_webhook_fail.py
+++ b/tests/test_discord_webhook_fail.py
@@ -1,0 +1,2 @@
+def test_discord_fail():
+    assert False, "Intentional fail to trigger Discord"


### PR DESCRIPTION
## Summary
- What changed & why:

## Checklist
- [ ] Tests added/updated
- [ ] `ruff check .` green locally
- [ ] `pytest -q` green locally
- [ ] No hardcoded params; YAML-driven only
- [ ] Contracts respected (indicator/exit/audit/spread)
- [ ] If backtest logic: smoke sanity run done
