### PR TITLE
chore: fix WFO imports to core.* and add metrics alias for smoke

### DIFF
--- a/analytics/metrics.py
+++ b/analytics/metrics.py
@@ -188,22 +188,28 @@ def compute_all(
 
 
 # Aliases for smoke test compatibility
-def compute_metrics_from_equity(equity_df, trades_df=None) -> dict:
+def compute_metrics_from_equity(equity_df, trades_df=None, rf_annual: float = 0.0) -> dict:
     """Alias for compute_all() for smoke test compatibility."""
     if isinstance(equity_df, (str, Path)):
         equity_df = pd.read_csv(equity_df)
-    return compute_all(equity_df, trades_df)
+    if isinstance(trades_df, (str, Path)):
+        trades_df = pd.read_csv(trades_df)
+    return compute_all(equity_df, trades_df, rf_annual)
 
 
-def compute_metrics(equity_df, trades_df=None) -> dict:
+def compute_metrics(equity_df, trades_df=None, rf_annual: float = 0.0) -> dict:
     """Alias for compute_all() for smoke test compatibility."""
     if isinstance(equity_df, (str, Path)):
         equity_df = pd.read_csv(equity_df)
-    return compute_all(equity_df, trades_df)
+    if isinstance(trades_df, (str, Path)):
+        trades_df = pd.read_csv(trades_df)
+    return compute_all(equity_df, trades_df, rf_annual)
 
 
-def metrics_from_equity(equity_df, trades_df=None) -> dict:
+def metrics_from_equity(equity_df, trades_df=None, rf_annual: float = 0.0) -> dict:
     """Alias for compute_all() for smoke test compatibility."""
     if isinstance(equity_df, (str, Path)):
         equity_df = pd.read_csv(equity_df)
-    return compute_all(equity_df, trades_df)
+    if isinstance(trades_df, (str, Path)):
+        trades_df = pd.read_csv(trades_df)
+    return compute_all(equity_df, trades_df, rf_annual)

--- a/analytics/metrics.py
+++ b/analytics/metrics.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -184,3 +185,25 @@ def compute_all(
         if v is None or not np.isfinite(float(v)):
             out[k] = 0.0
     return out
+
+
+# Aliases for smoke test compatibility
+def compute_metrics_from_equity(equity_df, trades_df=None) -> dict:
+    """Alias for compute_all() for smoke test compatibility."""
+    if isinstance(equity_df, (str, Path)):
+        equity_df = pd.read_csv(equity_df)
+    return compute_all(equity_df, trades_df)
+
+
+def compute_metrics(equity_df, trades_df=None) -> dict:
+    """Alias for compute_all() for smoke test compatibility."""
+    if isinstance(equity_df, (str, Path)):
+        equity_df = pd.read_csv(equity_df)
+    return compute_all(equity_df, trades_df)
+
+
+def metrics_from_equity(equity_df, trades_df=None) -> dict:
+    """Alias for compute_all() for smoke test compatibility."""
+    if isinstance(equity_df, (str, Path)):
+        equity_df = pd.read_csv(equity_df)
+    return compute_all(equity_df, trades_df)


### PR DESCRIPTION
## Summary
- What changed & why:

## Checklist
- [ ] Tests added/updated
- [ ] `ruff check .` green locally
- [ ] `pytest -q` green locally
- [ ] No hardcoded params; YAML-driven only
- [ ] Contracts respected (indicator/exit/audit/spread)
- [ ] If backtest logic: smoke sanity run done

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds alias wrappers around `compute_all` that accept `str/Path` inputs and auto-load CSVs for equity/trades.
> 
> - **Analytics/metrics**:
>   - **New Aliases**: `compute_metrics_from_equity`, `compute_metrics`, `metrics_from_equity` wrap `compute_all`.
>     - Accept `str`/`Path` for `equity_df`/`trades_df` and auto-`read_csv`.
>   - Import enhancement: add `Path` usage for path-like inputs.
>   - Core metrics logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 575e4945637c7c6eed0db0c0e20dcf9d649226e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->