### PR TITLE
feat: Pipeline D1 backtester extension (PR 1 of 2 — plumbing + close-at-market)

### DIFF
--- a/L_ARC_PROTOCOL.md
+++ b/L_ARC_PROTOCOL.md
@@ -126,11 +126,11 @@ Disjunctive across pipelines: archetype passes extractability if it clears E OR 
 ### Pipeline D1 — Deferred-identification
 
 1. Train t=N RF classifier on features at bar offset N.
-2. Signal fires → enter with archetype-appropriate initial SL → hold to bar N.
+2. Signal fires → enter with uniform pre-t SL (entry − 2.0 × ATR(14), matching KH-24 baseline) → hold to bar N. Archetype-specific SL replaces the pre-t SL at bar N once classifier verdict lands (PR 2 — not in PR 1).
 3. At bar N: classifier evaluates → apply archetype exit policy from §11.
-4. Trades classifier deems untradeable at bar N: close at break-even or small loss.
+4. Trades classifier deems untradeable at bar N: close at market on bar N+1 open. Expected outcome is near-break-even small loss after spread, given the short hold and pre-t SL — engine books the realised PnL.
 
-**Backtester:** REQUIRES EXTENSION. Conditional exits keyed on mid-trade classifier output. Estimate 3-5 days. Pipeline D1 archetypes cannot reach Step 6 WFO until extension lands (next engine PR per §13).
+**Backtester:** PR 1 lands plumbing + close-at-market (uniform pre-t SL, classifier evaluation at bar N, untradeable trades close at N+1 open). PR 2 ships per-archetype exit policies (archetype-specific SL replacement at bar N, custom trail distances, TP targets). Pipeline D1 archetypes can reach Step 6 WFO under PR 1 for the close-at-market path; the full archetype-policy WFO awaits PR 2.
 
 **Early-exit attrition:** smaller N preserves addressable pool but weakens signal; larger N improves signal but loses trades. 30% exclusion floor balances this.
 

