### PR TITLE
docs: add CLAUDE.md project brief for AI-assisted development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,370 @@
+# CLAUDE.md — Forex Backtester Project Brief
+
+> Briefing for a new senior developer (or AI assistant) joining this project.
+> The owner is a **complete beginner with coding and repos** — all instructions must be step-by-step, exact, and leave no guesswork. See `PROJECT_RULES.md` for the full delivery standard.
+
+---
+
+## Project Overview
+
+This is a **rule-based Forex backtesting engine** built on the NNFX (No-Nonsense Forex) framework. It simulates multi-indicator trading strategies on historical daily/H1/H4 OHLCV data and produces performance metrics to evaluate strategy quality before any live deployment.
+
+The goal is to **find robust, non-overfitted strategies** that hold up out-of-sample across multiple currency pairs and timeframes. The backtester is the core research tool — everything feeds into it or reads from it.
+
+**What it is NOT:** There is no live trading, broker integration, or real-time data feed. It is a pure research and simulation system.
+
+---
+
+## Folder Structure
+
+```
+Forex-Backtester/
+├── core/                        # Simulation engine (heart of the system)
+│   ├── backtester.py            # Main entry point: loads data, runs simulation loop
+│   ├── signal_logic.py          # Entry/exit signal generation (633 LOC)
+│   ├── backtester_helpers.py    # Trade finalization helpers
+│   └── utils.py                 # ATR calculation, pip conversion, summary helpers
+│
+├── indicators/                  # All trading indicators, organized by role
+│   ├── confirmation_funcs.py    # C1 & C2 confirmation indicators → {-1, 0, +1}
+│   ├── baseline_funcs.py        # Baseline/trend filters → df["baseline"] + {-1,0,+1}
+│   ├── volume_funcs.py          # Volume/AD veto signals → {-1,0,+1} or {0,1}
+│   ├── exit_funcs.py            # Exit rule indicators → {0,1} ONLY
+│   └── legacy_rejected/         # Quarantined indicators (repaint-suspected)
+│
+├── analytics/                   # Performance metrics
+│   ├── metrics.py               # Sharpe, Sortino, CAGR, max DD, MAR, skew, kurtosis
+│   └── monte_carlo.py           # Trade-sequence shuffling for robustness testing
+│
+├── scripts/                     # Runners / entry points
+│   ├── run_single_debug.py      # One backtest with CLI args (pair, date range, indicators)
+│   ├── run_from_yaml.py         # YAML-driven single run
+│   ├── smoke_test_selfcontained_v198.py  # Health check — run this first
+│   ├── batch_sweeper.py         # Parallel parameter sweeps
+│   ├── walk_forward.py          # Walk-forward optimization (WFO)
+│   └── phase{B,C,D}*/           # Research scripts (parameter sensitivity, diagnostics)
+│
+├── configs/                     # YAML strategy configs
+│   ├── config.yaml              # Main config (the one you edit)
+│   ├── sweeps.yaml              # Batch sweep parameter ranges
+│   ├── batch_config.yaml        # Aggregation settings for batch runs
+│   ├── BACKTESTER_TEMPLATE.yaml # Canonical template with all options documented
+│   └── phase*/                  # WFO and phase-specific configs
+│
+├── data/                        # Static market data (never auto-downloaded)
+│   ├── daily/                   # Daily OHLCV CSVs — one file per pair (EUR_USD.csv, etc.)
+│   ├── test/                    # Smaller test datasets (2009–2026)
+│   └── external/                # External indicators (e.g., dbcvix_synth.csv)
+│
+├── results/                     # All output goes here (mostly gitignored)
+│   ├── trades.csv               # Per-trade detail (30 columns)
+│   ├── summary.txt              # Aggregate performance metrics
+│   └── equity_curve.csv         # Time-series equity & drawdown
+│
+├── tests/                       # pytest suite (50+ test files)
+│
+├── validators_config.py         # Pydantic-based YAML config validation
+├── validators_util.py           # Indicator contract enforcement
+├── indicators_cache.py          # Parquet/feather caching layer
+│
+├── BACKTESTER_SCHEMA.json       # Full config schema
+├── BACKTESTER_TEMPLATE.yaml     # Template with all defaults
+├── BACKTESTER_AUDIT.md          # P&L pipeline audit / decision log
+├── PROJECT_RULES.md             # Team playbook — read this early
+└── docs/README.md               # User documentation
+```
+
+---
+
+## Key Dependencies
+
+```
+Python 3.12+
+pandas          # DataFrames & time series
+numpy           # Numerical computing
+pyyaml          # YAML config parsing
+pydantic        # Config validation & typed models
+pytest          # Test framework
+ruff            # Linting & formatting
+```
+
+No broker APIs, no live data feeds, no external databases. All data is local CSV files.
+
+---
+
+## How to Run the Backtester
+
+### 1. Smoke test (fastest validation — run this first after any change)
+
+```bash
+python scripts/smoke_test_selfcontained_v198.py -q --mode fast
+```
+
+Generates its own synthetic data. If this passes, the engine is healthy.
+
+### 2. Single backtest from YAML config
+
+```bash
+python core/backtester.py configs/config.yaml
+```
+
+Outputs to `results/trades.csv`, `results/summary.txt`, `results/equity_curve.csv`.
+
+### 3. Single backtest with CLI args (debug mode)
+
+```bash
+python scripts/run_single_debug.py \
+  --pair EUR_USD \
+  --from 2019-01-01 \
+  --to 2022-12-31 \
+  --timeframe D \
+  --c1 rsi_2 \
+  --c2 macd \
+  --baseline ema_50
+```
+
+### 4. Batch parameter sweep (parallel)
+
+```bash
+python scripts/batch_sweeper.py configs/sweeps.yaml
+```
+
+Results aggregated to `results/batch_summary.csv`.
+
+### 5. Walk-forward optimization (WFO)
+
+```bash
+python scripts/walk_forward.py -c configs/wfo_c1_smoothed_momentum.yaml
+```
+
+Outputs: `results/wfo_c1_<indicator>/wfo_folds.csv`, `oos_summary.txt`, `equity_curve.csv`.
+
+### Disable indicator cache
+
+```bash
+FB_NO_CACHE=1 python core/backtester.py configs/config.yaml
+```
+
+---
+
+## Data Format
+
+**CSV files in `data/daily/`:**
+```
+date,open,high,low,close,volume
+2010-01-02,1.4312,1.43425,1.42926,1.43036,1027
+```
+
+- Required: `open, high, low, close`
+- Optional: `volume` (needed for volume indicators)
+- Common column name variants are auto-normalized
+
+**External data in `data/external/`:**
+```
+date,value
+2010-01-02,15.2
+```
+Used for the DBCVIX volatility filter.
+
+---
+
+## Output Metrics & How to Interpret Them
+
+### Trade Statistics
+
+| Metric | What it means | Target |
+|--------|---------------|--------|
+| Win Rate | % of trades that hit TP1 (excl. scratches) | ≥ 45% |
+| Scratch Rate | % of trades that exit at breakeven (C1 reversed pre-TP1) | < 25% |
+| Avg Win / Avg Loss | Mean PnL on wins vs. losses | Ratio ≥ 1.2 |
+| Expectancy | Expected PnL per trade (AvgWin×WinRate − AvgLoss×LossRate) | Positive |
+
+### Return Metrics
+
+| Metric | What it means | Target |
+|--------|---------------|--------|
+| ROI (%) | Total return over the period | ≥ 10% annualized |
+| CAGR (%) | Annualized compound return | ≥ 10% |
+
+### Risk Metrics
+
+| Metric | What it means | Target |
+|--------|---------------|--------|
+| Max Drawdown | Worst peak-to-trough decline (negative %) | ≥ −20% |
+| Sharpe Ratio | Return per unit of total volatility | ≥ 1.0 |
+| Sortino Ratio | Return per unit of downside volatility only | ≥ 1.5 |
+| MAR Ratio | CAGR / |Max Drawdown| — recovery rate | ≥ 1.5 |
+| Volatility (ann.) | Annualized daily return std dev | < 10% |
+
+### Distribution Metrics
+
+| Metric | What it means | Target |
+|--------|---------------|--------|
+| Skewness | > 0 = right-tail wins (rare big wins); < 0 = left-tail losses | ≥ 0.3 |
+| Kurtosis | > 3 = fat tails (surprise moves) | 3–5 |
+
+### Quality Thresholds
+
+**Minimum viable (continue researching):**
+- Win rate ≥ 45%, Sharpe ≥ 0.5, Max DD ≥ −25%, Total trades ≥ 20
+
+**Good (worth pursuing):**
+- Win rate ≥ 52%, Sharpe ≥ 1.0, Max DD ≥ −15%, MAR ≥ 1.5, OOS Sharpe ≥ 0.6
+
+**Excellent (live-ready candidate):**
+- Win rate ≥ 55%, Sharpe ≥ 1.5, Max DD ≥ −10%, MAR ≥ 2.0, consistent across ≥ 3 pairs
+
+**Red flags — reject immediately:**
+- Win rate < 40%, Max DD > −40%, Sharpe < 0.3, any negative expectancy
+- OOS Sharpe < (IS Sharpe × 0.7) — this means overfitting
+
+---
+
+## Architecture & Conventions
+
+### NNFX Signal Stack
+
+The engine implements NNFX (No-Nonsense Forex) rules with four indicator roles:
+
+1. **C1 (primary confirmation)** — triggers the entry; must be ±1
+2. **C2 (secondary confirmation)** — optional direction filter; must agree with C1
+3. **Baseline** — price trend filter; close must be on correct side
+4. **Volume** — veto signal; must be +1 (pass) to allow entry
+5. **Exit** — optional early exit indicator
+
+All four are optional except C1. Each has a strict function contract (see below).
+
+### Indicator Contracts (never break these)
+
+Every indicator is a pure function with a fixed signature:
+
+```python
+# C1 / C2
+def c1_<name>(df: pd.DataFrame, *, signal_col: str = "c1_signal", **kwargs) -> pd.DataFrame:
+    # Must write df[signal_col] ∈ {-1, 0, +1}
+    return df
+
+# Baseline
+def baseline_<name>(df, *, signal_col: str = "baseline_signal", **kwargs) -> pd.DataFrame:
+    # Must write df["baseline"] (numeric series) AND df[signal_col] ∈ {-1, 0, +1}
+    return df
+
+# Volume
+def volume_<name>(df, *, signal_col: str = "volume_signal", **kwargs) -> pd.DataFrame:
+    # Must write df[signal_col] ∈ {-1, 0, +1} or {0, 1}
+    return df
+
+# Exit
+def exit_<name>(df, *, signal_col: str = "exit_signal", **kwargs) -> pd.DataFrame:
+    # Must write df[signal_col] ∈ {0, 1} ONLY — no -1
+    return df
+```
+
+`validators_util.py` enforces these contracts on every run.
+
+### Immutable Audit Fields
+
+Once a trade is opened, these fields are **permanently fixed** and must never change:
+- `entry_price`, `entry_date`, `entry_idx`
+- `tp1_at_entry_price`, `sl_at_entry_price` (ATR multiples frozen at entry)
+- `atr_at_entry_price`, `atr_at_entry_pips`
+
+Dynamic stops track in `current_sl`; the final value is recorded as `sl_at_exit_price`.
+
+### Config-Driven Only
+
+No hardcoded strategy parameters. Every tunable value lives in YAML configs. Pydantic (`validators_config.py`) validates the config before any data is loaded.
+
+### No-Lookahead Guarantee
+
+- Indicators are computed on bar `i-1` close, used to signal bar `i`
+- Entries execute at bar `i` close
+- Intrabar TP/SL arbitration is configurable (`tp_first` default)
+
+### Three-Tier Exit Model
+
+1. **Pre-TP1:** Check TP1 → SL → C1 reversal (scratch exit)
+2. **Post-TP1:** Trailing stop → C1 reversal → breakeven
+3. **Intrabar arbitration:** Configurable priority (default: TP first)
+
+### TDD Loop (always follow this)
+
+```
+Write failing test → minimal patch → pytest -q green → open PR → CI green → merge
+```
+
+### CI Requirements (every PR must pass)
+
+```bash
+ruff check .
+pytest -q
+python scripts/smoke_test_selfcontained_v198.py -q --mode fast
+```
+
+---
+
+## Tier-1 C1 Indicators (approved, non-repaint)
+
+These have been vetted and are safe for WFO:
+
+- `smoothed_momentum`
+- `kalman_filter`
+- `trend_akkam`
+- `lwpi`
+- `disparity_index`
+- `twiggs_money_flow`
+
+**Quarantined (suspected repaint — do not use):**
+- `fisher_transform`, `laguerre`, `doda_stochastic`, `supertrend`, `ehlers_reverse_ema`, `turtle_trading_channel`
+
+These live in `indicators/legacy_rejected/` and are excluded from WFO configs.
+
+---
+
+## Known Limitations
+
+1. **No live trading** — backtester only; no MT4/MT5, Oanda, or other broker integration
+2. **Fixed spreads only** — no dynamic spread modeling; slippage is not modeled beyond entry/exit
+3. **No liquidity constraints** — assumes any position size fills at any price
+4. **No regime detection** — indicators are static; no built-in market regime switching
+5. **Daily data is primary** — H1/H4 supported but less battle-tested
+6. **Single-account simulation** — no portfolio correlation or multi-account modeling
+7. **Repaint risk** — cache system assumes indicators are non-repainting; suspects quarantined but new indicators need manual audit
+
+---
+
+## Active Research Areas (TODOs)
+
+- Dynamic spread model (currently only fixed pips)
+- Regime filter (market structure detection in `signal_logic.py`)
+- Monte Carlo with correlation matrix (currently independent shuffles)
+- ML-style opportunity labeling (`docs/PHASE_D6F_CLEAN_LABELS.md`)
+- Feature engineering pipeline (`docs/PHASE_D2_LIFT_HARNESS.md`)
+- Execution bar off-by-one validation (`docs/phase8_execution_truth.md`)
+- Kurtosis overflow guard for extreme trade sequences (`analytics/metrics.py`)
+
+---
+
+## Tool Assignments (from PROJECT_RULES.md)
+
+| Task | Tool |
+|------|------|
+| Bug fix / small patch (≤ 3 files, ≤ 100 LOC) | Cursor |
+| New module / multi-file feature / refactor | Aider |
+| Find where X is used across the repo | Cody |
+| Architecture, acceptance criteria, analysis | ChatGPT |
+| YAML, CI, docs | Cursor |
+
+Rule: **one branch = one tool** — don't mix Cursor and Aider on the same branch.
+
+---
+
+## Key Documents to Read First
+
+| Document | Why |
+|----------|-----|
+| `PROJECT_RULES.md` | Delivery standard, guardrails, tool assignments |
+| `BACKTESTER_TEMPLATE.yaml` | All config options with defaults |
+| `BACKTESTER_AUDIT.md` | How the P&L pipeline works internally |
+| `docs/README.md` | Full user guide |
+| `BACKTESTER_SCHEMA.json` | Config schema reference |

