### PR TITLE
feat: Add MT5 parity harness for D1 validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ results_history/
 # Aider / agents
 .aider*
 .aiderignore
+
+# MT5 exports (machine-specific)
+mt5/**
+!mt5/.gitkeep
+!mt5/README.md

--- a/configs/validation/mt5_parity_d1.yaml
+++ b/configs/validation/mt5_parity_d1.yaml
@@ -1,0 +1,30 @@
+symbol: EURUSD
+timeframe: D1
+date_from: 2022-01-01
+date_to: 2024-12-31
+lot_size:
+  mode: fixed
+  value: 0.10
+spread:
+  enabled: false
+  mode: fixed
+  value_pips: 0.0
+commission:
+  enabled: false
+  per_lot: 0.0
+slippage_pips: 0.0
+engine:
+  fill_on_next_bar_open: true
+roles:
+  c1: sma_cross
+  c2: null
+  baseline: null
+  volume: null
+  exit: null
+c1:
+  fast_period: 20
+  slow_period: 50
+outputs:
+  dir: results/validation/mt5_parity_d1
+  write_trades_csv: true
+  write_equity_csv: true

--- a/mt5/README.md
+++ b/mt5/README.md
@@ -1,0 +1,3 @@
+# MT5 Exports Directory
+
+This folder stores local MT5 exports for parity validation. Files are ignored by Git.

--- a/scripts/mt5_compare.py
+++ b/scripts/mt5_compare.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+MT5 Comparison Tool
+
+Compares our backtest results with MT5 backtest results to validate parity.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+def load_our_trades(results_dir: Path) -> pd.DataFrame:
+    """Load our trades CSV and normalize to unified schema."""
+    trades_file = results_dir / "trades.csv"
+    if not trades_file.exists():
+        raise FileNotFoundError(f"Our trades file not found: {trades_file}")
+
+    df = pd.read_csv(trades_file)
+
+    # Normalize to unified schema
+    unified = pd.DataFrame()
+    unified["open_time"] = pd.to_datetime(df["entry_time"])
+    unified["close_time"] = pd.to_datetime(df["exit_time"])
+    unified["symbol"] = df["pair"]
+    unified["side"] = df["direction"]  # Assuming already +1/-1
+    unified["open_price"] = df["entry_price"]
+    unified["close_price"] = df["exit_price"]
+    unified["sl"] = df.get("sl_at_entry_price", np.nan)
+    unified["tp"] = df.get("tp1_at_entry_price", np.nan)
+    unified["pnl_pips"] = df["pnl_pips"]
+    unified["pnl_currency"] = df["pnl_currency"]
+    unified["tag"] = df.get("exit_reason", "unknown")
+
+    return unified
+
+
+def load_mt5_trades(mt5_dir: Path) -> pd.DataFrame:
+    """Load MT5 trades CSV and normalize to unified schema."""
+    trades_file = mt5_dir / "eurusd_d1_2022_2024_trades.csv"
+    report_file = mt5_dir / "report.html"
+
+    if not trades_file.exists():
+        if report_file.exists():
+            raise FileNotFoundError(
+                f"MT5 trades CSV not found: {trades_file}\n"
+                f"Found HTML report: {report_file}\n"
+                f"Please run: python tools/mt5_html_to_csv.py {report_file} {mt5_dir}"
+            )
+        else:
+            raise FileNotFoundError(f"MT5 trades file not found: {trades_file}")
+
+    df = pd.read_csv(trades_file)
+
+    # Normalize to unified schema
+    unified = pd.DataFrame()
+    unified["open_time"] = pd.to_datetime(df["time"])
+    # MT5 might not have close_time in the same format, use open_time as fallback
+    unified["close_time"] = pd.to_datetime(df.get("close_time", df["time"]))
+    unified["symbol"] = df["symbol"]
+
+    # Convert MT5 type (buy/sell) to side (+1/-1)
+    type_map = {"buy": 1, "sell": -1, "Buy": 1, "Sell": -1}
+    unified["side"] = df["type"].map(type_map)
+
+    unified["open_price"] = pd.to_numeric(df["price_open"], errors="coerce")
+    unified["close_price"] = pd.to_numeric(df["price_close"], errors="coerce")
+    unified["sl"] = pd.to_numeric(df["sl"], errors="coerce")
+    unified["tp"] = pd.to_numeric(df["tp"], errors="coerce")
+
+    # Calculate pnl_pips from price difference
+    price_diff = unified["close_price"] - unified["open_price"]
+    unified["pnl_pips"] = price_diff * unified["side"] * 10000  # Assuming 4-digit pairs
+
+    unified["pnl_currency"] = pd.to_numeric(df["profit"], errors="coerce")
+    unified["tag"] = "mt5"
+
+    return unified
+
+
+def match_trades(
+    our_trades: pd.DataFrame, mt5_trades: pd.DataFrame, price_tol: float, time_tol_bars: int
+) -> Tuple[List[Tuple], List[int], List[int]]:
+    """
+    Match trades between our results and MT5 results.
+
+    Returns:
+        matches: List of (our_idx, mt5_idx) tuples
+        unmatched_ours: List of our trade indices that couldn't be matched
+        unmatched_mt5: List of MT5 trade indices that couldn't be matched
+    """
+    matches = []
+    matched_ours = set()
+    matched_mt5 = set()
+
+    # Convert time tolerance from bars to timedelta (assuming D1 = 1 day per bar)
+    time_tol = pd.Timedelta(days=time_tol_bars)
+
+    for our_idx, our_trade in our_trades.iterrows():
+        best_match = None
+        best_score = float("inf")
+
+        for mt5_idx, mt5_trade in mt5_trades.iterrows():
+            if mt5_idx in matched_mt5:
+                continue
+
+            # Check side match
+            if our_trade["side"] != mt5_trade["side"]:
+                continue
+
+            # Check time proximity
+            time_diff = abs(our_trade["open_time"] - mt5_trade["open_time"])
+            if time_diff > time_tol:
+                continue
+
+            # Check price proximity
+            price_diff = abs(our_trade["open_price"] - mt5_trade["open_price"])
+            if price_diff > price_tol:
+                continue
+
+            # Calculate match score (lower is better)
+            score = time_diff.total_seconds() + price_diff * 1000000
+            if score < best_score:
+                best_score = score
+                best_match = mt5_idx
+
+        if best_match is not None:
+            matches.append((our_idx, best_match))
+            matched_ours.add(our_idx)
+            matched_mt5.add(best_match)
+
+    unmatched_ours = [i for i in our_trades.index if i not in matched_ours]
+    unmatched_mt5 = [i for i in mt5_trades.index if i not in matched_mt5]
+
+    return matches, unmatched_ours, unmatched_mt5
+
+
+def compare_totals(our_trades: pd.DataFrame, mt5_trades: pd.DataFrame, pnl_pct_tol: float) -> Dict:
+    """Compare aggregate statistics between our trades and MT5 trades."""
+    our_stats = {
+        "total_trades": len(our_trades),
+        "wins": len(our_trades[our_trades["pnl_currency"] > 0]),
+        "losses": len(our_trades[our_trades["pnl_currency"] < 0]),
+        "scratches": len(our_trades[our_trades["pnl_currency"] == 0]),
+        "gross_pnl": our_trades["pnl_currency"].sum(),
+        "net_pnl": our_trades["pnl_currency"].sum(),  # Assuming no commissions in parity test
+    }
+
+    mt5_stats = {
+        "total_trades": len(mt5_trades),
+        "wins": len(mt5_trades[mt5_trades["pnl_currency"] > 0]),
+        "losses": len(mt5_trades[mt5_trades["pnl_currency"] < 0]),
+        "scratches": len(mt5_trades[mt5_trades["pnl_currency"] == 0]),
+        "gross_pnl": mt5_trades["pnl_currency"].sum(),
+        "net_pnl": mt5_trades["pnl_currency"].sum(),
+    }
+
+    # Check tolerances
+    results = {"our_stats": our_stats, "mt5_stats": mt5_stats, "passed": True, "errors": []}
+
+    # Trade count must be identical
+    if our_stats["total_trades"] != mt5_stats["total_trades"]:
+        results["passed"] = False
+        results["errors"].append(
+            f"Trade count mismatch: ours={our_stats['total_trades']}, MT5={mt5_stats['total_trades']}"
+        )
+
+    # Check PnL within tolerance
+    for key in ["gross_pnl", "net_pnl"]:
+        our_val = our_stats[key]
+        mt5_val = mt5_stats[key]
+        if mt5_val != 0:
+            pct_diff = abs(our_val - mt5_val) / abs(mt5_val)
+            if pct_diff > pnl_pct_tol:
+                results["passed"] = False
+                results["errors"].append(
+                    f"{key} difference too large: {pct_diff:.4f} > {pnl_pct_tol:.4f} "
+                    f"(ours={our_val:.2f}, MT5={mt5_val:.2f})"
+                )
+
+    return results
+
+
+def print_comparison_results(
+    matches: List[Tuple], unmatched_ours: List[int], unmatched_mt5: List[int], totals_result: Dict
+):
+    """Print detailed comparison results."""
+    print("\n📊 Trade Matching Results:")
+    print(f"   Matched trades: {len(matches)}")
+    print(f"   Unmatched ours: {len(unmatched_ours)}")
+    print(f"   Unmatched MT5: {len(unmatched_mt5)}")
+
+    print("\n📈 Aggregate Statistics:")
+    our_stats = totals_result["our_stats"]
+    mt5_stats = totals_result["mt5_stats"]
+
+    print(f"   Total trades: ours={our_stats['total_trades']}, MT5={mt5_stats['total_trades']}")
+    print(f"   Wins: ours={our_stats['wins']}, MT5={mt5_stats['wins']}")
+    print(f"   Losses: ours={our_stats['losses']}, MT5={mt5_stats['losses']}")
+    print(f"   Scratches: ours={our_stats['scratches']}, MT5={mt5_stats['scratches']}")
+    print(f"   Gross PnL: ours={our_stats['gross_pnl']:.2f}, MT5={mt5_stats['gross_pnl']:.2f}")
+    print(f"   Net PnL: ours={our_stats['net_pnl']:.2f}, MT5={mt5_stats['net_pnl']:.2f}")
+
+    if totals_result["passed"]:
+        print("\n✅ All comparisons passed!")
+    else:
+        print("\n❌ Comparison failed:")
+        for error in totals_result["errors"]:
+            print(f"   • {error}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare our backtest results with MT5 results")
+    parser.add_argument(
+        "--ours",
+        default="results/validation/mt5_parity_d1",
+        help="Our results directory (default: results/validation/mt5_parity_d1)",
+    )
+    parser.add_argument(
+        "--mt5",
+        default="mt5/eurusd_d1_2022_2024",
+        help="MT5 results directory (default: mt5/eurusd_d1_2022_2024)",
+    )
+    parser.add_argument(
+        "--price-tol",
+        type=float,
+        default=0.00005,
+        help="Price tolerance for matching trades (default: 0.00005)",
+    )
+    parser.add_argument(
+        "--pnl-pct-tol", type=float, default=0.001, help="PnL percentage tolerance (default: 0.001)"
+    )
+    parser.add_argument(
+        "--time-tol-bars",
+        type=int,
+        default=1,
+        help="Time tolerance in bars for matching trades (default: 1)",
+    )
+
+    args = parser.parse_args()
+
+    our_dir = Path(args.ours)
+    mt5_dir = Path(args.mt5)
+
+    print("🔍 MT5 Parity Comparison")
+    print(f"   Our results: {our_dir}")
+    print(f"   MT5 results: {mt5_dir}")
+    print(f"   Price tolerance: {args.price_tol}")
+    print(f"   PnL tolerance: {args.pnl_pct_tol}")
+    print(f"   Time tolerance: {args.time_tol_bars} bars")
+
+    try:
+        # Load trades
+        print("\n📂 Loading trade data...")
+        our_trades = load_our_trades(our_dir)
+        mt5_trades = load_mt5_trades(mt5_dir)
+
+        print(f"   Our trades: {len(our_trades)}")
+        print(f"   MT5 trades: {len(mt5_trades)}")
+
+        # Match trades
+        print("\n🔗 Matching trades...")
+        matches, unmatched_ours, unmatched_mt5 = match_trades(
+            our_trades, mt5_trades, args.price_tol, args.time_tol_bars
+        )
+
+        # Compare totals
+        print("\n📊 Comparing totals...")
+        totals_result = compare_totals(our_trades, mt5_trades, args.pnl_pct_tol)
+
+        # Print results
+        print_comparison_results(matches, unmatched_ours, unmatched_mt5, totals_result)
+
+        # Exit with appropriate code
+        if totals_result["passed"] and not unmatched_ours and not unmatched_mt5:
+            sys.exit(0)
+        else:
+            sys.exit(1)
+
+    except Exception as e:
+        print(f"❌ Error during comparison: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mt5_parity_run.py
+++ b/scripts/mt5_parity_run.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+MT5 Parity Runner
+
+Runs a single backtest using the MT5 parity configuration to generate
+results for comparison with MT5 backtest reports.
+"""
+
+import sys
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# Import after path setup
+from core.backtester import run_backtest  # noqa: E402
+
+
+def main():
+    """Run MT5 parity backtest with fixed configuration."""
+    config_path = "configs/validation/mt5_parity_d1.yaml"
+
+    print("🚀 Running MT5 parity backtest...")
+    print(f"   Config: {config_path}")
+
+    try:
+        # Run backtest - results_dir will be taken from config outputs.dir
+        run_backtest(config_path)
+        print("✅ MT5 parity backtest completed!")
+
+        # Verify output files
+        results_dir = Path("results/validation/mt5_parity_d1")
+        trades_file = results_dir / "trades.csv"
+        equity_file = results_dir / "equity_curve.csv"
+
+        print("\n📁 Output files:")
+        for file_path in [trades_file, equity_file]:
+            status = "✅" if file_path.exists() else "❌"
+            print(f"   {status} {file_path}")
+
+    except Exception as e:
+        print(f"❌ Error running backtest: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mt5_parity.py
+++ b/tests/test_mt5_parity.py
@@ -1,0 +1,244 @@
+"""
+Tests for MT5 parity functionality.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Add project root to path for imports
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+# Import after path setup
+from scripts.mt5_compare import compare_totals, match_trades  # noqa: E402
+
+
+class TestMT5Comparator:
+    """Unit tests for MT5 comparison logic using synthetic data."""
+
+    def test_trade_matching_exact(self):
+        """Test trade matching with exact matches."""
+        # Create synthetic trade data
+        our_trades = pd.DataFrame(
+            {
+                "open_time": pd.to_datetime(["2022-01-01", "2022-01-02"]),
+                "close_time": pd.to_datetime(["2022-01-01", "2022-01-02"]),
+                "symbol": ["EURUSD", "EURUSD"],
+                "side": [1, -1],
+                "open_price": [1.1000, 1.1050],
+                "close_price": [1.1010, 1.1040],
+                "sl": [1.0950, 1.1100],
+                "tp": [1.1050, 1.1000],
+                "pnl_pips": [10.0, 10.0],
+                "pnl_currency": [100.0, 100.0],
+                "tag": ["tp1", "tp1"],
+            }
+        )
+
+        mt5_trades = pd.DataFrame(
+            {
+                "open_time": pd.to_datetime(["2022-01-01", "2022-01-02"]),
+                "close_time": pd.to_datetime(["2022-01-01", "2022-01-02"]),
+                "symbol": ["EURUSD", "EURUSD"],
+                "side": [1, -1],
+                "open_price": [1.1000, 1.1050],
+                "close_price": [1.1010, 1.1040],
+                "sl": [1.0950, 1.1100],
+                "tp": [1.1050, 1.1000],
+                "pnl_pips": [10.0, 10.0],
+                "pnl_currency": [100.0, 100.0],
+                "tag": ["mt5", "mt5"],
+            }
+        )
+
+        matches, unmatched_ours, unmatched_mt5 = match_trades(
+            our_trades, mt5_trades, price_tol=0.00005, time_tol_bars=1
+        )
+
+        assert len(matches) == 2
+        assert len(unmatched_ours) == 0
+        assert len(unmatched_mt5) == 0
+        assert (0, 0) in matches
+        assert (1, 1) in matches
+
+    def test_trade_matching_with_tolerance(self):
+        """Test trade matching with price and time tolerances."""
+        our_trades = pd.DataFrame(
+            {
+                "open_time": pd.to_datetime(["2022-01-01 00:00:00"]),
+                "close_time": pd.to_datetime(["2022-01-01 00:00:00"]),
+                "symbol": ["EURUSD"],
+                "side": [1],
+                "open_price": [1.1000],
+                "close_price": [1.1010],
+                "sl": [1.0950],
+                "tp": [1.1050],
+                "pnl_pips": [10.0],
+                "pnl_currency": [100.0],
+                "tag": ["tp1"],
+            }
+        )
+
+        # MT5 trade with slight time and price difference
+        mt5_trades = pd.DataFrame(
+            {
+                "open_time": pd.to_datetime(["2022-01-01 12:00:00"]),  # 12 hours later
+                "close_time": pd.to_datetime(["2022-01-01 12:00:00"]),
+                "symbol": ["EURUSD"],
+                "side": [1],
+                "open_price": [1.1000 + 0.00003],  # Within tolerance
+                "close_price": [1.1010],
+                "sl": [1.0950],
+                "tp": [1.1050],
+                "pnl_pips": [10.0],
+                "pnl_currency": [100.0],
+                "tag": ["mt5"],
+            }
+        )
+
+        matches, unmatched_ours, unmatched_mt5 = match_trades(
+            our_trades, mt5_trades, price_tol=0.00005, time_tol_bars=1
+        )
+
+        assert len(matches) == 1
+        assert len(unmatched_ours) == 0
+        assert len(unmatched_mt5) == 0
+
+    def test_trade_matching_no_match(self):
+        """Test trade matching when trades don't match."""
+        our_trades = pd.DataFrame(
+            {
+                "open_time": pd.to_datetime(["2022-01-01"]),
+                "close_time": pd.to_datetime(["2022-01-01"]),
+                "symbol": ["EURUSD"],
+                "side": [1],  # Buy
+                "open_price": [1.1000],
+                "close_price": [1.1010],
+                "sl": [1.0950],
+                "tp": [1.1050],
+                "pnl_pips": [10.0],
+                "pnl_currency": [100.0],
+                "tag": ["tp1"],
+            }
+        )
+
+        mt5_trades = pd.DataFrame(
+            {
+                "open_time": pd.to_datetime(["2022-01-01"]),
+                "close_time": pd.to_datetime(["2022-01-01"]),
+                "symbol": ["EURUSD"],
+                "side": [-1],  # Sell - different side
+                "open_price": [1.1000],
+                "close_price": [1.1010],
+                "sl": [1.0950],
+                "tp": [1.1050],
+                "pnl_pips": [10.0],
+                "pnl_currency": [100.0],
+                "tag": ["mt5"],
+            }
+        )
+
+        matches, unmatched_ours, unmatched_mt5 = match_trades(
+            our_trades, mt5_trades, price_tol=0.00005, time_tol_bars=1
+        )
+
+        assert len(matches) == 0
+        assert len(unmatched_ours) == 1
+        assert len(unmatched_mt5) == 1
+
+    def test_compare_totals_pass(self):
+        """Test total comparison with matching statistics."""
+        our_trades = pd.DataFrame({"pnl_currency": [100.0, -50.0, 0.0, 75.0]})
+
+        mt5_trades = pd.DataFrame({"pnl_currency": [100.0, -50.0, 0.0, 75.0]})
+
+        result = compare_totals(our_trades, mt5_trades, pnl_pct_tol=0.001)
+
+        assert result["passed"] is True
+        assert len(result["errors"]) == 0
+        assert result["our_stats"]["total_trades"] == 4
+        assert result["our_stats"]["wins"] == 2
+        assert result["our_stats"]["losses"] == 1
+        assert result["our_stats"]["scratches"] == 1
+
+    def test_compare_totals_fail_count(self):
+        """Test total comparison with mismatched trade counts."""
+        our_trades = pd.DataFrame({"pnl_currency": [100.0, -50.0]})
+
+        mt5_trades = pd.DataFrame({"pnl_currency": [100.0, -50.0, 75.0]})
+
+        result = compare_totals(our_trades, mt5_trades, pnl_pct_tol=0.001)
+
+        assert result["passed"] is False
+        assert len(result["errors"]) >= 1
+        assert any("Trade count mismatch" in error for error in result["errors"])
+
+    def test_compare_totals_fail_pnl(self):
+        """Test total comparison with PnL outside tolerance."""
+        our_trades = pd.DataFrame({"pnl_currency": [100.0]})
+
+        mt5_trades = pd.DataFrame(
+            {
+                "pnl_currency": [110.0]  # 10% difference
+            }
+        )
+
+        result = compare_totals(our_trades, mt5_trades, pnl_pct_tol=0.05)  # 5% tolerance
+
+        assert result["passed"] is False
+        assert len(result["errors"]) >= 1
+        assert any("difference too large" in error for error in result["errors"])
+
+
+class TestMT5ParityE2E:
+    """End-to-end tests for MT5 parity (skipped if MT5 data not available)."""
+
+    @pytest.mark.slow
+    def test_full_parity_pipeline(self):
+        """
+        Full E2E test: run parity backtest and compare with MT5 data.
+        Skipped if MT5 data is not available.
+        """
+        mt5_trades_file = Path("mt5/eurusd_d1_2022_2024/eurusd_d1_2022_2024_trades.csv")
+
+        if not mt5_trades_file.exists():
+            pytest.skip(
+                f"MT5 trades file not found: {mt5_trades_file}. "
+                "Please provide MT5 backtest data to run E2E parity test."
+            )
+
+        # Run our parity backtest
+        print("\n🚀 Running MT5 parity backtest...")
+        result = subprocess.run(
+            [sys.executable, "scripts/mt5_parity_run.py"],
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+        )
+
+        if result.returncode != 0:
+            pytest.fail(
+                f"Parity backtest failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+            )
+
+        # Run comparison
+        print("\n🔍 Running MT5 comparison...")
+        result = subprocess.run(
+            [sys.executable, "scripts/mt5_compare.py"],
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+        )
+
+        if result.returncode != 0:
+            pytest.fail(f"MT5 comparison failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}")
+
+        print("✅ Full MT5 parity pipeline completed successfully!")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tools/mt5_html_to_csv.py
+++ b/tools/mt5_html_to_csv.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+MT5 HTML to CSV Converter
+
+Converts an MT5 HTML backtest report to a trades CSV format.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+def convert_mt5_html_to_csv(input_html: str, output_dir: str) -> None:
+    """
+    Convert MT5 HTML backtest report to CSV format.
+
+    Args:
+        input_html: Path to MT5 HTML report
+        output_dir: Directory to write output CSV
+    """
+    input_path = Path(input_html)
+    output_path = Path(output_dir)
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input HTML file not found: {input_path}")
+
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Read all tables from HTML
+    try:
+        tables = pd.read_html(str(input_path), flavor="lxml")
+    except Exception as e:
+        raise ValueError(f"Failed to parse HTML tables: {e}")
+
+    if not tables:
+        raise ValueError("No tables found in HTML file")
+
+    # Find trades table - heuristic: contains "time" and "profit" columns
+    trades_table = None
+    for table in tables:
+        columns_lower = [str(col).lower() for col in table.columns]
+        if "time" in columns_lower and "profit" in columns_lower:
+            trades_table = table
+            break
+
+    # Fallback: use largest table
+    if trades_table is None:
+        trades_table = max(tables, key=len)
+        print("Warning: Could not identify trades table by column names, using largest table")
+
+    # Normalize column names to minimal schema
+    normalized_columns = {}
+    for col in trades_table.columns:
+        col_lower = str(col).lower()
+        if "time" in col_lower:
+            if "open" in col_lower or col_lower == "time":
+                normalized_columns[col] = "time"
+        elif "type" in col_lower:
+            normalized_columns[col] = "type"
+        elif "symbol" in col_lower:
+            normalized_columns[col] = "symbol"
+        elif "price" in col_lower:
+            if "open" in col_lower:
+                normalized_columns[col] = "price_open"
+            elif "close" in col_lower:
+                normalized_columns[col] = "price_close"
+        elif "s/l" in col_lower or "sl" in col_lower:
+            normalized_columns[col] = "sl"
+        elif "t/p" in col_lower or "tp" in col_lower:
+            normalized_columns[col] = "tp"
+        elif "profit" in col_lower:
+            normalized_columns[col] = "profit"
+        elif "volume" in col_lower or "lots" in col_lower:
+            normalized_columns[col] = "volume"
+        elif "ticket" in col_lower or "order" in col_lower:
+            normalized_columns[col] = "ticket"
+
+    # Rename columns
+    trades_df = trades_table.rename(columns=normalized_columns)
+
+    # Ensure we have the minimal required columns
+    required_cols = [
+        "time",
+        "type",
+        "symbol",
+        "price_open",
+        "price_close",
+        "sl",
+        "tp",
+        "profit",
+        "volume",
+        "ticket",
+    ]
+
+    for col in required_cols:
+        if col not in trades_df.columns:
+            trades_df[col] = None
+
+    # Select only the normalized columns
+    trades_df = trades_df[required_cols]
+
+    # Write to CSV
+    output_file = output_path / "eurusd_d1_2022_2024_trades.csv"
+    trades_df.to_csv(output_file, index=False)
+
+    print(f"Converted MT5 HTML report to CSV: {output_file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert MT5 HTML backtest report to CSV")
+    parser.add_argument("input_html", help="Path to MT5 HTML report file")
+    parser.add_argument("output_dir", help="Directory to write output CSV")
+
+    args = parser.parse_args()
+
+    try:
+        convert_mt5_html_to_csv(args.input_html, args.output_dir)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add MT5 directory structure with .gitignore patterns
- Create HTML to CSV converter for MT5 reports (tools/mt5_html_to_csv.py)
- Add MT5 parity configuration with zero spread/commission/slippage
- Implement parity runner script (scripts/mt5_parity_run.py)
- Create comparison tool with tolerance-based matching (scripts/mt5_compare.py)
- Add comprehensive unit tests for comparison logic
- Support fixed lot size and D1 timeframe validation
- Include E2E test pipeline (skipped if MT5 data unavailable)

All tests pass and linting is clean.

## Summary
Why + what changed (1-2 lines).

## Checks (paste results)
- [ ] ruff check .
- [ ] pytest -q
- [ ] python scripts/smoke_test_selfcontained_v198.py -q --mode fast
- [ ] Indicator contracts respected (C1/C2/baseline/volume/exit)
- [ ] Config-driven only (no hardcoded params)
- [ ] Results unchanged unless intended (trade counts stable)
