### PR TITLE
chore(smoke): accept -q/--quiet for backward-compat; docs/examples up…

### DIFF
--- a/docs/FOLDER_STRUCTURE.md
+++ b/docs/FOLDER_STRUCTURE.md
@@ -118,6 +118,8 @@ Forex_Backtester/
 ```bash
 # Smoke test
 python scripts/smoke_test_selfcontained_v198.py --mode fast
+# Or with quiet output:
+python scripts/smoke_test_selfcontained_v198.py -q --mode fast
 
 # Main backtest
 python core/backtester.py configs/config.yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,8 @@ Forex_Backtester/
 ### 1. Run Smoke Test
 ```bash
 python scripts/smoke_test_selfcontained_v198.py --mode fast
+# Or with quiet output:
+python scripts/smoke_test_selfcontained_v198.py -q --mode fast
 ```
 
 ### 2. Basic Backtest
@@ -207,7 +209,7 @@ ruff check .
 ### Adding New Indicators
 1. Add function to appropriate `indicators/*_funcs.py` file
 2. Follow the indicator contract for that role
-3. Test with smoke test: `python scripts/smoke_test_selfcontained_v198.py --mode fast`
+3. Test with smoke test: `python scripts/smoke_test_selfcontained_v198.py --mode fast` (add `-q` for quiet output)
 
 ### TDD Workflow
 1. Write failing test first

--- a/scripts/smoke_test_selfcontained_v198.py
+++ b/scripts/smoke_test_selfcontained_v198.py
@@ -38,9 +38,13 @@ CACHE_DIRS = [PROJECT_ROOT / ".cache", PROJECT_ROOT / "Cache", PROJECT_ROOT / "c
 # Add project root to Python path for imports
 sys.path.insert(0, str(PROJECT_ROOT))
 
+# Global quiet flag (set by main function)
+_QUIET = False
+
 
 def info(msg):
-    print(f"ℹ️  {msg}")
+    if not _QUIET:
+        print(f"ℹ️  {msg}")
 
 
 def ok(msg):
@@ -699,9 +703,14 @@ def check_cache(core: Dict[str, Any], cfg: dict, run_dir: Path):
 
 # ------------------------------ main ----------------------------------------
 def main():
+    global _QUIET
     ap = argparse.ArgumentParser(description="Self-contained smoketest (no config.yaml needed)")
     ap.add_argument("--mode", choices=["fast", "full"], default="fast")
+    ap.add_argument("-q", "--quiet", action="store_true", help="Suppress non-essential output")
     args = ap.parse_args()
+
+    # Set global quiet flag
+    _QUIET = args.quiet
 
     check_environment()
     core = import_core()


### PR DESCRIPTION
…dated

- Add -q/--quiet flag to smoke_test_selfcontained_v198.py
- Suppresses non-essential info() messages while preserving warnings/errors
- Maintains full backward compatibility with existing --mode flag
- Updated docs/README.md and docs/FOLDER_STRUCTURE.md with quiet examples
- No changes to simulation logic or outputs
- Validation: ruff + pytest pass, both command forms work

## Summary
- What changed & why:

## Checklist
- [ ] Tests added/updated
- [ ] `ruff check .` green locally
- [ ] `pytest -q` green locally
- [ ] No hardcoded params; YAML-driven only
- [ ] Contracts respected (indicator/exit/audit/spread)
- [ ] If backtest logic: smoke sanity run done

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a quiet mode to the smoketest to suppress non-essential output and updates docs with quiet usage examples.
> 
> - **Scripts**:
>   - `scripts/smoke_test_selfcontained_v198.py`
>     - Add `-q/--quiet` CLI flag and global `_QUIET` toggle.
>     - Make `info()` conditional on `_QUIET` to suppress non-essential logs.
> - **Docs**:
>   - `docs/README.md`, `docs/FOLDER_STRUCTURE.md`
>     - Add quiet-mode examples for the smoketest and note optional `-q` in guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0169cc212cdfa4df3ddf3c3084c4824184b206bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->