### PR TITLE
fix(ci): Add missing pyyaml dependency and clean up requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,4 @@ numpy
 pandas
 pytest
 ruff
-numpy
-pandas
-pytest
-ruff
+pyyaml


### PR DESCRIPTION
- Add pyyaml to requirements-dev.txt to fix 'ModuleNotFoundError: No module named yaml'
- Remove duplicate entries in requirements-dev.txt
- This should resolve the pytest import errors in CI

Fixes: CI failing with yaml module import errors
Resolves: pytest collection errors in GitHub Actions

## Summary
- What changed & why:

## Checklist
- [ ] Tests added/updated
- [ ] `ruff check .` green locally
- [ ] `pytest -q` green locally
- [ ] No hardcoded params; YAML-driven only
- [ ] Contracts respected (indicator/exit/audit/spread)
- [ ] If backtest logic: smoke sanity run done
