### PR TITLE
fix(ci): Fix Discord notification heredoc syntax error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,9 +127,6 @@ jobs:
             echo "$BODY" | jq -Rs '{content: .}' > payload.json
             curl -fsS -H "Content-Type: application/json" -d @payload.json "$DISCORD_WEBHOOK_URL"
           else
-            esc=$(printf '%s' "$BODY" | python - <<'PY'
-import json,sys; print(json.dumps({"content": sys.stdin.read()}))
-PY
-)
+            esc=$(printf '%s' "$BODY" | python -c "import json,sys; print(json.dumps({'content': sys.stdin.read()}))")
             curl -fsS -H "Content-Type: application/json" -d "$esc" "$DISCORD_WEBHOOK_URL"
           fi


### PR DESCRIPTION
## Summary
Fixes Discord notification step failing with exit code 2 due to heredoc syntax errors.

## Changes
- Replace problematic Python heredoc with simple `python -c` command
- Eliminates 'unexpected EOF' and 'delimited by end-of-file' errors
- Discord notifications now execute successfully on CI failures

## Testing
- ✅ Tested and verified working with Discord webhook integration
- ✅ YAML syntax validated
- ✅ Discord notifications sent successfully on CI failures

## Fixes
- Discord notification step failing with exit code 2
- CI workflow syntax errors preventing proper failure notifications

## Impact
- Discord notifications now work reliably on CI failures
- Rich failure messages with detailed logs and GitHub Actions URLs
- No breaking changes to existing CI workflow