### PR TITLE
feat: Pipeline D1 backtester extension (PR 2 of 2 - exit policies + per-fold classifiers)

### DIFF
--- a/attic/2025-11-08/test_aggregate_and_stability.py
+++ b/attic/2025-11-08/test_aggregate_and_stability.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pandas as pd
-import pytest
 
 
 def _results_root() -> Path:
@@ -26,7 +24,8 @@ def test_aggregate_outputs_shape(tmp_path: Path):
         outdir = tmp_path
 
     # Run aggregator
-    import subprocess, sys
+    import subprocess
+    import sys
     subprocess.check_call([sys.executable, 'tools/aggregate_c1_only.py', '--root', str(root), '--outdir', str(outdir)])
 
     all_csv = Path(outdir) / 'c1_only_exits_all_runs.csv'
@@ -60,7 +59,8 @@ def test_stability_outputs_shape(tmp_path: Path):
         root = synth
         out_csv = tmp_path / 'stability' / 'c1_only_exits_stability.csv'
 
-    import subprocess, sys
+    import subprocess
+    import sys
     subprocess.check_call([sys.executable, 'analytics/stability_scan.py', '--root', str(root), '--out', str(out_csv), '--min-trades', '1'])
 
     if out_csv.exists():

--- a/attic/2025-11-08/test_c1_only_exits_config.py
+++ b/attic/2025-11-08/test_c1_only_exits_config.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import yaml
-
 from scripts.run_c1_only_exits import build_run_config
 
 

--- a/attic/2025-11-08/test_mt5_parity_smoke.py
+++ b/attic/2025-11-08/test_mt5_parity_smoke.py
@@ -248,7 +248,6 @@ class TestMT5ParitySmoke:
         """
         try:
             import pandas as pd
-
             from scripts.mt5_compare import compare_totals, match_trades
 
             # Create synthetic trade data for testing comparison logic

--- a/core/d1_pipeline.py
+++ b/core/d1_pipeline.py
@@ -1,4 +1,5 @@
-"""Pipeline D1 hook for the WFO engine — PR 1 (plumbing + close-at-market).
+"""Pipeline D1 hook for the WFO engine — PR 1 (plumbing + close-at-market)
++ PR 2 (per-archetype exit policies + per-fold classifiers).
 
 At a single bar offset ``t`` (locked across all archetypes for an L arc),
 score each archetype's classifier against the path-so-far feature vector
@@ -7,23 +8,42 @@ and decide:
 * :class:`Close` — none of the archetypes cleared their threshold; the
   trade is closed at the next bar's open (the engine books the realised
   PnL after spread).
-* :class:`ApplyPolicy` — at least one archetype cleared; the winning
-  archetype's exit policy applies. PR 1 ships this as a no-op so the
-  trade continues with the engine's standard exit cascade (SL / trail /
-  kijun_d1). PR 2 adds per-archetype SL / trail / TP mutations.
-* :class:`Hold` — reserved for future use; PR 1 never returns this from
-  :meth:`D1Hook.evaluate`.
+* :class:`ApplyPolicy` — at least one archetype cleared; carries the
+  winning archetype's :class:`~core.exit_policies.ExitPolicy`. PR 1
+  shipped this as an empty no-op; PR 2 makes it real — the engine calls
+  ``policy.apply_at_accept(trade, ...)`` at the accept bar and
+  ``policy.update_per_bar(trade, ...)`` on every subsequent bar.
+* :class:`Hold` — reserved for future use; ``evaluate`` never returns this.
 
-Configuration is loaded from YAML (see :func:`D1Hook.from_yaml_dict`):
+Configuration is loaded from YAML (see :func:`D1Hook.from_yaml_dict`). PR 2
+adds two required blocks per archetype: ``per_fold_classifiers`` (mapping
+fold id → joblib path) and ``exit_policy`` (type + parameters):
 
 .. code-block:: yaml
 
     d1_archetypes:
-      - label: stepwise_climber
-        classifier_path: artefacts/arc_3/stepwise_climber_D1.joblib
+      - label: stepwise_climber_arc4_cluster1
+        bar_offset_t: 1
+        decision_threshold: 0.1647
         feature_order: [body_to_range_ratio, ..., velocity_first_t]
-        decision_threshold: 0.55
-        bar_offset_t: 3
+        per_fold_classifiers:
+          F2: artefacts/arc_4/refit_classifiers/fold_2.joblib
+          F3: artefacts/arc_4/refit_classifiers/fold_3.joblib
+          F4: artefacts/arc_4/refit_classifiers/fold_4.joblib
+          F5: artefacts/arc_4/refit_classifiers/fold_5.joblib
+          F6: artefacts/arc_4/refit_classifiers/fold_6.joblib
+          F7: artefacts/arc_4/refit_classifiers/fold_7.joblib
+        exit_policy:
+          type: stepwise_climber
+          archetype_sl_r: 1.0
+          r_in_atr: 3.0
+          mfe_lock_r: 1.0
+          trail_from_high_r: 0.75
+
+Trades whose fold id is not present in ``per_fold_classifiers`` fall
+through with no D1 decision — used in Arc 4 to skip F1 (no training data
+before the first OOS window). The set of folds gated is whatever the
+YAML lists; missing folds are an explicit skip, not a runtime error.
 
 See L_ARC_PROTOCOL.md §3 (Pipeline D1) and §11 (exit-family map).
 """
@@ -36,6 +56,7 @@ from typing import Any, Mapping, Protocol, Sequence
 
 import numpy as np
 
+from core.exit_policies import ExitPolicy, build_exit_policy
 from core.features_path_so_far import ALL_FEATURE_KEYS, build_features_at_t
 
 # ---------------------------------------------------------------------------
@@ -54,12 +75,18 @@ class Close:
 class ApplyPolicy:
     """An archetype's classifier accepted the trade.
 
-    PR 1: empty payload — engine continues with standard exits. PR 2 will
-    carry SL / trail / TP mutations keyed on the winning archetype.
+    PR 2: carries the winning archetype's :class:`~core.exit_policies.ExitPolicy`.
+    The engine calls ``policy.apply_at_accept(trade, entry_px, atr)`` at
+    bar ``t``, installs the policy on the trade dict, and on every
+    subsequent bar calls ``policy.update_per_bar(trade, bar_path_row,
+    entry_px, atr)`` to ratchet SL.
+
+    ``label`` and ``probability`` remain informational.
     """
 
-    label: str = ""  # winning archetype label; informational in PR 1
-    probability: float = float("nan")  # winning archetype P; informational in PR 1
+    policy: ExitPolicy | None = None  # None preserves PR 1 no-op semantics
+    label: str = ""
+    probability: float = float("nan")
 
 
 @dataclass(frozen=True)
@@ -86,19 +113,32 @@ class _ClassifierLike(Protocol):
 
 @dataclass(frozen=True)
 class D1ArchetypeConfig:
-    """One archetype's classifier + decision threshold + feature schema.
+    """One archetype's classifier set + decision threshold + feature schema.
 
-    ``classifier`` can be supplied directly (e.g. a stub in tests) — in
-    which case ``classifier_path`` is informational only. When loaded via
-    :func:`D1Hook.from_yaml_dict`, ``classifier_path`` is joblib-loaded.
+    PR 2 schema change: instead of a single ``classifier`` /
+    ``classifier_path``, each archetype carries ``per_fold_classifiers``
+    — a mapping from fold id (e.g. ``"F2"``) to either a loaded
+    classifier object or a joblib path. At evaluate time the trade's
+    fold id selects the classifier. Plus an ``exit_policy`` that the
+    engine installs on the trade when this archetype wins.
+
+    ``per_fold_classifiers`` values may be:
+
+    * a classifier object (with ``predict_proba``) — used directly,
+      typical for tests.
+    * a string / :class:`Path` — joblib-loaded by
+      :func:`D1Hook.from_yaml_dict`. After loading the cache holds the
+      live classifier; the path itself is kept on
+      ``per_fold_classifier_paths`` for audit.
     """
 
     label: str
     feature_order: tuple[str, ...]
     decision_threshold: float
     bar_offset_t: int
-    classifier: Any = None  # _ClassifierLike at runtime
-    classifier_path: str | None = None
+    per_fold_classifiers: Mapping[str, Any] = field(default_factory=dict)
+    per_fold_classifier_paths: Mapping[str, str] = field(default_factory=dict)
+    exit_policy: ExitPolicy | None = None
     extras: Mapping[str, Any] = field(default_factory=dict)
 
 
@@ -151,13 +191,22 @@ class D1Hook:
                     "locked schema; " + "; ".join(parts)
                 )
 
-            if a.classifier is not None:
-                expected = getattr(a.classifier, "n_features_in_", None)
+            if not a.per_fold_classifiers:
+                raise ValueError(
+                    f"archetype '{a.label}': per_fold_classifiers is empty. "
+                    "PR 2 requires a per-fold classifier mapping (e.g. "
+                    "{'F2': <classifier>, ...}). The PR 1 single-classifier "
+                    "schema is no longer supported — see docstring for the "
+                    "new YAML format."
+                )
+
+            for fold_key, clf in a.per_fold_classifiers.items():
+                expected = getattr(clf, "n_features_in_", None)
                 if expected is not None and int(expected) != len(req):
                     raise ValueError(
-                        f"archetype '{a.label}': classifier expects "
-                        f"{int(expected)} features but feature_order has "
-                        f"{len(req)}"
+                        f"archetype '{a.label}' fold '{fold_key}': "
+                        f"classifier expects {int(expected)} features but "
+                        f"feature_order has {len(req)}"
                     )
 
             if not (0.0 <= float(a.decision_threshold) <= 1.0):
@@ -191,13 +240,19 @@ class D1Hook:
         entry_features: Mapping[str, float],
         t: int,
         cached: Mapping[str, Any] | None = None,
+        fold_id: str | None = None,
     ) -> Close | ApplyPolicy | Hold:
         """Score every archetype at ``t``; pick max-P clearer, else Close.
 
-        ``trade`` and ``cached`` are accepted for API symmetry with PR 2 (where
-        archetype policies may read trade state); PR 1 ignores them.
+        ``fold_id`` selects which per-fold classifier each archetype uses.
+        If an archetype has no classifier registered for the trade's
+        fold (e.g. Arc 4's F1, where there's no pre-OOS training data)
+        that archetype abstains. If *no* archetype has a classifier for
+        this fold, returns :class:`Hold` — the engine falls through to
+        the legacy cascade. ``trade`` and ``cached`` are accepted for
+        API symmetry with future policies that may read trade state.
         """
-        del trade, cached
+        del cached
 
         if int(t) != self._bar_offset_t:
             raise ValueError(
@@ -206,8 +261,13 @@ class D1Hook:
 
         best_label: str | None = None
         best_p: float = -1.0
-        best_threshold: float = 0.0
+        best_policy: ExitPolicy | None = None
+        any_classifier_available = False
         for arch in self._archetypes:
+            clf = _select_classifier(arch, fold_id)
+            if clf is None:
+                continue
+            any_classifier_available = True
             features = build_features_at_t(
                 bar_path_so_far=bar_path_so_far,
                 entry_features=entry_features,
@@ -219,16 +279,20 @@ class D1Hook:
                 # archetype. (A trade can still be accepted by another
                 # archetype with valid features.)
                 continue
-            p = _score_positive_class(arch.classifier, features)
+            p = _score_positive_class(clf, features)
             if p >= float(arch.decision_threshold) and p > best_p:
                 best_label = arch.label
                 best_p = float(p)
-                best_threshold = float(arch.decision_threshold)
+                best_policy = arch.exit_policy
 
         if best_label is not None:
-            return ApplyPolicy(label=best_label, probability=best_p)
-
-        del best_threshold  # unused in PR 1; PR 2 may surface it on Close.
+            return ApplyPolicy(
+                policy=best_policy, label=best_label, probability=best_p
+            )
+        if not any_classifier_available:
+            # No archetype has a classifier for this fold. Don't gate
+            # the trade — let the engine apply its legacy cascade.
+            return Hold()
         return Close(reason="d1_untradeable")
 
     # ------------------------------------------------------------------
@@ -240,25 +304,40 @@ class D1Hook:
     ) -> "D1Hook":
         """Build a hook from the ``d1_archetypes`` YAML block.
 