--- a/configs/phaseF_roi_sanity/ceb_v3_sl2r_trailing.yaml
+++ b/configs/phaseF_roi_sanity/ceb_v3_sl2r_trailing.yaml
@@ -1,0 +1,130 @@
+# Phase F ROI sanity: CEB v3 only, SL=2R (3×ATR14), two runners + trailing, spreads ON.
+# No engine changes; config-driven only.
+# Output: results/phaseF_roi_sanity/ceb_v3_sl2r_trailing/
+
+strategy_version: "forex_backtester_v1.9.7"
+
+timeframe: "D"
+date_range:
+  start: "2019-01-01"
+  end: "2026-01-01"
+
+pairs:
+  - "EUR_USD"
+  - "GBP_USD"
+  - "USD_JPY"
+  - "USD_CHF"
+  - "USD_CAD"
+  - "AUD_USD"
+  - "NZD_USD"
+  - "EUR_GBP"
+  - "EUR_JPY"
+  - "EUR_CHF"
+  - "EUR_CAD"
+  - "EUR_AUD"
+  - "EUR_NZD"
+  - "GBP_JPY"
+  - "GBP_CHF"
+  - "GBP_CAD"
+  - "GBP_AUD"
+  - "GBP_NZD"
+  - "CHF_JPY"
+  - "CAD_JPY"
+  - "AUD_JPY"
+  - "NZD_JPY"
+  - "CAD_CHF"
+  - "AUD_CHF"
+  - "AUD_CAD"
+  - "AUD_NZD"
+  - "NZD_CHF"
+  - "NZD_CAD"
+
+spreads:
+  enabled: true
+  default_pips: 0.5
+  per_pair: {}
+  mode: "fixed"
+  atr_mult: 0.0
+
+indicators:
+  c1: "c1_compression_escape_ratio_state_machine"
+  use_c2: false
+  use_baseline: false
+  use_volume: false
+  use_exit: false
+  c2: null
+  baseline: null
+  volume: null
+  exit: null
+
+indicator_params:
+  c1_compression_escape_ratio_state_machine:
+    L_slow: 50
+    r_atr: 0.85
+    r_rng: 0.85
+    r_box: 1.1
+    M_enter: 4
+    M_exit: 3
+    K_max: 40
+    cooldown_bars: 10
+
+rules:
+  one_candle_rule: false
+  pullback_rule: false
+  bridge_too_far_days: 7
+  allow_baseline_as_catalyst: false
+
+entry:
+  sl_atr: 3.0
+  tp1_atr: 1.0
+  trail_after_atr: 2.0
+  ts_atr: 1.5
+
+execution:
+  intrabar_priority: "tp_first"
+
+engine:
+  allow_continuation: true
+  duplicate_open_policy: "block"
+
+exit:
+  use_trailing_stop: true
+  move_to_breakeven_after_atr: true
+  exit_on_c1_reversal: true
+  exit_on_baseline_cross: false
+  exit_on_exit_signal: false
+
+risk:
+  starting_balance: 10000.0
+  risk_per_trade_pct: 2.0
+  risk_per_trade: 0.02
+  account_ccy: "AUD"
+  fx_quotes: {}
+
+tracking:
+  track_win_loss_scratch: true
+  track_roi: true
+  track_drawdown: true
+  in_sim_equity: true
+  verbose_logs: false
+
+cache:
+  enabled: true
+  dir: "cache"
+  format: "parquet"
+
+validation:
+  enabled: true
+  fail_fast: true
+  strict_contract: false
+
+output:
+  results_dir: "results/phaseF_roi_sanity/ceb_v3_sl2r_trailing"
+
+outputs:
+  dir: "results/phaseF_roi_sanity/ceb_v3_sl2r_trailing"
+  write_trades_csv: true
+
+filters:
+  dbcvix:
+    enabled: false

