### PR TITLE
test(ci): force CI failure to validate Discord webhook (retry)

### DIFF
--- a/tests/test_force_fail_pr.py
+++ b/tests/test_force_fail_pr.py
@@ -1,0 +1,2 @@
+def test_force_fail_pr():
+    assert False, "Intentional fail to trigger Discord"


### PR DESCRIPTION
## Summary
- What changed & why:

## Checklist
- [ ] Tests added/updated
- [ ] `ruff check .` green locally
- [ ] `pytest -q` green locally
- [ ] No hardcoded params; YAML-driven only
- [ ] Contracts respected (indicator/exit/audit/spread)
- [ ] If backtest logic: smoke sanity run done