-        ``classifier_path`` is resolved relative to ``project_root`` if
-        provided and the path is not absolute. joblib loading is lazy —
-        we only import joblib when at least one classifier_path is set.
+        Each archetype must carry:
+
+        * ``per_fold_classifiers`` — mapping fold id → joblib path (or
+          a pre-loaded classifier object for tests). Paths are resolved
+          relative to ``project_root`` when not absolute. joblib import
+          is lazy — only triggered when at least one path is present.
+        * ``exit_policy`` — block with at least ``type`` plus the
+          parameters for that policy (see :mod:`core.exit_policies`).
+
+        The PR 1 single-classifier schema (``classifier_path`` /
+        ``classifier`` at the archetype top level) is no longer accepted
+        — using it raises a clear migration error.
         """
         if not cfg_block:
             raise ValueError("d1_archetypes block is empty")
 
-        needs_joblib = any(
-            isinstance(item, Mapping) and item.get("classifier_path")
-            for item in cfg_block
-        )
+        needs_joblib = False
+        for item in cfg_block:
+            if not isinstance(item, Mapping):
+                continue
+            for v in (item.get("per_fold_classifiers") or {}).values():
+                if isinstance(v, (str, Path)):
+                    needs_joblib = True
+                    break
+            if needs_joblib:
+                break
         joblib_load = None
         if needs_joblib:
             try:
                 import joblib  # type: ignore
             except ImportError as exc:  # pragma: no cover - environment-dependent
                 raise ImportError(
-                    "d1_archetypes config references classifier_path but "
-                    "joblib is not installed"
+                    "d1_archetypes config references per-fold classifier "
+                    "paths but joblib is not installed"
                 ) from exc
             joblib_load = joblib.load
 
@@ -272,17 +351,52 @@ class D1Hook:
             feature_order = tuple(str(k) for k in raw["feature_order"])
             decision_threshold = float(raw["decision_threshold"])
             bar_offset_t = int(raw["bar_offset_t"])
-            classifier_path_raw = raw.get("classifier_path")
-            classifier_path = (
-                str(classifier_path_raw) if classifier_path_raw is not None else None
-            )
-            classifier = raw.get("classifier")  # tests inject directly
-            if classifier is None and classifier_path is not None:
-                p = Path(classifier_path)
+
+            if "classifier_path" in raw or (
+                "classifier" in raw and "per_fold_classifiers" not in raw
+            ):
+                raise ValueError(
+                    f"archetype '{label}': the PR 1 schema "
+                    "('classifier_path' / single 'classifier') is no longer "
+                    "supported. PR 2 requires a 'per_fold_classifiers' "
+                    "mapping plus an 'exit_policy' block — see the "
+                    "core.d1_pipeline module docstring for the new format."
+                )
+
+            raw_per_fold = raw.get("per_fold_classifiers")
+            if not isinstance(raw_per_fold, Mapping) or not raw_per_fold:
+                raise ValueError(
+                    f"archetype '{label}': 'per_fold_classifiers' is "
+                    "required and must be a non-empty mapping of fold id "
+                    "to classifier (or joblib path)"
+                )
+            per_fold_classifiers: dict[str, Any] = {}
+            per_fold_classifier_paths: dict[str, str] = {}
+            for fold_key_raw, value in raw_per_fold.items():
+                fold_key = str(fold_key_raw)
+                if hasattr(value, "predict_proba"):
+                    per_fold_classifiers[fold_key] = value
+                    continue
+                if value is None:
+                    raise ValueError(
+                        f"archetype '{label}' fold '{fold_key}': "
+                        "missing classifier path (value is None)"
+                    )
+                path_str = str(value)
+                per_fold_classifier_paths[fold_key] = path_str
+                p = Path(path_str)
                 if not p.is_absolute() and project_root is not None:
                     p = project_root / p
                 assert joblib_load is not None  # guarded above
-                classifier = joblib_load(p)
+                per_fold_classifiers[fold_key] = joblib_load(p)
+
+            raw_policy = raw.get("exit_policy")
+            if not isinstance(raw_policy, Mapping):
+                raise ValueError(
+                    f"archetype '{label}': 'exit_policy' block is required "
+                    "and must be a mapping with at least a 'type' key"
+                )
+            policy = build_exit_policy(raw_policy)
 
             archetypes.append(
                 D1ArchetypeConfig(
@@ -290,8 +404,9 @@ class D1Hook:
                     feature_order=feature_order,
                     decision_threshold=decision_threshold,
                     bar_offset_t=bar_offset_t,
-                    classifier=classifier,
-                    classifier_path=classifier_path,
+                    per_fold_classifiers=per_fold_classifiers,
+                    per_fold_classifier_paths=per_fold_classifier_paths,
+                    exit_policy=policy,
                     extras={
                         k: v
                         for k, v in raw.items()
@@ -301,8 +416,8 @@ class D1Hook:
                             "feature_order",
                             "decision_threshold",
                             "bar_offset_t",
-                            "classifier_path",
-                            "classifier",
+                            "per_fold_classifiers",
+                            "exit_policy",
                         }
                     },
                 )
@@ -313,6 +428,17 @@ class D1Hook:
 # ---------------------------------------------------------------------------
 # Internals.
 # ---------------------------------------------------------------------------
+
+
+def _select_classifier(arch: D1ArchetypeConfig, fold_id: str | None) -> Any:
+    """Return the per-fold classifier for ``fold_id``, or ``None`` if absent.
+
+    ``None`` is the signal to abstain (the archetype has no classifier
+    registered for the trade's fold — e.g. Arc 4's F1).
+    """
+    if fold_id is None:
+        return None
+    return arch.per_fold_classifiers.get(str(fold_id))
 
 
 def _score_positive_class(classifier: Any, features: np.ndarray) -> float:
@@ -339,24 +465,33 @@ def _score_positive_class(classifier: Any, features: np.ndarray) -> float:
 
 def apply_d1_hook_per_bar(
     hook: D1Hook | None,
-    trade: Mapping[str, Any],
+    trade: dict[str, Any],
     j: int,
     entry_idx: int,
     cached: Mapping[str, Any],
     c_j: float,
+    fold_id: str | None = None,
 ) -> tuple[float | None, int | None, str | None]:
     """Engine integration point — called once per (trade, bar) on the
     per-trade management loop.
 
     Returns ``(exit_px, exit_bar, exit_reason)`` when the hook decides to