--- a/docs/ARCHETYPE_REGISTRY.md
+++ b/docs/ARCHETYPE_REGISTRY.md
@@ -2,6 +2,8 @@
 
 This registry is the **authoritative source** of graduated archetypes for union testing.
 
+**Ignition Pool Inclusion Rule:** Only archetypes with independently positive validation lift may be unioned.
+
 Each entry must include:
 
 - **Indicator name** — exact function identifier
@@ -57,7 +59,7 @@ Each entry must include:
 | **Indicator/function name** | `c1_lsr_v2` |
 | **Variant** | D_volexp (others rejected for now) |
 | **Graduation Date** | 2026-02-15 (Australia/Melbourne) |
-| **Status** | Graduated (Union-eligible) |
+| **Status** | Archived — Validation Negative (Not Union-Eligible) |
 
 **Structural definition:** stop sweep → rejection → displacement with volatility expansion
 
@@ -94,4 +96,15 @@ Each entry must include:
 - overlap: 0, conflict: 0
 - union coverage: 456 unique events (~30% coverage increase)
 
-**Union status:** Approved for union portfolio inclusion
+### Phase E-2 Union Evaluation Outcome
+
+- Standalone validation_lift: negative
+- P3R_val ≈ 0.1630
+- Union with CEB resulted in:
+    - P3R_val ≈ 0.2235
+    - validation_lift ≈ -0.0026
+- Caused collapse of CEB edge
+- Conclusion: Fails ignition qualification rule
+- Retired from ignition pool
+
+**Union status:** Archived — Not union-eligible (validation negative)