--- a/core/d1_pipeline.py
+++ b/core/d1_pipeline.py
@@ -1,0 +1,395 @@
+"""Pipeline D1 hook for the WFO engine — PR 1 (plumbing + close-at-market).
+
+At a single bar offset ``t`` (locked across all archetypes for an L arc),
+score each archetype's classifier against the path-so-far feature vector
+and decide:
+
+* :class:`Close` — none of the archetypes cleared their threshold; the
+  trade is closed at the next bar's open (the engine books the realised
+  PnL after spread).
+* :class:`ApplyPolicy` — at least one archetype cleared; the winning
+  archetype's exit policy applies. PR 1 ships this as a no-op so the
+  trade continues with the engine's standard exit cascade (SL / trail /
+  kijun_d1). PR 2 adds per-archetype SL / trail / TP mutations.
+* :class:`Hold` — reserved for future use; PR 1 never returns this from
+  :meth:`D1Hook.evaluate`.
+
+Configuration is loaded from YAML (see :func:`D1Hook.from_yaml_dict`):
+
+.. code-block:: yaml
+
+    d1_archetypes:
+      - label: stepwise_climber
+        classifier_path: artefacts/arc_3/stepwise_climber_D1.joblib
+        feature_order: [body_to_range_ratio, ..., velocity_first_t]
+        decision_threshold: 0.55
+        bar_offset_t: 3
+
+See L_ARC_PROTOCOL.md §3 (Pipeline D1) and §11 (exit-family map).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Protocol, Sequence
+
+import numpy as np
+
+from core.features_path_so_far import ALL_FEATURE_KEYS, build_features_at_t
+
+# ---------------------------------------------------------------------------
+# Decision dataclasses.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Close:
+    """Trade is untradeable per all archetypes — close at next bar's open."""
+
+    reason: str  # PR 1: always "d1_untradeable"
+
+
+@dataclass(frozen=True)
+class ApplyPolicy:
+    """An archetype's classifier accepted the trade.
+
+    PR 1: empty payload — engine continues with standard exits. PR 2 will
+    carry SL / trail / TP mutations keyed on the winning archetype.
+    """
+
+    label: str = ""  # winning archetype label; informational in PR 1
+    probability: float = float("nan")  # winning archetype P; informational in PR 1
+
+
+@dataclass(frozen=True)
+class Hold:
+    """Reserved. Not emitted by D1Hook.evaluate in PR 1."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Classifier protocol — anything with predict_proba(shape=(n,2)) works.
+# ---------------------------------------------------------------------------
+
+
+class _ClassifierLike(Protocol):
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:  # pragma: no cover
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Archetype config + hook.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class D1ArchetypeConfig:
+    """One archetype's classifier + decision threshold + feature schema.
+
+    ``classifier`` can be supplied directly (e.g. a stub in tests) — in
+    which case ``classifier_path`` is informational only. When loaded via
+    :func:`D1Hook.from_yaml_dict`, ``classifier_path`` is joblib-loaded.
+    """
+
+    label: str
+    feature_order: tuple[str, ...]
+    decision_threshold: float
+    bar_offset_t: int
+    classifier: Any = None  # _ClassifierLike at runtime
+    classifier_path: str | None = None
+    extras: Mapping[str, Any] = field(default_factory=dict)
+
+
+class D1Hook:
+    """Pipeline D1 hook — load once at engine start, call once per trade
+    at the configured bar offset ``t``.
+
+    Constructor validates that:
+
+    * at least one archetype is configured
+    * all archetypes share the same ``bar_offset_t`` (PR 1 constraint)
+    * each archetype's ``feature_order`` matches the locked schema
+    * each archetype's classifier (if attached) reports an expected
+      feature count matching the length of ``feature_order``
+
+    All validation failures raise :class:`ValueError` with a clear,
+    actionable message.
+    """
+
+    def __init__(self, archetypes: Sequence[D1ArchetypeConfig]):
+        if not archetypes:
+            raise ValueError("D1Hook requires at least one archetype config")
+
+        ts = {a.bar_offset_t for a in archetypes}
+        if len(ts) > 1:
+            raise ValueError(
+                "PR 1 constraint: all archetypes must share bar_offset_t; "
+                f"got {sorted(ts)}"
+            )
+        self._bar_offset_t = int(next(iter(ts)))
+
+        known = set(ALL_FEATURE_KEYS)
+        for a in archetypes:
+            req = list(a.feature_order)
+            if len(req) != len(set(req)):
+                raise ValueError(
+                    f"archetype '{a.label}': feature_order has duplicate keys"
+                )
+            req_set = set(req)
+            unexpected = sorted(req_set - known)
+            missing = sorted(known - req_set)
+            if unexpected or missing:
+                parts: list[str] = []
+                if unexpected:
+                    parts.append("unexpected: " + ", ".join(unexpected))
+                if missing:
+                    parts.append("missing: " + ", ".join(missing))
+                raise ValueError(
+                    f"archetype '{a.label}': feature_order does not match the "
+                    "locked schema; " + "; ".join(parts)
+                )
+
+            if a.classifier is not None:
+                expected = getattr(a.classifier, "n_features_in_", None)
+                if expected is not None and int(expected) != len(req):
+                    raise ValueError(
+                        f"archetype '{a.label}': classifier expects "
+                        f"{int(expected)} features but feature_order has "
+                        f"{len(req)}"
+                    )
+
+            if not (0.0 <= float(a.decision_threshold) <= 1.0):
+                raise ValueError(
+                    f"archetype '{a.label}': decision_threshold "
+                    f"{a.decision_threshold} not in [0, 1]"
+                )
+            if int(a.bar_offset_t) < 1:
+                raise ValueError(
+                    f"archetype '{a.label}': bar_offset_t must be >= 1; "
+                    f"got {a.bar_offset_t}"
+                )
+
+        self._archetypes: tuple[D1ArchetypeConfig, ...] = tuple(archetypes)
+
+    # ------------------------------------------------------------------
+    @property
+    def bar_offset_t(self) -> int:
+        """The single ``t`` shared across all archetypes."""
+        return self._bar_offset_t
+
+    @property
+    def archetypes(self) -> tuple[D1ArchetypeConfig, ...]:
+        return self._archetypes
+
+    # ------------------------------------------------------------------
+    def evaluate(
+        self,
+        trade: Mapping[str, Any],
+        bar_path_so_far: Sequence[Mapping[str, float]],
+        entry_features: Mapping[str, float],
+        t: int,
+        cached: Mapping[str, Any] | None = None,
+    ) -> Close | ApplyPolicy | Hold:
+        """Score every archetype at ``t``; pick max-P clearer, else Close.
+
+        ``trade`` and ``cached`` are accepted for API symmetry with PR 2 (where
+        archetype policies may read trade state); PR 1 ignores them.
+        """
+        del trade, cached
+
+        if int(t) != self._bar_offset_t:
+            raise ValueError(
+                f"D1Hook.evaluate called at t={t}; configured t={self._bar_offset_t}"
+            )
+
+        best_label: str | None = None
+        best_p: float = -1.0
+        best_threshold: float = 0.0
+        for arch in self._archetypes:
+            features = build_features_at_t(
+                bar_path_so_far=bar_path_so_far,
+                entry_features=entry_features,
+                t=int(t),
+                feature_order=list(arch.feature_order),
+            )
+            if not np.isfinite(features).all():
+                # Missing warmup or invalid path — abstain on this
+                # archetype. (A trade can still be accepted by another
+                # archetype with valid features.)
+                continue
+            p = _score_positive_class(arch.classifier, features)
+            if p >= float(arch.decision_threshold) and p > best_p:
+                best_label = arch.label
+                best_p = float(p)
+                best_threshold = float(arch.decision_threshold)
+
+        if best_label is not None:
+            return ApplyPolicy(label=best_label, probability=best_p)
+
+        del best_threshold  # unused in PR 1; PR 2 may surface it on Close.
+        return Close(reason="d1_untradeable")
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_yaml_dict(
+        cls,
+        cfg_block: Sequence[Mapping[str, Any]],
+        project_root: Path | None = None,
+    ) -> "D1Hook":
+        """Build a hook from the ``d1_archetypes`` YAML block.
+
+        ``classifier_path`` is resolved relative to ``project_root`` if
+        provided and the path is not absolute. joblib loading is lazy —
+        we only import joblib when at least one classifier_path is set.
+        """
+        if not cfg_block:
+            raise ValueError("d1_archetypes block is empty")
+
+        needs_joblib = any(
+            isinstance(item, Mapping) and item.get("classifier_path")
+            for item in cfg_block
+        )
+        joblib_load = None
+        if needs_joblib:
+            try:
+                import joblib  # type: ignore
+            except ImportError as exc:  # pragma: no cover - environment-dependent
+                raise ImportError(
+                    "d1_archetypes config references classifier_path but "
+                    "joblib is not installed"
+                ) from exc
+            joblib_load = joblib.load
+
+        archetypes: list[D1ArchetypeConfig] = []
+        for raw in cfg_block:
+            if not isinstance(raw, Mapping):
+                raise ValueError(
+                    f"d1_archetypes entries must be mappings; got {type(raw).__name__}"
+                )
+            label = str(raw["label"])
+            feature_order = tuple(str(k) for k in raw["feature_order"])
+            decision_threshold = float(raw["decision_threshold"])
+            bar_offset_t = int(raw["bar_offset_t"])
+            classifier_path_raw = raw.get("classifier_path")
+            classifier_path = (
+                str(classifier_path_raw) if classifier_path_raw is not None else None
+            )
+            classifier = raw.get("classifier")  # tests inject directly
+            if classifier is None and classifier_path is not None:
+                p = Path(classifier_path)
+                if not p.is_absolute() and project_root is not None:
+                    p = project_root / p
+                assert joblib_load is not None  # guarded above
+                classifier = joblib_load(p)
+
+            archetypes.append(
+                D1ArchetypeConfig(
+                    label=label,
+                    feature_order=feature_order,
+                    decision_threshold=decision_threshold,
+                    bar_offset_t=bar_offset_t,
+                    classifier=classifier,
+                    classifier_path=classifier_path,
+                    extras={
+                        k: v
+                        for k, v in raw.items()
+                        if k
+                        not in {
+                            "label",
+                            "feature_order",
+                            "decision_threshold",
+                            "bar_offset_t",
+                            "classifier_path",
+                            "classifier",
+                        }
+                    },
+                )
+            )
+        return cls(archetypes)
+
+
+# ---------------------------------------------------------------------------
+# Internals.
+# ---------------------------------------------------------------------------
+
+
+def _score_positive_class(classifier: Any, features: np.ndarray) -> float:
+    """Return P(class=1) from a binary classifier's ``predict_proba``.
+
+    Accepts the standard sklearn ``predict_proba`` output of shape
+    ``(n, 2)``. Single-sample input is reshaped to ``(1, n_features)``.
+    """
+    X = np.asarray(features, dtype=np.float64).reshape(1, -1)
+    proba = classifier.predict_proba(X)
+    proba = np.asarray(proba)
+    if proba.ndim != 2 or proba.shape[0] != 1 or proba.shape[1] < 2:
+        raise ValueError(
+            f"classifier.predict_proba returned shape {proba.shape}; "
+            "expected (1, 2) for binary classification"
+        )
+    return float(proba[0, 1])
+
+
+# ---------------------------------------------------------------------------
+# Engine helper.
+# ---------------------------------------------------------------------------
+
+
+def apply_d1_hook_per_bar(
+    hook: D1Hook | None,
+    trade: Mapping[str, Any],
+    j: int,
+    entry_idx: int,
+    cached: Mapping[str, Any],
+    c_j: float,
+) -> tuple[float | None, int | None, str | None]:
+    """Engine integration point — called once per (trade, bar) on the
+    per-trade management loop.
+
+    Returns ``(exit_px, exit_bar, exit_reason)`` when the hook decides to
+    Close the trade at bar ``j``, or ``(None, None, None)`` when the engine
+    should fall through to its legacy exit cascade (hook is None, bar
+    offset doesn't match, or hook returned ApplyPolicy / Hold).
+
+    Fill resolution mirrors the engine's standard next-bar-open pattern
+    (see scripts/phase_kgl_v2_4h_wfo.py:1376-1384). When ``j + 1`` is past
+    end-of-data the fill collapses to bar ``j``'s close — same as every
+    other engine exit branch.
+    """
+    if hook is None:
+        return None, None, None
+    bars_held = int(j) - int(entry_idx)
+    if bars_held != hook.bar_offset_t:
+        return None, None, None
+    entry_features = trade.get("entry_features")
+    if entry_features is None:
+        # Trade was opened without entry features (e.g. KH-16 / KH-17
+        # re-entry paths in PR 1). Fall through to legacy exits.
+        return None, None, None
+    decision = hook.evaluate(
+        trade=trade,
+        bar_path_so_far=trade["bar_path"],
+        entry_features=entry_features,
+        t=bars_held,
+        cached=cached,
+    )
+    if isinstance(decision, Close):
+        opens = cached["o"]
+        n = len(opens)
+        if j + 1 < n:
+            return float(opens[j + 1]), int(j + 1), decision.reason
+        return float(c_j), int(j), decision.reason
+    # ApplyPolicy / Hold — PR 1 no-op, fall through to legacy exits.
+    return None, None, None
+
+
+__all__ = (
+    "Close",
+    "ApplyPolicy",
+    "Hold",
+    "D1ArchetypeConfig",
+    "D1Hook",
+    "apply_d1_hook_per_bar",
+)

--- a/core/features_path_so_far.py
+++ b/core/features_path_so_far.py
@@ -1,0 +1,337 @@
+"""Pipeline D1 feature builder — single source of truth.
+
+Used by both training scripts (offline) and the WFO engine (runtime). The
+feature vector at bar offset ``t`` is the concatenation of:
+
+  * 8 base entry features captured at the signal bar (immutable, passed in
+    via ``entry_features``).
+  * 7 path-so-far features derived from ``bar_path_so_far`` rows whose
+    ``bar_offset <= t``.
+
+The schema is locked. ``feature_order`` lets callers pick the layout that
+matches the trained model — the builder validates it against the keys it
+actually produces and raises ``ValueError`` on any mismatch.
+
+See L_ARC_PROTOCOL.md §3 (Pipeline D1) and §8 (Step 4 — extractability).
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Sequence
+
+import numpy as np
+
+ENTRY_FEATURE_KEYS: tuple[str, ...] = (
+    "body_to_range_ratio",
+    "upper_wick_ratio",
+    "lower_wick_ratio",
+    "range_to_atr_14",
+    "ret_5bar_atr",
+    "ret_20bar_atr",
+    "pos_in_20bar_range",
+    "rsi_14",
+)
+
+PATH_FEATURE_KEYS: tuple[str, ...] = (
+    "close_r_at_t",
+    "mfe_so_far_r_at_t",
+    "mae_so_far_r_at_t",
+    "bars_in_profit_at_t",
+    "local_peaks_so_far_at_t",
+    "monotonicity_so_far_at_t",
+    "velocity_first_t",
+)
+
+ALL_FEATURE_KEYS: tuple[str, ...] = ENTRY_FEATURE_KEYS + PATH_FEATURE_KEYS
+
+
+def _validate_feature_order(feature_order: Sequence[str]) -> None:
+    requested = list(feature_order)
+    if len(requested) != len(set(requested)):
+        seen: set[str] = set()
+        dupes = sorted({k for k in requested if (k in seen) or seen.add(k)})  # type: ignore[func-returns-value]
+        raise ValueError(
+            "feature_order contains duplicate keys: " + ", ".join(dupes)
+        )
+    known = set(ALL_FEATURE_KEYS)
+    requested_set = set(requested)
+    unexpected = sorted(requested_set - known)
+    missing = sorted(known - requested_set)
+    if unexpected or missing:
+        parts: list[str] = []
+        if unexpected:
+            parts.append("unexpected: " + ", ".join(unexpected))
+        if missing:
+            parts.append("missing: " + ", ".join(missing))
+        raise ValueError(
+            "feature_order does not match the locked schema "
+            f"(expected {len(ALL_FEATURE_KEYS)} keys: "
+            + ", ".join(ALL_FEATURE_KEYS)
+            + "); "
+            + "; ".join(parts)
+        )
+
+
+def _compute_path_features(
+    bar_path_so_far: Sequence[Mapping[str, float]],
+    t: int,
+) -> dict[str, float]:
+    """Derive the 7 path-so-far features from ``bar_path_so_far`` at offset ``t``.
+
+    No-lookahead invariant: only rows with ``bar_offset <= t`` participate.
+    Rows beyond ``t`` are ignored even if present in the input list.
+    """
+    if t < 0:
+        raise ValueError(f"t must be >= 0; got {t}")
+
+    held: list[Mapping[str, float]] = [
+        r for r in bar_path_so_far if int(r["bar_offset"]) <= t
+    ]
+    if not held:
+        raise ValueError(
+            f"bar_path_so_far has no rows with bar_offset <= {t}"
+        )
+    held.sort(key=lambda r: int(r["bar_offset"]))
+
+    row_at_t: Mapping[str, float] | None = None
+    for r in held:
+        if int(r["bar_offset"]) == t:
+            row_at_t = r
+            break
+    if row_at_t is None:
+        raise ValueError(
+            f"bar_path_so_far has no row with bar_offset == {t}"
+        )
+
+    close_r_at_t = float(row_at_t["close_r"])
+    mfe_so_far_r_at_t = float(row_at_t["mfe_so_far_r"])
+    mae_so_far_r_at_t = float(row_at_t["mae_so_far_r"])
+
+    bars_in_profit_at_t = sum(1 for r in held if float(r["close_r"]) > 0.0)
+
+    local_peaks_so_far_at_t = 0
+    prev_mfe: float | None = None
+    for r in held:
+        m = float(r["mfe_so_far_r"])
+        if prev_mfe is not None and m > prev_mfe:
+            local_peaks_so_far_at_t += 1
+        prev_mfe = m
+
+    # Monotonicity: among in-profit bars, fraction whose close_r >=
+    # previous in-profit close_r. First in-profit bar is counted as
+    # "monotone" (no prior in-profit bar to break order).
+    in_profit_closes: list[float] = [
+        float(r["close_r"]) for r in held if float(r["close_r"]) > 0.0
+    ]
+    if in_profit_closes:
+        monotone = 1
+        for prev, cur in zip(in_profit_closes, in_profit_closes[1:]):
+            if cur >= prev:
+                monotone += 1
+        monotonicity_so_far_at_t = monotone / max(1, len(in_profit_closes))
+    else:
+        monotonicity_so_far_at_t = 0.0
+
+    velocity_first_t = mfe_so_far_r_at_t / max(1, t)
+
+    return {
+        "close_r_at_t": close_r_at_t,
+        "mfe_so_far_r_at_t": mfe_so_far_r_at_t,
+        "mae_so_far_r_at_t": mae_so_far_r_at_t,
+        "bars_in_profit_at_t": float(bars_in_profit_at_t),
+        "local_peaks_so_far_at_t": float(local_peaks_so_far_at_t),
+        "monotonicity_so_far_at_t": float(monotonicity_so_far_at_t),
+        "velocity_first_t": float(velocity_first_t),
+    }
+
+
+def build_features_at_t(
+    bar_path_so_far: Sequence[Mapping[str, float]],
+    entry_features: Mapping[str, float],
+    t: int,
+    feature_order: Sequence[str],
+) -> np.ndarray:
+    """Build the ordered feature vector for the Pipeline D1 classifier at ``t``.
+
+    Parameters
+    ----------
+    bar_path_so_far : sequence of dicts
+        Per-bar trade-path rows with the v1.3 schema (``bar_offset``,
+        ``high_r``, ``low_r``, ``close_r``, ``mfe_so_far_r``,
+        ``mae_so_far_r``, ``is_held``). Only rows with ``bar_offset <= t``
+        are consumed.
+    entry_features : mapping
+        The 8 base entry features captured at the signal bar. Must contain
+        every key in :data:`ENTRY_FEATURE_KEYS`.
+    t : int
+        Bar offset at which the classifier evaluates. ``t=0`` is the entry
+        bar; ``t=3`` is the fourth bar of the trade.
+    feature_order : sequence of str
+        Locked feature order from the trained classifier. Must match
+        :data:`ALL_FEATURE_KEYS` as a set; ordering is arbitrary and
+        determines the output layout.
+
+    Returns
+    -------
+    np.ndarray of float64, shape ``(len(feature_order),)``.
+
+    Raises
+    ------
+    ValueError
+        If ``feature_order`` has duplicates, missing keys, or unexpected
+        keys; if ``t`` is negative; if ``bar_path_so_far`` has no row at
+        offset ``t``; or if ``entry_features`` is missing a required key.
+    """
+    _validate_feature_order(feature_order)
+
+    missing_entry = [k for k in ENTRY_FEATURE_KEYS if k not in entry_features]
+    if missing_entry:
+        raise ValueError(
+            "entry_features is missing required keys: " + ", ".join(missing_entry)
+        )
+
+    path_feats = _compute_path_features(bar_path_so_far, t)
+
+    values: list[float] = []
+    for key in feature_order:
+        if key in path_feats:
+            values.append(float(path_feats[key]))
+        else:
+            values.append(float(entry_features[key]))
+    return np.asarray(values, dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# Entry-feature computation — used by the engine at trade open.
+# ---------------------------------------------------------------------------
+
+
+def _wilder_rsi_last(closes: Sequence[float], period: int = 14) -> float:
+    """Wilder's RSI at the last index of ``closes``.
+
+    Returns ``NaN`` if there are fewer than ``period + 1`` valid closes.
+    Pure-Python — used once per trade entry, so vectorisation is unnecessary.
+    """
+    c = np.asarray(closes, dtype=np.float64)
+    n = c.size
+    if n < period + 1 or not np.isfinite(c).all():
+        return float("nan")
+    diffs = np.diff(c)
+    gains = np.where(diffs > 0, diffs, 0.0)
+    losses = np.where(diffs < 0, -diffs, 0.0)
+    avg_gain = float(np.mean(gains[:period]))
+    avg_loss = float(np.mean(losses[:period]))
+    for i in range(period, diffs.size):
+        avg_gain = (avg_gain * (period - 1) + gains[i]) / period
+        avg_loss = (avg_loss * (period - 1) + losses[i]) / period
+    if avg_loss == 0.0:
+        return 100.0 if avg_gain > 0.0 else 50.0
+    rs = avg_gain / avg_loss
+    return 100.0 - 100.0 / (1.0 + rs)
+
+
+def build_entry_features_at_signal_bar(
+    open_arr: Sequence[float],
+    high_arr: Sequence[float],
+    low_arr: Sequence[float],
+    close_arr: Sequence[float],
+    atr_at_signal_bar: float,
+    signal_bar_idx: int,
+) -> dict[str, float]:
+    """Compute the 8 base entry features at the signal bar.
+
+    All inputs use only bars at indices ``<= signal_bar_idx`` — strict
+    no-lookahead. Returns NaN for any feature whose window extends before
+    bar 0 (warmup); the engine treats NaN as "unevaluable" — the D1 hook
+    falls through to its standard exit path in that case.
+
+    Feature definitions (signal bar = ``N``, ATR = ATR(14) at bar N):
+
+    - ``body_to_range_ratio = |close - open| / (high - low)``
+    - ``upper_wick_ratio   = (high - max(open, close)) / (high - low)``
+    - ``lower_wick_ratio   = (min(open, close) - low) / (high - low)``
+    - ``range_to_atr_14    = (high - low) / ATR``
+    - ``ret_5bar_atr       = (close[N] - close[N-5]) / ATR``
+    - ``ret_20bar_atr      = (close[N] - close[N-20]) / ATR``
+    - ``pos_in_20bar_range = (close[N] - min(low[N-19..N])) /
+                              (max(high[N-19..N]) - min(low[N-19..N]))``
+    - ``rsi_14             = Wilder RSI(14) at bar N``
+    """
+    i = int(signal_bar_idx)
+    o_arr = np.asarray(open_arr, dtype=np.float64)
+    h_arr = np.asarray(high_arr, dtype=np.float64)
+    l_arr = np.asarray(low_arr, dtype=np.float64)
+    c_arr = np.asarray(close_arr, dtype=np.float64)
+
+    if not (0 <= i < c_arr.size):
+        raise ValueError(f"signal_bar_idx={i} out of bounds for length {c_arr.size}")
+
+    o = float(o_arr[i])
+    h = float(h_arr[i])
+    lo = float(l_arr[i])
+    c = float(c_arr[i])
+    a = float(atr_at_signal_bar) if atr_at_signal_bar is not None else float("nan")
+
+    bar_range = h - lo
+    if bar_range > 0.0:
+        body_to_range_ratio = abs(c - o) / bar_range
+        upper_wick_ratio = (h - max(o, c)) / bar_range
+        lower_wick_ratio = (min(o, c) - lo) / bar_range
+    else:
+        body_to_range_ratio = float("nan")
+        upper_wick_ratio = float("nan")
+        lower_wick_ratio = float("nan")
+
+    if a is not None and np.isfinite(a) and a > 0.0:
+        range_to_atr_14 = bar_range / a
+        ret_5bar_atr = (
+            (c - float(c_arr[i - 5])) / a if i - 5 >= 0 else float("nan")
+        )
+        ret_20bar_atr = (
+            (c - float(c_arr[i - 20])) / a if i - 20 >= 0 else float("nan")
+        )
+    else:
+        range_to_atr_14 = float("nan")
+        ret_5bar_atr = float("nan")
+        ret_20bar_atr = float("nan")
+
+    if i - 19 >= 0:
+        window_lo = float(np.min(l_arr[i - 19 : i + 1]))
+        window_hi = float(np.max(h_arr[i - 19 : i + 1]))
+        denom = window_hi - window_lo
+        pos_in_20bar_range = (c - window_lo) / denom if denom > 0.0 else float("nan")
+    else:
+        pos_in_20bar_range = float("nan")
+
+    if i - 14 >= 0:
+        rsi_14 = _wilder_rsi_last(c_arr[: i + 1].tolist(), period=14)
+    else:
+        rsi_14 = float("nan")
+
+    return {
+        "body_to_range_ratio": float(body_to_range_ratio),
+        "upper_wick_ratio": float(upper_wick_ratio),
+        "lower_wick_ratio": float(lower_wick_ratio),
+        "range_to_atr_14": float(range_to_atr_14),
+        "ret_5bar_atr": float(ret_5bar_atr),
+        "ret_20bar_atr": float(ret_20bar_atr),
+        "pos_in_20bar_range": float(pos_in_20bar_range),
+        "rsi_14": float(rsi_14),
+    }
+
+
+def entry_features_have_warmup(entry_features: Mapping[str, float]) -> bool:
+    """True iff all 8 entry features are finite at the signal bar."""
+    return all(
+        np.isfinite(entry_features[k]) for k in ENTRY_FEATURE_KEYS
+    )
+
+
+__all__: Iterable[str] = (
+    "ENTRY_FEATURE_KEYS",
+    "PATH_FEATURE_KEYS",
+    "ALL_FEATURE_KEYS",
+    "build_features_at_t",
+    "build_entry_features_at_signal_bar",
+    "entry_features_have_warmup",
+)

--- a/scripts/arc_2_redo/step1_build_pool.py
+++ b/scripts/arc_2_redo/step1_build_pool.py
@@ -25,7 +25,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -41,7 +41,6 @@ from scripts.arc_2_redo.signal import (  # noqa: E402
     wilder_atr,
 )
 from scripts.lchar.compute_spread_floors import compute_body_sha256  # noqa: E402
-
 
 # ============================================================
 # Constants
@@ -753,7 +752,7 @@ def write_summary(
     lines.append("")
     lines.append("Two-run byte-identical hashes (sha256):")
     lines.append("")
-    lines.append(f"- `trades_all.csv`")
+    lines.append("- `trades_all.csv`")
     lines.append(f"  - run 1: `{trades_csv_sha_run1}`")
     if trades_csv_sha_run2 is not None:
         lines.append(f"  - run 2: `{trades_csv_sha_run2}`")
@@ -762,7 +761,7 @@ def write_summary(
         )
     else:
         lines.append("  - run 2: skipped (cfg.output.determinism_check=false)")
-    lines.append(f"- `trades_paths.csv`")
+    lines.append("- `trades_paths.csv`")
     lines.append(f"  - run 1: `{paths_csv_sha_run1}`")
     if paths_csv_sha_run2 is not None:
         lines.append(f"  - run 2: `{paths_csv_sha_run2}`")

--- a/scripts/arc_3/step1_backtest.py
+++ b/scripts/arc_3/step1_backtest.py
@@ -43,7 +43,7 @@ import json
 import math
 import platform
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/scripts/phase_kgl_v2_4h_wfo.py
+++ b/scripts/phase_kgl_v2_4h_wfo.py
@@ -46,6 +46,8 @@ sys.path.insert(0, str(PROJECT_ROOT))
 os.chdir(PROJECT_ROOT)
 warnings.filterwarnings("ignore")
 
+from core.d1_pipeline import D1Hook, apply_d1_hook_per_bar  # noqa: E402
+from core.features_path_so_far import build_entry_features_at_signal_bar  # noqa: E402
 from core.utils import get_pip_size, load_pair_csv  # noqa: E402
 from signals.kb_exhaustion_bar import _wilder_atr  # noqa: E402
 
@@ -423,6 +425,11 @@ RISK_PCT       = 0.02
 INITIAL_BAL    = 10_000.0
 EXPOSURE_CAP   = 1
 SIGNAL_DIRECTION = "long"  # "long" or "short" — set via config direction: short
+
+# ── Pipeline D1 hook (L_ARC_PROTOCOL v2.0 §3) ────────────────────────────────
+# None preserves baseline byte-for-byte. Configured at run-start from the
+# top-level ``d1_archetypes`` YAML block. See core/d1_pipeline.py.
+D1_HOOK: "D1Hook | None" = None
 
 # ── WFO configuration ─────────────────────────────────────────────────────────
 WFO_START       = datetime(2019, 1, 1)
@@ -1350,6 +1357,20 @@ def _simulate_kgl_v2(
             exit_bar    = j
             exit_reason = None
 
+            # Pipeline D1 hook (L_ARC_PROTOCOL v2.0 §3). When configured,
+            # fires exactly once per trade at bar offset t == D1_HOOK.bar_offset_t.
+            # Close decision: exit at next bar's open with reason "d1_untradeable"
+            # (last-bar fallback collapses to bar j close). ApplyPolicy / Hold
+            # are no-ops in PR 1 — the legacy cascade below handles the trade.
+            if D1_HOOK is not None:
+                _d1_px, _d1_bar, _d1_reason = apply_d1_hook_per_bar(
+                    D1_HOOK, trade, j, entry_idx, cached, c_j,
+                )
+                if _d1_reason is not None:
+                    exit_px     = _d1_px
+                    exit_bar    = _d1_bar
+                    exit_reason = _d1_reason
+
             # Priority 1: Intrabar hard SL
             if exit_reason is None:
                 if SIGNAL_DIRECTION == "short":
@@ -2269,6 +2290,21 @@ def _simulate_kgl_v2(
                 currency_exposure[base]  += 1
                 currency_exposure[quote] -= 1
 
+            # Pipeline D1: compute the 8 base entry features at signal bar N
+            # for downstream classifier evaluation at bar offset t. Storage is
+            # gated on D1_HOOK so the baseline path remains byte-identical when
+            # no D1 archetypes are configured.
+            entry_features_dict: dict[str, float] | None = None
+            if D1_HOOK is not None:
+                entry_features_dict = build_entry_features_at_signal_bar(
+                    open_arr=cached["o"],
+                    high_arr=cached["h"],
+                    low_arr=cached["lo"],
+                    close_arr=cached["c"],
+                    atr_at_signal_bar=float(a),
+                    signal_bar_idx=int(i),
+                )
+
             open_trades.append({
                 "pair":           pair,
                 "base_ccy":       base,
@@ -2312,6 +2348,7 @@ def _simulate_kgl_v2(
                 ),
                 "time_to_peak_mfe":    0,
                 "time_to_trough_mae":  0,
+                "entry_features":      entry_features_dict,
             })
 
     # Close any remaining open trades at last available close
@@ -3588,6 +3625,7 @@ def main() -> None:
     global KH17_WATCH_WINDOW_BARS, KH17_WATCH_SL_ATR_MULT
     global KH17_STATE1_SL_ATR_MULT
     global KH17_BAR6_MFE_THRESHOLD, KH17_BAR6_MAE_THRESHOLD
+    global D1_HOOK
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", default=None)
@@ -3999,6 +4037,18 @@ def main() -> None:
             raise ValueError(
                 "kh25_reentry_enabled is mutually exclusive with kh17_enabled "
                 "and kh18_enabled. Enable at most one per run."
+            )
+
+        # Pipeline D1 hook (L_ARC_PROTOCOL v2.0 §3). Absent or empty block
+        # leaves D1_HOOK = None and the engine behaves byte-identically to
+        # the baseline. See core/d1_pipeline.py for schema details.
+        if cfg.get("d1_archetypes"):
+            D1_HOOK = D1Hook.from_yaml_dict(
+                cfg["d1_archetypes"], project_root=PROJECT_ROOT,
+            )
+            print(
+                f"  Pipeline D1: ENABLED — {len(D1_HOOK.archetypes)} archetype(s), "
+                f"bar_offset_t={D1_HOOK.bar_offset_t}"
             )
 
     D1_ATR_DIST_CAP = args.threshold

--- a/tests/test_arc_3_step1_lookahead.py
+++ b/tests/test_arc_3_step1_lookahead.py
@@ -23,13 +23,13 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from scripts.arc_3.step1_backtest import _wilder_atr_1h
 from signals.lchar_d1atr_top_decile import (
     _compute_d1_atr_sma,
     _lookback_d1_to_1h,
     _trailing_top_decile,
     compute_signal,
 )
-from scripts.arc_3.step1_backtest import _wilder_atr_1h
 
 
 def _make_d1(n: int = 200, seed: int = 7) -> pd.DataFrame:

--- a/tests/test_d1_pipeline.py
+++ b/tests/test_d1_pipeline.py
@@ -1,0 +1,695 @@
+"""Tests for Pipeline D1 plumbing (PR 1 of 2).
+
+Covers:
+
+* :mod:`core.features_path_so_far` — feature builder validation and the
+  no-lookahead invariant.
+* :mod:`core.d1_pipeline` — ``D1Hook`` initialization checks, the
+  ``Close`` / ``ApplyPolicy`` decision boundary, multi-archetype max-P
+  tie-breaking, and the engine helper ``apply_d1_hook_per_bar`` (correct
+  bar-offset gating + next-open vs last-bar fill).
+* Engine integration — the patched lines in
+  ``scripts/phase_kgl_v2_4h_wfo.py`` exist, the global ``D1_HOOK`` defaults
+  to ``None`` (baseline byte-identical), and the SL formula stays
+  ``entry - 2.0 * ATR(14)`` for all original trades.
+
+Tests use a stub classifier — no joblib / sklearn import required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from core.d1_pipeline import (
+    ApplyPolicy,
+    Close,
+    D1ArchetypeConfig,
+    D1Hook,
+    apply_d1_hook_per_bar,
+)
+from core.features_path_so_far import (
+    ALL_FEATURE_KEYS,
+    ENTRY_FEATURE_KEYS,
+    PATH_FEATURE_KEYS,
+    build_entry_features_at_signal_bar,
+    build_features_at_t,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# Stub classifier — deterministic P from a single path feature.
+# ---------------------------------------------------------------------------
+
+
+class StubClassifier:
+    """Returns P(class=1) per a single-feature rule.
+
+    Default: P=0.9 if features[``mfe_idx``] > ``threshold``, else P=0.1.
+    Tests can subclass or pass ``fixed_p`` for a constant probability.
+    """
+
+    def __init__(
+        self,
+        feature_order: list[str],
+        *,
+        gate_feature: str = "mfe_so_far_r_at_t",
+        threshold: float = 1.0,
+        p_high: float = 0.9,
+        p_low: float = 0.1,
+        fixed_p: float | None = None,
+    ):
+        self.n_features_in_ = len(feature_order)
+        self._gate_idx = feature_order.index(gate_feature)
+        self._threshold = float(threshold)
+        self._p_high = float(p_high)
+        self._p_low = float(p_low)
+        self._fixed_p = fixed_p
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        X = np.asarray(X, dtype=np.float64)
+        n = X.shape[0]
+        out = np.zeros((n, 2), dtype=np.float64)
+        for k in range(n):
+            if self._fixed_p is not None:
+                p = float(self._fixed_p)
+            else:
+                p = self._p_high if X[k, self._gate_idx] > self._threshold else self._p_low
+            out[k, 1] = p
+            out[k, 0] = 1.0 - p
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Fixtures.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def entry_features_finite() -> dict[str, float]:
+    """Locked finite entry-feature dict for use across tests."""
+    return {
+        "body_to_range_ratio": 0.6,
+        "upper_wick_ratio": 0.2,
+        "lower_wick_ratio": 0.2,
+        "range_to_atr_14": 1.1,
+        "ret_5bar_atr": 0.3,
+        "ret_20bar_atr": 0.5,
+        "pos_in_20bar_range": 0.7,
+        "rsi_14": 60.0,
+    }
+
+
+def _bar_path(close_rs: list[float]) -> list[dict[str, float]]:
+    """Build a v1.3-shape bar_path with running mfe/mae bookkeeping.
+
+    high_r / low_r are pinned at close_r ± 0.1; running mfe is the max of
+    high_r so far, running mae the min of low_r so far.
+    """
+    rows: list[dict[str, float]] = []
+    mfe = -np.inf
+    mae = np.inf
+    for k, cr in enumerate(close_rs):
+        hr = float(cr) + 0.1
+        lr = float(cr) - 0.1
+        mfe = max(mfe, hr)
+        mae = min(mae, lr)
+        rows.append(
+            {
+                "bar_offset": k,
+                "high_r": hr,
+                "low_r": lr,
+                "close_r": float(cr),
+                "mfe_so_far_r": float(mfe),
+                "mae_so_far_r": float(mae),
+                "is_held": 1,
+            }
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# 1. Feature builder validation.
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureBuilderValidation:
+    def test_known_keys_all_present(self):
+        assert set(ALL_FEATURE_KEYS) == set(ENTRY_FEATURE_KEYS) | set(PATH_FEATURE_KEYS)
+        assert len(set(ENTRY_FEATURE_KEYS) & set(PATH_FEATURE_KEYS)) == 0
+
+    def test_unknown_feature_raises(self, entry_features_finite):
+        order = list(ALL_FEATURE_KEYS) + ["bogus_feature"]
+        with pytest.raises(ValueError, match="unexpected: bogus_feature"):
+            build_features_at_t(
+                bar_path_so_far=_bar_path([0.0, 0.5, 1.0]),
+                entry_features=entry_features_finite,
+                t=2,
+                feature_order=order,
+            )
+
+    def test_missing_feature_raises(self, entry_features_finite):
+        order = [k for k in ALL_FEATURE_KEYS if k != "rsi_14"]
+        with pytest.raises(ValueError, match="missing: rsi_14"):
+            build_features_at_t(
+                bar_path_so_far=_bar_path([0.0, 0.5, 1.0]),
+                entry_features=entry_features_finite,
+                t=2,
+                feature_order=order,
+            )
+
+    def test_duplicate_feature_raises(self, entry_features_finite):
+        order = list(ALL_FEATURE_KEYS) + ["rsi_14"]
+        with pytest.raises(ValueError, match="duplicate"):
+            build_features_at_t(
+                bar_path_so_far=_bar_path([0.0]),
+                entry_features=entry_features_finite,
+                t=0,
+                feature_order=order,
+            )
+
+    def test_entry_features_missing_raises(self):
+        bad_entry = {k: 0.0 for k in ENTRY_FEATURE_KEYS if k != "rsi_14"}
+        with pytest.raises(ValueError, match="rsi_14"):
+            build_features_at_t(
+                bar_path_so_far=_bar_path([0.0, 1.0]),
+                entry_features=bad_entry,
+                t=1,
+                feature_order=list(ALL_FEATURE_KEYS),
+            )
+
+    def test_negative_t_raises(self, entry_features_finite):
+        with pytest.raises(ValueError, match="t must be >= 0"):
+            build_features_at_t(
+                bar_path_so_far=_bar_path([0.0, 0.5]),
+                entry_features=entry_features_finite,
+                t=-1,
+                feature_order=list(ALL_FEATURE_KEYS),
+            )
+
+    def test_returns_numpy_float64(self, entry_features_finite):
+        feats = build_features_at_t(
+            bar_path_so_far=_bar_path([0.0, 0.5, 1.5]),
+            entry_features=entry_features_finite,
+            t=2,
+            feature_order=list(ALL_FEATURE_KEYS),
+        )
+        assert isinstance(feats, np.ndarray)
+        assert feats.dtype == np.float64
+        assert feats.shape == (len(ALL_FEATURE_KEYS),)
+
+
+# ---------------------------------------------------------------------------
+# 2. Feature builder: no-lookahead invariant.
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureBuilderNoLookahead:
+    def test_features_at_t_ignore_post_t_rows(self, entry_features_finite):
+        """Mutating bar_offset > t rows must not change features at t."""
+        order = list(ALL_FEATURE_KEYS)
+        path_short = _bar_path([0.0, 0.5, 1.0])           # bars 0..2
+        path_long = _bar_path([0.0, 0.5, 1.0, 99.9, -99.9])  # extends with wild bars
+
+        feats_short = build_features_at_t(
+            bar_path_so_far=path_short,
+            entry_features=entry_features_finite,
+            t=2,
+            feature_order=order,
+        )
+        feats_long = build_features_at_t(
+            bar_path_so_far=path_long,
+            entry_features=entry_features_finite,
+            t=2,
+            feature_order=order,
+        )
+        np.testing.assert_array_equal(feats_short, feats_long)
+
+    def test_t_must_exist_in_path(self, entry_features_finite):
+        with pytest.raises(ValueError, match="no row with bar_offset == 5"):
+            build_features_at_t(
+                bar_path_so_far=_bar_path([0.0, 0.5, 1.0]),  # bars 0..2
+                entry_features=entry_features_finite,
+                t=5,
+                feature_order=list(ALL_FEATURE_KEYS),
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. Path feature semantics.
+# ---------------------------------------------------------------------------
+
+
+class TestPathFeatureSemantics:
+    """Spot-checks that the derived path features compute the spec values."""
+
+    def test_close_r_and_mfe_mae_at_t(self, entry_features_finite):
+        # Path: close_r = [0.0, 0.5, -0.2, 1.2]; we evaluate at t=3.
+        path = _bar_path([0.0, 0.5, -0.2, 1.2])
+        order = ["close_r_at_t", "mfe_so_far_r_at_t", "mae_so_far_r_at_t"] + [
+            k for k in ALL_FEATURE_KEYS
+            if k not in ("close_r_at_t", "mfe_so_far_r_at_t", "mae_so_far_r_at_t")
+        ]
+        feats = build_features_at_t(path, entry_features_finite, 3, order)
+        assert feats[0] == pytest.approx(1.2)             # close_r_at_t
+        assert feats[1] == pytest.approx(1.3, abs=1e-9)   # mfe_so_far_r_at_t = max high_r = 1.2+0.1
+        assert feats[2] == pytest.approx(-0.3, abs=1e-9)  # mae_so_far_r_at_t = min low_r = -0.2-0.1
+
+    def test_bars_in_profit_count(self, entry_features_finite):
+        # close_r values: 1 positive, 1 zero, 2 negative -> bars_in_profit = 1.
+        path = _bar_path([0.5, 0.0, -0.1, -0.2])
+        order = ["bars_in_profit_at_t"] + [
+            k for k in ALL_FEATURE_KEYS if k != "bars_in_profit_at_t"
+        ]
+        feats = build_features_at_t(path, entry_features_finite, 3, order)
+        assert feats[0] == pytest.approx(1.0)
+
+    def test_velocity_first_t(self, entry_features_finite):
+        # mfe_so_far_r_at_t = 1.1 (= 1.0+0.1), t = 4 → velocity = 1.1 / 4.
+        path = _bar_path([0.0, 0.5, 1.0, 0.7, 0.3])
+        order = ["velocity_first_t"] + [
+            k for k in ALL_FEATURE_KEYS if k != "velocity_first_t"
+        ]
+        feats = build_features_at_t(path, entry_features_finite, 4, order)
+        assert feats[0] == pytest.approx(1.1 / 4)
+
+
+# ---------------------------------------------------------------------------
+# 4. D1Hook initialization.
+# ---------------------------------------------------------------------------
+
+
+class TestD1HookInit:
+    def test_empty_archetypes_raises(self):
+        with pytest.raises(ValueError, match="at least one archetype"):
+            D1Hook([])
+
+    def test_mixed_bar_offset_t_raises(self):
+        a = D1ArchetypeConfig(
+            label="x",
+            feature_order=tuple(ALL_FEATURE_KEYS),
+            decision_threshold=0.5,
+            bar_offset_t=3,
+            classifier=StubClassifier(list(ALL_FEATURE_KEYS)),
+        )
+        b = D1ArchetypeConfig(
+            label="y",
+            feature_order=tuple(ALL_FEATURE_KEYS),
+            decision_threshold=0.5,
+            bar_offset_t=5,
+            classifier=StubClassifier(list(ALL_FEATURE_KEYS)),
+        )
+        with pytest.raises(ValueError, match="must share bar_offset_t"):
+            D1Hook([a, b])
+
+    def test_bad_feature_order_raises(self):
+        a = D1ArchetypeConfig(
+            label="x",
+            feature_order=tuple(list(ALL_FEATURE_KEYS) + ["bogus"]),
+            decision_threshold=0.5,
+            bar_offset_t=3,
+        )
+        with pytest.raises(ValueError, match="bogus"):
+            D1Hook([a])
+
+    def test_classifier_feature_count_mismatch_raises(self):
+        # Mutate the stub's n_features_in_ to a value that mismatches the
+        # length of feature_order — provokes the explicit validation message.
+        order = list(ALL_FEATURE_KEYS)
+        stub = StubClassifier(order)
+        stub.n_features_in_ = 99
+        a = D1ArchetypeConfig(
+            label="x",
+            feature_order=tuple(order),
+            decision_threshold=0.5,
+            bar_offset_t=3,
+            classifier=stub,
+        )
+        with pytest.raises(ValueError, match="expects 99 features"):
+            D1Hook([a])
+
+    def test_threshold_out_of_range_raises(self):
+        a = D1ArchetypeConfig(
+            label="x",
+            feature_order=tuple(ALL_FEATURE_KEYS),
+            decision_threshold=1.5,
+            bar_offset_t=3,
+            classifier=StubClassifier(list(ALL_FEATURE_KEYS)),
+        )
+        with pytest.raises(ValueError, match="decision_threshold"):
+            D1Hook([a])
+
+    def test_bar_offset_t_must_be_positive(self):
+        a = D1ArchetypeConfig(
+            label="x",
+            feature_order=tuple(ALL_FEATURE_KEYS),
+            decision_threshold=0.5,
+            bar_offset_t=0,
+            classifier=StubClassifier(list(ALL_FEATURE_KEYS)),
+        )
+        with pytest.raises(ValueError, match="bar_offset_t"):
+            D1Hook([a])
+
+
+# ---------------------------------------------------------------------------
+# 5. D1Hook.evaluate — Close / ApplyPolicy decision.
+# ---------------------------------------------------------------------------
+
+
+def _make_single_hook(threshold: float = 0.5, t: int = 3) -> D1Hook:
+    order = list(ALL_FEATURE_KEYS)
+    arch = D1ArchetypeConfig(
+        label="stepwise_climber",
+        feature_order=tuple(order),
+        decision_threshold=threshold,
+        bar_offset_t=t,
+        classifier=StubClassifier(order, gate_feature="mfe_so_far_r_at_t", threshold=1.0),
+    )
+    return D1Hook([arch])
+
+
+class TestD1HookEvaluate:
+    def test_returns_apply_policy_when_mfe_high(self, entry_features_finite):
+        hook = _make_single_hook(threshold=0.5, t=3)
+        # mfe_so_far_r at t=3 = 1.5 + 0.1 = 1.6 > stub threshold 1.0 → P=0.9 ≥ 0.5.
+        path = _bar_path([0.0, 0.5, 1.0, 1.5])
+        decision = hook.evaluate(
+            trade={}, bar_path_so_far=path, entry_features=entry_features_finite,
+            t=3, cached={},
+        )
+        assert isinstance(decision, ApplyPolicy)
+        assert decision.label == "stepwise_climber"
+        assert decision.probability == pytest.approx(0.9)
+
+    def test_returns_close_when_mfe_low(self, entry_features_finite):
+        hook = _make_single_hook(threshold=0.5, t=3)
+        path = _bar_path([0.0, 0.1, 0.2, 0.3])  # max high_r = 0.4 < 1.0 → P=0.1
+        decision = hook.evaluate(
+            trade={}, bar_path_so_far=path, entry_features=entry_features_finite,
+            t=3, cached={},
+        )
+        assert isinstance(decision, Close)
+        assert decision.reason == "d1_untradeable"
+
+    def test_raises_when_t_does_not_match(self, entry_features_finite):
+        hook = _make_single_hook(threshold=0.5, t=3)
+        path = _bar_path([0.0, 0.5, 1.0, 1.5])
+        with pytest.raises(ValueError, match="configured t=3"):
+            hook.evaluate(
+                trade={}, bar_path_so_far=path,
+                entry_features=entry_features_finite, t=2, cached={},
+            )
+
+    def test_nan_entry_features_abstain(self):
+        hook = _make_single_hook(threshold=0.5, t=3)
+        # All entry features NaN → archetype abstains → Close.
+        nan_entry = {k: float("nan") for k in ENTRY_FEATURE_KEYS}
+        path = _bar_path([0.0, 0.5, 1.0, 1.5])
+        decision = hook.evaluate(
+            trade={}, bar_path_so_far=path, entry_features=nan_entry,
+            t=3, cached={},
+        )
+        assert isinstance(decision, Close)
+
+
+# ---------------------------------------------------------------------------
+# 6. Multi-archetype max-P + tie-break.
+# ---------------------------------------------------------------------------
+
+
+class TestMultiArchetype:
+    def _two_arch_hook(self, p_a: float, p_b: float) -> D1Hook:
+        order = list(ALL_FEATURE_KEYS)
+        arch_a = D1ArchetypeConfig(
+            label="a",
+            feature_order=tuple(order),
+            decision_threshold=0.5,
+            bar_offset_t=3,
+            classifier=StubClassifier(order, fixed_p=p_a),
+        )
+        arch_b = D1ArchetypeConfig(
+            label="b",
+            feature_order=tuple(order),
+            decision_threshold=0.5,
+            bar_offset_t=3,
+            classifier=StubClassifier(order, fixed_p=p_b),
+        )
+        return D1Hook([arch_a, arch_b])
+
+    def test_max_p_wins(self, entry_features_finite):
+        hook = self._two_arch_hook(p_a=0.6, p_b=0.9)
+        decision = hook.evaluate(
+            trade={}, bar_path_so_far=_bar_path([0.0, 0.5, 1.0, 1.5]),
+            entry_features=entry_features_finite, t=3, cached={},
+        )
+        assert isinstance(decision, ApplyPolicy)
+        assert decision.label == "b"
+        assert decision.probability == pytest.approx(0.9)
+
+    def test_tie_resolves_to_first_in_config_order(self, entry_features_finite):
+        hook = self._two_arch_hook(p_a=0.8, p_b=0.8)
+        decision = hook.evaluate(
+            trade={}, bar_path_so_far=_bar_path([0.0, 0.5, 1.0, 1.5]),
+            entry_features=entry_features_finite, t=3, cached={},
+        )
+        assert isinstance(decision, ApplyPolicy)
+        assert decision.label == "a"
+
+    def test_all_below_threshold_returns_close(self, entry_features_finite):
+        hook = self._two_arch_hook(p_a=0.4, p_b=0.45)
+        decision = hook.evaluate(
+            trade={}, bar_path_so_far=_bar_path([0.0, 0.5, 1.0, 1.5]),
+            entry_features=entry_features_finite, t=3, cached={},
+        )
+        assert isinstance(decision, Close)
+
+
+# ---------------------------------------------------------------------------
+# 7. apply_d1_hook_per_bar — engine helper (fill resolution, bar gating).
+# ---------------------------------------------------------------------------
+
+
+def _trade_with(t: int, close_rs: list[float], entry_features: dict[str, float]) -> dict:
+    return {
+        "entry_idx": 0,
+        "bar_path": _bar_path(close_rs),
+        "entry_features": entry_features,
+    }
+
+
+class TestApplyD1HookPerBar:
+    def test_none_hook_is_noop(self, entry_features_finite):
+        cached = {"o": np.array([1.0, 1.01, 1.02, 1.03, 1.04])}
+        trade = _trade_with(3, [0.0, 0.5, 1.0, 1.5], entry_features_finite)
+        out = apply_d1_hook_per_bar(
+            hook=None, trade=trade, j=3, entry_idx=0, cached=cached, c_j=1.03,
+        )
+        assert out == (None, None, None)
+
+    def test_wrong_bar_is_noop(self, entry_features_finite):
+        hook = _make_single_hook(threshold=0.5, t=3)
+        cached = {"o": np.array([1.0, 1.01, 1.02, 1.03, 1.04])}
+        trade = _trade_with(3, [0.0, 0.5], entry_features_finite)
+        # j - entry_idx = 1 != bar_offset_t = 3.
+        out = apply_d1_hook_per_bar(
+            hook=hook, trade=trade, j=1, entry_idx=0, cached=cached, c_j=1.01,
+        )
+        assert out == (None, None, None)
+
+    def test_close_fills_next_bar_open(self, entry_features_finite):
+        hook = _make_single_hook(threshold=0.5, t=3)
+        opens = np.array([1.0, 1.01, 1.02, 1.03, 1.0399, 1.05])
+        cached = {"o": opens}
+        trade = _trade_with(3, [0.0, 0.1, 0.2, 0.3], entry_features_finite)  # low mfe → Close
+        out = apply_d1_hook_per_bar(
+            hook=hook, trade=trade, j=3, entry_idx=0, cached=cached, c_j=1.03,
+        )
+        exit_px, exit_bar, exit_reason = out
+        assert exit_reason == "d1_untradeable"
+        assert exit_bar == 4
+        assert exit_px == pytest.approx(1.0399)
+
+    def test_close_last_bar_fallback_uses_c_j(self, entry_features_finite):
+        hook = _make_single_hook(threshold=0.5, t=3)
+        # opens has length 4 → indices 0..3. At j=3, j+1=4 is past end.
+        opens = np.array([1.0, 1.01, 1.02, 1.03])
+        cached = {"o": opens}
+        trade = _trade_with(3, [0.0, 0.1, 0.2, 0.3], entry_features_finite)
+        out = apply_d1_hook_per_bar(
+            hook=hook, trade=trade, j=3, entry_idx=0, cached=cached, c_j=1.0301,
+        )
+        exit_px, exit_bar, exit_reason = out
+        assert exit_reason == "d1_untradeable"
+        assert exit_bar == 3
+        assert exit_px == pytest.approx(1.0301)
+
+    def test_apply_policy_returns_noop_tuple(self, entry_features_finite):
+        hook = _make_single_hook(threshold=0.5, t=3)
+        cached = {"o": np.array([1.0, 1.01, 1.02, 1.03, 1.04])}
+        # High mfe path → P=0.9 ≥ 0.5 → ApplyPolicy.
+        trade = _trade_with(3, [0.0, 0.5, 1.0, 1.5], entry_features_finite)
+        out = apply_d1_hook_per_bar(
+            hook=hook, trade=trade, j=3, entry_idx=0, cached=cached, c_j=1.03,
+        )
+        assert out == (None, None, None)
+
+    def test_missing_entry_features_fall_through(self):
+        """Re-entry trades (no entry_features) must fall through without erroring."""
+        hook = _make_single_hook(threshold=0.5, t=3)
+        cached = {"o": np.array([1.0, 1.01, 1.02, 1.03, 1.04])}
+        trade = {
+            "entry_idx": 0,
+            "bar_path": _bar_path([0.0, 0.5, 1.0, 1.5]),
+            # no "entry_features" key
+        }
+        out = apply_d1_hook_per_bar(
+            hook=hook, trade=trade, j=3, entry_idx=0, cached=cached, c_j=1.03,
+        )
+        assert out == (None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# 8. Entry-feature builder — signal-bar definitions.
+# ---------------------------------------------------------------------------
+
+
+def _synth_ohlc(n: int = 60) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(0)
+    close = 1.1000 + np.cumsum(rng.normal(0, 0.001, size=n))
+    open_ = np.concatenate(([close[0]], close[:-1]))
+    high = np.maximum(open_, close) + np.abs(rng.normal(0, 0.001, size=n))
+    low = np.minimum(open_, close) - np.abs(rng.normal(0, 0.001, size=n))
+    return open_, high, low, close
+
+
+class TestEntryFeatureBuilder:
+    def test_all_eight_keys_present(self):
+        o, h, l_, c = _synth_ohlc(60)
+        feats = build_entry_features_at_signal_bar(o, h, l_, c, 0.001, 40)
+        assert set(feats.keys()) == set(ENTRY_FEATURE_KEYS)
+
+    def test_warmup_returns_nan(self):
+        # signal_bar_idx=10 → ret_20bar_atr, pos_in_20bar_range, rsi_14 may be NaN.
+        o, h, l_, c = _synth_ohlc(60)
+        feats = build_entry_features_at_signal_bar(o, h, l_, c, 0.001, 10)
+        assert not np.isfinite(feats["ret_20bar_atr"])
+        assert not np.isfinite(feats["pos_in_20bar_range"])
+
+    def test_no_lookahead(self):
+        # Mutate future bars; signal-bar features at idx=40 must stay invariant.
+        o, h, l_, c = _synth_ohlc(80)
+        feats1 = build_entry_features_at_signal_bar(o, h, l_, c, 0.001, 40)
+        c2 = c.copy()
+        c2[50:] *= 5.0
+        h2 = h.copy()
+        h2[50:] *= 5.0
+        l2 = l_.copy()
+        l2[50:] *= 5.0
+        feats2 = build_entry_features_at_signal_bar(o, h2, l2, c2, 0.001, 40)
+        for k in ENTRY_FEATURE_KEYS:
+            assert feats1[k] == feats2[k], f"feature {k} changed under future-bar mutation"
+
+
+# ---------------------------------------------------------------------------
+# 9. from_yaml_dict factory — stub-injected classifier.
+# ---------------------------------------------------------------------------
+
+
+class TestFromYamlDict:
+    def test_inline_classifier_is_used(self):
+        order = list(ALL_FEATURE_KEYS)
+        stub = StubClassifier(order, fixed_p=0.99)
+        yaml_block = [
+            {
+                "label": "stepwise_climber",
+                "feature_order": order,
+                "decision_threshold": 0.5,
+                "bar_offset_t": 3,
+                "classifier": stub,  # bypass joblib loading
+            }
+        ]
+        hook = D1Hook.from_yaml_dict(yaml_block)
+        assert hook.bar_offset_t == 3
+        assert hook.archetypes[0].label == "stepwise_climber"
+        assert hook.archetypes[0].classifier is stub
+
+    def test_empty_block_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            D1Hook.from_yaml_dict([])
+
+
+# ---------------------------------------------------------------------------
+# 10. Engine integration — patched lines exist; baseline is byte-identical.
+# ---------------------------------------------------------------------------
+
+
+ENGINE_PATH = PROJECT_ROOT / "scripts" / "phase_kgl_v2_4h_wfo.py"
+
+
+class TestEnginePatch:
+    """The engine patch is exercised end-to-end by the WFO pytest suite.
+    Here we verify the static contract: globals default to off, the hook
+    call site is exactly where the spec says, and SL still uses 2.0×ATR.
+    """
+
+    def test_engine_file_has_d1_hook_default_none(self):
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        assert re.search(r"^D1_HOOK:\s*\"?D1Hook\s*\|\s*None\"?\s*=\s*None", src, re.M), (
+            "D1_HOOK must default to None at module scope"
+        )
+
+    def test_engine_calls_helper_with_close_branch(self):
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        assert "apply_d1_hook_per_bar(" in src
+        # The hook call sits in the per-trade exit cascade — before SL.
+        d1_call_idx = src.index("apply_d1_hook_per_bar(")
+        sl_priority_idx = src.index("# Priority 1: Intrabar hard SL")
+        assert d1_call_idx < sl_priority_idx, (
+            "D1 hook must fire before the Priority-1 SL check"
+        )
+
+    def test_entry_features_stored_only_when_hook_active(self):
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        # The build_entry_features call must be guarded by an `if D1_HOOK is not None:`.
+        m = re.search(
+            r"if\s+D1_HOOK\s+is\s+not\s+None:\s*\n\s+entry_features_dict\s*=\s*"
+            r"build_entry_features_at_signal_bar",
+            src,
+        )
+        assert m, (
+            "entry_features computation must be guarded by `if D1_HOOK is not None:` "
+            "to preserve byte-identity when D1 is off"
+        )
+
+    def test_sl_formula_is_2_0_times_atr_long(self):
+        """Pre-t SL must remain entry - 2.0 × ATR (KH-24 baseline).
+
+        Asserted at the source level rather than the runtime level — the
+        SL formula on the long path is `entry_px - SL_MULT * a` with
+        SL_MULT = 2.0 at module scope.
+        """
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        assert re.search(r"^SL_MULT\s*=\s*2\.0", src, re.M), "SL_MULT must be 2.0"
+        assert "sl_px        = entry_px - SL_MULT * a" in src, (
+            "long-side SL formula must be `entry_px - SL_MULT * a`"
+        )
+
+    def test_d1_hook_none_means_no_engine_state_change(self):
+        """Static contract: with D1_HOOK = None, the hook block is a no-op."""
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        # Locate the hook block and assert the early-return guard exists.
+        m = re.search(
+            r"if\s+D1_HOOK\s+is\s+not\s+None:\s*\n\s+_d1_px,\s*_d1_bar,\s*_d1_reason"
+            r"\s*=\s*apply_d1_hook_per_bar\(",
+            src,
+        )
+        assert m, "hook block must be guarded by `if D1_HOOK is not None:`"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements **L_ARC_PROTOCOL v2.0 §3 — Pipeline D1** (deferred-identification): at a configured bar offset `t`, score path-shape + entry-feature classifiers per archetype and close the trade at the next bar's open (reason `"d1_untradeable"`) when no archetype clears its threshold. When an archetype clears, the trade continues with the engine's standard exit cascade — **PR 2 will add per-archetype exit policies** (MFE-lock, custom trail distances, TP targets). `ApplyPolicy` / `Hold` are no-ops in PR 1 by design.

> **PR 1 of 2.** PR 2 adds per-archetype exit policies after Arc 3 generates classifiers.

References this prompt + L_ARC_PROTOCOL v2.0 §3.

## What this PR ships

### New modules

- **`core/features_path_so_far.py`** — single source of truth for D1 feature computation. `build_features_at_t` derives the 7 path-so-far features from the v1.3 `bar_path` schema (`scripts/phase_kgl_v2_4h_wfo.py:1307-1315`) and concatenates with 8 base entry features computed at signal bar via `build_entry_features_at_signal_bar`. Validates `feature_order` against the locked 15-key schema with clear error messages on missing / unexpected / duplicate keys.
- **`core/d1_pipeline.py`** — `Close` / `ApplyPolicy` / `Hold` dataclasses + `D1Hook` (validates archetypes share a single `bar_offset_t` and that classifier `n_features_in_` matches `feature_order` length) + `apply_d1_hook_per_bar` engine helper (returns next-open fill or last-bar fallback for `Close`; no-op for `ApplyPolicy` / `Hold`). `D1Hook.from_yaml_dict` factory with lazy joblib loading — classifiers can be injected directly for testing.

### Engine patch — `scripts/phase_kgl_v2_4h_wfo.py`

- Module-level `D1_HOOK: D1Hook | None = None` preserves baseline byte-identity when no `d1_archetypes` block is in YAML.
- Per-trade Phase 1 cascade: hook fires immediately after the v1.3 `bar_path` append (line 1307-1315) and immediately before the Priority-1 SL check. `Close` decisions stamp `exit_reason = "d1_untradeable"` and short-circuit the legacy cascade via the existing `if exit_reason is None` guards.
- Entry-features storage at original trade open, gated on `if D1_HOOK is not None` so the baseline path stays byte-identical.
- `main()` loads the `d1_archetypes` YAML block into `D1_HOOK` at run-start. Absent block → engine unchanged.

### Protocol — `L_ARC_PROTOCOL.md` §3

Pipeline D1 numbered list rewritten per the Arc 3 dispatch:
- uniform pre-t SL (entry − 2.0 × ATR(14), matching KH-24 baseline) replaces v1.x "archetype-appropriate initial SL" wording;
- close-at-market on bar N+1 open replaces "break-even or small loss" with explicit engine-books-PnL semantics;
- backtester paragraph updated to reflect PR 1 / PR 2 split.

### Tests — `tests/test_d1_pipeline.py` (41 tests, all green)

- Feature builder validation (unknown / missing / duplicate keys; NaN warmup) + no-lookahead invariant (post-`t` rows ignored).
- Path feature semantics spot-checks (`close_r_at_t`, `mfe_so_far_r_at_t`, `bars_in_profit_at_t`, `velocity_first_t`).
- `D1Hook` init checks (empty / mixed `bar_offset_t` / bad `feature_order` / classifier feature-count mismatch / threshold out of range).
- `Close` vs `ApplyPolicy` decision; multi-archetype max-P with config-list tie-break; NaN entry features → archetype abstains.
- `apply_d1_hook_per_bar` engine helper (None hook, wrong bar, next-open fill, last-bar fallback, missing `entry_features` fall-through for KH-16 / KH-17 re-entries).
- **Engine-patch static contract**: `D1_HOOK` defaults to `None`, hook fires before Priority-1 SL, entry-features storage is guarded by `if D1_HOOK is not None`, `SL_MULT = 2.0` (KH-24 baseline preserved).
- `from_yaml_dict` factory with inline classifier injection (no joblib required).
- Entry-feature builder: 8-key schema, warmup NaN, no-lookahead.

### Two commits in this PR

1. **`ci: auto-fix pre-existing ruff errors on three plumbing files`** — origin/main HEAD (debc7ae) shipped F401 unused imports, F541 empty f-string, I001 import-order errors on three arc plumbing files. `ruff --fix` cleans them with zero behaviour change; required to make CI green on the feat branch's base.
2. **`feat: Pipeline D1 backtester extension (PR 1 of 2 — plumbing + close-at-market)`** — the work above.

### Out of scope (per directive)

- KH-24 paths
- `configs/wfo_kh24.yaml`
- `configs/spread_floors_5ers.yaml`
- `signals/kb_exhaustion_bar.py`

## Test plan

- [x] `pytest tests/test_d1_pipeline.py -v` — 41 / 41 passing locally.
- [x] `pytest -m "not research" --ignore=attic` — 1015 passed, 20 skipped, 7 deselected (no regressions).
- [x] `ruff check .` clean across all changed files and the engine patch.
- [ ] CI green on this PR (ruff + pytest + smoke).
- [ ] Engine smoke run with a YAML that contains `d1_archetypes` once Arc 3 generates a real classifier — out of scope for PR 1.
- [ ] PR 2 — per-archetype exit policies (MFE-lock, custom trail distances, TP targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)