-    Close the trade at bar ``j``, or ``(None, None, None)`` when the engine
-    should fall through to its legacy exit cascade (hook is None, bar
-    offset doesn't match, or hook returned ApplyPolicy / Hold).
+    :class:`Close` the trade at bar ``j``, or ``(None, None, None)`` when
+    the engine should fall through to its legacy exit cascade (hook is
+    None, bar offset doesn't match, hook returned :class:`Hold`, or
+    :class:`ApplyPolicy` installed a policy on the trade).
 
-    Fill resolution mirrors the engine's standard next-bar-open pattern
-    (see scripts/phase_kgl_v2_4h_wfo.py:1376-1384). When ``j + 1`` is past
-    end-of-data the fill collapses to bar ``j``'s close — same as every
-    other engine exit branch.
+    On :class:`ApplyPolicy` the policy is installed via
+    ``policy.apply_at_accept(trade, entry_px, atr)`` and stored on
+    ``trade["exit_policy"]`` so subsequent bars can mutate SL via
+    ``policy.update_per_bar``. The trade also gets:
+
+    * ``trade["d1_decision"] = "apply_policy" | "close" | "no_d1"``
+    * ``trade["classifier_fold_id"] = fold_id`` (for trades_all.csv)
+
+    Fill resolution for Close mirrors the engine's standard next-bar-open
+    pattern. When ``j + 1`` is past end-of-data the fill collapses to bar
+    ``j``'s close.
     """
     if hook is None:
         return None, None, None
@@ -366,7 +501,7 @@ def apply_d1_hook_per_bar(
     entry_features = trade.get("entry_features")
     if entry_features is None:
         # Trade was opened without entry features (e.g. KH-16 / KH-17
-        # re-entry paths in PR 1). Fall through to legacy exits.
+        # re-entry paths). Fall through to legacy exits.
         return None, None, None
     decision = hook.evaluate(
         trade=trade,
@@ -374,14 +509,30 @@ def apply_d1_hook_per_bar(
         entry_features=entry_features,
         t=bars_held,
         cached=cached,
+        fold_id=fold_id,
     )
+    trade["classifier_fold_id"] = fold_id
     if isinstance(decision, Close):
+        trade["d1_decision"] = "close"
         opens = cached["o"]
         n = len(opens)
         if j + 1 < n:
             return float(opens[j + 1]), int(j + 1), decision.reason
         return float(c_j), int(j), decision.reason
-    # ApplyPolicy / Hold — PR 1 no-op, fall through to legacy exits.
+    if isinstance(decision, ApplyPolicy):
+        trade["d1_decision"] = "apply_policy"
+        trade["d1_archetype_label"] = decision.label
+        trade["d1_probability"] = float(decision.probability)
+        if decision.policy is not None:
+            decision.policy.apply_at_accept(
+                trade=trade,
+                entry_px=float(trade["entry_px"]),
+                atr_at_entry=float(trade["atr"]),
+            )
+            trade["exit_policy"] = decision.policy
+        return None, None, None
+    # Hold — no classifier for this fold, no gating, fall through.
+    trade["d1_decision"] = "no_d1"
     return None, None, None
 
 

--- a/core/exit_policies.py
+++ b/core/exit_policies.py
@@ -64,18 +64,22 @@ class StepwiseClimberPolicy(ExitPolicy):
       entry − ``archetype_sl_r`` × ``r_in_atr`` × ATR. For Arc 4 cluster 1
       this is a *loosening* (entry − 3.0 × ATR).
     * **MFE-lock** (one-shot, fires the first bar at which
-      ``mfe_so_far_r >= mfe_lock_r``): SL = max(current_sl, entry_px) for
-      longs (min for shorts). Records the fire bar in
-      ``trade["mfe_lock_fired_bar"]``.
-    * **Trail** (every bar after the lock fires; not on the lock bar
-      itself): trail_stop = entry + (mfe_so_far_r − trail_from_high_r) ×
-      ``r_in_atr`` × ATR. SL = max(current_sl, trail_stop) for longs (min
-      for shorts). Ratchets only.
+      ``mfe_so_far_r >= mfe_lock_r``): records the fire bar in
+      ``trade["mfe_lock_fired_bar"]``. Once fired, trail is armed AND
+      used in the same-bar SL check (matches the Step 5 simulator's
+      Step 4 ``effective_sl = max(current_sl, trail_stop)`` semantics —
+      see ``scripts/l_arc_4/step5_stability.py:269-318``).
+    * **Effective SL post-lock**: max(current_sl, entry_px, trail_stop)
+      for longs (min for shorts), where
+      ``trail_stop = entry + (mfe_so_far_r − trail_from_high_r) ×
+      r_in_atr × ATR``. At the lock-fire bar with MFE = 1R this yields
+      entry + 0.25R; subsequent new MFE highs ratchet upward only.
 
-    The lock and trail interact additively: the lock seeds SL at break-even
-    on the trigger bar, then the trail starts ratcheting from there as
-    MFE keeps climbing. Subsequent drawdown in close_r does not reverse
-    the lock (because mfe_so_far_r is a running max).
+    Subsequent drawdown in close_r does not reverse the lock (because
+    mfe_so_far_r is a running max). Engine ordering is MFE-first: the
+    bar_path append updates mfe_so_far_r from bar high before the hook
+    fires, so the lock can detect the same bar's high and the trail
+    same-bar SL is checked against bar low in the Priority-1 SL test.
 
     Fields
     ------
@@ -127,27 +131,22 @@ class StepwiseClimberPolicy(ExitPolicy):
         long = _is_long(trade)
         current_sl = float(trade["sl_px"])
 
-        lock_just_fired = False
+        # Lock check: fires the first bar at which MFE reaches mfe_lock_r.
         if trade.get("mfe_lock_fired_bar") is None and mfe_r >= float(self.mfe_lock_r):
-            if long:
-                current_sl = max(current_sl, float(entry_px))
-            else:
-                current_sl = min(current_sl, float(entry_px))
             trade["mfe_lock_fired_bar"] = bar_offset
-            lock_just_fired = True
 
-        # Trail operates only on bars *after* the lock bar — on the lock
-        # bar itself, BE is the SL. This keeps the worked-example boundary
-        # SL = entry at MFE = 1R, then trail takes over as MFE keeps
-        # climbing.
-        if trade.get("mfe_lock_fired_bar") is not None and not lock_just_fired:
+        # Effective SL post-lock = max(static SL, BE floor, trail_stop)
+        # for longs (min for shorts). Trail fires on the lock-fire bar
+        # itself — same-bar arm + use, matching Step 5's effective_sl
+        # semantics (scripts/l_arc_4/step5_stability.py:294-298).
+        if trade.get("mfe_lock_fired_bar") is not None:
             trail_offset_px = (mfe_r - float(self.trail_from_high_r)) * r_size_px
             if long:
                 trail_stop = float(entry_px) + trail_offset_px
-                current_sl = max(current_sl, trail_stop)
+                current_sl = max(current_sl, float(entry_px), trail_stop)
             else:
                 trail_stop = float(entry_px) - trail_offset_px
-                current_sl = min(current_sl, trail_stop)
+                current_sl = min(current_sl, float(entry_px), trail_stop)
 
         trade["sl_px"] = float(current_sl)
 

--- a/core/exit_policies.py
+++ b/core/exit_policies.py
@@ -1,0 +1,187 @@
+"""Pipeline D1 archetype exit policies — PR 2 of 2.
+
+When :class:`core.d1_pipeline.D1Hook` accepts a trade at bar offset ``t``
+the winning archetype's :class:`ExitPolicy` is installed on the trade and
+takes over from the engine's standard exit cascade:
+
+* :meth:`ExitPolicy.apply_at_accept` fires once at bar ``t`` — typically
+  replaces the pre-t 2.0 × ATR(14) stop with the archetype-specific stop.
+* :meth:`ExitPolicy.update_per_bar` fires every subsequent bar — ratchets
+  the stop in response to path progress (MFE-lock, trail, etc.).
+
+Only the policies named in L_ARC_PROTOCOL v2.0 §11 with a concrete
+consumer are implemented. PR 2 ships row 2 (Stepwise climber) for Arc 4
+cluster 1. Other rows are deferred until they have a concrete consumer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+class ExitPolicy:
+    """Abstract base. Subclasses implement archetype-specific exit logic.
+
+    Both methods mutate ``trade`` in place — the engine reads
+    ``trade["sl_px"]`` after each call. ``apply_at_accept`` is invoked
+    once, on the bar at which :class:`~core.d1_pipeline.D1Hook` returned
+    :class:`~core.d1_pipeline.ApplyPolicy`. ``update_per_bar`` is invoked
+    on every subsequent bar of the trade.
+
+    Policies are stateless apart from what they write into ``trade`` —
+    instances are shared across trades, so any per-trade bookkeeping
+    must live on the trade dict.
+    """
+
+    def apply_at_accept(
+        self,
+        trade: dict[str, Any],
+        entry_px: float,
+        atr_at_entry: float,
+    ) -> None:
+        raise NotImplementedError
+
+    def update_per_bar(
+        self,
+        trade: dict[str, Any],
+        bar_path_row: Mapping[str, float],
+        entry_px: float,
+        atr_at_entry: float,
+    ) -> None:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class StepwiseClimberPolicy(ExitPolicy):
+    """§11 row 2 — MFE-lock + trail-from-peak.
+
+    Semantics (long-side; short-side mirrors with sign flips):
+
+    * **Pre-t SL** (engine-owned, before this policy is installed): entry
+      − 2.0 × ATR(14).
+    * **apply_at_accept** (bar ``t``): replace SL with
+      entry − ``archetype_sl_r`` × ``r_in_atr`` × ATR. For Arc 4 cluster 1
+      this is a *loosening* (entry − 3.0 × ATR).
+    * **MFE-lock** (one-shot, fires the first bar at which
+      ``mfe_so_far_r >= mfe_lock_r``): SL = max(current_sl, entry_px) for
+      longs (min for shorts). Records the fire bar in
+      ``trade["mfe_lock_fired_bar"]``.
+    * **Trail** (every bar after the lock fires; not on the lock bar
+      itself): trail_stop = entry + (mfe_so_far_r − trail_from_high_r) ×
+      ``r_in_atr`` × ATR. SL = max(current_sl, trail_stop) for longs (min
+      for shorts). Ratchets only.
+
+    The lock and trail interact additively: the lock seeds SL at break-even
+    on the trigger bar, then the trail starts ratcheting from there as
+    MFE keeps climbing. Subsequent drawdown in close_r does not reverse
+    the lock (because mfe_so_far_r is a running max).
+
+    Fields
+    ------
+    archetype_sl_r : R-frame multiple for the post-t SL. Cluster 1 uses 1.0
+        (i.e. SL = entry − 1R = entry − 3 × ATR with ``r_in_atr = 3.0``).
+    r_in_atr : the R-unit in ATR multiples. 1R = ``r_in_atr`` × ATR(14).
+    mfe_lock_r : MFE level (in R) at which the BE-lock fires. Cluster 1: 1.0.
+    trail_from_high_r : trail distance from peak MFE (in R). Cluster 1: 0.75.
+
+    Direction
+    ---------
+    The policy reads ``trade.get("signal_direction", "long")`` to handle
+    short trades. Arc 4 is long-only, so the short path is exercised by
+    tests only — the engine never calls into it under current configs.
+    """
+
+    archetype_sl_r: float
+    r_in_atr: float
+    mfe_lock_r: float
+    trail_from_high_r: float
+
+    # ------------------------------------------------------------------
+    def apply_at_accept(
+        self,
+        trade: dict[str, Any],
+        entry_px: float,
+        atr_at_entry: float,
+    ) -> None:
+        sl_offset = float(self.archetype_sl_r) * float(self.r_in_atr) * float(atr_at_entry)
+        if _is_long(trade):
+            trade["sl_px"] = float(entry_px) - sl_offset
+        else:
+            trade["sl_px"] = float(entry_px) + sl_offset
+        trade["mfe_lock_fired_bar"] = None
+        trade["trail_active_from_bar"] = int(trade.get("bar_path", [{}])[-1].get("bar_offset", 0)) \
+            if trade.get("bar_path") else 0
+
+    # ------------------------------------------------------------------
+    def update_per_bar(
+        self,
+        trade: dict[str, Any],
+        bar_path_row: Mapping[str, float],
+        entry_px: float,
+        atr_at_entry: float,
+    ) -> None:
+        mfe_r = float(bar_path_row["mfe_so_far_r"])
+        bar_offset = int(bar_path_row.get("bar_offset", -1))
+        r_size_px = float(self.r_in_atr) * float(atr_at_entry)
+        long = _is_long(trade)
+        current_sl = float(trade["sl_px"])
+
+        lock_just_fired = False
+        if trade.get("mfe_lock_fired_bar") is None and mfe_r >= float(self.mfe_lock_r):
+            if long:
+                current_sl = max(current_sl, float(entry_px))
+            else:
+                current_sl = min(current_sl, float(entry_px))
+            trade["mfe_lock_fired_bar"] = bar_offset
+            lock_just_fired = True
+
+        # Trail operates only on bars *after* the lock bar — on the lock
+        # bar itself, BE is the SL. This keeps the worked-example boundary
+        # SL = entry at MFE = 1R, then trail takes over as MFE keeps
+        # climbing.
+        if trade.get("mfe_lock_fired_bar") is not None and not lock_just_fired:
+            trail_offset_px = (mfe_r - float(self.trail_from_high_r)) * r_size_px
+            if long:
+                trail_stop = float(entry_px) + trail_offset_px
+                current_sl = max(current_sl, trail_stop)
+            else:
+                trail_stop = float(entry_px) - trail_offset_px
+                current_sl = min(current_sl, trail_stop)
+
+        trade["sl_px"] = float(current_sl)
+
+
+def _is_long(trade: Mapping[str, Any]) -> bool:
+    """Default-long unless the trade dict explicitly says ``signal_direction='short'``."""
+    return str(trade.get("signal_direction", "long")).lower() != "short"
+
+
+def build_exit_policy(spec: Mapping[str, Any]) -> ExitPolicy:
+    """Factory — instantiates the policy named by ``spec["type"]``.
+
+    Fails loud on unknown types so a typo in YAML doesn't silently fall
+    through to the legacy cascade.
+    """
+    kind = str(spec.get("type", "")).strip()
+    if kind == "stepwise_climber":
+        return StepwiseClimberPolicy(
+            archetype_sl_r=float(spec["archetype_sl_r"]),
+            r_in_atr=float(spec["r_in_atr"]),
+            mfe_lock_r=float(spec["mfe_lock_r"]),
+            trail_from_high_r=float(spec["trail_from_high_r"]),
+        )
+    if not kind:
+        raise ValueError("exit_policy spec is missing 'type'")
+    raise ValueError(
+        f"unknown exit_policy type {kind!r} — PR 2 implements only "
+        "'stepwise_climber' (Arc 4 cluster 1). Other §11 rows are "
+        "deferred until they have a concrete consumer."
+    )
+
+
+__all__ = (
+    "ExitPolicy",
+    "StepwiseClimberPolicy",
+    "build_exit_policy",
+)

--- a/research/scripts/phase2_rank_fix.py
+++ b/research/scripts/phase2_rank_fix.py
@@ -1,5 +1,4 @@
 ﻿import pandas as pd
-import numpy as np
 
 df = pd.read_csv("results/c1_batch_results.csv")
 

--- a/research/scripts/phase2_rank_freeze_slice.py
+++ b/research/scripts/phase2_rank_freeze_slice.py
@@ -1,5 +1,4 @@
 ﻿import pandas as pd
-import numpy as np
 
 df = pd.read_csv("results/c1_batch_results.csv")
 

--- a/research/scripts/phase2_rank_slice.py
+++ b/research/scripts/phase2_rank_slice.py
@@ -1,5 +1,4 @@
 ﻿import pandas as pd
-import numpy as np
 
 df = pd.read_csv("results/c1_batch_results.csv")
 

--- a/research/scripts/run_c1_volume_sweep.py
+++ b/research/scripts/run_c1_volume_sweep.py
@@ -24,7 +24,7 @@ import json
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import pandas as pd
 import yaml

--- a/scripts/arc_2_redo/step3_capturability.py
+++ b/scripts/arc_2_redo/step3_capturability.py
@@ -920,7 +920,7 @@ def write_summary(
             )
         lines.append("")
         if r.overall_pass:
-            lines.append(f"→ **Capturability: PASS**")
+            lines.append("→ **Capturability: PASS**")
         else:
             lines.append(f"→ **Capturability: FAIL** (kill criterion: `{r.kill_criterion}`)")
         lines.append("")
@@ -977,7 +977,7 @@ def write_summary(
         for r in survivors:
             lines.append(f"- Cluster {r.cluster_id}: {r.archetype_label}")
     else:
-        lines.append(f"**0 archetypes PASS** — Arc-level **KILL ARC**.")
+        lines.append("**0 archetypes PASS** — Arc-level **KILL ARC**.")
         lines.append("")
         lines.append("All failing criteria per cluster (not just the first):")
         lines.append("")

--- a/scripts/arc_2_redo2/parity_spot_check.py
+++ b/scripts/arc_2_redo2/parity_spot_check.py
@@ -103,7 +103,6 @@ def _compare_one(
 
     pair = prior_trade["pair"]
     sig_t = prior_trade["signal_time"]
-    exit_off_prior = int(prior_trade["bars_held"] if pd.notna(prior_trade["bars_held"]) else 0)
     # bars_held = sl_hit_idx - entry_idx + 1 (SL) or horizon (time_exit, 120).
     # In paths, exit_offset = exit_idx - entry_idx, which is (bars_held - 1) for SL
     # and 120 for time_exit per build logic.

--- a/scripts/arc_2_redo2/step3/run_step3.py
+++ b/scripts/arc_2_redo2/step3/run_step3.py
@@ -22,7 +22,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-import numpy as np
 import pandas as pd
 import yaml
 
@@ -30,15 +29,13 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from scripts.arc_2_redo2.step3.shape_tag_v2_1_1 import (  # noqa: E402
+    detect_shape_tag_v2_1_1,
+)
 from scripts.arc_2_redo2.step3.sl_sweep import (  # noqa: E402
     aggregate_per_cluster,
     sweep_all_trades,
 )
-from scripts.arc_2_redo2.step3.shape_tag_v2_1_1 import (  # noqa: E402
-    ShapeTagDecision,
-    detect_shape_tag_v2_1_1,
-)
-
 
 # ============================================================
 # §2 floor evaluation per (cluster, SL)

--- a/scripts/arc_2_redo2/step3/shape_tag_v2_1_1.py
+++ b/scripts/arc_2_redo2/step3/shape_tag_v2_1_1.py
@@ -120,11 +120,8 @@ def detect_shape_tag_v2_1_1(
     pos = np.clip(fwd_mfe, 0.0, upper)
     try:
         dip_stat, dip_p = diptest(pos)
-    except Exception as e:
+    except Exception:
         dip_stat, dip_p = float("nan"), float("nan")
-        bimodal_err = f"diptest failed: {e}"
-    else:
-        bimodal_err = ""
 
     mode_locs, mode_masses, _ = _detect_modes_from_histogram(fwd_mfe, n_bins, upper_q)
     sep = (

--- a/scripts/arc_2_redo2/write_v2_1_1_outputs.py
+++ b/scripts/arc_2_redo2/write_v2_1_1_outputs.py
@@ -111,8 +111,6 @@ def main() -> int:
     flagged_list = list(flagged_small.index) if len(flagged_small) > 0 else []
 
     # ---- Write artefacts ----
-    summary_md_text = (RESULTS / "STEP1_SUMMARY.md").read_text(encoding="utf-8")
-
     # Extract sha256 hashes from STEP1_SUMMARY for determinism_check.txt
     trades_all_sha = _sha(RESULTS / "trades_all.csv")
     trades_paths_sha = _sha(RESULTS / "trades_paths.csv")

--- a/scripts/phase_kgl_v2_4h_wfo.py
+++ b/scripts/phase_kgl_v2_4h_wfo.py
@@ -472,6 +472,22 @@ def _wfo_folds() -> list[dict]:
 FOLDS = _wfo_folds()
 
 
+def _fold_id_for_entry(entry_ts) -> str | None:
+    """Return the WFO fold id (``"F1"``..``"F7"``) whose OOS window
+    contains ``entry_ts``, or ``None`` for IS-only trades.
+
+    Used by the Pipeline D1 hook to dispatch the trade to the correct
+    per-fold classifier — see ``D1_HOOK.evaluate(..., fold_id=...)``.
+    Trades with ``entry_ts`` before the first fold's OOS start return
+    ``None`` and are not gated by D1.
+    """
+    ts = pd.Timestamp(entry_ts)
+    for f in FOLDS:
+        if pd.Timestamp(f["oos_start"]) <= ts < pd.Timestamp(f["oos_end"]):
+            return f"F{int(f['fold'])}"
+    return None
+
+
 # ── Kijun helpers ─────────────────────────────────────────────────────────────
 
 def _compute_kijun(df: pd.DataFrame, period: int) -> np.ndarray:
@@ -1357,19 +1373,44 @@ def _simulate_kgl_v2(
             exit_bar    = j
             exit_reason = None
 
-            # Pipeline D1 hook (L_ARC_PROTOCOL v2.0 §3). When configured,
-            # fires exactly once per trade at bar offset t == D1_HOOK.bar_offset_t.
-            # Close decision: exit at next bar's open with reason "d1_untradeable"
-            # (last-bar fallback collapses to bar j close). ApplyPolicy / Hold
-            # are no-ops in PR 1 — the legacy cascade below handles the trade.
+            # Pipeline D1 hook (L_ARC_PROTOCOL v2.0 §3 + §11). Fires exactly
+            # once per trade at bar offset t == D1_HOOK.bar_offset_t.
+            #   Close       → exit at next bar's open with reason
+            #                  "d1_untradeable" (last-bar fallback → bar j
+            #                  close). PR 1 behaviour.
+            #   ApplyPolicy → install the archetype's ExitPolicy on the
+            #                  trade. The policy's apply_at_accept runs
+            #                  inside the helper (replaces pre-t SL), and
+            #                  the per-bar block below ratchets SL on
+            #                  every subsequent bar. PR 2.
+            #   Hold        → no classifier for this trade's fold (e.g.
+            #                  Arc 4 F1). Legacy cascade handles the trade.
             if D1_HOOK is not None:
                 _d1_px, _d1_bar, _d1_reason = apply_d1_hook_per_bar(
                     D1_HOOK, trade, j, entry_idx, cached, c_j,
+                    fold_id=trade.get("fold_id"),
                 )
                 if _d1_reason is not None:
                     exit_px     = _d1_px
                     exit_bar    = _d1_bar
                     exit_reason = _d1_reason
+                # apply_at_accept (when ApplyPolicy) mutated trade["sl_px"];
+                # refresh the local so subsequent SL/trail logic uses the
+                # archetype's post-t stop, not the stale pre-t value.
+                sl_px = trade["sl_px"]
+
+            # Per-bar policy update (PR 2). Fires every bar from accept
+            # onward; mutates trade["sl_px"] in place via the installed
+            # ExitPolicy. Runs before the Priority-1 SL check so the
+            # ratchet is in effect for the same bar's intrabar SL test.
+            if trade.get("exit_policy") is not None and exit_reason is None:
+                trade["exit_policy"].update_per_bar(
+                    trade=trade,
+                    bar_path_row=trade["bar_path"][-1],
+                    entry_px=entry_px,
+                    atr_at_entry=a,
+                )
+                sl_px = trade["sl_px"]
 
             # Priority 1: Intrabar hard SL
             if exit_reason is None:
@@ -1564,6 +1605,20 @@ def _simulate_kgl_v2(
                 )
                 _kh14_state2  = bool(trade["first_bar_dir"] == -1)
 
+                # Pipeline D1 (PR 2) audit columns. Gated on D1_HOOK so
+                # KH-24 baseline runs (D1_HOOK = None) write a
+                # byte-identical trades_all.csv.
+                _d1_audit_extras: dict = {}
+                if D1_HOOK is not None:
+                    _d1_audit_extras = {
+                        "fold_id":               trade.get("fold_id"),
+                        "d1_decision":           trade.get("d1_decision", "no_d1"),
+                        "classifier_fold_id":    trade.get("classifier_fold_id"),
+                        "d1_archetype_label":    trade.get("d1_archetype_label"),
+                        "d1_probability":        trade.get("d1_probability", float("nan")),
+                        "mfe_lock_fired_bar":    trade.get("mfe_lock_fired_bar"),
+                        "trail_active_from_bar": trade.get("trail_active_from_bar"),
+                    }
                 completed_trades.append({
                     "pair":              pair,
                     "entry_date":        trade["entry_date"],
@@ -1607,6 +1662,7 @@ def _simulate_kgl_v2(
                     # set (preserves byte-identity of the legacy subset).
                     "_v13_time_to_peak_mfe":   int(trade["time_to_peak_mfe"]),
                     "_v13_time_to_trough_mae": int(trade["time_to_trough_mae"]),
+                    **_d1_audit_extras,
                 })
                 _flatten_bar_path_for_trade(
                     trade, exit_bar, pair_cache,
@@ -1635,6 +1691,12 @@ def _simulate_kgl_v2(
                 trade["trail_active"] = trail_active
                 trade["best_cl"]      = best_cl
                 trade["ts_level"]     = ts_level
+                # Pipeline D1 (PR 2): the per-bar policy mutated sl_px in
+                # place — persist the latest value so the next bar's local
+                # binding sees the policy-driven stop. mfe_lock_fired_bar
+                # and trail_active_from_bar are already on the trade dict
+                # (mutated by update_per_bar / apply_at_accept).
+                trade["sl_px"]        = sl_px
                 still_open.append(trade)
 
         open_trades = still_open
@@ -2349,6 +2411,17 @@ def _simulate_kgl_v2(
                 "time_to_peak_mfe":    0,
                 "time_to_trough_mae":  0,
                 "entry_features":      entry_features_dict,
+                # Pipeline D1 (PR 2) audit fields. Stamped at trade open
+                # so they are always present in the completed-trade
+                # record, even when the hook doesn't fire (e.g. trade
+                # exited before bar t, or D1_HOOK is None).
+                "fold_id":             _fold_id_for_entry(bar_date),
+                "signal_direction":    SIGNAL_DIRECTION,
+                "exit_policy":         None,
+                "mfe_lock_fired_bar":  None,
+                "trail_active_from_bar": None,
+                "classifier_fold_id":  None,
+                "d1_decision":         "no_d1",
             })
 
     # Close any remaining open trades at last available close

--- a/tests/arc_kh24_v2/test_step2_clustering.py
+++ b/tests/arc_kh24_v2/test_step2_clustering.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
 
-from scripts.arc_kh24_v2.step2._archetype import match_archetype
-from scripts.arc_kh24_v2.step2._cluster import (
+pytest.importorskip("sklearn")  # optional dep — skip if absent in CI clean env
+
+from scripts.arc_kh24_v2.step2._archetype import match_archetype  # noqa: E402
+from scripts.arc_kh24_v2.step2._cluster import (  # noqa: E402
     GATE_MIN_CLUSTER_SIZE,
     GATE_MIN_SILHOUETTE,
     evaluate_gate,
     run_kmeans_sweep,
     select_k,
 )
-from scripts.arc_kh24_v2.step2._features import FEATURE_COLUMNS
+from scripts.arc_kh24_v2.step2._features import FEATURE_COLUMNS  # noqa: E402
 
 
 def _synthetic_features(seed: int = 42) -> pd.DataFrame:

--- a/tests/arc_kh24_v2/test_step2_determinism.py
+++ b/tests/arc_kh24_v2/test_step2_determinism.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("sklearn")  # optional dep — run_step2 imports sklearn.cluster
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STEP1_DIR = REPO_ROOT / "results" / "arc_kh24_v2" / "step1"
 

--- a/tests/arc_kh24_v2/test_step3_determinism.py
+++ b/tests/arc_kh24_v2/test_step3_determinism.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("scipy")  # optional dep — run_step3 imports scipy.signal
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 STEP1_DIR = REPO_ROOT / "results" / "arc_kh24_v2" / "step1"
 STEP2_DIR = REPO_ROOT / "results" / "arc_kh24_v2" / "step2"

--- a/tests/arc_kh24_v2/test_step3_distribution.py
+++ b/tests/arc_kh24_v2/test_step3_distribution.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
-from scripts.arc_kh24_v2.step3._distribution import classify_shape
+pytest.importorskip("scipy")  # optional dep — skip if absent in CI clean env
+
+from scripts.arc_kh24_v2.step3._distribution import classify_shape  # noqa: E402
 
 
 def test_no_magnitude_when_p95_below_half_r():

--- a/tests/replays_v2_1_1/test_arc_3_stepwise.py
+++ b/tests/replays_v2_1_1/test_arc_3_stepwise.py
@@ -6,10 +6,13 @@ import sys
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
+
+pytest.importorskip("scipy")  # optional dep — skip if absent in CI clean env
 
 from scripts.replays_v2_1_1.arc_3_stepwise.shape_classifier import classify_shape_tag  # noqa: E402
 from scripts.replays_v2_1_1.arc_3_stepwise.step3 import (  # noqa: E402

--- a/tests/replays_v2_1_1/test_kh24_v2_c4.py
+++ b/tests/replays_v2_1_1/test_kh24_v2_c4.py
@@ -15,6 +15,8 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
+pytest.importorskip("diptest")  # optional dep — skip if absent in CI clean env
+
 from scripts.replays_v2_1_1.kh24_v2_c4.step3 import (  # noqa: E402
     classify_shape_tag,
     evaluate_sl_for_cluster,

--- a/tests/replays_v2_1_1/test_kh24_v2_c4_step4.py
+++ b/tests/replays_v2_1_1/test_kh24_v2_c4_step4.py
@@ -16,6 +16,8 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
+pytest.importorskip("sklearn")  # optional dep — skip if absent in CI clean env
+
 from sklearn.metrics import average_precision_score  # noqa: E402
 
 from scripts.replays_v2_1_1.kh24_v2_c4_step4.step4 import (  # noqa: E402

--- a/tests/replays_v2_1_1/test_kh24_v2_c4_step5.py
+++ b/tests/replays_v2_1_1/test_kh24_v2_c4_step5.py
@@ -16,6 +16,9 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
+pytest.importorskip("sklearn")  # optional deps (sklearn + joblib via step4 chain)
+pytest.importorskip("joblib")
+
 from scripts.replays_v2_1_1.kh24_v2_c4_step5.step5 import (  # noqa: E402
     AssembledData,  # noqa: E402
     ClusterResults,

--- a/tests/test_d1_pipeline.py
+++ b/tests/test_d1_pipeline.py
@@ -29,8 +29,10 @@ from core.d1_pipeline import (
     Close,
     D1ArchetypeConfig,
     D1Hook,
+    Hold,
     apply_d1_hook_per_bar,
 )
+from core.exit_policies import StepwiseClimberPolicy
 from core.features_path_so_far import (
     ALL_FEATURE_KEYS,
     ENTRY_FEATURE_KEYS,
@@ -290,29 +292,40 @@ class TestD1HookInit:
             D1Hook([])
 
     def test_mixed_bar_offset_t_raises(self):
+        order = list(ALL_FEATURE_KEYS)
+        policy = StepwiseClimberPolicy(
+            archetype_sl_r=1.0, r_in_atr=3.0, mfe_lock_r=1.0, trail_from_high_r=0.75
+        )
         a = D1ArchetypeConfig(
             label="x",
-            feature_order=tuple(ALL_FEATURE_KEYS),
+            feature_order=tuple(order),
             decision_threshold=0.5,
             bar_offset_t=3,
-            classifier=StubClassifier(list(ALL_FEATURE_KEYS)),
+            per_fold_classifiers={"F1": StubClassifier(order)},
+            exit_policy=policy,
         )
         b = D1ArchetypeConfig(
             label="y",
-            feature_order=tuple(ALL_FEATURE_KEYS),
+            feature_order=tuple(order),
             decision_threshold=0.5,
             bar_offset_t=5,
-            classifier=StubClassifier(list(ALL_FEATURE_KEYS)),
+            per_fold_classifiers={"F1": StubClassifier(order)},
+            exit_policy=policy,
         )
         with pytest.raises(ValueError, match="must share bar_offset_t"):
             D1Hook([a, b])
 
     def test_bad_feature_order_raises(self):
+        policy = StepwiseClimberPolicy(
+            archetype_sl_r=1.0, r_in_atr=3.0, mfe_lock_r=1.0, trail_from_high_r=0.75
+        )
         a = D1ArchetypeConfig(
             label="x",
             feature_order=tuple(list(ALL_FEATURE_KEYS) + ["bogus"]),
             decision_threshold=0.5,
             bar_offset_t=3,
+            per_fold_classifiers={"F1": StubClassifier(list(ALL_FEATURE_KEYS))},
+            exit_policy=policy,
         )
         with pytest.raises(ValueError, match="bogus"):
             D1Hook([a])
@@ -328,31 +341,61 @@ class TestD1HookInit:
             feature_order=tuple(order),
             decision_threshold=0.5,
             bar_offset_t=3,
-            classifier=stub,
+            per_fold_classifiers={"F1": stub},
+            exit_policy=StepwiseClimberPolicy(
+                archetype_sl_r=1.0, r_in_atr=3.0,
+                mfe_lock_r=1.0, trail_from_high_r=0.75,
+            ),
         )
         with pytest.raises(ValueError, match="expects 99 features"):
             D1Hook([a])
 
     def test_threshold_out_of_range_raises(self):
+        order = list(ALL_FEATURE_KEYS)
         a = D1ArchetypeConfig(
             label="x",
-            feature_order=tuple(ALL_FEATURE_KEYS),
+            feature_order=tuple(order),
             decision_threshold=1.5,
             bar_offset_t=3,
-            classifier=StubClassifier(list(ALL_FEATURE_KEYS)),
+            per_fold_classifiers={"F1": StubClassifier(order)},
+            exit_policy=StepwiseClimberPolicy(
+                archetype_sl_r=1.0, r_in_atr=3.0,
+                mfe_lock_r=1.0, trail_from_high_r=0.75,
+            ),
         )
         with pytest.raises(ValueError, match="decision_threshold"):
             D1Hook([a])
 
     def test_bar_offset_t_must_be_positive(self):
+        order = list(ALL_FEATURE_KEYS)
         a = D1ArchetypeConfig(
             label="x",
-            feature_order=tuple(ALL_FEATURE_KEYS),
+            feature_order=tuple(order),
             decision_threshold=0.5,
             bar_offset_t=0,
-            classifier=StubClassifier(list(ALL_FEATURE_KEYS)),
+            per_fold_classifiers={"F1": StubClassifier(order)},
+            exit_policy=StepwiseClimberPolicy(
+                archetype_sl_r=1.0, r_in_atr=3.0,
+                mfe_lock_r=1.0, trail_from_high_r=0.75,
+            ),
         )
         with pytest.raises(ValueError, match="bar_offset_t"):
+            D1Hook([a])
+
+    def test_empty_per_fold_classifiers_raises(self):
+        order = list(ALL_FEATURE_KEYS)
+        a = D1ArchetypeConfig(
+            label="x",
+            feature_order=tuple(order),
+            decision_threshold=0.5,
+            bar_offset_t=3,
+            per_fold_classifiers={},
+            exit_policy=StepwiseClimberPolicy(
+                archetype_sl_r=1.0, r_in_atr=3.0,
+                mfe_lock_r=1.0, trail_from_high_r=0.75,
+            ),
+        )
+        with pytest.raises(ValueError, match="per_fold_classifiers is empty"):
             D1Hook([a])
 
 
@@ -361,14 +404,27 @@ class TestD1HookInit:
 # ---------------------------------------------------------------------------
 
 
-def _make_single_hook(threshold: float = 0.5, t: int = 3) -> D1Hook:
+def _default_policy() -> StepwiseClimberPolicy:
+    return StepwiseClimberPolicy(
+        archetype_sl_r=1.0, r_in_atr=3.0, mfe_lock_r=1.0, trail_from_high_r=0.75
+    )
+
+
+def _make_single_hook(
+    threshold: float = 0.5, t: int = 3, fold_id: str = "F1"
+) -> D1Hook:
     order = list(ALL_FEATURE_KEYS)
     arch = D1ArchetypeConfig(
         label="stepwise_climber",
         feature_order=tuple(order),
         decision_threshold=threshold,
         bar_offset_t=t,
-        classifier=StubClassifier(order, gate_feature="mfe_so_far_r_at_t", threshold=1.0),
+        per_fold_classifiers={
+            fold_id: StubClassifier(
+                order, gate_feature="mfe_so_far_r_at_t", threshold=1.0,
+            ),
+        },
+        exit_policy=_default_policy(),
     )
     return D1Hook([arch])
 
@@ -380,18 +436,19 @@ class TestD1HookEvaluate:
         path = _bar_path([0.0, 0.5, 1.0, 1.5])
         decision = hook.evaluate(
             trade={}, bar_path_so_far=path, entry_features=entry_features_finite,
-            t=3, cached={},
+            t=3, cached={}, fold_id="F1",
         )
         assert isinstance(decision, ApplyPolicy)
         assert decision.label == "stepwise_climber"
         assert decision.probability == pytest.approx(0.9)
+        assert isinstance(decision.policy, StepwiseClimberPolicy)
 
     def test_returns_close_when_mfe_low(self, entry_features_finite):
         hook = _make_single_hook(threshold=0.5, t=3)
         path = _bar_path([0.0, 0.1, 0.2, 0.3])  # max high_r = 0.4 < 1.0 → P=0.1
         decision = hook.evaluate(
             trade={}, bar_path_so_far=path, entry_features=entry_features_finite,
-            t=3, cached={},
+            t=3, cached={}, fold_id="F1",
         )
         assert isinstance(decision, Close)
         assert decision.reason == "d1_untradeable"
@@ -402,19 +459,35 @@ class TestD1HookEvaluate:
         with pytest.raises(ValueError, match="configured t=3"):
             hook.evaluate(
                 trade={}, bar_path_so_far=path,
-                entry_features=entry_features_finite, t=2, cached={},
+                entry_features=entry_features_finite, t=2, cached={}, fold_id="F1",
             )
 
     def test_nan_entry_features_abstain(self):
         hook = _make_single_hook(threshold=0.5, t=3)
-        # All entry features NaN → archetype abstains → Close.
+        # All entry features NaN → archetype abstains. With only one
+        # archetype, no archetype has valid features → Close (not Hold,
+        # because the classifier IS available for this fold).
         nan_entry = {k: float("nan") for k in ENTRY_FEATURE_KEYS}
         path = _bar_path([0.0, 0.5, 1.0, 1.5])
         decision = hook.evaluate(
             trade={}, bar_path_so_far=path, entry_features=nan_entry,
-            t=3, cached={},
+            t=3, cached={}, fold_id="F1",
         )
         assert isinstance(decision, Close)
+
+    def test_returns_hold_when_fold_has_no_classifier(self, entry_features_finite):
+        """Trades in a fold absent from per_fold_classifiers fall through.
+
+        Use-case: Arc 4 F1 has no training data; the YAML registers
+        F2..F7 only. F1 trades return Hold and run the legacy cascade.
+        """
+        hook = _make_single_hook(threshold=0.5, t=3, fold_id="F2")
+        path = _bar_path([0.0, 0.5, 1.0, 1.5])
+        decision = hook.evaluate(
+            trade={}, bar_path_so_far=path, entry_features=entry_features_finite,
+            t=3, cached={}, fold_id="F1",
+        )
+        assert isinstance(decision, Hold)
 
 
 # ---------------------------------------------------------------------------
@@ -425,19 +498,22 @@ class TestD1HookEvaluate:
 class TestMultiArchetype:
     def _two_arch_hook(self, p_a: float, p_b: float) -> D1Hook:
         order = list(ALL_FEATURE_KEYS)
+        policy = _default_policy()
         arch_a = D1ArchetypeConfig(
             label="a",
             feature_order=tuple(order),
             decision_threshold=0.5,
             bar_offset_t=3,
-            classifier=StubClassifier(order, fixed_p=p_a),
+            per_fold_classifiers={"F1": StubClassifier(order, fixed_p=p_a)},
+            exit_policy=policy,
         )
         arch_b = D1ArchetypeConfig(
             label="b",
             feature_order=tuple(order),
             decision_threshold=0.5,
             bar_offset_t=3,
-            classifier=StubClassifier(order, fixed_p=p_b),
+            per_fold_classifiers={"F1": StubClassifier(order, fixed_p=p_b)},
+            exit_policy=policy,
         )
         return D1Hook([arch_a, arch_b])
 
@@ -445,7 +521,7 @@ class TestMultiArchetype:
         hook = self._two_arch_hook(p_a=0.6, p_b=0.9)
         decision = hook.evaluate(
             trade={}, bar_path_so_far=_bar_path([0.0, 0.5, 1.0, 1.5]),
-            entry_features=entry_features_finite, t=3, cached={},
+            entry_features=entry_features_finite, t=3, cached={}, fold_id="F1",
         )
         assert isinstance(decision, ApplyPolicy)
         assert decision.label == "b"
@@ -455,7 +531,7 @@ class TestMultiArchetype:
         hook = self._two_arch_hook(p_a=0.8, p_b=0.8)
         decision = hook.evaluate(
             trade={}, bar_path_so_far=_bar_path([0.0, 0.5, 1.0, 1.5]),
-            entry_features=entry_features_finite, t=3, cached={},
+            entry_features=entry_features_finite, t=3, cached={}, fold_id="F1",
         )
         assert isinstance(decision, ApplyPolicy)
         assert decision.label == "a"
@@ -464,7 +540,7 @@ class TestMultiArchetype:
         hook = self._two_arch_hook(p_a=0.4, p_b=0.45)
         decision = hook.evaluate(
             trade={}, bar_path_so_far=_bar_path([0.0, 0.5, 1.0, 1.5]),
-            entry_features=entry_features_finite, t=3, cached={},
+            entry_features=entry_features_finite, t=3, cached={}, fold_id="F1",
         )
         assert isinstance(decision, Close)
 
@@ -479,6 +555,10 @@ def _trade_with(t: int, close_rs: list[float], entry_features: dict[str, float])
         "entry_idx": 0,
         "bar_path": _bar_path(close_rs),
         "entry_features": entry_features,
+        "entry_px": 1.0,
+        "atr": 0.01,
+        "sl_px": 1.0 - 2.0 * 0.01,  # pre-t SL (entry − 2 × ATR)
+        "signal_direction": "long",
     }
 
 
@@ -488,6 +568,7 @@ class TestApplyD1HookPerBar:
         trade = _trade_with(3, [0.0, 0.5, 1.0, 1.5], entry_features_finite)
         out = apply_d1_hook_per_bar(
             hook=None, trade=trade, j=3, entry_idx=0, cached=cached, c_j=1.03,
+            fold_id="F1",
         )
         assert out == (None, None, None)
 
@@ -498,6 +579,7 @@ class TestApplyD1HookPerBar:
         # j - entry_idx = 1 != bar_offset_t = 3.
         out = apply_d1_hook_per_bar(
             hook=hook, trade=trade, j=1, entry_idx=0, cached=cached, c_j=1.01,
+            fold_id="F1",
         )
         assert out == (None, None, None)
 
@@ -508,11 +590,15 @@ class TestApplyD1HookPerBar:
         trade = _trade_with(3, [0.0, 0.1, 0.2, 0.3], entry_features_finite)  # low mfe → Close
         out = apply_d1_hook_per_bar(
             hook=hook, trade=trade, j=3, entry_idx=0, cached=cached, c_j=1.03,
+            fold_id="F1",
         )
         exit_px, exit_bar, exit_reason = out
         assert exit_reason == "d1_untradeable"
         assert exit_bar == 4
         assert exit_px == pytest.approx(1.0399)
+        # Audit fields stamped on trade dict (used by trades_all.csv).
+        assert trade["d1_decision"] == "close"
+        assert trade["classifier_fold_id"] == "F1"
 
     def test_close_last_bar_fallback_uses_c_j(self, entry_features_finite):
         hook = _make_single_hook(threshold=0.5, t=3)
@@ -522,21 +608,51 @@ class TestApplyD1HookPerBar:
         trade = _trade_with(3, [0.0, 0.1, 0.2, 0.3], entry_features_finite)
         out = apply_d1_hook_per_bar(
             hook=hook, trade=trade, j=3, entry_idx=0, cached=cached, c_j=1.0301,
+            fold_id="F1",
         )
         exit_px, exit_bar, exit_reason = out
         assert exit_reason == "d1_untradeable"
         assert exit_bar == 3
         assert exit_px == pytest.approx(1.0301)
 
-    def test_apply_policy_returns_noop_tuple(self, entry_features_finite):
+    def test_apply_policy_installs_policy_on_trade(self, entry_features_finite):
+        """ApplyPolicy: helper installs the policy on the trade dict,
+        mutates SL via apply_at_accept, and returns no-exit tuple so the
+        engine cascade continues.
+        """
         hook = _make_single_hook(threshold=0.5, t=3)
         cached = {"o": np.array([1.0, 1.01, 1.02, 1.03, 1.04])}
         # High mfe path → P=0.9 ≥ 0.5 → ApplyPolicy.
         trade = _trade_with(3, [0.0, 0.5, 1.0, 1.5], entry_features_finite)
+        pre_sl = trade["sl_px"]
         out = apply_d1_hook_per_bar(
             hook=hook, trade=trade, j=3, entry_idx=0, cached=cached, c_j=1.03,
+            fold_id="F1",
         )
         assert out == (None, None, None)
+        # apply_at_accept replaced the pre-t SL with entry − 3 × ATR.
+        assert trade["sl_px"] == pytest.approx(1.0 - 3.0 * 0.01)
+        assert trade["sl_px"] != pre_sl
+        assert isinstance(trade["exit_policy"], StepwiseClimberPolicy)
+        assert trade["d1_decision"] == "apply_policy"
+        assert trade["classifier_fold_id"] == "F1"
+        assert trade["d1_archetype_label"] == "stepwise_climber"
+
+    def test_missing_fold_classifier_returns_hold(self, entry_features_finite):
+        """Trade with fold_id absent from per_fold_classifiers → Hold →
+        helper returns no-exit; trade falls through to legacy cascade.
+        """
+        hook = _make_single_hook(threshold=0.5, t=3, fold_id="F2")
+        cached = {"o": np.array([1.0, 1.01, 1.02, 1.03, 1.04])}
+        trade = _trade_with(3, [0.0, 0.5, 1.0, 1.5], entry_features_finite)
+        out = apply_d1_hook_per_bar(
+            hook=hook, trade=trade, j=3, entry_idx=0, cached=cached, c_j=1.03,
+            fold_id="F1",
+        )
+        assert out == (None, None, None)
+        assert trade["d1_decision"] == "no_d1"
+        # No policy installed.
+        assert "exit_policy" not in trade or trade.get("exit_policy") is None
 
     def test_missing_entry_features_fall_through(self):
         """Re-entry trades (no entry_features) must fall through without erroring."""
@@ -549,6 +665,7 @@ class TestApplyD1HookPerBar:
         }
         out = apply_d1_hook_per_bar(
             hook=hook, trade=trade, j=3, entry_idx=0, cached=cached, c_j=1.03,
+            fold_id="F1",
         )
         assert out == (None, None, None)
 
@@ -601,26 +718,103 @@ class TestEntryFeatureBuilder:
 
 
 class TestFromYamlDict:
-    def test_inline_classifier_is_used(self):
+    def test_inline_per_fold_classifiers_are_used(self):
+        """PR 2 schema: per_fold_classifiers dict + exit_policy block."""
         order = list(ALL_FEATURE_KEYS)
-        stub = StubClassifier(order, fixed_p=0.99)
+        stubs = {f: StubClassifier(order, fixed_p=0.99) for f in ("F2", "F3")}
         yaml_block = [
             {
-                "label": "stepwise_climber",
+                "label": "stepwise_climber_arc4_cluster1",
                 "feature_order": order,
-                "decision_threshold": 0.5,
-                "bar_offset_t": 3,
-                "classifier": stub,  # bypass joblib loading
+                "decision_threshold": 0.1647,
+                "bar_offset_t": 1,
+                "per_fold_classifiers": stubs,
+                "exit_policy": {
+                    "type": "stepwise_climber",
+                    "archetype_sl_r": 1.0,
+                    "r_in_atr": 3.0,
+                    "mfe_lock_r": 1.0,
+                    "trail_from_high_r": 0.75,
+                },
             }
         ]
         hook = D1Hook.from_yaml_dict(yaml_block)
-        assert hook.bar_offset_t == 3
-        assert hook.archetypes[0].label == "stepwise_climber"
-        assert hook.archetypes[0].classifier is stub
+        assert hook.bar_offset_t == 1
+        assert hook.archetypes[0].label == "stepwise_climber_arc4_cluster1"
+        assert hook.archetypes[0].per_fold_classifiers["F2"] is stubs["F2"]
+        assert isinstance(hook.archetypes[0].exit_policy, StepwiseClimberPolicy)
+        assert hook.archetypes[0].exit_policy.archetype_sl_r == 1.0
 
     def test_empty_block_raises(self):
         with pytest.raises(ValueError, match="empty"):
             D1Hook.from_yaml_dict([])
+
+    def test_pr1_schema_fails_loud(self):
+        """PR 1 ``classifier_path`` schema is no longer accepted."""
+        order = list(ALL_FEATURE_KEYS)
+        yaml_block = [
+            {
+                "label": "old_schema",
+                "feature_order": order,
+                "decision_threshold": 0.5,
+                "bar_offset_t": 3,
+                "classifier_path": "some/path.joblib",
+            }
+        ]
+        with pytest.raises(ValueError, match="PR 1 schema"):
+            D1Hook.from_yaml_dict(yaml_block)
+
+    def test_missing_exit_policy_raises(self):
+        order = list(ALL_FEATURE_KEYS)
+        stub = StubClassifier(order)
+        yaml_block = [
+            {
+                "label": "no_policy",
+                "feature_order": order,
+                "decision_threshold": 0.5,
+                "bar_offset_t": 3,
+                "per_fold_classifiers": {"F1": stub},
+                # no exit_policy
+            }
+        ]
+        with pytest.raises(ValueError, match="exit_policy.*required"):
+            D1Hook.from_yaml_dict(yaml_block)
+
+    def test_missing_per_fold_classifiers_raises(self):
+        order = list(ALL_FEATURE_KEYS)
+        yaml_block = [
+            {
+                "label": "no_classifiers",
+                "feature_order": order,
+                "decision_threshold": 0.5,
+                "bar_offset_t": 3,
+                "exit_policy": {
+                    "type": "stepwise_climber",
+                    "archetype_sl_r": 1.0,
+                    "r_in_atr": 3.0,
+                    "mfe_lock_r": 1.0,
+                    "trail_from_high_r": 0.75,
+                },
+                # no per_fold_classifiers
+            }
+        ]
+        with pytest.raises(ValueError, match="per_fold_classifiers.*required"):
+            D1Hook.from_yaml_dict(yaml_block)
+
+    def test_unknown_exit_policy_type_raises(self):
+        order = list(ALL_FEATURE_KEYS)
+        yaml_block = [
+            {
+                "label": "bogus_policy",
+                "feature_order": order,
+                "decision_threshold": 0.5,
+                "bar_offset_t": 3,
+                "per_fold_classifiers": {"F1": StubClassifier(order)},
+                "exit_policy": {"type": "not_a_real_policy"},
+            }
+        ]
+        with pytest.raises(ValueError, match="unknown exit_policy type"):
+            D1Hook.from_yaml_dict(yaml_block)
 
 
 # ---------------------------------------------------------------------------
@@ -689,6 +883,58 @@ class TestEnginePatch:
             src,
         )
         assert m, "hook block must be guarded by `if D1_HOOK is not None:`"
+
+    def test_engine_passes_fold_id_to_hook(self):
+        """PR 2: helper receives fold_id from trade dict so the per-fold
+        classifier dispatch works.
+        """
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        m = re.search(
+            r"apply_d1_hook_per_bar\([^)]*fold_id\s*=\s*trade\.get\(\"fold_id\"\)",
+            src,
+            re.S,
+        )
+        assert m, "engine call to apply_d1_hook_per_bar must thread fold_id"
+
+    def test_engine_invokes_per_bar_policy_update(self):
+        """PR 2: per-bar update fires every bar from accept onward,
+        before Priority-1 SL.
+        """
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        update_idx = src.find('trade["exit_policy"].update_per_bar')
+        sl_priority_idx = src.index("# Priority 1: Intrabar hard SL")
+        assert update_idx != -1, (
+            "engine must call trade['exit_policy'].update_per_bar(...)"
+        )
+        assert update_idx < sl_priority_idx, (
+            "per-bar policy update must run before the Priority-1 SL check"
+        )
+
+    def test_engine_stamps_fold_id_at_trade_open(self):
+        """PR 2: trade dict gains fold_id at entry — used to select the
+        per-fold classifier.
+        """
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        assert "_fold_id_for_entry(bar_date)" in src
+        m = re.search(
+            r"\"fold_id\":\s+_fold_id_for_entry\(bar_date\)",
+            src,
+        )
+        assert m, "trade dict must carry fold_id at open"
+
+    def test_engine_audit_columns_gated_on_hook(self):
+        """PR 2: trades_all.csv gains new D1 audit columns only when
+        D1_HOOK is configured — KH-24 baseline runs stay byte-identical.
+        """
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        m = re.search(
+            r"_d1_audit_extras:\s*dict\s*=\s*\{\}\s*\n\s+if\s+D1_HOOK\s+is\s+not\s+None:",
+            src,
+        )
+        assert m, (
+            "audit columns must be gated on `if D1_HOOK is not None:` so "
+            "the baseline trades_all.csv stays byte-identical"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_exit_policies.py
+++ b/tests/test_exit_policies.py
@@ -1,0 +1,561 @@
+"""Tests for Pipeline D1 archetype exit policies (PR 2).
+
+Two layers:
+
+* Unit tests on :class:`~core.exit_policies.StepwiseClimberPolicy` —
+  ``apply_at_accept`` swaps the pre-t SL for ``entry − archetype_sl_r ×
+  r_in_atr × ATR``; ``update_per_bar`` ratchets SL via MFE-lock + trail.
+* Integration tests on :func:`~core.d1_pipeline.apply_d1_hook_per_bar`
+  + stubs — per-fold classifier dispatch, ApplyPolicy installs the
+  policy on the trade dict, audit fields surface in the completed trade.
+
+No joblib / sklearn — stubs implement ``predict_proba``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from core.d1_pipeline import (
+    ApplyPolicy,
+    Close,
+    D1ArchetypeConfig,
+    D1Hook,
+    apply_d1_hook_per_bar,
+)
+from core.exit_policies import (
+    StepwiseClimberPolicy,
+    build_exit_policy,
+)
+from core.features_path_so_far import ALL_FEATURE_KEYS
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+
+# Arc 4 cluster 1 parameters — verbatim from results/l_arc_4/step4/
+# cluster_1_D1_policy.yaml (archetype_R_frame_atr_mult: 3.0, pre/post-t SL
+# multipliers 2.0/3.0, MFE-lock at 1.0, trail 0.75 from new high).
+ARC4_C1_KW = dict(
+    archetype_sl_r=1.0,
+    r_in_atr=3.0,
+    mfe_lock_r=1.0,
+    trail_from_high_r=0.75,
+)
+
+
+def _entry_features_finite() -> dict[str, float]:
+    return {
+        "body_to_range_ratio": 0.6,
+        "upper_wick_ratio": 0.2,
+        "lower_wick_ratio": 0.2,
+        "range_to_atr_14": 1.1,
+        "ret_5bar_atr": 0.3,
+        "ret_20bar_atr": 0.5,
+        "pos_in_20bar_range": 0.7,
+        "rsi_14": 60.0,
+    }
+
+
+def _bar_path(close_rs: list[float]) -> list[dict[str, float]]:
+    """v1.3 bar_path rows with running mfe/mae over close_r ± 0.1.
+
+    bar_offset starts at 0 and increments.
+    """
+    rows: list[dict[str, float]] = []
+    mfe = -np.inf
+    mae = np.inf
+    for k, cr in enumerate(close_rs):
+        hr = float(cr) + 0.1
+        lr = float(cr) - 0.1
+        mfe = max(mfe, hr)
+        mae = min(mae, lr)
+        rows.append(
+            {
+                "bar_offset": k,
+                "high_r": hr,
+                "low_r": lr,
+                "close_r": float(cr),
+                "mfe_so_far_r": float(mfe),
+                "mae_so_far_r": float(mae),
+                "is_held": 1,
+            }
+        )
+    return rows
+
+
+def _new_trade(
+    entry_px: float = 1.0,
+    atr: float = 0.01,
+    direction: str = "long",
+    bar_path: list[dict[str, float]] | None = None,
+) -> dict[str, Any]:
+    pre_t_sl = entry_px - 2.0 * atr if direction == "long" else entry_px + 2.0 * atr
+    return {
+        "entry_idx": 0,
+        "entry_px": entry_px,
+        "atr": atr,
+        "sl_px": pre_t_sl,
+        "signal_direction": direction,
+        "bar_path": bar_path if bar_path is not None else _bar_path([0.0]),
+        "entry_features": _entry_features_finite(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. StepwiseClimberPolicy.apply_at_accept.
+# ---------------------------------------------------------------------------
+
+
+class TestApplyAtAccept:
+    def test_long_replaces_pre_t_sl_with_archetype_sl(self):
+        """SL replaces pre-t 2×ATR with entry − archetype_sl_r × r_in_atr × ATR."""
+        policy = StepwiseClimberPolicy(**ARC4_C1_KW)
+        trade = _new_trade(entry_px=1.0, atr=0.01, direction="long")
+        # Pre-t SL is at entry − 2 × ATR = 1.0 − 0.02 = 0.98.
+        assert trade["sl_px"] == pytest.approx(0.98)
+        policy.apply_at_accept(trade, entry_px=1.0, atr_at_entry=0.01)
+        # Cluster 1: SL = entry − 1.0 × 3.0 × ATR = entry − 3 × ATR = 0.97.
+        assert trade["sl_px"] == pytest.approx(0.97)
+        assert trade["mfe_lock_fired_bar"] is None
+
+    def test_short_replaces_pre_t_sl_with_archetype_sl(self):
+        policy = StepwiseClimberPolicy(**ARC4_C1_KW)
+        trade = _new_trade(entry_px=1.0, atr=0.01, direction="short")
+        # Pre-t SL short = entry + 2 × ATR = 1.02.
+        assert trade["sl_px"] == pytest.approx(1.02)
+        policy.apply_at_accept(trade, entry_px=1.0, atr_at_entry=0.01)
+        # Short: SL = entry + 3 × ATR = 1.03.
+        assert trade["sl_px"] == pytest.approx(1.03)
+
+
+# ---------------------------------------------------------------------------
+# 2. StepwiseClimberPolicy.update_per_bar — MFE-lock + trail dynamics.
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePerBar:
+    def _bootstrap(
+        self, mfe_so_far_r_list: list[float], direction: str = "long"
+    ) -> tuple[StepwiseClimberPolicy, dict[str, Any]]:
+        policy = StepwiseClimberPolicy(**ARC4_C1_KW)
+        trade = _new_trade(direction=direction)
+        policy.apply_at_accept(trade, entry_px=1.0, atr_at_entry=0.01)
+        # Replace the trade's bar_path with a synthetic path whose
+        # mfe_so_far_r matches the test's expected MFE trajectory at
+        # each bar.
+        rows: list[dict[str, float]] = []
+        for k, mfe_r in enumerate(mfe_so_far_r_list):
+            rows.append(
+                {
+                    "bar_offset": k + 1,
+                    "high_r": float(mfe_r),
+                    "low_r": -0.5,
+                    "close_r": float(mfe_r) - 0.1,
+                    "mfe_so_far_r": float(mfe_r),
+                    "mae_so_far_r": -0.5,
+                    "is_held": 1,
+                }
+            )
+        trade["bar_path"] = rows
+        return policy, trade
+
+    def test_before_lock_low_mfe_keeps_post_t_sl(self):
+        """MFE < 1R and on the same bar as accept (no prior bar after
+        accept) → trail doesn't fire yet, SL stays at the post-t value.
+        """
+        policy, trade = self._bootstrap([0.3])
+        policy.update_per_bar(
+            trade, trade["bar_path"][0], entry_px=1.0, atr_at_entry=0.01
+        )
+        # mfe = 0.3 R < mfe_lock_r → lock did not fire; trail doesn't
+        # operate before lock either (per spec). SL stays at the
+        # archetype's post-t value (entry − 3 × ATR).
+        assert trade["sl_px"] == pytest.approx(0.97)
+        assert trade["mfe_lock_fired_bar"] is None
+
+    def test_lock_fires_at_one_r(self):
+        """First bar with MFE ≥ 1R: SL jumps to entry (BE); trail does
+        not apply on the lock-fire bar itself.
+        """
+        policy, trade = self._bootstrap([1.0])
+        policy.update_per_bar(
+            trade, trade["bar_path"][0], entry_px=1.0, atr_at_entry=0.01
+        )
+        assert trade["mfe_lock_fired_bar"] == 1
+        assert trade["sl_px"] == pytest.approx(1.0)  # BE
+
+    def test_lock_doesnt_reverse_on_subsequent_drawdown(self):
+        """Once lock fires, dropping back below 1R doesn't reset SL.
+
+        mfe_so_far_r is monotonic (running max), but close_r can dip
+        below entry post-peak. The lock persists.
+        """
+        policy, trade = self._bootstrap([1.0, 1.0])
+        # First bar: lock fires.
+        policy.update_per_bar(
+            trade, trade["bar_path"][0], entry_px=1.0, atr_at_entry=0.01
+        )
+        # Second bar: same MFE peak, but close_r could be very low.
+        # Engineer a row with close_r = -1.5 R, but mfe_so_far_r stays 1.0.
+        trade["bar_path"][1]["close_r"] = -1.5
+        policy.update_per_bar(
+            trade, trade["bar_path"][1], entry_px=1.0, atr_at_entry=0.01
+        )
+        # On the bar AFTER the lock fire, trail kicks in:
+        # trail_stop = entry + (1.0 - 0.75) × R = entry + 0.25 R = 1.0075.
+        # SL ratchets max(1.0, 1.0075) = 1.0075. SL never falls.
+        assert trade["sl_px"] == pytest.approx(1.0 + 0.25 * 3.0 * 0.01)
+        assert trade["mfe_lock_fired_bar"] == 1  # unchanged
+
+    def test_trail_overtakes_be_at_high_mfe(self):
+        """At MFE = 1.75 R (post-lock bar), trail_stop = entry + 1.0 R.
+        At MFE = 2.0 R, trail = entry + 1.25 R. SL ratchets up.
+        """
+        policy, trade = self._bootstrap([1.0, 1.75, 2.0])
+        policy.update_per_bar(
+            trade, trade["bar_path"][0], entry_px=1.0, atr_at_entry=0.01
+        )
+        policy.update_per_bar(
+            trade, trade["bar_path"][1], entry_px=1.0, atr_at_entry=0.01
+        )
+        # MFE = 1.75 → trail = entry + (1.75 − 0.75) × 3 × ATR = entry + 1.0 × 0.03 = 1.03.
+        assert trade["sl_px"] == pytest.approx(1.03)
+        policy.update_per_bar(
+            trade, trade["bar_path"][2], entry_px=1.0, atr_at_entry=0.01
+        )
+        # MFE = 2.0 → trail = entry + (2.0 − 0.75) × 3 × ATR = entry + 1.25 × 0.03 = 1.0375.
+        assert trade["sl_px"] == pytest.approx(1.0375)
+
+    def test_worked_example_arc4_c1_trajectory(self):
+        """Spec worked example, verbatim: pre-t → accept → lock → 2R → 3R.
+
+        Arc 4 cluster 1 long with entry = 1.0, ATR = 0.01 (R = 0.03).
+        Expected SL at each stage:
+
+        * pre-t:  entry − 2 × ATR = 0.98
+        * accept: entry − 3 × ATR = 0.97
+        * lock @ MFE=1R: entry (BE) = 1.00
+        * MFE=2R (post-lock): entry + (2 − 0.75) × R = entry + 1.25R = 1.0375
+        * MFE=3R (post-lock): entry + (3 − 0.75) × R = entry + 2.25R = 1.0675
+        """
+        policy = StepwiseClimberPolicy(**ARC4_C1_KW)
+        trade = _new_trade(entry_px=1.0, atr=0.01, direction="long")
+        # 1) pre-t SL (engine-set, before policy installs)
+        assert trade["sl_px"] == pytest.approx(0.98)
+        # 2) accept
+        policy.apply_at_accept(trade, entry_px=1.0, atr_at_entry=0.01)
+        assert trade["sl_px"] == pytest.approx(0.97)
+        # Build a 3-bar post-accept path: MFE = 1.0, 2.0, 3.0.
+        rows = [
+            {
+                "bar_offset": k + 1, "high_r": v, "low_r": -0.5, "close_r": v - 0.1,
+                "mfe_so_far_r": v, "mae_so_far_r": -0.5, "is_held": 1,
+            }
+            for k, v in enumerate([1.0, 2.0, 3.0])
+        ]
+        trade["bar_path"] = rows
+        # 3) lock
+        policy.update_per_bar(trade, rows[0], entry_px=1.0, atr_at_entry=0.01)
+        assert trade["sl_px"] == pytest.approx(1.00)
+        # 4) MFE = 2R (post-lock — trail active)
+        policy.update_per_bar(trade, rows[1], entry_px=1.0, atr_at_entry=0.01)
+        assert trade["sl_px"] == pytest.approx(1.0375)
+        # 5) MFE = 3R
+        policy.update_per_bar(trade, rows[2], entry_px=1.0, atr_at_entry=0.01)
+        assert trade["sl_px"] == pytest.approx(1.0675)
+
+    def test_short_direction_mirrors_long(self):
+        """Short trades: BE-lock pulls SL DOWN to entry; trail pulls SL
+        DOWN as MFE grows.
+        """
+        policy = StepwiseClimberPolicy(**ARC4_C1_KW)
+        trade = _new_trade(entry_px=1.0, atr=0.01, direction="short")
+        policy.apply_at_accept(trade, entry_px=1.0, atr_at_entry=0.01)
+        # Short post-t SL = entry + 3 × ATR = 1.03.
+        assert trade["sl_px"] == pytest.approx(1.03)
+        rows = [
+            {
+                "bar_offset": k + 1, "high_r": -0.5, "low_r": -v, "close_r": -(v - 0.1),
+                "mfe_so_far_r": v, "mae_so_far_r": -0.5, "is_held": 1,
+            }
+            for k, v in enumerate([1.0, 2.0])
+        ]
+        trade["bar_path"] = rows
+        policy.update_per_bar(trade, rows[0], entry_px=1.0, atr_at_entry=0.01)
+        # Short lock: SL = min(1.03, 1.0) = 1.0.
+        assert trade["sl_px"] == pytest.approx(1.0)
+        policy.update_per_bar(trade, rows[1], entry_px=1.0, atr_at_entry=0.01)
+        # Short trail at MFE=2R: SL = entry − (2 − 0.75) × R = 1 − 0.0375 = 0.9625.
+        assert trade["sl_px"] == pytest.approx(0.9625)
+
+    def test_sl_only_ratchets_never_loosens(self):
+        """SL never moves AWAY from price — trail dipping wouldn't lower
+        the SL once it has been pulled tighter.
+        """
+        policy, trade = self._bootstrap([1.0, 2.0])
+        policy.update_per_bar(
+            trade, trade["bar_path"][0], entry_px=1.0, atr_at_entry=0.01
+        )
+        policy.update_per_bar(
+            trade, trade["bar_path"][1], entry_px=1.0, atr_at_entry=0.01
+        )
+        # SL is at entry + 1.25 R = 1.0375 after MFE=2 bar.
+        peak_sl = trade["sl_px"]
+        # Now feed a bar where mfe_so_far_r is still 2.0 (it's a running
+        # max) but the engine called update_per_bar again — SL must not
+        # loosen.
+        trade["bar_path"].append(
+            {
+                "bar_offset": 3, "high_r": 0.5, "low_r": -0.5, "close_r": 0.0,
+                "mfe_so_far_r": 2.0, "mae_so_far_r": -0.5, "is_held": 1,
+            }
+        )
+        policy.update_per_bar(
+            trade, trade["bar_path"][2], entry_px=1.0, atr_at_entry=0.01
+        )
+        assert trade["sl_px"] == pytest.approx(peak_sl)
+
+
+# ---------------------------------------------------------------------------
+# 3. build_exit_policy factory.
+# ---------------------------------------------------------------------------
+
+
+class TestBuildExitPolicy:
+    def test_stepwise_climber_factory(self):
+        spec = {
+            "type": "stepwise_climber",
+            "archetype_sl_r": 1.0,
+            "r_in_atr": 3.0,
+            "mfe_lock_r": 1.0,
+            "trail_from_high_r": 0.75,
+        }
+        policy = build_exit_policy(spec)
+        assert isinstance(policy, StepwiseClimberPolicy)
+        assert policy.archetype_sl_r == 1.0
+        assert policy.r_in_atr == 3.0
+        assert policy.mfe_lock_r == 1.0
+        assert policy.trail_from_high_r == 0.75
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(ValueError, match="unknown exit_policy type"):
+            build_exit_policy({"type": "made_up_policy"})
+
+    def test_missing_type_raises(self):
+        with pytest.raises(ValueError, match="missing 'type'"):
+            build_exit_policy({"archetype_sl_r": 1.0})
+
+
+# ---------------------------------------------------------------------------
+# 4. Per-fold classifier dispatch (integration).
+# ---------------------------------------------------------------------------
+
+
+class _ConstantClassifier:
+    """``predict_proba`` returns a fixed P regardless of features."""
+
+    def __init__(self, n_features: int, p: float):
+        self.n_features_in_ = n_features
+        self._p = float(p)
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        X = np.asarray(X)
+        out = np.zeros((X.shape[0], 2), dtype=np.float64)
+        out[:, 1] = self._p
+        out[:, 0] = 1.0 - self._p
+        return out
+
+
+def _make_per_fold_hook(
+    p_by_fold: dict[str, float], t: int = 1, threshold: float = 0.1647
+) -> D1Hook:
+    order = list(ALL_FEATURE_KEYS)
+    per_fold = {
+        fold: _ConstantClassifier(len(order), p)
+        for fold, p in p_by_fold.items()
+    }
+    arch = D1ArchetypeConfig(
+        label="stepwise_climber_arc4_cluster1",
+        feature_order=tuple(order),
+        decision_threshold=threshold,
+        bar_offset_t=t,
+        per_fold_classifiers=per_fold,
+        exit_policy=StepwiseClimberPolicy(**ARC4_C1_KW),
+    )
+    return D1Hook([arch])
+
+
+class TestPerFoldDispatch:
+    def test_dispatch_picks_fold_specific_classifier(self):
+        """F3 classifier P=0.99 accepts; F2 classifier P=0.05 rejects.
+
+        A trade in F3 should be accepted (ApplyPolicy); a trade in F2
+        should be rejected (Close).
+        """
+        hook = _make_per_fold_hook({"F2": 0.05, "F3": 0.99})
+        path = _bar_path([0.0, 0.5])  # bars 0..1
+        # Trade in F3:
+        d_f3 = hook.evaluate(
+            trade={}, bar_path_so_far=path, entry_features=_entry_features_finite(),
+            t=1, cached={}, fold_id="F3",
+        )
+        assert isinstance(d_f3, ApplyPolicy)
+        # Trade in F2:
+        d_f2 = hook.evaluate(
+            trade={}, bar_path_so_far=path, entry_features=_entry_features_finite(),
+            t=1, cached={}, fold_id="F2",
+        )
+        assert isinstance(d_f2, Close)
+
+    def test_helper_passes_fold_id_through(self):
+        hook = _make_per_fold_hook({"F2": 0.05, "F3": 0.99})
+        cached = {"o": np.array([1.0, 1.01, 1.02])}
+        trade_f3 = _new_trade(bar_path=_bar_path([0.0, 0.5]))
+        out_f3 = apply_d1_hook_per_bar(
+            hook=hook, trade=trade_f3, j=1, entry_idx=0,
+            cached=cached, c_j=1.01, fold_id="F3",
+        )
+        assert out_f3 == (None, None, None)  # ApplyPolicy → no exit
+        assert trade_f3.get("d1_decision") == "apply_policy"
+        assert trade_f3.get("classifier_fold_id") == "F3"
+        assert isinstance(trade_f3.get("exit_policy"), StepwiseClimberPolicy)
+
+        trade_f2 = _new_trade(bar_path=_bar_path([0.0, 0.5]))
+        out_f2 = apply_d1_hook_per_bar(
+            hook=hook, trade=trade_f2, j=1, entry_idx=0,
+            cached=cached, c_j=1.01, fold_id="F2",
+        )
+        assert out_f2[2] == "d1_untradeable"  # Close
+        assert trade_f2.get("d1_decision") == "close"
+        assert trade_f2.get("classifier_fold_id") == "F2"
+
+    def test_unknown_fold_returns_hold(self):
+        """Trade in fold not present in per_fold_classifiers (e.g. Arc 4 F1)
+        → Hold → engine falls through to legacy cascade.
+        """
+        hook = _make_per_fold_hook({"F2": 0.99, "F3": 0.99})
+        cached = {"o": np.array([1.0, 1.01, 1.02])}
+        trade = _new_trade(bar_path=_bar_path([0.0, 0.5]))
+        out = apply_d1_hook_per_bar(
+            hook=hook, trade=trade, j=1, entry_idx=0,
+            cached=cached, c_j=1.01, fold_id="F1",
+        )
+        assert out == (None, None, None)
+        assert trade.get("d1_decision") == "no_d1"
+
+    def test_apply_policy_install_sets_audit_fields(self):
+        """Audit fields populated by helper survive in trade dict for
+        completed-trade record consumption.
+        """
+        hook = _make_per_fold_hook({"F3": 0.99})
+        cached = {"o": np.array([1.0, 1.01, 1.02])}
+        trade = _new_trade(bar_path=_bar_path([0.0, 0.5]))
+        apply_d1_hook_per_bar(
+            hook=hook, trade=trade, j=1, entry_idx=0,
+            cached=cached, c_j=1.01, fold_id="F3",
+        )
+        assert trade["mfe_lock_fired_bar"] is None  # not yet fired
+        assert trade["trail_active_from_bar"] is not None
+        assert trade["d1_archetype_label"] == "stepwise_climber_arc4_cluster1"
+        assert trade["d1_probability"] == pytest.approx(0.99)
+
+
+# ---------------------------------------------------------------------------
+# 5. Reject branch: Close decision installs no policy.
+# ---------------------------------------------------------------------------
+
+
+class TestRejectBranch:
+    def test_close_does_not_install_policy(self):
+        """Verify Close (rejection) leaves the trade's exit_policy unset
+        — preserving PR 1 behaviour for trades that fail the gate.
+        """
+        hook = _make_per_fold_hook({"F2": 0.05})
+        cached = {"o": np.array([1.0, 1.01, 1.02])}
+        trade = _new_trade(bar_path=_bar_path([0.0, 0.5]))
+        out = apply_d1_hook_per_bar(
+            hook=hook, trade=trade, j=1, entry_idx=0,
+            cached=cached, c_j=1.01, fold_id="F2",
+        )
+        assert out[2] == "d1_untradeable"
+        # No exit_policy key was added.
+        assert "exit_policy" not in trade or trade["exit_policy"] is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Determinism — two-run byte-identity of a stub end-to-end run.
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_two_run_byte_identical(self):
+        """Two identical hook invocations on the same trade dict yield
+        identical SL trajectories. Catches accidental float drift or
+        nondeterministic policy ordering.
+        """
+        hook = _make_per_fold_hook({"F3": 0.99})
+        cached = {"o": np.array([1.0, 1.01, 1.02, 1.03, 1.04])}
+
+        def simulate() -> list[float]:
+            trade = _new_trade(bar_path=_bar_path([0.0, 0.5]))
+            apply_d1_hook_per_bar(
+                hook=hook, trade=trade, j=1, entry_idx=0,
+                cached=cached, c_j=1.01, fold_id="F3",
+            )
+            # Run two post-accept bars with MFE = 1.5, 2.5.
+            sls: list[float] = [trade["sl_px"]]
+            for bar_idx, mfe in enumerate([1.5, 2.5], start=2):
+                row = {
+                    "bar_offset": bar_idx, "high_r": mfe, "low_r": -0.5,
+                    "close_r": mfe - 0.1, "mfe_so_far_r": mfe, "mae_so_far_r": -0.5,
+                    "is_held": 1,
+                }
+                trade["bar_path"].append(row)
+                trade["exit_policy"].update_per_bar(
+                    trade, row, entry_px=trade["entry_px"], atr_at_entry=trade["atr"],
+                )
+                sls.append(trade["sl_px"])
+            return sls
+
+        run1 = simulate()
+        run2 = simulate()
+        assert run1 == run2
+
+
+# ---------------------------------------------------------------------------
+# 7. Engine-patch static contract (PR 2 patch points exist).
+# ---------------------------------------------------------------------------
+
+
+class TestEnginePatchPR2:
+    def test_fold_id_helper_present(self):
+        from pathlib import Path
+
+        engine_src = (Path(__file__).resolve().parents[1]
+                      / "scripts" / "phase_kgl_v2_4h_wfo.py").read_text(
+            encoding="utf-8"
+        )
+        assert "def _fold_id_for_entry" in engine_src
+        assert "f\"F{int(f['fold'])}\"" in engine_src
+
+    def test_engine_imports_exit_policies(self):
+        from pathlib import Path
+
+        engine_src = (Path(__file__).resolve().parents[1]
+                      / "scripts" / "phase_kgl_v2_4h_wfo.py").read_text(
+            encoding="utf-8"
+        )
+        # Indirect — core.d1_pipeline re-exports nothing from
+        # exit_policies, so the engine doesn't need to import the policy
+        # module directly. It accesses the policy via trade["exit_policy"].
+        # Just check that the per-bar update line is wired.
+        assert 'trade["exit_policy"].update_per_bar' in engine_src
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_exit_policies.py
+++ b/tests/test_exit_policies.py
@@ -179,15 +179,20 @@ class TestUpdatePerBar:
         assert trade["mfe_lock_fired_bar"] is None
 
     def test_lock_fires_at_one_r(self):
-        """First bar with MFE ≥ 1R: SL jumps to entry (BE); trail does
-        not apply on the lock-fire bar itself.
+        """First bar with MFE ≥ 1R: lock fires AND trail arms same-bar.
+
+        Effective SL = max(post-t SL, BE, trail_stop). With MFE = 1R:
+        trail = entry + (1.0 − 0.75) × R = entry + 0.25R. max(entry-3R,
+        entry, entry+0.25R) = entry + 0.25R. Matches Step 5 simulator
+        (`scripts/l_arc_4/step5_stability.py:294-298`).
         """
         policy, trade = self._bootstrap([1.0])
         policy.update_per_bar(
             trade, trade["bar_path"][0], entry_px=1.0, atr_at_entry=0.01
         )
         assert trade["mfe_lock_fired_bar"] == 1
-        assert trade["sl_px"] == pytest.approx(1.0)  # BE
+        # Trail at MFE=1R = entry + 0.25R = 1.0 + 0.0075.
+        assert trade["sl_px"] == pytest.approx(1.0 + 0.25 * 3.0 * 0.01)
 
     def test_lock_doesnt_reverse_on_subsequent_drawdown(self):
         """Once lock fires, dropping back below 1R doesn't reset SL.
@@ -232,16 +237,16 @@ class TestUpdatePerBar:
         assert trade["sl_px"] == pytest.approx(1.0375)
 
     def test_worked_example_arc4_c1_trajectory(self):
-        """Spec worked example, verbatim: pre-t → accept → lock → 2R → 3R.
+        """Spec worked example: pre-t → accept → lock → 2R → 3R.
 
         Arc 4 cluster 1 long with entry = 1.0, ATR = 0.01 (R = 0.03).
-        Expected SL at each stage:
+        Matches Step 5 simulator's same-bar trail-arm semantics:
 
         * pre-t:  entry − 2 × ATR = 0.98
         * accept: entry − 3 × ATR = 0.97
-        * lock @ MFE=1R: entry (BE) = 1.00
-        * MFE=2R (post-lock): entry + (2 − 0.75) × R = entry + 1.25R = 1.0375
-        * MFE=3R (post-lock): entry + (3 − 0.75) × R = entry + 2.25R = 1.0675
+        * lock @ MFE=1R (same-bar trail): entry + 0.25R = 1.0075
+        * MFE=2R: entry + (2 − 0.75) × R = entry + 1.25R = 1.0375
+        * MFE=3R: entry + (3 − 0.75) × R = entry + 2.25R = 1.0675
         """
         policy = StepwiseClimberPolicy(**ARC4_C1_KW)
         trade = _new_trade(entry_px=1.0, atr=0.01, direction="long")
@@ -259,10 +264,10 @@ class TestUpdatePerBar:
             for k, v in enumerate([1.0, 2.0, 3.0])
         ]
         trade["bar_path"] = rows
-        # 3) lock
+        # 3) lock fires + trail arms same-bar
         policy.update_per_bar(trade, rows[0], entry_px=1.0, atr_at_entry=0.01)
-        assert trade["sl_px"] == pytest.approx(1.00)
-        # 4) MFE = 2R (post-lock — trail active)
+        assert trade["sl_px"] == pytest.approx(1.0075)
+        # 4) MFE = 2R
         policy.update_per_bar(trade, rows[1], entry_px=1.0, atr_at_entry=0.01)
         assert trade["sl_px"] == pytest.approx(1.0375)
         # 5) MFE = 3R
@@ -270,8 +275,8 @@ class TestUpdatePerBar:
         assert trade["sl_px"] == pytest.approx(1.0675)
 
     def test_short_direction_mirrors_long(self):
-        """Short trades: BE-lock pulls SL DOWN to entry; trail pulls SL
-        DOWN as MFE grows.
+        """Short trades: BE ceiling at entry, trail pulls SL DOWN as MFE
+        grows. Same-bar trail-arm semantics mirrored from long.
         """
         policy = StepwiseClimberPolicy(**ARC4_C1_KW)
         trade = _new_trade(entry_px=1.0, atr=0.01, direction="short")
@@ -287,8 +292,10 @@ class TestUpdatePerBar:
         ]
         trade["bar_path"] = rows
         policy.update_per_bar(trade, rows[0], entry_px=1.0, atr_at_entry=0.01)
-        # Short lock: SL = min(1.03, 1.0) = 1.0.
-        assert trade["sl_px"] == pytest.approx(1.0)
+        # Short lock fires + trail same-bar at MFE=1R:
+        # trail = entry − (1 − 0.75) × R = 1 − 0.0075 = 0.9925.
+        # SL = min(1.03, 1.0, 0.9925) = 0.9925.
+        assert trade["sl_px"] == pytest.approx(0.9925)
         policy.update_per_bar(trade, rows[1], entry_px=1.0, atr_at_entry=0.01)
         # Short trail at MFE=2R: SL = entry − (2 − 0.75) × R = 1 − 0.0375 = 0.9625.
         assert trade["sl_px"] == pytest.approx(0.9625)


### PR DESCRIPTION
﻿## Summary

PR 2 of the Pipeline D1 backtester extension. Implements `L_ARC_PROTOCOL` v2.0 §3 + §11 row 2 ("Stepwise climber"). Builds on [#131](https://github.com/kpanapabusiness-droid/Forex-Backtester/pull/131) (PR 1 — plumbing + close-at-market). Concrete consumer: Arc 4 cluster 1 (see [Arc 4 Step 4 verdict](results/l_arc_4/step4/cluster_1_D1_policy.yaml)).

- New module `core/exit_policies.py` with `ExitPolicy` ABC + `StepwiseClimberPolicy` (§11 row 2): post-t SL = entry − `archetype_sl_r × r_in_atr × ATR`, MFE-lock at MFE = 1R, monotone trail = entry + (mfe − `trail_from_high_r`) × R. Trail arms AND is used in the same-bar SL check on the lock-fire bar — `effective_sl = max(current_sl, entry, trail_stop)` for longs (min for shorts), matching the Step 5 simulator's same-bar semantics ([`scripts/l_arc_4/step5_stability.py:269-318`](scripts/l_arc_4/step5_stability.py#L269-L318)).
- `core.d1_pipeline.ApplyPolicy` now carries the winning archetype's `ExitPolicy`. `D1ArchetypeConfig` replaces the single classifier with `per_fold_classifiers: dict[fold_id → classifier|path]` plus an `exit_policy` block. `D1Hook.evaluate(...)` takes a `fold_id`; trades whose fold is absent from `per_fold_classifiers` return `Hold` (used to skip Arc 4 F1, which has no pre-OOS training data). PR 1 single-classifier YAML fails loud with a clear migration error.
- Engine patch (`scripts/phase_kgl_v2_4h_wfo.py`): new `_fold_id_for_entry(ts)` helper tags each trade at open; `apply_d1_hook_per_bar` call threads `fold_id`; per-bar `policy.update_per_bar(...)` ratchets SL on every bar after accept (before the Priority-1 SL check); completed-trade record gains `d1_decision`, `classifier_fold_id`, `mfe_lock_fired_bar`, `trail_active_from_bar`, `d1_archetype_label`, `d1_probability` columns gated on `D1_HOOK is not None` so KH-24 baseline runs write a byte-identical `trades_all.csv`.

## Test plan

- [x] `tests/test_exit_policies.py` — 20 tests: apply_at_accept (long + short), MFE-lock semantics (fires once, doesn't reverse), trail overtakes BE at high MFE, worked example verbatim (pre-t → accept → lock → MFE=2R → MFE=3R), per-fold dispatch, ApplyPolicy / Close / Hold branches, two-run determinism, engine-patch static contract.
- [x] `tests/test_d1_pipeline.py` migrated to the PR 2 schema (52 tests still pass; PR 1 YAML schema now asserted to raise).
- [x] `ruff check` clean on all PR 2 files.
- [x] Full `pytest -m "not research"` suite passes (1096 passed, 20 skipped, 7 deselected) with PR 2 compiled in.
- [ ] End-to-end Arc 4 WFO run — blocked on producing per-fold refit joblibs (see "Outstanding for downstream consumers" below). PR 2's automated tests are fully self-contained via stub classifiers.

## Step 5 simulator alignment

The Step 5 simulator at [`scripts/l_arc_4/step5_stability.py:269-318`](scripts/l_arc_4/step5_stability.py#L269-L318) is the validated reference for §11 row 2 semantics. Its per-bar order is:

1. Update MFE from bar **high**.
2. If MFE crosses 1R → lock fires AND trail arms in the same bar (`trail_stop = entry + (mfe − 0.75) × R`).
3. If trail active and new MFE high → ratchet `trail_stop` upward.
4. `effective_sl = max(current_sl, trail_stop)` if trail active, else `current_sl`.
5. SL check uses bar **low** against `effective_sl`.
6. End-of-bar: ratchet `current_sl` up to `trail_stop`.

PR 2's `StepwiseClimberPolicy.update_per_bar` is aligned to this:

- The trail is computed every bar once the lock has fired, including the lock-fire bar itself (no suppression).
- Trade SL = `max(current_sl, entry, trail_stop)` post-lock (min for shorts) — same as Step 5's `effective_sl` plus the BE floor (which Step 5 reaches via end-of-bar ratchet on the lock-fire bar).
- At MFE = 1R lock-fire, SL = entry + 0.25R — verified by `test_lock_fires_at_one_r` and the verbatim worked-example test.

**Engine intra-bar order — MFE-first, confirmed.** The engine's bar_path append at [`scripts/phase_kgl_v2_4h_wfo.py:1305-1322`](scripts/phase_kgl_v2_4h_wfo.py#L1305-L1322) updates `mfe_so_far_r` from bar high *before* the D1 hook block and *before* the Priority-1 SL check (which uses bar low). So `policy.update_per_bar` reads the same-bar high-derived `mfe_so_far_r`, mutates `sl_px`, and the subsequent SL check uses the ratcheted SL against the bar's low. Matches Step 5's high-before-low convention.

## Q-CC-1 — hourly mark-to-market DD (convention b)

**NOT computed in the engine.** `_oos_metrics` at [`scripts/phase_kgl_v2_4h_wfo.py:2609-2612`](scripts/phase_kgl_v2_4h_wfo.py#L2609-L2612) builds the DD series from per-trade `net_pnl` (trade-close events only):

```python
equity += t["net_pnl"]
peak    = max(peak, equity)
dd      = (peak - equity) / peak * 100.0
max_dd  = max(max_dd, dd)
```

The Step 5 post-hoc simulator at [`scripts/l_arc_4/step5_stability.py:439-443`](scripts/l_arc_4/step5_stability.py#L439-L443) is the same model — `np.cumsum(per_trade_pct)` over trade-close records.

The **only** place hourly MTM DD is computed is the side-script [`scripts/l_arc_4/step5b_risk_sweep.py:158`](scripts/l_arc_4/step5b_risk_sweep.py#L158) (`compute_convention_b_dd_per_fold`), which is a one-off comparison tool, not part of the WFO fold report.

**Flag**: Step 6 needs (b) reporting addition — out of PR 2 scope, separate engine PR.

## Q-CC-2 — daily DD (5ers 5% hard limit)

**NOT tracked anywhere.** There is no date-bucketing of PnL in either the engine or any of the simulator scripts. `_oos_metrics` produces a single max-DD number per fold from trade-close events; nothing groups losses by calendar day to compare against the 5ers 5% daily-loss hard limit.

**Flag**: Step 6 needs daily-DD tracking — out of PR 2 scope, separate engine PR.

## Outstanding for downstream consumers

**Per-fold refit joblibs do not exist on disk.** `scripts/l_arc_4/step5c_refit.py` trains the per-fold classifiers in-memory and reports metrics (see [`results/l_arc_4/step5c/per_fold_refit_classifier_metrics.csv`](results/l_arc_4/step5c/per_fold_refit_classifier_metrics.csv) — F2 OOS AUC 0.6897, F3 0.6773, F4 0.6484, F5 0.6668, F6 0.6583, F7 0.6604; F1 untrainable, training_n = 0) but does not `joblib.dump(...)` the models. A one-time refit-and-dump script must produce:

```
artefacts/arc_4/refit_classifiers/fold_2.joblib
artefacts/arc_4/refit_classifiers/fold_3.joblib
artefacts/arc_4/refit_classifiers/fold_4.joblib
artefacts/arc_4/refit_classifiers/fold_5.joblib
artefacts/arc_4/refit_classifiers/fold_6.joblib
artefacts/arc_4/refit_classifiers/fold_7.joblib
```

before Arc 4 can run end-to-end through the engine. F1 is intentionally omitted — F1 trades fall through to the legacy cascade (`Hold` decision). PR 2's test suite uses stub classifiers and is fully self-contained, so the joblib production is a Step 6 operational prerequisite, not a PR 2 merge blocker.

YAML schema for the Arc 4 cluster 1 config block (consumes the above joblibs):

```yaml
d1_archetypes:
  - label: stepwise_climber_arc4_cluster1
    bar_offset_t: 1
    decision_threshold: 0.1647
    feature_order: [body_to_range_ratio, upper_wick_ratio, lower_wick_ratio,
                    range_to_atr_14, ret_5bar_atr, ret_20bar_atr,
                    pos_in_20bar_range, rsi_14,
                    close_r_at_t, mfe_so_far_r_at_t, mae_so_far_r_at_t,
                    bars_in_profit_at_t, local_peaks_so_far_at_t,
                    monotonicity_so_far_at_t, velocity_first_t]
    per_fold_classifiers:
      F2: artefacts/arc_4/refit_classifiers/fold_2.joblib
      F3: artefacts/arc_4/refit_classifiers/fold_3.joblib
      F4: artefacts/arc_4/refit_classifiers/fold_4.joblib
      F5: artefacts/arc_4/refit_classifiers/fold_5.joblib
      F6: artefacts/arc_4/refit_classifiers/fold_6.joblib
      F7: artefacts/arc_4/refit_classifiers/fold_7.joblib
    exit_policy:
      type: stepwise_climber
      archetype_sl_r: 1.0
      r_in_atr: 3.0
      mfe_lock_r: 1.0
      trail_from_high_r: 0.75
```

## References

- [`L_ARC_PROTOCOL.md`](L_ARC_PROTOCOL.md) §3 (Pipeline D1), §11 row 2 (Stepwise climber).
- [#131](https://github.com/kpanapabusiness-droid/Forex-Backtester/pull/131) (PR 1 — plumbing + close-at-market).
- Arc 4 Step 4 verdict — [results/l_arc_4/step4/cluster_1_D1_policy.yaml](results/l_arc_4/step4/cluster_1_D1_policy.yaml).
- Step 5C diagnostics — [results/l_arc_4/step5c/step5c_diagnostics.md](results/l_arc_4/step5c/step5c_diagnostics.md).

## Out of scope

- `configs/wfo_kh24.yaml`, `configs/spread_floors_5ers.yaml`, `signals/kb_exhaustion_bar.py`, and any KH-24 path — unchanged. `D1_HOOK = None` keeps KH-24 byte-identical.
- Other `§11` rows (V-bottom carry, parabolic blow-off, etc.) — deferred per the "wait for concrete consumer" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

