### PR TITLE
signal_logic: always emit entry_signal + legacy 'entrysignal'; ensure…

### DIFF
--- a/tests/test_signal_exits.py
+++ b/tests/test_signal_exits.py
@@ -31,4 +31,4 @@ def test_exit_on_c1_reversal_disabled():
     df = _df_with_signals()
     cfg = {"indicators": {}, "rules": {}, "exit": {"exit_on_c1_reversal": False}}
     out = apply_signal_logic(df, cfg)
-    assert pd.isna(out.loc[3, "exit_signal"])
+    assert out.loc[3, "exit_signal"] == 0  # Should be 0 (int) when disabled, not NaN


### PR DESCRIPTION
… exit columns and int/no-NaN domains

## Summary
Why + what changed (1-2 lines).

## Checks (paste results)
- [ ] ruff check .
- [ ] pytest -q
- [ ] python scripts/smoke_test_selfcontained_v198.py -q --mode fast
- [ ] Indicator contracts respected (C1/C2/baseline/volume/exit)
- [ ] Config-driven only (no hardcoded params)
- [ ] Results unchanged unless intended (trade counts stable)
