### PR TITLE
feat: engine generalisation — signal adapter, timeframe, time-exit, spread-floor

### DIFF
--- a/configs/wfo_kh24.yaml
+++ b/configs/wfo_kh24.yaml
@@ -13,6 +13,16 @@ description: "4H WFO — exposure cap=2 + 1H close-in-range filter T=0.28, 1% ri
 timeframe: "H4"
 data_dir: "data/4hr"
 
+# Signal timeframe + data block (engine-generalisation PR). For KH-24 these
+# resolve to the same paths the engine used pre-PR; for new arcs the signal
+# timeframe is configurable here.
+signal_tf: "H4"
+data:
+  signal_tf_dir: "data/4hr"
+  aux:
+    h1: "data/1hr"
+    d1: "data/daily"
+
 pairs:
   - "AUD_CAD"
   - "AUD_CHF"
@@ -45,6 +55,14 @@ pairs:
 
 signal: kb_exhaustion_bar
 direction: long
+
+# Pluggable signal adapter (engine-generalisation PR). For KH-24 the adapter
+# delegates to the in-engine _build_signal_series helper so behaviour is
+# byte-identical to the pre-PR baseline. All KH-24 parameters continue to
+# come from indicator_params.kb_exhaustion_bar / top-level keys below — the
+# adapter itself takes no kwargs.
+signal_adapter: signals.kb_exhaustion_bar_adapter:KbExhaustionBarAdapter
+signal_adapter_kwargs: {}
 
 indicator_params:
   kb_exhaustion_bar:

--- a/core/signal_adapter.py
+++ b/core/signal_adapter.py
@@ -19,7 +19,10 @@ Contract:
   by the Pipeline D1 hook (see core/d1_pipeline.py).
 - ``per_trade_init(trade, df, idx, aux)``: stamp signal-specific fields
   onto the trade dict (e.g. KH-24's kh13_triggered/kh14_triggered/
-  first_bar_dir initial values).
+  first_bar_dir initial values). Called only from the primary entry
+  path. Adapters whose features must populate on re-entry paths need
+  to extend those paths separately — KH-24 re-entry / KH-17 paths
+  preserve inline init for byte-identity.
 """
 
 from __future__ import annotations

--- a/core/signal_adapter.py
+++ b/core/signal_adapter.py
@@ -1,0 +1,113 @@
+"""SignalAdapter protocol for engine signal pluggability.
+
+Used by scripts/phase_kgl_v2_4h_wfo.py to decouple the signal definition
+from the engine. Each L arc / system can supply its own adapter via
+``signal_adapter`` / ``signal_adapter_kwargs`` config keys.
+
+Contract:
+
+- ``required_aux_data()``: declares aux data keys ("h1", "d1") the engine
+  must load. Unknown keys are rejected loudly at startup.
+- ``compute_signal_mask(df, aux)``: returns ``(mask, extras)``. ``mask`` is
+  an int/bool array, length len(df), 1 at signal-bar close where an entry
+  should fire. ``extras`` is a dict of signal-specific cache data that the
+  engine merges into the per-pair cache (e.g. KH-24's d1_dist_ratio_by_bar).
+  Returning extras as part of the call (rather than a separate query) keeps
+  the cache build single-pass.
+- ``compute_signal_atr(df, idx, aux)``: 1R-anchor ATR at signal bar.
+- ``compute_entry_features(df, idx, aux)``: signal-bar feature dict consumed
+  by the Pipeline D1 hook (see core/d1_pipeline.py).
+- ``per_trade_init(trade, df, idx, aux)``: stamp signal-specific fields
+  onto the trade dict (e.g. KH-24's kh13_triggered/kh14_triggered/
+  first_bar_dir initial values).
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+import pandas as pd
+
+
+@runtime_checkable
+class SignalAdapter(Protocol):
+    """Minimal plug-in signal contract. See module docstring for shape."""
+
+    def required_aux_data(self) -> list[str]:
+        ...
+
+    def compute_signal_mask(
+        self,
+        df_signal_tf: pd.DataFrame,
+        aux: dict[str, Any],
+    ) -> tuple[np.ndarray, dict[str, Any]]:
+        ...
+
+    def compute_signal_atr(
+        self,
+        df_signal_tf: pd.DataFrame,
+        idx: int,
+        aux: dict[str, Any],
+    ) -> float:
+        ...
+
+    def compute_entry_features(
+        self,
+        df_signal_tf: pd.DataFrame,
+        idx: int,
+        aux: dict[str, Any],
+    ) -> dict[str, float]:
+        ...
+
+    def per_trade_init(
+        self,
+        trade: dict[str, Any],
+        df_signal_tf: pd.DataFrame,
+        idx: int,
+        aux: dict[str, Any],
+    ) -> None:
+        ...
+
+
+ALLOWED_AUX_KEYS: frozenset[str] = frozenset({"h1", "d1"})
+
+
+def import_class(spec: str) -> type:
+    """Load a class from a 'module.path:ClassName' spec string.
+
+    Fails loud at startup with a clear message if the module or class is
+    not importable — preferred over a silent fallback to a default adapter.
+    """
+    if not isinstance(spec, str) or ":" not in spec:
+        raise ImportError(
+            f"signal_adapter spec must be of form 'module.path:ClassName', "
+            f"got {spec!r}"
+        )
+    module_path, class_name = spec.split(":", 1)
+    module_path = module_path.strip()
+    class_name = class_name.strip()
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as e:
+        raise ImportError(
+            f"signal_adapter: cannot import module '{module_path}' "
+            f"(from spec '{spec}'): {e}"
+        ) from e
+    if not hasattr(module, class_name):
+        raise ImportError(
+            f"signal_adapter: class '{class_name}' not found in module "
+            f"'{module_path}' (from spec '{spec}')"
+        )
+    return getattr(module, class_name)
+
+
+def validate_aux_declaration(declared: list[str], spec: str) -> None:
+    """Ensure adapter-declared aux keys are within the recognised set."""
+    unknown = [k for k in declared if k not in ALLOWED_AUX_KEYS]
+    if unknown:
+        raise ValueError(
+            f"signal_adapter '{spec}' declared unknown aux keys: {unknown}. "
+            f"Allowed: {sorted(ALLOWED_AUX_KEYS)}"
+        )

--- a/scripts/phase_kgl_v2_4h_wfo.py
+++ b/scripts/phase_kgl_v2_4h_wfo.py
@@ -46,16 +46,75 @@ sys.path.insert(0, str(PROJECT_ROOT))
 os.chdir(PROJECT_ROOT)
 warnings.filterwarnings("ignore")
 
+# When this file is launched directly (``py scripts/phase_kgl_v2_4h_wfo.py``)
+# Python registers it as ``__main__``. Helpers in the signals package that
+# later do ``from scripts.phase_kgl_v2_4h_wfo import X`` would otherwise
+# import a second module copy with default globals — bypassing the cfg
+# overrides applied by main(). Aliasing __main__ to the package path keeps
+# globals (USE_C8, NO_VOLUME_FILTER, …) consistent across both lookups.
+if __name__ == "__main__":
+    sys.modules.setdefault("scripts.phase_kgl_v2_4h_wfo", sys.modules[__name__])
+
 from core.d1_pipeline import D1Hook, apply_d1_hook_per_bar  # noqa: E402
-from core.features_path_so_far import build_entry_features_at_signal_bar  # noqa: E402
+from core.signal_adapter import SignalAdapter, import_class, validate_aux_declaration  # noqa: E402
+from core.spread_floor import (  # noqa: E402
+    STATE_CFG_KEY,
+    apply_spread_floor_to_pips,
+    format_startup_log,
+    format_summary_log,
+    load_spread_floor,
+)
 from core.utils import get_pip_size, load_pair_csv  # noqa: E402
 from signals.kb_exhaustion_bar import _wilder_atr  # noqa: E402
 
+# Bag dict used to ferry the SpreadFloorState into apply_spread_floor_to_pips.
+# core/spread_floor.py expects a cfg-shaped dict with the state under
+# STATE_CFG_KEY. Engine populates this in main() from cfg.
+_SPREAD_FLOOR_BAG: dict = {}
+
+
+def _apply_spread_floor(pair: str, raw_pips: float) -> float:
+    return float(apply_spread_floor_to_pips(_SPREAD_FLOOR_BAG, pair, float(raw_pips)))
+
+# ── Signal adapter (set in main() from cfg) ──────────────────────────────────
+# None → caller must call _ensure_signal_adapter() before the pair cache build.
+# main() always sets this; tests that import the engine directly should too.
+SIGNAL_ADAPTER: "SignalAdapter | None" = None
+
+_DEFAULT_SIGNAL_ADAPTER_SPEC = "signals.kb_exhaustion_bar_adapter:KbExhaustionBarAdapter"
+
+
+def _ensure_signal_adapter() -> "SignalAdapter":
+    """Fallback to the KH-24 adapter when main() hasn't set one.
+
+    Keeps legacy direct imports (no config) byte-identical: KH-24 was the
+    only signal before this PR, so defaulting to its adapter matches the
+    pre-PR behaviour.
+    """
+    global SIGNAL_ADAPTER
+    if SIGNAL_ADAPTER is None:
+        adapter_cls = import_class(_DEFAULT_SIGNAL_ADAPTER_SPEC)
+        SIGNAL_ADAPTER = adapter_cls()
+        validate_aux_declaration(
+            SIGNAL_ADAPTER.required_aux_data(),
+            _DEFAULT_SIGNAL_ADAPTER_SPEC,
+        )
+    return SIGNAL_ADAPTER
+
 # ── Directories ───────────────────────────────────────────────────────────────
+# DATA_DIR_4H is retained by name for backward compatibility — it now stores
+# the signal-timeframe data directory regardless of timeframe. SIGNAL_TF holds
+# the textual label (e.g. "H4", "H1"). Both are cfg-overridable in main().
+SIGNAL_TF   = "H4"
 DATA_DIR_4H = PROJECT_ROOT / "data" / "4hr"
 D1_DATA_DIR = PROJECT_ROOT / "data" / "daily"
 H1_DATA_DIR = PROJECT_ROOT / "data" / "1hr"
 OUT_ROOT    = PROJECT_ROOT / "results" / "phase_kg" / "kg_l_v2"
+
+# PATH_FORWARD_BARS semantics: bars in the SIGNAL timeframe. At signal_tf=H4
+# this is 240 × 4h = 40 calendar days; at H1 it's 240 × 1h = 10 calendar days.
+# Documented here because the constant is defined below without timeframe
+# context.
 
 # ── D1 filter parameters ──────────────────────────────────────────────────────
 D1_REGIME_FILTER  = True
@@ -430,6 +489,12 @@ SIGNAL_DIRECTION = "long"  # "long" or "short" — set via config direction: sho
 # None preserves baseline byte-for-byte. Configured at run-start from the
 # top-level ``d1_archetypes`` YAML block. See core/d1_pipeline.py.
 D1_HOOK: "D1Hook | None" = None
+
+# ── Time-exit cap (engine-generalisation PR) ─────────────────────────────────
+# None disables; positive int = max bars from entry_idx before forcing an
+# exit at the NEXT bar's open (last-bar fallback: c_j on bar j). Fires at
+# the END of the exit cascade so any other exit wins on tie.
+TIME_EXIT_BARS: "int | None" = None
 
 # ── WFO configuration ─────────────────────────────────────────────────────────
 WFO_START       = datetime(2019, 1, 1)
@@ -1021,6 +1086,10 @@ def _build_pair_cache(pairs: list[str] | None = None) -> dict:
     target_pairs = pairs if pairs is not None else ALL_PAIRS
     pair_cache: dict[str, dict] = {}
 
+    adapter_aux = set(_ensure_signal_adapter().required_aux_data())
+    load_d1 = "d1" in adapter_aux
+    load_h1 = "h1" in adapter_aux
+
     for pair in target_pairs:
         try:
             df = load_pair_csv(pair, DATA_DIR_4H)
@@ -1028,8 +1097,8 @@ def _build_pair_cache(pairs: list[str] | None = None) -> dict:
             df = df.sort_values("date").reset_index(drop=True)
             if "volume" not in df.columns:
                 df["volume"] = 0.0
-            d1_filt = _load_d1_filter(pair) if D1_REGIME_FILTER else None
-            h1_df   = _load_h1_data(pair)
+            d1_filt = _load_d1_filter(pair) if (load_d1 and D1_REGIME_FILTER) else None
+            h1_df   = _load_h1_data(pair) if load_h1 else None
             (d1_close_arr, d1_kijun_arr,
              d1_close_lag2_arr, d1_kijun_lag2_arr,
              d1_atr_lag1_arr,
@@ -1074,11 +1143,19 @@ def _build_pair_cache(pairs: list[str] | None = None) -> dict:
                 baseline_vals = None
 
             min_warm = WARMUP_BARS.get(BASELINE_TYPE, 0)
-            sig, n_blocked, n_passed, n_cond9, cond9_dates, d1_dist_ratios = _build_signal_series(
-                df, d1_filt,
-                baseline_override=baseline_vals,
-                min_warmup=min_warm if baseline_vals is not None else None,
-            )
+            adapter = _ensure_signal_adapter()
+            _signal_aux = {
+                "d1_filter":         d1_filt,
+                "h1_df":             h1_df,
+                "baseline_override": baseline_vals,
+                "min_warmup":        min_warm if baseline_vals is not None else None,
+            }
+            sig, _signal_extras = adapter.compute_signal_mask(df, _signal_aux)
+            n_blocked      = int(_signal_extras.get("n_d1_blocked", 0))
+            n_passed       = int(_signal_extras.get("n_d1_passed", 0))
+            n_cond9        = int(_signal_extras.get("n_cond9_blocked", 0))
+            cond9_dates    = list(_signal_extras.get("cond9_block_dates", []))
+            d1_dist_ratios = dict(_signal_extras.get("d1_dist_ratio_by_bar", {}))
 
             ema50_arr = _compute_ema(closes_arr, REGIME_EMA_PERIOD)
             ema50_series = pd.Series(ema50_arr, index=pd.DatetimeIndex(df["date"].values))
@@ -1523,6 +1600,20 @@ def _simulate_kgl_v2(
                         exit_px     = c_j
                     exit_reason = "kijun_d1"
 
+            # Priority 6: time-exit cap (TIME_EXIT_BARS=None disables).
+            # Fires LAST so SL / trail / kijun_d1 / KH-13 / KH-14 / D1 hook
+            # all win if they would trigger on this bar first.
+            if exit_reason is None and TIME_EXIT_BARS is not None:
+                if (j - entry_idx) >= TIME_EXIT_BARS:
+                    n = len(cached["o"])
+                    if j + 1 < n:
+                        exit_bar    = j + 1
+                        exit_px     = cached["o"][j + 1]
+                    else:
+                        exit_bar    = j
+                        exit_px     = c_j
+                    exit_reason = "time_exit"
+
             if exit_reason is not None:
                 # v1.3: when the exit fills at the next bar's open
                 # (exit_bar > j), the regular per-bar emission stopped at
@@ -1738,7 +1829,9 @@ def _simulate_kgl_v2(
                     risk_pp_re  = REENTRY_SL_ATR_MULT * a_re
                     sl_px_re    = re_px - risk_pp_re
                     ta_px_re    = re_px + TRAIL_ACT_MULT * a_re
-                    sp_pips_re  = re_cac["sp"][re_idx] / POINTS_PER_PIP
+                    sp_pips_re  = _apply_spread_floor(
+                        re_pair, re_cac["sp"][re_idx] / POINTS_PER_PIP
+                    )
                     pos_size_re = (INITIAL_BAL * RISK_PCT) / risk_pp_re
                     sc_re       = (sp_pips_re * re_cac["pip"]) * pos_size_re
                     best_cl_re  = re_cac["c"][re_idx]
@@ -1871,7 +1964,9 @@ def _simulate_kgl_v2(
                         continue
                     sl_px_s1 = e_px - risk_pp_s1
                     ta_px_s1 = e_px + TRAIL_ACT_MULT * a_f
-                    sp_pips_s1  = cac17["sp"][e_idx] / POINTS_PER_PIP
+                    sp_pips_s1  = _apply_spread_floor(
+                        p17, cac17["sp"][e_idx] / POINTS_PER_PIP
+                    )
                     pos_size_s1 = (INITIAL_BAL * RISK_PCT) / risk_pp_s1
                     sc_s1       = (sp_pips_s1 * cac17["pip"]) * pos_size_s1
                     best_cl_s1  = cac17["c"][e_idx]
@@ -2044,7 +2139,9 @@ def _simulate_kgl_v2(
                         continue
                     sl_px_r = r_px - risk_pp_r
                     ta_px_r = r_px + TRAIL_ACT_MULT * a_r
-                    sp_pips_r  = cac17["sp"][re_idx] / POINTS_PER_PIP
+                    sp_pips_r  = _apply_spread_floor(
+                        p17, cac17["sp"][re_idx] / POINTS_PER_PIP
+                    )
                     pos_size_r = (INITIAL_BAL * RISK_PCT) / risk_pp_r
                     sc_r       = (sp_pips_r * cac17["pip"]) * pos_size_r
                     best_cl_r  = cac17["c"][re_idx]
@@ -2252,7 +2349,7 @@ def _simulate_kgl_v2(
                 ATR_SIZING_REDUCED_PCT if atr_sized_down_flag else RISK_PCT
             )
 
-            spread_pips  = cached["sp"][entry_idx] / POINTS_PER_PIP
+            spread_pips  = _apply_spread_floor(pair, cached["sp"][entry_idx] / POINTS_PER_PIP)
             spread_price = spread_pips * cached["pip"]
             pos_size     = (INITIAL_BAL * effective_risk_pct) / risk_pp
             spread_cost  = spread_price * pos_size
@@ -2355,16 +2452,12 @@ def _simulate_kgl_v2(
             # Pipeline D1: compute the 8 base entry features at signal bar N
             # for downstream classifier evaluation at bar offset t. Storage is
             # gated on D1_HOOK so the baseline path remains byte-identical when
-            # no D1 archetypes are configured.
+            # no D1 archetypes are configured. Routed through the signal
+            # adapter so non-KH-24 signals can supply their own feature set.
             entry_features_dict: dict[str, float] | None = None
             if D1_HOOK is not None:
-                entry_features_dict = build_entry_features_at_signal_bar(
-                    open_arr=cached["o"],
-                    high_arr=cached["h"],
-                    low_arr=cached["lo"],
-                    close_arr=cached["c"],
-                    atr_at_signal_bar=float(a),
-                    signal_bar_idx=int(i),
+                entry_features_dict = _ensure_signal_adapter().compute_entry_features(
+                    cached["df"], int(i), aux={},
                 )
 
             open_trades.append({
@@ -3669,6 +3762,9 @@ def run_kgl_v2() -> None:
     print("    trades_all.csv")
     print("    trades_paths.csv  (v1.3 per-bar capturability extension)")
     print("    kgl_v2_report.md")
+    _spread_floor_state = _SPREAD_FLOOR_BAG.get(STATE_CFG_KEY)
+    if _spread_floor_state is not None:
+        print(format_summary_log(_spread_floor_state))
     print("\n=== KG-L-V2 complete ===")
 
 
@@ -3699,6 +3795,9 @@ def main() -> None:
     global KH17_STATE1_SL_ATR_MULT
     global KH17_BAR6_MFE_THRESHOLD, KH17_BAR6_MAE_THRESHOLD
     global D1_HOOK
+    global SIGNAL_ADAPTER
+    global SIGNAL_TF, H1_DATA_DIR
+    global TIME_EXIT_BARS
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", default=None)
@@ -3732,13 +3831,34 @@ def main() -> None:
             OUT_ROOT = PROJECT_ROOT / out_dir
             OUT_ROOT.mkdir(parents=True, exist_ok=True)
 
-        # Override data directories
-        data_4h = cfg.get("data_dir")
-        if data_4h:
-            DATA_DIR_4H = PROJECT_ROOT / data_4h
-        d1_dir = cfg.get("indicator_params", {}).get("kb_exhaustion_bar", {}).get("d1_data_dir")
-        if d1_dir:
-            D1_DATA_DIR = PROJECT_ROOT / d1_dir
+        # Signal timeframe label (informational + for reports / logs)
+        if "signal_tf" in cfg:
+            SIGNAL_TF = str(cfg["signal_tf"])
+
+        # Data directories — modern `data:` block takes precedence; falls
+        # back to legacy `data_dir` / `indicator_params.*.d1_data_dir`.
+        data_block = cfg.get("data") or {}
+        data_signal_dir = data_block.get("signal_tf_dir") or cfg.get("data_dir")
+        if data_signal_dir:
+            DATA_DIR_4H = PROJECT_ROOT / data_signal_dir
+        aux_block = data_block.get("aux") or {}
+        aux_h1 = aux_block.get("h1")
+        if aux_h1:
+            H1_DATA_DIR = PROJECT_ROOT / aux_h1
+        aux_d1 = (
+            aux_block.get("d1")
+            or cfg.get("indicator_params", {}).get("kb_exhaustion_bar", {}).get("d1_data_dir")
+        )
+        if aux_d1:
+            D1_DATA_DIR = PROJECT_ROOT / aux_d1
+
+        # Track which aux keys are actually configured so the adapter
+        # declaration can be validated below.
+        _configured_aux = set()
+        if aux_h1:
+            _configured_aux.add("h1")
+        if aux_d1:
+            _configured_aux.add("d1")
 
         # Override WFO fold definitions if folds are explicitly listed in config
         wfo_cfg = cfg.get("wfo", {})
@@ -4111,6 +4231,44 @@ def main() -> None:
                 "kh25_reentry_enabled is mutually exclusive with kh17_enabled "
                 "and kh18_enabled. Enable at most one per run."
             )
+
+        # Signal adapter (per-arc plug-in). Defaults to KbExhaustionBarAdapter
+        # when absent so pre-PR configs (and KH-24 itself, until its YAML adds
+        # the keys) remain byte-identical.
+        _adapter_spec = cfg.get("signal_adapter", _DEFAULT_SIGNAL_ADAPTER_SPEC)
+        _adapter_kwargs = cfg.get("signal_adapter_kwargs") or {}
+        adapter_cls = import_class(_adapter_spec)
+        SIGNAL_ADAPTER = adapter_cls(**_adapter_kwargs)
+        _adapter_aux = SIGNAL_ADAPTER.required_aux_data()
+        validate_aux_declaration(_adapter_aux, _adapter_spec)
+        # When the cfg uses the explicit `data.aux` block, every adapter-
+        # declared aux key must have a configured path; otherwise it's a
+        # silent data-missing bug at load time.
+        if data_block:
+            _missing_aux = sorted(set(_adapter_aux) - _configured_aux)
+            if _missing_aux:
+                raise ValueError(
+                    f"signal_adapter '{_adapter_spec}' declared aux "
+                    f"{_adapter_aux} but cfg.data.aux is missing: {_missing_aux}"
+                )
+
+        # Spread-floor application (engine-generalisation PR). Field names
+        # (`enabled`, `source`, `expected_body_sha256`) follow the existing
+        # core/spread_floor.py contract — see ``load_spread_floor``. Absent
+        # block or enabled=False is a no-op.
+        _spread_floor_state = load_spread_floor(cfg)
+        _SPREAD_FLOOR_BAG[STATE_CFG_KEY] = _spread_floor_state
+        print(format_startup_log(_spread_floor_state))
+
+        # Time-exit cap: max bars from entry before forcing an exit at the
+        # next bar's open. Absent / null = no enforcement (baseline).
+        if cfg.get("time_exit_bars") is not None:
+            t = cfg["time_exit_bars"]
+            if not isinstance(t, int) or t < 1:
+                raise ValueError(
+                    f"Invalid time_exit_bars '{t}'. Must be a positive int."
+                )
+            TIME_EXIT_BARS = t
 
         # Pipeline D1 hook (L_ARC_PROTOCOL v2.0 §3). Absent or empty block
         # leaves D1_HOOK = None and the engine behaves byte-identically to

--- a/signals/kb_exhaustion_bar_adapter.py
+++ b/signals/kb_exhaustion_bar_adapter.py
@@ -1,0 +1,141 @@
+"""KbExhaustionBarAdapter — SignalAdapter wrapping the KH-24 signal.
+
+KH-24 is a long-running, locked-in-production signal whose mask logic
+lives in ``scripts.phase_kgl_v2_4h_wfo._build_signal_series``. To preserve
+byte-identical behaviour while exposing the SignalAdapter contract, this
+adapter delegates to the engine helper rather than re-implementing the
+logic. Future arc adapters (Arc 4+) will be self-contained.
+
+The engine populates its parameter globals (ATR_PERIOD, BODY_THRESH, etc.)
+from cfg in ``main()``. Those globals are read by ``_build_signal_series``
+at call time, so the adapter doesn't need to thread them through.
+
+Required aux: ``["h1", "d1"]`` — both are used by the KH-24 system
+(D1 for C8/C9 regime gates inside the signal mask; H1 for the engine-level
+KH-22/24 close-in-range filter at entry time).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from core.features_path_so_far import build_entry_features_at_signal_bar
+from signals.kb_exhaustion_bar import _wilder_atr
+
+
+class KbExhaustionBarAdapter:
+    """Adapter implementing the SignalAdapter contract for KH-24."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        # KH-24 sources its parameters from cfg via the engine's module
+        # globals (set in main()). kwargs is reserved for future signals
+        # but accepted-and-ignored here so the engine can pass an empty
+        # ``signal_adapter_kwargs: {}`` block without raising.
+        self._extra_kwargs = dict(kwargs)
+        # Per-df ATR cache: signal_bar ATR is recomputed many times across
+        # a run; cache by df identity to keep compute_signal_atr O(1).
+        self._atr_cache: dict[int, np.ndarray] = {}
+
+    def required_aux_data(self) -> list[str]:
+        # h1: KH-22/24 close-in-range entry filter (engine-level).
+        # d1: C8/C9 regime gates inside the signal mask.
+        return ["h1", "d1"]
+
+    def compute_signal_mask(
+        self,
+        df_signal_tf: pd.DataFrame,
+        aux: dict[str, Any],
+    ) -> tuple[np.ndarray, dict[str, Any]]:
+        # Deferred import: the engine imports this adapter at module load,
+        # so a top-level import would be circular. When the engine is run
+        # as __main__, scripts/phase_kgl_v2_4h_wfo.py aliases its module
+        # under the package path so this import returns the SAME module
+        # whose globals main() populated (otherwise cfg overrides like
+        # NO_VOLUME_FILTER would silently revert to defaults here).
+        from scripts.phase_kgl_v2_4h_wfo import _build_signal_series
+
+        d1_filter = aux.get("d1_filter")
+        baseline_override = aux.get("baseline_override")
+        min_warmup = aux.get("min_warmup")
+
+        sig, n_blocked, n_passed, n_cond9, cond9_dates, d1_dist_ratios = (
+            _build_signal_series(
+                df_signal_tf,
+                d1_filter,
+                baseline_override=baseline_override,
+                min_warmup=min_warmup,
+            )
+        )
+
+        extras: dict[str, Any] = {
+            "n_d1_blocked":         n_blocked,
+            "n_d1_passed":          n_passed,
+            "n_cond9_blocked":      n_cond9,
+            "cond9_block_dates":    cond9_dates,
+            "d1_dist_ratio_by_bar": dict(d1_dist_ratios),
+        }
+        return sig, extras
+
+    def _get_atr_array(self, df_signal_tf: pd.DataFrame) -> np.ndarray:
+        key = id(df_signal_tf)
+        arr = self._atr_cache.get(key)
+        if arr is None:
+            arr = _wilder_atr(df_signal_tf, 14).values
+            self._atr_cache[key] = arr
+        return arr
+
+    def compute_signal_atr(
+        self,
+        df_signal_tf: pd.DataFrame,
+        idx: int,
+        aux: dict[str, Any],
+    ) -> float:
+        return float(self._get_atr_array(df_signal_tf)[idx])
+
+    def compute_entry_features(
+        self,
+        df_signal_tf: pd.DataFrame,
+        idx: int,
+        aux: dict[str, Any],
+    ) -> dict[str, float]:
+        atr_at_signal = self.compute_signal_atr(df_signal_tf, idx, aux)
+        return build_entry_features_at_signal_bar(
+            open_arr=df_signal_tf["open"].values.astype(float),
+            high_arr=df_signal_tf["high"].values.astype(float),
+            low_arr=df_signal_tf["low"].values.astype(float),
+            close_arr=df_signal_tf["close"].values.astype(float),
+            atr_at_signal_bar=float(atr_at_signal),
+            signal_bar_idx=int(idx),
+        )
+
+    def per_trade_init(
+        self,
+        trade: dict[str, Any],
+        df_signal_tf: pd.DataFrame,
+        idx: int,
+        aux: dict[str, Any],
+    ) -> None:
+        # KH-24-specific trade fields. The engine's primary entry path
+        # already initialises these inline (kept for compatibility with
+        # the re-entry paths that don't route through per_trade_init);
+        # we stamp them again here so the adapter contract is honoured
+        # and any field-by-field changes only need to happen in one place.
+        entry_idx = idx + 1
+        n = len(df_signal_tf)
+        if entry_idx < n:
+            entry_open = float(df_signal_tf["open"].iloc[entry_idx])
+            entry_close = float(df_signal_tf["close"].iloc[entry_idx])
+            if entry_close > entry_open:
+                fbd = 1
+            elif entry_close < entry_open:
+                fbd = -1
+            else:
+                fbd = 0
+        else:
+            fbd = 0
+        trade.setdefault("first_bar_dir", fbd)
+        trade.setdefault("kh13_triggered", False)
+        trade.setdefault("kh14_triggered", False)

--- a/tests/test_d1_pipeline.py
+++ b/tests/test_d1_pipeline.py
@@ -849,10 +849,13 @@ class TestEnginePatch:
 
     def test_entry_features_stored_only_when_hook_active(self):
         src = ENGINE_PATH.read_text(encoding="utf-8")
-        # The build_entry_features call must be guarded by an `if D1_HOOK is not None:`.
+        # Engine-generalisation PR routes feature building through the
+        # signal adapter; the guard requirement is unchanged but the call
+        # target moved from the bare helper to the adapter method.
         m = re.search(
             r"if\s+D1_HOOK\s+is\s+not\s+None:\s*\n\s+entry_features_dict\s*=\s*"
-            r"build_entry_features_at_signal_bar",
+            r"(build_entry_features_at_signal_bar"
+            r"|_ensure_signal_adapter\(\)\.compute_entry_features)",
             src,
         )
         assert m, (

--- a/tests/test_engine_generalisation.py
+++ b/tests/test_engine_generalisation.py
@@ -1,0 +1,301 @@
+"""Tests for the engine-generalisation PR (signal adapter, timeframe
+pluggability, time-exit cap, spread-floor wiring).
+
+Byte-identical KH-24 is verified manually (full WFO is too slow for CI);
+this file covers the new code paths via unit / focused integration tests.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.signal_adapter import (  # noqa: E402
+    ALLOWED_AUX_KEYS,
+    import_class,
+    validate_aux_declaration,
+)
+from core.spread_floor import (  # noqa: E402
+    STATE_CFG_KEY,
+    SpreadFloorState,
+    apply_spread_floor_to_pips,
+    load_spread_floor,
+)
+from signals.kb_exhaustion_bar_adapter import KbExhaustionBarAdapter  # noqa: E402
+
+# ─── Part 1: SignalAdapter protocol + helpers ────────────────────────────────
+
+
+class _StubAdapter:
+    """Minimal SignalAdapter for tests — supplies a constant mask."""
+
+    def __init__(self, aux_keys: list[str] | None = None) -> None:
+        self._aux = list(aux_keys) if aux_keys is not None else []
+
+    def required_aux_data(self) -> list[str]:
+        return list(self._aux)
+
+    def compute_signal_mask(self, df, aux):
+        return np.zeros(len(df), dtype=int), {}
+
+    def compute_signal_atr(self, df, idx, aux):
+        return 1.0
+
+    def compute_entry_features(self, df, idx, aux):
+        return {}
+
+    def per_trade_init(self, trade, df, idx, aux):
+        trade.setdefault("test_field", True)
+
+
+def test_import_class_valid():
+    cls = import_class("signals.kb_exhaustion_bar_adapter:KbExhaustionBarAdapter")
+    assert cls is KbExhaustionBarAdapter
+
+
+def test_import_class_missing_colon():
+    with pytest.raises(ImportError, match="module.path:ClassName"):
+        import_class("not_a_valid_spec")
+
+
+def test_import_class_missing_module():
+    with pytest.raises(ImportError, match="cannot import module"):
+        import_class("does.not.exist:Whatever")
+
+
+def test_import_class_missing_class():
+    with pytest.raises(ImportError, match="class .* not found"):
+        import_class("signals.kb_exhaustion_bar_adapter:NoSuchClass")
+
+
+def test_validate_aux_accepts_known_keys():
+    validate_aux_declaration(["h1", "d1"], "test")  # must not raise
+    validate_aux_declaration([], "test")
+    validate_aux_declaration(["d1"], "test")
+
+
+def test_validate_aux_rejects_unknown_keys():
+    with pytest.raises(ValueError, match="unknown aux keys"):
+        validate_aux_declaration(["h1", "moon_phase"], "test_spec")
+
+
+def test_allowed_aux_keys_contract():
+    # Doc invariant — engine code paths depend on these two keys exactly.
+    assert ALLOWED_AUX_KEYS == frozenset({"h1", "d1"})
+
+
+def test_kb_adapter_required_aux():
+    a = KbExhaustionBarAdapter()
+    assert a.required_aux_data() == ["h1", "d1"]
+
+
+def test_kb_adapter_accepts_empty_kwargs():
+    # Engine passes signal_adapter_kwargs as **{} when block is empty.
+    KbExhaustionBarAdapter(**{})  # must not raise
+
+
+def test_kb_adapter_per_trade_init_stamps_defaults():
+    a = KbExhaustionBarAdapter()
+    n = 20
+    df = pd.DataFrame(
+        {
+            "open":  [1.0] * n,
+            "high":  [1.1] * n,
+            "low":   [0.9] * n,
+            "close": [1.05] * n,
+        }
+    )
+    trade: dict = {}
+    a.per_trade_init(trade, df, idx=5, aux={})
+    assert trade["kh13_triggered"] is False
+    assert trade["kh14_triggered"] is False
+    # Entry bar idx+1 has close > open → first_bar_dir = 1
+    assert trade["first_bar_dir"] == 1
+
+
+def test_kb_adapter_per_trade_init_preserves_existing():
+    a = KbExhaustionBarAdapter()
+    df = pd.DataFrame({"open": [1.0], "high": [1.0], "low": [1.0], "close": [1.0]})
+    trade = {"kh13_triggered": True}  # pre-set
+    a.per_trade_init(trade, df, idx=0, aux={})
+    # setdefault must NOT overwrite existing values
+    assert trade["kh13_triggered"] is True
+
+
+# ─── Part 4: spread_floor (the engine wiring uses it as a no-op for KH-24) ──
+
+
+def test_spread_floor_disabled_when_block_absent():
+    state = load_spread_floor({})
+    assert isinstance(state, SpreadFloorState)
+    assert state.enabled is False
+
+
+def test_spread_floor_disabled_explicit():
+    state = load_spread_floor({"spread_floor": {"enabled": False}})
+    assert state.enabled is False
+
+
+def test_spread_floor_enabled_requires_source_and_sha():
+    with pytest.raises(ValueError, match="'source' and 'expected_body_sha256'"):
+        load_spread_floor({"spread_floor": {"enabled": True}})
+
+
+def test_spread_floor_enabled_missing_source_raises():
+    cfg = {
+        "spread_floor": {
+            "enabled": True,
+            "source": "nonexistent/path/spreads.yaml",
+            "expected_body_sha256": "0" * 64,
+        }
+    }
+    with pytest.raises(FileNotFoundError):
+        load_spread_floor(cfg)
+
+
+def test_apply_spread_floor_noop_when_state_missing():
+    # cfg lacks STATE_CFG_KEY → no floor, returns input unchanged.
+    assert apply_spread_floor_to_pips({}, "AUD_USD", 1.5) == 1.5
+
+
+def test_apply_spread_floor_noop_when_disabled():
+    cfg = {STATE_CFG_KEY: SpreadFloorState(enabled=False)}
+    assert apply_spread_floor_to_pips(cfg, "AUD_USD", 1.5) == 1.5
+
+
+def test_apply_spread_floor_raises_when_below():
+    state = SpreadFloorState(enabled=True, floors_pips={"AUD_USD": 2.0})
+    cfg = {STATE_CFG_KEY: state}
+    # raw 1.0 < floor 2.0 → return floor
+    assert apply_spread_floor_to_pips(cfg, "AUD_USD", 1.0) == 2.0
+    assert state.n_applications == 1
+    # raw 3.0 > floor → return raw
+    assert apply_spread_floor_to_pips(cfg, "AUD_USD", 3.0) == 3.0
+    assert state.n_applications == 1  # unchanged
+    # pair not in floors_pips → return raw
+    assert apply_spread_floor_to_pips(cfg, "EUR_USD", 1.0) == 1.0
+
+
+# ─── Part 2 + Part 3: engine integration via subprocess ──────────────────────
+
+
+def _engine_cmd(cfg_path: Path, out_dir: Path) -> list[str]:
+    return [
+        sys.executable,
+        str(PROJECT_ROOT / "scripts" / "phase_kgl_v2_4h_wfo.py"),
+        "--config",
+        str(cfg_path),
+        "--out-dir",
+        str(out_dir),
+    ]
+
+
+def _make_tiny_synthetic_data(pair_dir: Path, pair: str, freq: str, n_bars: int) -> None:
+    """Write a tiny CSV the engine's load_pair_csv can read.
+
+    Synthetic deterministic OHLCV with no signal-triggering structure — used
+    to exercise engine plumbing without depending on real market data files.
+    """
+    pair_dir.mkdir(parents=True, exist_ok=True)
+    dates = pd.date_range("2020-01-01", periods=n_bars, freq=freq)
+    closes = 1.0 + 0.0001 * np.arange(n_bars)
+    df = pd.DataFrame(
+        {
+            "date":   dates,
+            "open":   closes,
+            "high":   closes + 0.001,
+            "low":    closes - 0.001,
+            "close":  closes,
+            "volume": 1000.0,
+            "spread": 1.0,
+        }
+    )
+    df.to_csv(pair_dir / f"{pair}.csv", index=False)
+
+
+def test_engine_main_aux_missing_raises(tmp_path):
+    """Adapter declares ['h1', 'd1'] but cfg.data.aux omits h1 → fail loud."""
+    cfg = {
+        "phase": "test",
+        "signal_tf": "H4",
+        "data": {
+            "signal_tf_dir": "data/4hr",
+            "aux": {"d1": "data/daily"},  # h1 missing
+        },
+        "signal_adapter": "signals.kb_exhaustion_bar_adapter:KbExhaustionBarAdapter",
+        "signal_adapter_kwargs": {},
+    }
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    out_dir = tmp_path / "out"
+
+    result = subprocess.run(_engine_cmd(cfg_path, out_dir), capture_output=True, text=True)
+    assert result.returncode != 0, "Engine should have errored"
+    combined = (result.stdout + result.stderr)
+    assert "missing" in combined.lower() or "aux" in combined.lower(), combined[-500:]
+
+
+def test_engine_main_bad_adapter_spec_raises(tmp_path):
+    cfg = {
+        "phase": "test",
+        "signal_adapter": "nonexistent.module:NoSuchAdapter",
+    }
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    out_dir = tmp_path / "out"
+    result = subprocess.run(_engine_cmd(cfg_path, out_dir), capture_output=True, text=True)
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "cannot import module" in combined or "not found" in combined
+
+
+def test_engine_main_rejects_invalid_time_exit_bars(tmp_path):
+    cfg = {
+        "phase": "test",
+        "signal_adapter": "signals.kb_exhaustion_bar_adapter:KbExhaustionBarAdapter",
+        "signal_adapter_kwargs": {},
+        "time_exit_bars": 0,
+    }
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    out_dir = tmp_path / "out"
+    result = subprocess.run(_engine_cmd(cfg_path, out_dir), capture_output=True, text=True)
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "time_exit_bars" in combined
+
+
+def test_engine_main_rejects_spread_floor_missing_source(tmp_path):
+    cfg = {
+        "phase": "test",
+        "signal_adapter": "signals.kb_exhaustion_bar_adapter:KbExhaustionBarAdapter",
+        "signal_adapter_kwargs": {},
+        "spread_floor": {
+            "enabled": True,
+            "source": "configs/does_not_exist.yaml",
+            "expected_body_sha256": "0" * 64,
+        },
+    }
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+    out_dir = tmp_path / "out"
+    result = subprocess.run(_engine_cmd(cfg_path, out_dir), capture_output=True, text=True)
+    assert result.returncode != 0
+    combined = (result.stdout + result.stderr).lower()
+    assert "spread_floor" in combined or "not found" in combined
+
+
+# Two-run KH-24 determinism verification was performed manually during PR
+# preparation (sha256 08118567a6ef…58e80ab0 reproduced exactly across the
+# pre-PR main and post-PR branch heads). Not encoded as a pytest test
+# because the engine's run_kgl_v2 calls OUT_ROOT.relative_to(PROJECT_ROOT)
+# which requires --out-dir to live inside the worktree — incompatible with
+# pytest's tmp_path. The byte-identical proof lives in the PR description.


### PR DESCRIPTION
## Summary

Adds four plumbing capabilities to `scripts/phase_kgl_v2_4h_wfo.py` so the backtester can run signals beyond KH-24. KH-24 itself remains byte-identical to pre-PR main.

- **Part 1**: Pluggable `SignalAdapter` protocol; `KbExhaustionBarAdapter` wraps the existing KH-24 logic
- **Part 2**: `signal_tf` + `data.{signal_tf_dir, aux.{h1,d1}}` config; adapter-declared aux loading
- **Part 3**: `time_exit_bars` cap, fires last in the exit cascade
- **Part 4**: Spread-floor wiring at all four entry-side spread reads (uses existing `core/spread_floor.py`)

## Byte-identical proof

`configs/wfo_kh24.yaml` produces identical `trades_all.csv` before and after this PR:

```
pre-PR  (main bf7381a):     08118567a6ef6325eb1b6b817aa9ea3e99e2124558f32f9db8d0decf58e80ab0
post-PR (head 2025489):     08118567a6ef6325eb1b6b817aa9ea3e99e2124558f32f9db8d0decf58e80ab0
```

All four KH-24 output artefacts match (`trades_all.csv`, `trades_paths.csv`, `wfo_fold_results_4h.csv`, `wfo_per_pair_4h.csv`).

## File-by-file changes

| File | Change |
|---|---|
| `core/signal_adapter.py` | **NEW** — `SignalAdapter` Protocol + `import_class` + `validate_aux_declaration` |
| `signals/kb_exhaustion_bar_adapter.py` | **NEW** — `KbExhaustionBarAdapter`; deferred import of `_build_signal_series` to avoid module-load cycle |
| `scripts/phase_kgl_v2_4h_wfo.py` | +212 / -29 — adapter wiring (Part 1), `SIGNAL_TF` + cfg `data` block + aux gating (Part 2), `TIME_EXIT_BARS` + cascade tail (Part 3), `_apply_spread_floor` at four entry sites (Part 4), `sys.modules` alias for `__main__`-vs-package import consistency |
| `configs/wfo_kh24.yaml` | +18 — `signal_adapter` / `signal_adapter_kwargs` / `signal_tf` / `data` block (all preserving existing paths and behaviour) |
| `tests/test_engine_generalisation.py` | **NEW** — 22 unit + subprocess-integration tests across the four parts |
| `tests/test_d1_pipeline.py` | +6 / -1 — regex updated to accept both the legacy and new entry-features call sites |

## Tests

- New file: **22 passed** (`test_engine_generalisation.py`)
- Full suite: **1075 passed, 62 skipped** (research + slow marks)
- Ruff: clean on all modified/new files

One pre-existing test failure (`test_spread_floors_lock.py::test_spread_floors_locked`) is unrelated to this PR — it's a Windows-specific CRLF-vs-LF mismatch caused by `core.autocrlf=true` and the absence of `.gitattributes` for the locked YAML file. Same failure reproduces on main; not in scope for this PR to fix.

## Judgment calls / deviations from the spec

1. **`compute_signal_mask` return shape**: the spec described `-> pd.Series`. I return `tuple[ndarray, dict]` instead because KH-24's `_build_signal_series` produces signal-specific diagnostic extras (`d1_dist_ratio_by_bar`, `n_d1_blocked`, etc.) that are load-bearing for `trades_all.csv` byte-identity. A separate query method would double-walk the data. Future adapters can return `(mask, {})` if they have no extras.
2. **`KbExhaustionBarAdapter` delegates rather than re-implementing**: KH-24 is locked in production and the signal logic uses ~20 engine module globals populated from cfg. Re-homing the function would have meant re-plumbing every parameter. The adapter file imports `_build_signal_series` via deferred import; the spec's intent (plug-in point) is honoured at the engine level. Arc 4+ adapters will be self-contained.
3. **Spread-floor cfg keys**: spec proposed `spread_floor.{enabled, config_path}`. I used the existing `core/spread_floor.py` field names (`enabled`, `source`, `expected_body_sha256`) to avoid duplicating the body-sha256 verification logic. Same semantic, different key names.
4. **`per_trade_init` only called from the primary entry path**: the re-entry / KH-17 entry paths preserve their existing inline init for byte-identity. The adapter uses `setdefault` so even if called from those paths it would be a no-op for KH-24. Documented in the adapter.
5. **`sys.modules` alias hack**: when `py scripts/phase_kgl_v2_4h_wfo.py` runs, the engine loads as `__main__`. The adapter's deferred `from scripts.phase_kgl_v2_4h_wfo import _build_signal_series` would otherwise load a second copy of the module with default globals, silently breaking byte-identity (caught and fixed during Part 1 development — Wilder ATR was identical but `NO_VOLUME_FILTER=False` defaulted, blocking many signals).

## Recovery note

This PR went through a state-recovery event partway through implementation (a parallel CC session in a shared worktree caused a checkout collision, losing the two new adapter files). The final commit was built in a dedicated git worktree at `../Forex-Backtester-engine-gen` with engine + config restored from `stash@{0}` and the two new files rewritten from the in-context design. All four byte-identical verifications were re-run from the recovered state.

## Test plan

- [x] KH-24 byte-identical (manual sha256 verification, four runs)
- [x] `test_engine_generalisation.py` green (22/22)
- [x] `test_d1_pipeline.py` green (updated regex now matches new call site)
- [x] Full suite green except the pre-existing CRLF-locked test
- [x] Ruff clean on all modified/new files
- [ ] CI green on PR (pending push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)