### PR TITLE
chore: bump version and changelog for Hard-Stop Realism baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v1.9.9-hardstop
+- New Golden Standard: Hard-Stop Realism
+  - Intrabar touch of TP/BE/TS exits immediately.
+  - Trailing Stop activates & updates on closes only (monotone), exits intrabar when touched.
+  - Pre-TP1 C1 reversal scratch ≈ 0 PnL (tolerance allows spread).
+- Invariants preserved: audit fields immutable; spreads change PnL only, not trade counts.

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,1 @@
+v1.9.9-hardstop


### PR DESCRIPTION
## Summary
Why + what changed (1-2 lines).

## Checks (paste results)
- [ ] ruff check .
- [ ] pytest -q
- [ ] python scripts/smoke_test_selfcontained_v198.py -q --mode fast
- [ ] Indicator contracts respected (C1/C2/baseline/volume/exit)
- [ ] Config-driven only (no hardcoded params)
- [ ] Results unchanged unless intended (trade counts stable)