--- a/docs/ARCHETYPE_REGISTRY.md
+++ b/docs/ARCHETYPE_REGISTRY.md
@@ -1,0 +1,97 @@
+# Archetype Registry
+
+This registry is the **authoritative source** of graduated archetypes for union testing.
+
+Each entry must include:
+
+- **Indicator name** — exact function identifier
+- **Exact file path** — where the indicator is defined
+- **Metrics** — Phase E / Phase E-1 summary statistics
+- **Parameter envelope** — bounded ranges used for graduation
+- **Status** — graduation tier, archive/active, union-eligible
+
+---
+
+## Archetype A — Compression Ignition (CEB v3)
+
+| Field | Value |
+|-------|-------|
+| **Indicator Location** | `indicators/confirmation_funcs.py` |
+| **Indicator/function name** | `c1_compression_escape_ratio_state_machine` |
+| **Graduation Date** | 2026-02-15 (Australia/Melbourne) |
+| **Status** | Graduated (Low-Frequency Specialist; Archive; Union-eligible) |
+
+**Primary objective:** P(3R before 2R heat)
+
+**Key metrics (from Phase E-1 summary):**
+
+| Metric | Value |
+|--------|-------|
+| P3R_disc | ≈ 0.355 |
+| P3R_val | ≈ 0.256 |
+| discovery_lift | ≈ +0.54 |
+| validation_lift | ≈ +0.126 |
+
+**Frequency behavior:**
+
+- strict: ~1.8 signals/pair/year (too low)
+- relaxed: 17–46/year portfolio-wide but geometry decays
+
+**Structural notes:**
+
+- compression→breakout ignition specialist
+- geometry collapses under frequency push
+- stable clustering
+
+**Union notes:**
+
+- Specialist ignition layer; do not force corridor alone
+
+---
+
+## Archetype B — Liquidity Displacement Ignition (LSR v2 — D_volexp)
+
+| Field | Value |
+|-------|-------|
+| **Indicator Location** | `indicators/confirmation_funcs.py` |
+| **Indicator/function name** | `c1_lsr_v2` |
+| **Variant** | D_volexp (others rejected for now) |
+| **Graduation Date** | 2026-02-15 (Australia/Melbourne) |
+| **Status** | Graduated (Union-eligible) |
+
+**Structural definition:** stop sweep → rejection → displacement with volatility expansion
+
+**Graduation envelope (bounded ranges):**
+
+| Parameter | Range |
+|-----------|-------|
+| vol_expand_atr | [0.8, 1.1] |
+| sweep_atr | [0.2, 0.3] |
+| lookback_n | [15, 20] |
+| wick_min_frac | [0.65, 0.75] |
+| body_max_frac | [0.35, 0.45] |
+| close_pos_min | [0.75, 0.85] |
+| reclaim_frac | [0.0, 0.1] |
+| cooldown_bars | [5, 8] |
+
+**Validation snapshot:**
+
+| Metric | Value |
+|--------|-------|
+| P3R_disc | ≈ 0.372 |
+| P3R_val | ≈ 0.298 |
+| discovery_lift | ≈ +0.60 |
+| validation_lift | ≈ +0.34 |
+
+**Frequency:** ~100 signals over ~7 years (~14/year portfolio-wide)
+
+**Clustering:** clustering_ratio = 0.0
+
+**Coexistence:**
+
+- CEB signals: 355
+- LSR signals: 101
+- overlap: 0, conflict: 0
+- union coverage: 456 unique events (~30% coverage increase)
+
+**Union status:** Approved for union portfolio inclusion

--- a/docs/ARCHETYPE_REGISTRY.md
+++ b/docs/ARCHETYPE_REGISTRY.md
@@ -108,3 +108,59 @@ Each entry must include:
 - Retired from ignition pool
 
 **Union status:** Archived — Not union-eligible (validation negative)
+
+---
+
+## Archived / Failed Archetypes (Not Union-Eligible)
+
+### Archetype C — TPI v2 Compexp State (Compression–Expansion–Reclaim)
+
+**Status:** FAILED — Geometric Misalignment (Permanently Retired; Not Union-Eligible)
+
+| Field | Value |
+|-------|-------|
+| **Indicator/function name** | `c1_tpi_v2_compexp_state` |
+| **Indicator Location** | `indicators/confirmation_funcs.py`, line 1940 |
+| **Graduation Date** | 2026-02-15 |
+
+**Intent (what it tried to do):**
+
+- Detect trend direction
+- Detect pullback to backbone
+- Detect volatility compression
+- Hold phase
+- Fire on expansion + reclaim
+- Target structured continuation ignition from compressed pullbacks
+
+**Final evaluation (D-6G, clean labels, primary objective = P(3R before 2R heat)):**
+
+| Metric | Value |
+|--------|-------|
+| P3R_disc | 0.186 |
+| P3R_val | 0.107 |
+| discovery_lift | -0.189 |
+| validation_lift | -0.513 |
+| Raw signals | ≈24,816 (very high-frequency) |
+| annual_signals_per_pair | ≈0.38 (after alignment filtering) |
+| clustering_ratio | 0.000 |
+| PASS | False |
+
+**Failure reason (locked):**
+
+- Not starvation (unstarve proved pipeline works)
+- Structural misfit on D1 FX: ATR compression ratio ~0.99 median; compression signal not meaningful
+- Fires regime-agnostically (everywhere), does not condition clean opportunity geometry
+- Negative lift on discovery and catastrophically negative on validation
+- Not fixable by tuning; permanently retired
+
+**Key debugging notes (for institutional memory):**
+
+- Fixed structural impossibility: qualified_long based on hold_prev not same-bar pullback
+- Loosened comp_ratio_max up to 1.0 to unstarve
+- Even when unstarved, geometry remained negative → confirms true misalignment
+
+**Decision:**
+
+- Do not tune further
+- Do not include in union tests
+- Keep code for reference only

--- a/scripts/phaseF_run_ceb_roi_sanity.py
+++ b/scripts/phaseF_run_ceb_roi_sanity.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Phase F: CEB v3 ROI sanity run (SL=2R, trailing, two-leg). Prints compact summary from outputs."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.backtester import load_config, run_backtest
+from core.utils import summarize_results
+
+
+def _compute_extra_metrics(results_dir: Path, cfg: dict) -> dict:
+    """Compute profit_factor, expectancy_R, years, trades_per_year from trades/equity."""
+    out: dict = {}
+    trades_path = results_dir / "trades.csv"
+    equity_path = results_dir / "equity_curve.csv"
+
+    risk_cfg = cfg.get("risk") or {}
+    starting_balance = float(risk_cfg.get("starting_balance", 10_000.0))
+    risk_pct = risk_cfg.get("risk_per_trade")
+    if risk_pct is None and "risk_per_trade_pct" in risk_cfg:
+        risk_pct = float(risk_cfg["risk_per_trade_pct"]) / 100.0
+    if risk_pct is None:
+        risk_pct = 0.02
+    risk_per_trade = float(starting_balance * risk_pct)
+
+    if trades_path.exists():
+        import pandas as pd
+
+        df = pd.read_csv(trades_path)
+        pnl = pd.to_numeric(df.get("pnl", 0), errors="coerce").fillna(0.0)
+        win = df.get("win", pd.Series(dtype=bool))
+        if "win" in df.columns:
+            win = win.fillna(False).astype(bool)
+        else:
+            win = pnl > 0
+        loss = df.get("loss", pd.Series(dtype=bool))
+        if "loss" in df.columns:
+            loss = loss.fillna(False).astype(bool)
+        else:
+            loss = pnl < 0
+
+        gross_profit = float(pnl[win].sum())
+        gross_loss = float(pnl[loss].sum())
+        if gross_loss < 0:
+            out["profit_factor"] = gross_profit / abs(gross_loss)
+        else:
+            out["profit_factor"] = float("inf") if gross_profit > 0 else 0.0
+        if risk_per_trade > 0 and len(df) > 0:
+            out["expectancy_R"] = float(pnl.sum()) / (len(df) * risk_per_trade)
+            ns = (win | loss).sum()
+            if ns > 0:
+                out["avg_trade_R"] = float(pnl[win | loss].sum()) / (ns * risk_per_trade)
+            else:
+                out["avg_trade_R"] = 0.0
+        else:
+            out["expectancy_R"] = 0.0
+            out["avg_trade_R"] = 0.0
+
+    years = 0.0
+    if equity_path.exists():
+        import pandas as pd
+
+        eq = pd.read_csv(equity_path)
+        if "date" in eq.columns and len(eq) >= 2:
+            eq["date"] = pd.to_datetime(eq["date"])
+            days = (eq["date"].iloc[-1] - eq["date"].iloc[0]).days
+            years = max(0.0, days / 365.25)
+    if years <= 0:
+        dr = cfg.get("date_range") or {}
+        start_s = dr.get("start") or "2019-01-01"
+        end_s = dr.get("end") or "2026-01-01"
+        try:
+            from pandas import to_datetime
+
+            days = (to_datetime(end_s) - to_datetime(start_s)).days
+            years = max(0.0, days / 365.25)
+        except Exception:
+            years = 7.0
+
+    out["years"] = years
+    if years > 0 and trades_path.exists():
+        import pandas as pd
+
+        n = len(pd.read_csv(trades_path))
+        out["trades_per_year"] = n / years
+    else:
+        out["trades_per_year"] = 0.0
+
+    return out
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parent.parent
+    default_config = root / "configs" / "phaseF_roi_sanity" / "ceb_v3_sl2r_trailing.yaml"
+
+    parser = argparse.ArgumentParser(description="Phase F: CEB v3 ROI sanity run (SL=2R, trailing, two-leg)")
+    parser.add_argument("-c", "--config", type=str, default=str(default_config), help="Path to YAML config")
+    args = parser.parse_args()
+
+    config_path = Path(args.config)
+    if not config_path.is_absolute():
+        config_path = root / config_path
+    config_path = config_path.resolve()
+
+    cfg = load_config(str(config_path))
+    out_dir = (cfg.get("outputs") or {}).get("dir") or (cfg.get("output") or {}).get("results_dir") or "results"
+    if not Path(out_dir).is_absolute():
+        out_dir = str(root / out_dir)
+    results_dir = Path(out_dir).resolve()
+
+    run_backtest(config_path=str(config_path), results_dir=str(results_dir))
+
+    _, metrics = summarize_results(str(results_dir), starting_balance=cfg.get("risk", {}).get("starting_balance", 10_000.0))
+    extra = _compute_extra_metrics(results_dir, cfg)
+
+    total = metrics.get("total_trades", 0)
+    win_rate = metrics.get("win_rate_ns", 0.0)
+    expectancy = metrics.get("expectancy", 0.0)
+    roi_pct = metrics.get("roi_pct", 0.0)
+    max_dd = metrics.get("max_dd_pct", 0.0)
+
+    print("\n" + "=" * 60)
+    print("CEB v3 ROI SANITY — Compact Summary")
+    print("=" * 60)
+    print(f"  total_trades      : {total}")
+    print(f"  win_rate (ns) %   : {win_rate:.2f}")
+    print(f"  expectancy ($)    : {expectancy:.2f}")
+    print(f"  expectancy (R)    : {extra.get('expectancy_R', 0.0):.4f}")
+    print(f"  net ROI %         : {roi_pct:.2f}")
+    print(f"  max drawdown %    : {max_dd:.2f}")
+    print(f"  profit_factor     : {extra.get('profit_factor', 0.0):.2f}")
+    print(f"  avg trade R       : {extra.get('avg_trade_R', 0.0):.4f}")
+    print(f"  years             : {extra.get('years', 0):.2f}")
+    print(f"  trades/year       : {extra.get('trades_per_year', 0):.1f}")
+    print("=" * 60)
+    print(f"  output_dir        : {results_dir}")
+    print("=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_phaseF_roi_sanity_runner.py
+++ b/tests/test_phaseF_roi_sanity_runner.py
@@ -1,0 +1,102 @@
+# Phase F: CEB v3 ROI sanity runner — tests for scripts/phaseF_run_ceb_roi_sanity.py
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _minimal_ceb_v3_config(tmp_path: Path, out_dir: Path) -> dict:
+    """Minimal CEB v3 config for fast integration test (1 pair, short range)."""
+    return {
+        "strategy_version": "forex_backtester_v1.9.7",
+        "timeframe": "D",
+        "date_range": {"start": "2020-01-01", "end": "2020-06-30"},
+        "pairs": ["EUR_USD"],
+        "spreads": {"enabled": True, "default_pips": 0.5, "per_pair": {}, "mode": "fixed", "atr_mult": 0.0},
+        "indicators": {
+            "c1": "c1_compression_escape_ratio_state_machine",
+            "use_c2": False,
+            "use_baseline": False,
+            "use_volume": False,
+            "use_exit": False,
+            "c2": None,
+            "baseline": None,
+            "volume": None,
+            "exit": None,
+        },
+        "indicator_params": {
+            "c1_compression_escape_ratio_state_machine": {
+                "L_slow": 50,
+                "r_atr": 0.85,
+                "r_rng": 0.85,
+                "r_box": 1.1,
+                "M_enter": 4,
+                "M_exit": 3,
+                "K_max": 40,
+                "cooldown_bars": 10,
+            }
+        },
+        "rules": {
+            "one_candle_rule": False,
+            "pullback_rule": False,
+            "bridge_too_far_days": 7,
+            "allow_baseline_as_catalyst": False,
+        },
+        "entry": {"sl_atr": 3.0, "tp1_atr": 1.0, "trail_after_atr": 2.0, "ts_atr": 1.5},
+        "execution": {"intrabar_priority": "tp_first"},
+        "engine": {"allow_continuation": True, "duplicate_open_policy": "block"},
+        "exit": {
+            "use_trailing_stop": True,
+            "move_to_breakeven_after_atr": True,
+            "exit_on_c1_reversal": True,
+            "exit_on_baseline_cross": False,
+            "exit_on_exit_signal": False,
+        },
+        "risk": {"starting_balance": 10000.0, "risk_per_trade_pct": 2.0, "risk_per_trade": 0.02},
+        "output": {"results_dir": str(out_dir)},
+        "outputs": {"dir": str(out_dir), "write_trades_csv": True},
+        "tracking": {
+            "track_win_loss_scratch": True,
+            "track_roi": True,
+            "track_drawdown": True,
+            "in_sim_equity": True,
+            "verbose_logs": False,
+        },
+        "filters": {"dbcvix": {"enabled": False}},
+    }
+
+
+def test_phaseF_run_ceb_roi_sanity_produces_outputs(tmp_path: Path) -> None:
+    """Run phaseF runner with minimal config (1 pair, 6 months); verify outputs exist."""
+    root = Path(__file__).resolve().parent.parent
+    data_dir = root / "data" / "daily"
+    if not data_dir.exists() or not list(data_dir.glob("*.csv")):
+        pytest.skip("data/daily missing")
+
+    out_dir = tmp_path / "phaseF_out"
+    cfg = _minimal_ceb_v3_config(tmp_path, out_dir)
+    cfg["data_dir"] = str(data_dir)
+    cfg_path = tmp_path / "ceb_v3_mini.yaml"
+    with cfg_path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f, sort_keys=False)
+
+    env = {**os.environ, "PYTHONPATH": str(root)}
+    result = subprocess.run(
+        [sys.executable, str(root / "scripts" / "phaseF_run_ceb_roi_sanity.py"), "-c", str(cfg_path)],
+        cwd=str(root),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (result.stdout or "") + (result.stderr or "")
+
+    assert (out_dir / "trades.csv").exists(), "trades.csv must exist"
+    assert (out_dir / "summary.txt").exists(), "summary.txt must exist"
+    assert (out_dir / "equity_curve.csv").exists(), "equity_curve.csv must exist"
+    assert "total_trades" in (result.stdout or ""), "Printed summary should include total_trades"
+    assert "output_dir" in (result.stdout or ""), "Printed summary should include output_dir"


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md`, a comprehensive project briefing document designed for new developers and AI assistants joining the Forex Backtester project.

## Contents

- **Project Overview**: Rule-based Forex backtesting engine built on the NNFX framework
- **Folder Structure**: Complete directory map with descriptions of each module
- **Key Dependencies**: Python 3.12+, pandas, numpy, pyyaml, pydantic, pytest, ruff
- **Usage Guide**: How to run smoke tests, single backtests, batch sweeps, and walk-forward optimization
- **Data Format**: CSV structure specifications for OHLCV data
- **Output Metrics**: Trade statistics, return metrics, risk metrics, and quality thresholds
- **Architecture**: NNFX signal stack, indicator contracts, immutable audit fields, TDD loop
- **Tier-1 Indicators**: Approved and quarantined indicators list
- **Limitations**: Known constraints (no live trading, fixed spreads, no regime detection, etc.)
- **Active Research**: Current TODOs and experimental areas
- **Tool Assignments**: Cursor, Aider, Cody, ChatGPT usage guidelines from PROJECT_RULES.md
- **Key Documents**: Reading priority for understanding the system

This document serves as the canonical onboarding reference and must be read before working on the codebase.