### PR TITLE
v2.3 amendment landing: Step 5 removal + renumbering + Open-22/23/24 closures + housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## L_ARC_PROTOCOL v2.3 AMENDMENT | 2026-05-18 | doc-only
+
+Step 5 cross-fold stability (§9) removed; Step 6 WFO (§10) renumbered as Step 5. Open-22 closed by structural removal; Open-23 closed by D1 cost-language documentation; Open-24 closed in protocol with engine PR pending. SHELVED informal register at SHELVED_ARCS.md.
+
+### Substantive changes
+- §9 deprecated — Step 5 cross-fold stability removed. Admit-only fold gating for Pipeline D1 was structurally misaligned with deployed-system economics; Step 5 WFO (renumbered) measures full-pool by construction. v2.2 §1 sign-flip mechanisation obsoleted.
+- §10 retitled — formerly "Step 6 — WFO"; now "Step 5 — WFO". Pipeline is five-step: 1 plumbing, 2 clustering, 3 capturability, 4 extractability, 5 WFO.
+- §3 / §8 — Pipeline D1 cost-language correction (Open-23): rejected-pool cost empirically −0.15 to −0.46R; pre-t losses −0.45 to −0.69R on ~10-15% of signals.
+- §3 — Pipeline D1 pre-t SL spec (Open-24): pre-t SL = cluster's Step 3 selected SL multiplier (was uniform 2.0×ATR). Engine PR pending; default 2.0 preserves anchor.
+- §16a — failing-step list position 5 semantic now = WFO (not stability). Path A/B logic unchanged.
+- Orchestrator halt point — end of Step 5 → end of Step 4.
+- §1a live-execution equivalence — Step 1 + Step 5 (was Step 6). Wording unchanged otherwise.
+
+### Open items resolved
+- Open-22 (full-pool gate at §9): CLOSED — by structural removal of §9
+- Open-23 (D1 cost-language): CLOSED — documentation correction in §3 / §8
+- Open-24 (pre-t SL per archetype): CLOSED in protocol; engine PR pending
+
+### v2.2 amendment items obsoleted or updated
+- v2.2 §1 (sign-flip mechanisation): OBSOLETED — Step 5 stability gate no longer exists
+- v2.2 §2 (Tier 2 lift cap): UNCHANGED
+- v2.2 §3 (max-F1 fallback removal): UNCHANGED
+- v2.2 §4 (FIFO queue): UNCHANGED
+- v2.2 §5 (§16a HALT/KILL): UPDATED — Step 5 semantic shift to WFO; Path A/B unchanged
+- v2.2 §6 (no mid-arc sign-off): UPDATED — halt at end of Step 4 (not Step 5)
+- v2.2 §7 (§1a live-execution equivalence): UPDATED — Step 1 + Step 5 (was Step 6)
+
+### Anchor preservation
+KH-24 K=4 archetype 3 passes Step 5 WFO by deployment. Step 3 selected SL = 2.0×ATR, identical to v2.2 uniform pre-t SL — Open-24 spec change is a no-op for the anchor. v2.2 §1 sign-flip mechanisation was anchor-preserving (anchor passed all 7 folds positive); its obsoletion does not affect anchor evaluation.
+
+### Files
+- L_ARC_PROTOCOL_v2_3_AMENDMENT.md added to repo
+- L_ARC_PROTOCOL.md unchanged (separate engineering PR pending to apply v2.2 + v2.3 amendments into protocol doc proper)
+- prompts/cc_arc_orchestrator_template.md updated (renumbering + halt point shift + Step 5 section removal)
+- SHELVED_ARCS.md added (empty initial register)
+- STATUS.md, SESSION_ZERO.md, PROTOCOL_IMPROVEMENT_BACKLOG.md updated
+
 ## L_ARC_PROTOCOL v2.2 AMENDMENT | 2026-05-18 | doc-only
 
 L_ARC_PROTOCOL v2.2 amendment landed. Mechanises remaining chat-judgement carve-outs in steps 1-5, closes Step 4 max-F1 fallback gap surfaced by Arc 7, asserts live-execution equivalence for steps 1 and 6. Methodology unchanged. CC can now run arcs 1→5 unattended in parallel without analyst sign-off mid-arc.

--- a/L_ARC_PROTOCOL_v2_3_AMENDMENT.md
+++ b/L_ARC_PROTOCOL_v2_3_AMENDMENT.md
@@ -1,0 +1,360 @@
+# L_ARC_PROTOCOL v2.3 — Amendment: Step 5 Removal, Pipeline Renumbering, Open-22/23/24
+
+> Status: DRAFT for review. Lands on top of v2.2.
+> Purpose: remove Step 5 cross-fold stability (a misleading admit-only proxy for Step 6 WFO), renumber Step 6 → Step 5, close Open-22 by structural removal, correct Pipeline D1 cost-language (Open-23), and respec Pipeline D1 pre-t SL to track the cluster's Step 3 selected SL (Open-24).
+> Scope: protocol mechanisation + documentation correction + one structural removal. No engine change required for §9 removal or Open-22/23. Open-24 spec change may require small engine PR to expose per-archetype `pre_t_sl_atr_multiplier`; spec lands now, engine PR follows.
+> Anchor preservation: KH-24 K=4 archetype 3 unaffected — anchor passes by virtue of Step 5 (WFO, was Step 6) which it passes by deployment. Open-24's pre-t SL respec is a no-op for the anchor (deployed SL = 2.0×ATR = anchor's Step 3 selected SL).
+
+---
+
+## §0. What v2.3 changes from v2.2
+
+| Dimension | v2.2 | v2.3 |
+|---|---|---|
+| Step 5 (cross-fold stability) | §9 conjunctive gate on admit-set fold metrics | **Removed.** §9 deprecated. Pipeline is 1-2-3-4-5 with Step 5 = WFO. |
+| Step 6 (WFO) | §10 named "Step 6" | §10 named "Step 5" (renumbered) |
+| Orchestrator halt point | End of Step 5 | End of Step 4 |
+| v2.2 §1 (sign-flip mechanisation) | Mechanises the Step 5 gate 1 override | **Obsoleted by §9 removal.** No Step 5 gate exists to mechanise. |
+| v2.2 §6 (no mid-arc sign-off) | Halts at end of Step 5 | Halts at end of Step 4 |
+| §16a (HALT/KILL) failing-step list | {1, 2, 3, 4, 5} where 5 = stability | {1, 2, 3, 4, 5} where 5 = WFO. Numeric identifier unchanged, semantic changed. |
+| Pipeline D1 pre-t SL | Uniform 2.0×ATR for all archetypes | Per-archetype: cluster's Step 3 selected SL multiplier |
+| Pipeline D1 cost language | Rejected-pool cost implicit / understated | Empirical bounds documented: rejected pool ~−0.15 to −0.46R, early-exit pool ~−0.45 to −0.69R |
+| SHELVED disposition | Used informally in Arc 5 closure | Informal alias for KILL-with-portfolio-archive. Register in `SHELVED_ARCS.md`, not §16a. |
+
+These changes close Open-22 (by structural removal of the admit-only gate), Open-23 (by documentation correction), and Open-24 (by spec change tracking Step 3 SL). v2.2's §1 sign-flip mechanisation is obsoleted by structural removal of the gate it mechanised — recorded for change-tracking, not a calibration loss.
+
+Rationale: Arc 4 RERUN and Arc 5 closures established that Step 5 evaluated admit-set fold stability for Pipeline D1 archetypes, while the deployed system's economics depend on full-pool (admit + early-exit) performance. The gate measured the wrong population. Step 6 (WFO) runs full execution and inherently measures the right population. Step 5 was a cheaper, less-accurate proxy that introduced false confidence. Removing it simplifies the protocol and structurally closes the deployment-fatal blind spot.
+
+---
+
+## §1. §9 — Step 5 (cross-fold stability) removed
+
+### Amended text
+
+§9 is marked DEPRECATED. Section content is removed. Section number is reserved for backward-reference to v2.2 and earlier closures; no v2.3+ content references it.
+
+The L arc pipeline is now five steps:
+
+| Step | Section | Purpose |
+|---|---|---|
+| 1 | §5 | Plumbing — deterministic pool generation |
+| 2 | §6 | Path-shape clustering |
+| 3 | §7 | Capturability characterisation |
+| 4 | §8 | Extractability + artefact production |
+| 5 | §10 | WFO truth + pass-deployable / pass-viable gate |
+
+### Why
+
+Step 5 cross-fold stability gated on admit-set `final_r_mean`. For Pipeline E (entry filter) this equals deployed-system performance because rejected trades never enter the book. For Pipeline D1 (deferred policy) this diverges from deployed-system performance because every signal enters the book at bar 0 and a substantial fraction (Arc 5: ~78%) closes early at bar t with cost (Arc 5: −0.46R mean on the rejected pool).
+
+For E archetypes: Step 5 was redundant with Step 6 worst-fold ROI > 5% (sign consistency catches the same failures) + Step 6 trade-count floor (size variance catches the same failures) + Step 6 worst-fold DD < 8% (DD ceiling catches the same failures).
+
+For D1 archetypes: Step 5 was actively misleading. An archetype with admit-set +1.5R and reject-set −0.5R on 78% of pool can pass admit-only sign consistency while deploying as a negative-expectancy system. Arc 4 RERUN confirmed this empirically: full-pool ROI −76.98%, DD 76.98%, daily DD breach 5.12% on a system that had passed admit-set gates.
+
+Step 6 runs the full backtester across all 7 OOS folds with real execution — every signal in the population goes through the engine, including reject-set early closures with their actual costs. Step 6 inherently measures full-pool. There is no separate Step 5 question that Step 6 doesn't answer more accurately.
+
+Compute trade-off: Step 5 was cheap (uses already-trained classifier + admit set); Step 6 is expensive (full WFO). The "filter bad archetypes before spending Step 6 compute" rationale doesn't justify the misleading-data problem. Compute saved on a few archetypes per arc is not worth the protocol surface area or the documented Arc 4 RERUN deployment-fatal failure mode.
+
+### Anchor preservation
+
+KH-24 K=4 archetype 3 is deployed and passes Step 5 (WFO, was Step 6) by virtue of its live performance: worst-fold ROI +1.92%, worst-fold DD 6.37%, all 7 OOS folds positive. v2.2 Step 5 (cross-fold stability, now removed) had been satisfied trivially by the same fold data. No interaction.
+
+---
+
+## §2. Step renumbering
+
+### Amended text
+
+§10 (formerly titled "Step 6 — WFO truth + pass-deployable gate") is retitled "Step 5 — WFO truth + pass-deployable gate."
+
+Internal protocol cross-references update:
+- All references to "Step 6" in §1, §2, §3, §11, §12, §13, §14, §15, §16, §17, §16a → "Step 5"
+- §15 trade-count floor row "Step 6" → "Step 5"
+- §16a failing-step list semantic: position 5 now means WFO (not stability)
+- v2.2 §1a (live-execution equivalence): references to "Step 6" → "Step 5"
+- v2.2 §3 (Step 4 threshold sweep failure rule): wording unchanged; downstream "Step 6 trade-count floor" → "Step 5 trade-count floor"
+
+### Old documents are not retroactively renumbered
+
+Closure docs, CHANGELOG entries, STATUS / SESSION_ZERO Phase History entries, and any other historical document written under v2.2 or earlier keep their "Step 6" terminology verbatim. The protocol version of a document anchors which numbering applies:
+
+- Documents written under v2.2 or earlier: "Step 6 = WFO"
+- Documents written under v2.3+: "Step 5 = WFO"
+
+The protocol header line in each document is the source of truth for which numbering applies.
+
+### Why
+
+"Step 5 = stability" was a structural step that we are now removing. Having an empty step number (1, 2, 3, 4, _, 6) creates persistent confusion. Renumbering Step 6 → Step 5 produces a clean 1-2-3-4-5 pipeline. Cost: ambiguity between v2.2 and v2.3 documents — managed by protocol-version anchoring.
+
+### Anchor preservation
+
+Cosmetic only. No semantic change. Holds.
+
+---
+
+## §3. Open-22 — admit-only framing — CLOSED
+
+### Resolution
+
+Open-22 ("Full-pool gate at §9 or earlier (admit-only framing misses deployment-fatal cost)") is closed by structural removal of §9 (Step 5). There is no longer a step that gates on admit-only data. Step 5 (WFO, was Step 6) measures full-pool by construction.
+
+No threshold change. No new gate. The misleading proxy is removed.
+
+### Anchor preservation
+
+Anchor passes Step 5 WFO regardless of admit/full-pool framing. Holds.
+
+---
+
+## §4. Open-23 — Pipeline D1 cost language correction
+
+### Amended text
+
+§3 Pipeline shapes — Pipeline D1 description, and §8 Pipeline assignment & artefact production — Pipeline D1 row: append empirical cost bounds drawn from closed-arc evidence.
+
+Pipeline D1 admits trades whose entry-bar classifier accepts at bar t. Trades whose classifier rejects close at bar t. Pipeline D1's full-pool economics depend on three populations:
+
+| Population | Definition | Empirical R cost (Arc 4 RERUN, Arc 5 evidence) |
+|---|---|---|
+| Admit pool | classifier accepts at bar t → continues per §11 exit policy | Variable per archetype; selected for positive expectancy at Step 4 |
+| Rejected pool (early-close) | classifier rejects at bar t → close at bar t open | Empirically −0.15 to −0.46R per closed-arc D1 archetype |
+| Pre-t losers | trade hits pre-t SL before bar t | Empirically −0.45 to −0.69R on ~10-15% of signals; bounded by pre-t SL × (1 − approx breakeven on intra-bar tracking) |
+
+Full-pool Pipeline D1 expected R = admit_fraction × admit_mean_R + reject_fraction × reject_mean_R + pre_t_loss_fraction × pre_t_mean_R.
+
+Step 5 WFO measures this end-to-end. Pipeline D1 archetypes must clear pass-deployable / pass-viable thresholds on full-pool ROI, not admit-pool ROI.
+
+### Wording fixes in §3 and §8
+
+The §3 description of Pipeline D1 previously emphasised admit-set predictability without quantifying reject-pool cost. The §8 Pipeline D1 row described threshold-sweep selection without referencing the structural cost of rejection. Wording updates make the full-pool framing explicit:
+
+- §3 Pipeline D1: "Predict at bar t which trades to close vs continue. Rejected trades close at bar t with cost ~−0.15 to −0.46R; this is empirical, not a parameter."
+- §8 Pipeline D1 row: "Clears D1 threshold (RF AUC ≥ 0.60 at chosen t, exclusion ≤ 30%) → train t-bar classifier; sweep threshold; define exit policy from §11. Full-pool R = admit-weighted R + reject-weighted R; full-pool evaluation occurs at Step 5 WFO."
+
+### Why
+
+Open-23 surfaced from Arc 5 closure: protocol language understated the cost of the rejected pool. The Arc 5 cost language correction is documentation, not a threshold change. Arc 5's KILL disposition was correct under v2.2; the documentation gap was that an analyst reading §3 / §8 in v2.2 might infer rejected trades were cost-free.
+
+### Anchor preservation
+
+Anchor uses Pipeline D1 at t=3. The documentation correction does not change anchor evaluation. Holds.
+
+---
+
+## §5. Open-24 — Pipeline D1 pre-t SL per archetype
+
+### Amended text
+
+§3 Pipeline shapes — Pipeline D1, augmented with pre-t SL specification:
+
+Pipeline D1's pre-t period (bars 0..t) is the window between trade entry and classifier decision. During this window the trade is exposed to the market and requires a real stop loss for risk management. v2.2 used a uniform pre-t SL = 2.0×ATR for all D1 archetypes.
+
+v2.3 spec: **pre-t SL = cluster's Step 3 selected SL multiplier.** The SL distance selected at §7 SL sweep (per cluster, by capturability composite) is the SL used pre-t for that cluster's Pipeline D1 deployment.
+
+### Why
+
+§7 SL sweep selects each cluster's SL by capturability composite — the SL that maximises (mono_pre_peak − 0.55) + (frac_reach_1R − 0.70) + (0.30 − frac_wrong_way_pre_peak). This is the SL at which the cluster's structural edge was characterised. Imposing a different pre-t SL during deployment (uniform 2.0×ATR) breaks the link between §7 characterisation and deployed behaviour.
+
+Empirical cost (Open-24 origin): for archetypes whose Step 3 selected SL was tighter than 2.0×ATR, the uniform 2.0×ATR pre-t SL admitted into the pre-t exposure period a class of trades that would have stopped out under the cluster's characterised SL. For archetypes whose selected SL was wider, the uniform 2.0×ATR was overly tight pre-t and stopped out trades that would have continued under their cluster's characterised SL. Either direction is structural drift between characterisation and deployment.
+
+The fix is one line of spec: pre-t SL distance follows the cluster's Step 3 selection.
+
+### Engine impact
+
+The Pipeline D1 engine (post-PR2) supports per-archetype config for §11 exit policies. v2.3 spec requires the per-archetype D1 config to additionally express `pre_t_sl_atr_multiplier` (default 2.0 for backward compatibility with v2.2 behaviour and anchor preservation).
+
+Engine PR scope (separate from this protocol amendment):
+- Add `pre_t_sl_atr_multiplier` field to per-archetype D1 YAML schema
+- Default 2.0 (matches v2.2 behaviour)
+- Read at trade entry; apply to pre-t SL distance calculation
+- Step 3 archetype YAML emission writes `pre_t_sl_atr_multiplier = selected_sl_multiplier`
+
+Backward compatibility: existing per-archetype YAMLs without the new field continue to use 2.0×ATR. KH-24 anchor's D1 config: pre_t_sl_atr_multiplier = 2.0 (matches Step 3 selected SL = 2.0×ATR). No-op for anchor.
+
+### Anchor preservation
+
+KH-24 K=4 archetype 3 Step 3 selected SL = 2.0×ATR (matches v2.0 anchor metrics fwd_mfe_p50 measured at 2.0×ATR frame). Pre-t SL under v2.3 = 2.0×ATR (cluster's Step 3 selected). Identical to v2.2's uniform 2.0×ATR. Anchor evaluation unchanged. Holds.
+
+---
+
+## §6. SHELVED arcs — informal register
+
+### Amended text
+
+§16a (HALT/KILL disposition rule from v2.2) is unchanged. SHELVED is not a formal §16a disposition.
+
+SHELVED is an informal status meaning "Step 5 WFO fail but archetype is structurally interesting enough to archive as a portfolio composition candidate (Open-05)." Mechanically SHELVED maps to KILL for §16a purposes — the arc closes, the archetype does not deploy, the closure doc records the disposition.
+
+What distinguishes SHELVED from KILL is the analyst's note that the archetype merits later portfolio review. This is bookkeeping, not protocol.
+
+New companion document: `SHELVED_ARCS.md` (in repo root or `docs/`).
+
+### `SHELVED_ARCS.md` format
+
+```markdown
+# Shelved Arcs Register
+
+> Informal register of arcs that closed KILL at Step 5 WFO but whose archetypes carry structural interest as portfolio composition candidates (per L_ARC_PROTOCOL §16 Open-05).
+> SHELVED is not a formal §16a disposition. Each entry here is a KILL closure with portfolio-candidate annotation.
+
+## Active shelved archetypes
+
+| Arc | Archetype | Pipeline | Closure date | Result doc | Why shelved | Portfolio review status |
+|---|---|---|---|---|---|---|
+
+## Archived (no longer candidates)
+
+| Arc | Archetype | Date moved | Reason |
+|---|---|---|---|
+```
+
+Analyst adds rows to the Active table when a closure doc flags SHELVED. Archived rows on portfolio composition decisions (post-v2.4+).
+
+### Why
+
+SHELVED captures real semantics — Arc 5 closure flagged its archetypes as portfolio candidates rather than dead. Formalising SHELVED in §16a would add a disposition that is mechanically identical to KILL except for an annotation; cleaner to keep §16a's three dispositions and track the annotation separately.
+
+### Anchor preservation
+
+KH-24 anchor is deployed (SHIPPED), not shelved. No interaction.
+
+---
+
+## §7. v2.2 amendment items obsoleted or updated
+
+| v2.2 item | Status under v2.3 |
+|---|---|
+| §1 sign-flip mechanisation | **OBSOLETED.** Mechanised the Step 5 gate 1 override; Step 5 is removed. No replacement needed. |
+| §2 Tier 2 lift cap | **UNCHANGED.** Still ≤ 5 candidates per archetype. |
+| §3 Step 4 max-F1 fallback removal | **UNCHANGED.** No fallback. Archetype dies at Step 4. |
+| §4 Arc selection FIFO via queue | **UNCHANGED.** §15b stands. |
+| §5 §16a HALT/KILL rule | **UPDATED.** Failing-step list semantics: position 5 means WFO (not stability). Numeric identifier and Path A/B logic unchanged. |
+| §6 No mid-arc analyst sign-off | **UPDATED.** Halt at end of Step 4 (not Step 5). |
+| §7 §1a live-execution equivalence | **UPDATED.** Step 1 + Step 5 (not Step 6). Wording unchanged otherwise. |
+
+---
+
+## §8. §16a — updated
+
+### Amended text
+
+§16a from v2.2 §5 stands with one wording update:
+
+The failing-step list "{1, 2, 3, 4, 5}" remains. The semantic of position 5 is now "Step 5 WFO" (not "Step 5 cross-fold stability"). All other §16a logic — single-criterion-fail, cohort viability, Path A near-miss, Path B categorical with strong magnitude — is unchanged.
+
+Step 5 WFO failures admit §16a HALT under either path:
+- Path A (numeric near-miss): worst-fold ROI margin < 0.03 absolute below 0.05 pass-deployable threshold; OR worst-fold DD margin < 0.03 above 0.08 ceiling; AND all other criteria pass cleanly
+- Path B (categorical with strong magnitude): trade-count floor categorical fail AND cohort's `fwd_mfe_h240_p50 ≥ 3.0R`
+
+KILL otherwise.
+
+### Why
+
+§9 removal means "Step 5" semantic shifts. §16a's HALT/KILL is preserved for the new Step 5 (WFO) because near-miss WFO failures with strong magnitude are exactly the cohorts that warrant cross-arc calibration consideration.
+
+### Anchor preservation
+
+§16a doesn't apply to anchor (anchor is SHIPPED). No interaction.
+
+---
+
+## §9. Orchestrator halt point — updated
+
+### Amended text
+
+v2.2 §6 (no mid-arc analyst sign-off) stands with one wording update:
+
+The single CC dispatch (per `prompts/cc_arc_orchestrator_template.md`) executes steps 1-4 end-to-end and halts only at:
+
+- **End of step 4 (PASS)** — returns halt summary, awaits Step 5 WFO dispatch from chat
+- Mid-step KILL — closure doc per §16a, queue update, dispatch ends
+- Mid-step HALT — closure doc per §16a with calibration candidate section, queue update, dispatch ends
+- Engine-touching boundary breach — halt with halt summary, no commits to engine paths
+- Protocol ambiguity — halt with halt summary citing clause
+
+Chat does NOT review mid-arc state. Chat reviews:
+- Step 4 halt summaries (for Step 5 WFO dispatch decisions)
+- HALT closure docs in batch (for cross-arc calibration cycles)
+- KILL closure docs by skim (informational)
+
+### Orchestrator template updates
+
+`prompts/cc_arc_orchestrator_template.md` requires the following changes when v2.3 lands:
+
+1. Remove Step 5 (cross-fold stability) section entirely
+2. Renumber existing Step 6 references throughout the template to Step 5 (WFO)
+3. Update halt summary template: remove Step 5 fold-stability table; surviving archetypes table moves to end-of-Step-4 halt
+4. Update "Failure modes" section: no Step 5 failure mode
+5. Update "What this template does NOT cover" section: Step 5 WFO dispatch is now the analyst-review checkpoint
+
+### Why
+
+Halt point shifts because the protocol step it halted on no longer exists. Mechanical.
+
+### Anchor preservation
+
+Anchor doesn't go through the orchestrator (anchor is deployed). No interaction.
+
+---
+
+## §10. What v2.3 does NOT change
+
+Explicit non-changes:
+
+- §2 floor numbers
+- §6 K-selection or clustering rules
+- §7 SL sweep mechanics or capturability composite formula
+- §8 extractability AUC thresholds (Pipeline E 0.65, Pipeline D1 0.60), feature budget, threshold sweep recall ≥ 0.60 rule (v2.2 §3 stands)
+- §10 (renumbered as Step 5) WFO mechanics or pass-deployable / pass-viable / clean-null tier thresholds
+- §11 archetype map and exit policies
+- §14 anchor
+- §15 pool floor / arc-internal floors
+- §15a Step 1 schema requirement
+- §15b queue
+- §16 open questions (Open-22/23/24 close; others unchanged)
+- §16a Path A / Path B logic
+- v2.2 §2 (Tier 2 lift cap), §3 (max-F1 fallback removal), §4 (FIFO queue)
+- No engine change required for §9 removal, Step renumbering, Open-22 closure, Open-23 documentation, SHELVED register
+- Engine change required for Open-24 (separate PR; spec lands now)
+
+---
+
+## §11. Migration
+
+| Action | Owner | Required |
+|---|---|---|
+| Land v2.3 as PR to `L_ARC_PROTOCOL.md` (apply §9 deprecation, retitle §10, update internal references, update §16a, append §1a updates) | Engineering (Cursor) | Yes — protocol doc is PR-required scope |
+| Update `prompts/cc_arc_orchestrator_template.md` per §9 above | Chat | Yes — direct-to-main |
+| Create `SHELVED_ARCS.md` initial empty register; add any existing shelved entries (Arc 5 archetypes if analyst flags them) | Chat | Yes — direct-to-main |
+| Engine PR: per-archetype D1 `pre_t_sl_atr_multiplier` field, default 2.0 | Engineering | Yes for Open-24 honour; can land independently of v2.3 protocol |
+| Update STATUS.md / SESSION_ZERO.md / CHANGELOG.md / PROTOCOL_IMPROVEMENT_BACKLOG.md for v2.3 | Chat | Yes — direct-to-main (or single housekeeping dispatch) |
+| Re-evaluate past arcs under v2.3 | N/A | No — v2.3 applies to Arc 8 onward |
+
+---
+
+## §12. Open items moved by v2.3
+
+| Item | v2.2 status | v2.3 status |
+|---|---|---|
+| Open-22 (full-pool gate at §9) | Active backlog (HIGH) | **CLOSED** — by structural removal of §9 |
+| Open-23 (D1 cost-language) | Active backlog (MEDIUM) | **CLOSED** — documentation correction in §3 / §8 |
+| Open-24 (pre-t SL per archetype) | Active backlog (MEDIUM) | **CLOSED in protocol; engine PR pending** |
+| Open-17 (composite weighting) | v2.2 backlog | Unchanged |
+| Open-05 (multi-signal portfolio) | v2.2+ deferred | Unchanged; SHELVED_ARCS.md is the register feeding it |
+| Open-19 (engine schema portability) | Closed in v2.1.2 §15a | Unchanged |
+
+---
+
+## Document control
+
+| Field | Value |
+|---|---|
+| Version | v2.3 (DRAFT) |
+| Supersedes | v2.2 |
+| Active for arcs | Arc 8+ |
+| Methodology change | Yes — Step 5 (stability) removed; Pipeline D1 pre-t SL respec'd |
+| Engine change | None required for §9 removal / renumber / Open-22 / Open-23; separate PR for Open-24 honour |
+| Anchor preservation | Verified — anchor passes Step 5 WFO by deployment; Step 3 selected SL = 2.0×ATR matches v2.2 uniform pre-t SL |
+| Drafted | 2026-05-18 |
+| Companion files | `prompts/cc_arc_orchestrator_template.md` (updates required), `SHELVED_ARCS.md` (new), `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` (predecessor) |

--- a/PROTOCOL_IMPROVEMENT_BACKLOG.md
+++ b/PROTOCOL_IMPROVEMENT_BACKLOG.md
@@ -12,11 +12,12 @@
 |---|---|---|
 | Resolved in v2.1 / v2.1.1 | 11 | P0.1 (v2.1 + v2.1.1 composite refinement), P0.2, P0.3, P0.4, P0.5, P1.6, P1.9, P1.11 (via PR #131), P2.13, P2.15, P3.16 |
 | Partial in v2.1 | 1 | P1.8 |
-| Closed in v2.2 | 4 | §8 max-F1 fallback (v2.2 §3); mid-arc analyst sign-off carve-outs spanning §9/§12/§16a (v2.2 §1/§2/§5/§6); FIFO arc selection state file (v2.2 §4 new §15b); live-execution equivalence (v2.2 §7 new §1a, asserted not closed) |
-| Still open | 7 | P1.7 (refresh execution — pending KH-24 v2.0 re-run only under v2.1.1), P1.10, P1.12, P2.14; Open-22 (HIGH), Open-23 (MEDIUM), Open-24 (MEDIUM) — Pipeline D1 full-pool gating (Arc 4 RERUN + Arc 5) |
+| Closed in v2.2 | 4 | §8 max-F1 fallback (v2.2 §3); mid-arc analyst sign-off carve-outs spanning §9/§12/§16a (v2.2 §1/§2/§5/§6); FIFO arc selection state file (v2.2 §4 new §15b); live-execution equivalence (v2.2 §7 new §1a, asserted not closed). Note: v2.2 §1 sign-flip mechanisation obsoleted by v2.3 §9 removal — the gate it mechanised no longer exists. |
+| Closed in v2.3 | 3 | Open-22 (full-pool gate at §9, structural removal in v2.3 §1); Open-23 (Pipeline D1 cost-language, documentation correction in v2.3 §4); Open-24 (Pipeline D1 pre-t SL per archetype, protocol spec in v2.3 §5 — engine PR pending) |
+| Still open | 4 | P1.7 (refresh execution — pending KH-24 v2.0 re-run only under v2.1.1), P1.10, P1.12, P2.14 |
 | Partial in v2.2 | 1 | Open-21 (Step 4 deployability gate) — proposal (a) strict-mode max-F1 fallback closed by v2.2 §3; alternates (b) recall floor 0.30 + (c) AUC floor 0.70 remain on calibration backlog |
 
-Last updated: 2026-05-18 alongside L_ARC_PROTOCOL v2.2 amendment (governance + carve-out mechanisation + Step 4 max-F1 closure + live-execution equivalence assertion).
+Last updated: 2026-05-18 alongside L_ARC_PROTOCOL v2.3 amendment (Step 5 cross-fold stability removed; Step 6 WFO renumbered as Step 5; Open-22/23/24 closed in protocol with engine PR pending for Open-24). v2.2 amendment landed earlier same day.
 
 ---
 
@@ -499,23 +500,21 @@ Three items raised by Arc 6 closure (failed-breakout reversal long, out-of-regis
 
 Three items raised by the Arc 4 re-run closure (FAIL Step 6 under p50 floors) plus the Arc 5 closure (SHELVED Step 6 FAIL). Both arcs PASSED §9 admit-only stability and FAILED §10 full-pool deployment. Cross-arc structural finding: Pipeline D1 carries mandatory reject-pool + early-exit-pool cost that §9's admit-only framing cannot see. Numbering continues the Open-NN sequence (Open-21 was the last assigned).
 
-### Open-22 — Full-pool gate at §9 or earlier (HIGH)
+### Open-22 — Full-pool gate at §9 or earlier (HIGH) — CLOSED in v2.3
 
 - **Description.** §9 currently evaluates admit-only stability. Arc 4 and Arc 5 both PASS §9 and FAIL §10 full-pool deployment. The protocol burns Steps 1-5 of compute and analyst time on arcs whose architectural failure mode is invisible until Step 6.
 
-    Candidate amendments:
+    Candidate amendments (historical, pre-v2.3):
     - Add a full-pool variant to §9 (require both admit-only AND full-pool sign-consistency to advance)
     - Add a Step 4 full-pool preview (admit/reject/early-exit decomposition with expectancy estimate at the classifier-locking gate)
     - Restructure §9 + §10 sequencing so the deployment-blocking metric is the primary stability gate
     - Pre-Step 6 admit/reject/early-exit expectancy summary as standardised Step 4 output
 
-    Decision belongs in cross-arc calibration session. Quantitative inputs available from Arc 4 + Arc 5 step6 artefacts.
-
 - **Surface arc.** Arc 4 rerun (2026-05-18) + Arc 5 closure (recent).
-- **Owner.** Cross-arc calibration session.
-- **Status.** OPEN.
+- **Resolution (v2.3, 2026-05-18).** Closed by structural removal of §9 in v2.3 §1. Step 5 (WFO, was Step 6) measures full-pool by construction. No replacement gate needed. See "Resolved in v2.3 amendment" section below.
+- **Status.** CLOSED in v2.3.
 
-### Open-23 — §8 Pipeline D1 cost-language correction (MEDIUM)
+### Open-23 — §8 Pipeline D1 cost-language correction (MEDIUM) — CLOSED in v2.3
 
 - **Description.** §8 describes Pipeline D1 reject pool as "near-break-even small loss after spread, given the short hold and pre-t SL." Empirical evidence from Arc 4 + Arc 5:
 
@@ -524,28 +523,24 @@ Three items raised by the Arc 4 re-run closure (FAIL Step 6 under p50 floors) pl
     | Arc 4 cluster 1 | −0.232 | 32.2% | −0.685 | 10.6% |
     | Arc 5 (per closure) | ~−0.46 | ~78% (Arc 5 specific) | — | — |
 
-    §8 wording understates reject-pool cost. Empirically the reject pool costs ~−0.15 to −0.46R per trade depending on classifier discrimination strength, and the early-exit pool (pre-t SL hits before t=1) is a separate architectural cost at ~−0.45 to −0.69R on ~10-15% of signals.
-
-    Proposed amendment: update §8 description to specify empirical cost ranges and mandate full-pool reporting at Step 4-6 evaluation.
+    §8 wording understated reject-pool cost. Empirically the reject pool costs ~−0.15 to −0.46R per trade depending on classifier discrimination strength, and the early-exit pool (pre-t SL hits before t=1) is a separate architectural cost at ~−0.45 to −0.69R on ~10-15% of signals.
 
 - **Surface arc.** Arc 4 rerun + Arc 5 closure.
-- **Owner.** Cross-arc calibration session.
-- **Status.** OPEN.
+- **Resolution (v2.3, 2026-05-18).** Closed by documentation correction in v2.3 §4. §3 and §8 Pipeline D1 wording updated with empirical cost ranges; full-pool R = admit + reject + pre-t-loss contributions; evaluated at Step 5 WFO. See "Resolved in v2.3 amendment" section below.
+- **Status.** CLOSED in v2.3.
 
-### Open-24 — Early-exit pool architectural cost (MEDIUM)
+### Open-24 — Pipeline D1 pre-t SL per archetype (MEDIUM) — CLOSED in protocol in v2.3; engine PR pending
 
 - **Description.** Pre-t SL of 2×ATR (§8 Pipeline D1 default) fires on 10-15% of signals before the classifier evaluates at bar t. This is pure architectural cost — not classifier-induced, not exit-policy-induced. The classifier cannot filter these trades and the bail-out doesn't apply. Arc 4 cluster 1 saw 1,005 / 9,474 signals (10.6%) hit pre-t SL at −0.685R mean.
 
-    Candidate structural responses:
+    Candidate structural responses (historical, pre-v2.3):
     - Widen uniform pre-t SL (reduces early-exit rate; increases per-event loss)
     - Shorten t (less time for SL to fire; smaller classifier feature set)
     - Hybrid: per-archetype pre-t SL calibrated to early-exit rate observed at Step 1
 
-    Currently §8 uses uniform 2×ATR as a pre-amendment default matching KH-24 baseline. Per-archetype calibration may be justified by empirical data from Arc 4 + Arc 5.
-
 - **Surface arc.** Arc 4 rerun.
-- **Owner.** Cross-arc calibration session.
-- **Status.** OPEN.
+- **Resolution (v2.3, 2026-05-18).** Closed in protocol via v2.3 §5: pre-t SL = cluster's Step 3 selected SL multiplier (was uniform 2.0×ATR). Engine PR pending to expose per-archetype `pre_t_sl_atr_multiplier` field (default 2.0 for backward compatibility / anchor preservation). Per-archetype YAML schema extension; Step 3 archetype YAML emission writes `pre_t_sl_atr_multiplier = selected_sl_multiplier`. See "Resolved in v2.3 amendment" section below.
+- **Status.** CLOSED in protocol; engine PR pending.
 
 ---
 
@@ -573,6 +568,37 @@ Recommend executing P0.1 first (mechanical, cheap, almost certainly resolves muc
 P0.1, P0.2, P0.3, P0.5 are anchor-safe by construction (anchor values are at least as favourable under new metric definitions, anchor already passes the looser shape_tag taxonomy via D1, anchor is a single cluster not aggregated, anchor monotonicity comfortably clears any plausible loosened floor).
 
 P0.4 is the exception: Path 2 (SL scaled to horizon) cannot retrofit to KH-24 without rebuilding the live system. Anchor preservation requires Path 2 to apply forward only, with KH-24 documented as a per-system exception.
+
+---
+
+## Resolved in v2.3 amendment (2026-05-18)
+
+L_ARC_PROTOCOL v2.3 amendment landed 2026-05-18 (`L_ARC_PROTOCOL_v2_3_AMENDMENT.md`). Seven §0 changes; three items from this backlog close:
+
+### CLOSED in v2.3 §1 — Open-22 full-pool gate at §9 (structural removal)
+
+- **Surface:** Arc 4 RERUN (2026-05-18) + Arc 5 closure. Both arcs PASSED §9 admit-only stability and FAILED §10 full-pool deployment. §9 evaluated admit-set fold metrics; deployed-system economics for Pipeline D1 depend on full-pool (admit + reject + early-exit). The gate measured the wrong population.
+- **Resolution.** v2.3 §1 removes §9 entirely. Pipeline is now 1-2-3-4-5 with Step 5 = WFO (renumbered from Step 6). Step 5 WFO runs the full backtester across all 7 OOS folds with real execution — every signal in the population goes through the engine, including reject-set early closures with their actual costs. Step 5 inherently measures full-pool. No separate Step 5 question that Step 6 doesn't answer more accurately.
+- **Compute trade-off acknowledged.** Step 5 was cheap (uses already-trained classifier + admit set); Step 5 WFO is expensive (full WFO). "Filter bad archetypes before spending Step 6 compute" rationale doesn't justify the misleading-data problem documented in Arc 4 RERUN's deployment-fatal failure mode.
+- **Anchor preservation.** KH-24 K=4 archetype 3 passes Step 5 WFO by deployment (worst-fold ROI +1.92%, worst-fold DD 6.37%, all 7 OOS folds positive). v2.2 Step 5 cross-fold stability (now removed) had been satisfied trivially by the same fold data. No interaction.
+
+### CLOSED in v2.3 §4 — Open-23 Pipeline D1 cost-language correction (documentation)
+
+- **Surface:** Arc 5 closure surfaced the gap; Arc 4 RERUN reinforced.
+- **Resolution.** v2.3 §4 updates §3 and §8 Pipeline D1 wording. §3 Pipeline D1 description now reads: "Predict at bar t which trades to close vs continue. Rejected trades close at bar t with cost ~−0.15 to −0.46R; this is empirical, not a parameter." §8 Pipeline D1 row now references full-pool R = admit-weighted + reject-weighted + pre-t-loss contributions, evaluated at Step 5 WFO. Three-population structure documented (admit / rejected / pre-t losers) with empirical cost bounds from closed-arc evidence.
+- **No threshold change.** Documentation correction only. Arc 5's KILL disposition was correct under v2.2; the gap was that an analyst reading §3 / §8 in v2.2 might infer rejected trades were cost-free.
+- **Anchor preservation.** Anchor uses Pipeline D1 at t=3. Documentation correction does not change anchor evaluation.
+
+### CLOSED in v2.3 §5 — Open-24 Pipeline D1 pre-t SL per archetype (protocol; engine PR pending)
+
+- **Surface:** Arc 4 RERUN — uniform 2.0×ATR pre-t SL fired on 10.6% of signals at −0.685R mean, structurally separate cost from classifier-induced reject pool.
+- **Resolution.** v2.3 §5 specifies pre-t SL = cluster's Step 3 selected SL multiplier (was uniform 2.0×ATR for all D1 archetypes). The SL distance selected at §7 SL sweep (per cluster, by capturability composite) is the SL used pre-t for that cluster's Pipeline D1 deployment.
+- **Engine impact.** Pipeline D1 engine (post-PR2) supports per-archetype config for §11 exit policies. v2.3 spec requires the per-archetype D1 config to additionally express `pre_t_sl_atr_multiplier` (default 2.0 for backward compatibility with v2.2 behaviour and anchor preservation). Engine PR scope: add field to per-archetype D1 YAML schema; default 2.0; read at trade entry; apply to pre-t SL distance calculation; Step 3 archetype YAML emission writes `pre_t_sl_atr_multiplier = selected_sl_multiplier`. Can land independently of v2.3 protocol amendment doc.
+- **Anchor preservation.** KH-24 K=4 archetype 3 Step 3 selected SL = 2.0×ATR (matches v2.0 anchor metrics fwd_mfe_p50 measured at 2.0×ATR frame). Pre-t SL under v2.3 = 2.0×ATR (cluster's Step 3 selected) = identical to v2.2's uniform 2.0×ATR. Open-24 spec change is a no-op for the anchor.
+
+### Cross-cutting note on v2.2 §1 obsoletion
+
+v2.2 §1 (sign-flip mechanisation) is OBSOLETED by v2.3 §1 — it mechanised the Step 5 gate 1 override; the gate no longer exists. v2.2 §2/§3/§4/§7 stand unchanged; v2.2 §5 (§16a) and §6 (halt point) updated for renumbering. Recorded for change-tracking, not a calibration loss.
 
 ---
 
@@ -681,4 +707,5 @@ Items 1-3 (NEW) are candidates for the v2.3 / v2.1.3 calibration cycle. Items 5 
 | Arc 6 cross-arc items added | 2026-05-17 — Open-21 (Step 4 deployability gate, new), Open-17 expansion (Tiebreak 1 noise floor), unnumbered reach_1R noise tolerance note |
 | Arc 4 RERUN + Arc 5 items added | 2026-05-18 — Open-22/23/24 (Pipeline D1 full-pool gating); Arc 5 P-series (P0: §9-FRAMING, D1-VIABILITY, D1-REJECT-BIAS; P1: F9-RESELECT; P2: CLUSTERING-LEAKAGE, SPREAD-FLOOR-DOC, §11-MATCH-FORMULA, OPEN-18-RECONCILE) |
 | Arc 7 cross-arc items added | 2026-05-18 (housekeeping pass) — 7 items (3 NEW, 1 VALIDATED, 1 UNRESOLVED, 2 CLEANUP) from `phase/l_arc_7` closure doc |
-| v2.2 amendment date | 2026-05-18 — `L_ARC_PROTOCOL_v2_2_AMENDMENT.md`. Closed in v2.2: §8 max-F1 fallback (v2.2 §3, closing Arc 6/7 case), mid-arc analyst sign-off carve-outs (v2.2 §1/§2/§5/§6), FIFO arc selection (v2.2 §4 new §15b), live-execution equivalence asserted (v2.2 §7 new §1a). Open-21 partial: proposal (a) strict-mode closed; (b)/(c) on backlog. Open-22/23/24 (Pipeline D1 full-pool gating) NOT closed by v2.2 — remain top P0 for next cross-arc calibration cycle. |
+| v2.2 amendment date | 2026-05-18 — `L_ARC_PROTOCOL_v2_2_AMENDMENT.md`. Closed in v2.2: §8 max-F1 fallback (v2.2 §3, closing Arc 6/7 case), mid-arc analyst sign-off carve-outs (v2.2 §1/§2/§5/§6), FIFO arc selection (v2.2 §4 new §15b), live-execution equivalence asserted (v2.2 §7 new §1a). Open-21 partial: proposal (a) strict-mode closed; (b)/(c) on backlog. Open-22/23/24 (Pipeline D1 full-pool gating) NOT closed by v2.2 — addressed in v2.3 (row below). |
+| v2.3 amendment date | 2026-05-18 — `L_ARC_PROTOCOL_v2_3_AMENDMENT.md`. Closed in v2.3: Open-22 (v2.3 §1 structural removal of §9); Open-23 (v2.3 §4 §3/§8 cost-language correction); Open-24 (v2.3 §5 per-archetype pre-t SL spec; engine PR pending for `pre_t_sl_atr_multiplier`). Step 5 cross-fold stability removed; Step 6 WFO renumbered as Step 5; orchestrator halt point shifted end of Step 5 → end of Step 4; v2.2 §1 sign-flip mechanisation OBSOLETED (gate no longer exists); §16a position-5 semantic shifted to WFO; §1a Step 1 + Step 5 (was Step 6). New informal register at `SHELVED_ARCS.md`. Anchor preservation verified (KH-24 K=4 archetype 3 passes Step 5 WFO by deployment; Step 3 selected SL = 2.0×ATR matches v2.2 uniform pre-t SL — Open-24 no-op for anchor). Companion file: `prompts/cc_arc_orchestrator_template.md` updated to v1.1. |

--- a/SESSION_ZERO.md
+++ b/SESSION_ZERO.md
@@ -1,30 +1,34 @@
 # SESSION ZERO — Forex Ignition Rebuild
-> 5-minute primer. Read this first, then read `L_ARC_PROTOCOL.md` (v2.1.2 base) + `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` (v2.2 active for Arc 8+).
-> Last updated: 2026-05-18 — L_ARC_PROTOCOL v2.2 amendment landed (mechanises remaining chat-judgement carve-outs, closes Step 4 max-F1 fallback, asserts live-execution equivalence). Arcs 4-7 all closed (Arc 4 RERUN FAIL Step 6; Arc 5 SHELVED Step 6 FAIL; Arc 6 DIES Step 4; Arc 7 CLEAN-NULL Step 4). Arc queue empty pending analyst signal selection for Arc 8+. KH-24 live deployment unchanged.
+> 5-minute primer. Read this first, then read `L_ARC_PROTOCOL.md` (v2.1.2 base) + `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` (v2.2) + `L_ARC_PROTOCOL_v2_3_AMENDMENT.md` (v2.3 active for Arc 8+).
+> Last updated: 2026-05-18 — L_ARC_PROTOCOL v2.3 amendment landed (Step 5 cross-fold stability removed; Step 6 WFO renumbered as Step 5; Open-22/23/24 closed in protocol with engine PR pending for Open-24). v2.2 amendment landed earlier same day. Arcs 4-7 all closed. Arc queue empty pending analyst signal selection for Arc 8+. KH-24 live deployment unchanged.
 
 ---
 
 ## Pointers
 
-- Active protocol: `L_ARC_PROTOCOL.md` v2.1.2 base + `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` v2.2 amendment (active for Arc 8+)
+- Active protocol: `L_ARC_PROTOCOL.md` v2.1.2 base + `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` v2.2 + `L_ARC_PROTOCOL_v2_3_AMENDMENT.md` v2.3 (all three binding for Arc 8+)
 - Arc queue: `results/ARC_QUEUE.md` (Active: none; Unrun: none; Closed: see file)
-- Orchestrator: `prompts/cc_arc_orchestrator_template.md` — one arc per CC chat session (unattended Steps 1-5)
+- Orchestrator: `prompts/cc_arc_orchestrator_template.md` v1.1 — one arc per CC chat session (unattended Steps 1-4 under v2.3)
+- Shelved register: `SHELVED_ARCS.md` — informal register for KILL closures with portfolio-candidate annotation (per v2.3 §6)
 - v1.x archive: `archive/`
 
 ---
 
 ## Current State
 
-**L_ARC_PROTOCOL v2.2 AMENDMENT LANDED 2026-05-18.** Mechanises remaining chat-judgement carve-outs in steps 1-5, closes Step 4 max-F1 fallback gap surfaced by Arc 7, asserts live-execution equivalence for steps 1 and 6. Methodology unchanged. CC can now run arcs 1→5 unattended in parallel without analyst sign-off mid-arc. Companion files (`prompts/cc_arc_orchestrator_template.md`, `results/ARC_QUEUE.md`) landed same day.
+**L_ARC_PROTOCOL v2.3 AMENDMENT LANDED 2026-05-18.** Step 5 cross-fold stability (§9) removed — pipeline is now five steps (1 plumbing, 2 clustering, 3 capturability, 4 extractability, 5 WFO). Step 6 WFO renumbered as Step 5. Closes Open-22 (full-pool gate at §9) by structural removal; closes Open-23 (Pipeline D1 cost-language) by documentation correction in §3/§8; closes Open-24 (pre-t SL per archetype) in protocol with engine PR pending. v2.2 §1 sign-flip mechanisation OBSOLETED (Step 5 stability gate no longer exists). Orchestrator halt point: end of Step 5 → end of Step 4. §1a live-execution equivalence: Step 1 + Step 5 (was Step 6). SHELVED informal register at new `SHELVED_ARCS.md`. Anchor preservation verified — KH-24 K=4 archetype 3 passes Step 5 WFO by deployment; Step 3 selected SL = 2.0×ATR matches v2.2 uniform pre-t SL (Open-24 no-op for anchor).
+
+**v2.2 amendment landed earlier same day (2026-05-18).** Mechanises remaining chat-judgement carve-outs in steps 1-5, closes Step 4 max-F1 fallback gap surfaced by Arc 7, asserts live-execution equivalence for steps 1 and 6 (now Step 1 + Step 5 under v2.3 §7). Methodology unchanged. CC can now run arcs unattended through Steps 1-4 without analyst sign-off mid-arc. Companion files (`prompts/cc_arc_orchestrator_template.md`, `results/ARC_QUEUE.md`) landed same day; orchestrator template updated to v1.1 for v2.3.
 
 **Arc queue currently empty.** Arcs 4-7 all closed in the 2026-05-17/2026-05-18 batch. Analyst populates `results/ARC_QUEUE.md` Unrun section with Arc 8+ signal specs (registry exhausted after Arc 5; Arc 6+ use standalone `signal_spec_<name>_v<version>.md` docs per v2.2 §15b).
 
-**LIVE SYSTEM: KH-24 unchanged on VPS.** None of the seven v2.2 §0 items were invoked on the KH-24 anchor under v2.0 or v2.1.x — anchor preservation verified.
+**LIVE SYSTEM: KH-24 unchanged on VPS.** None of the seven v2.2 §0 items were invoked on the KH-24 anchor under v2.0 or v2.1.x — anchor preservation verified. v2.3 §0 changes are anchor-preserving by construction (anchor passes Step 5 WFO by deployment; Open-24 default 2.0 matches anchor's Step 3 selected SL).
 
 **Next chat tasks:**
 1. Analyst signal selection for Arc 8+ (populate `results/ARC_QUEUE.md` Unrun)
-2. Cross-arc calibration session for Open-22/23/24 (Pipeline D1 full-pool gating — surfaced by Arc 4 + Arc 5 closures, NOT closed by v2.2)
-3. Engineering pass to apply the v2.2 amendment text into `L_ARC_PROTOCOL.md` itself (PR-required per amendment §9)
+2. Engine PR for Open-24 honour (per-archetype D1 `pre_t_sl_atr_multiplier`; default 2.0 preserves anchor) — can land independently of protocol-doc PR
+3. Engineering pass to apply v2.2 + v2.3 amendment text into `L_ARC_PROTOCOL.md` itself (PR-required; option to bundle both amendments into a single consolidation PR)
+4. Analyst decision on whether Arc 5 archetypes should be pre-populated in `SHELVED_ARCS.md` Active table (analyst signal call)
 
 ### Arcs 4-7 closure batch summary
 
@@ -58,19 +62,18 @@ KH-24 is locked and out of scope for L arc work. No modifications without an exp
 
 ### Active research direction
 
-**L arc signal testing under v2.2 amendment (Arc 8+); v2.1.2 base.** Source of truth: `L_ARC_PROTOCOL.md` v2.1.2 + `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` v2.2 amendment (methodology unchanged from v2.1.2; v2.2 is governance + carve-out mechanisation). v1.x ops spec is archived for historical reference.
+**L arc signal testing under v2.3 amendment (Arc 8+); v2.1.2 base + v2.2 governance.** Source of truth: `L_ARC_PROTOCOL.md` v2.1.2 + `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` v2.2 amendment + `L_ARC_PROTOCOL_v2_3_AMENDMENT.md` v2.3 amendment (methodology unchanged from v2.1.2; v2.2 is governance + carve-out mechanisation; v2.3 removes Step 5 cross-fold stability and renumbers Step 6 → Step 5). v1.x ops spec is archived for historical reference.
 
-L arc tests each candidate signal through a six-step pipeline:
+L arc tests each candidate signal through a five-step pipeline (v2.3):
 1. Plumbing (deterministic full-pool generation; pool ≥ 500)
 2. Path-shape clustering (outcome-blind features: monotonicity, local_peaks, pullback, time_to_peak_rel)
 3. Capturability characterisation (per §2 hard floors: clean shape + meaningful magnitude)
 4. Extractability + artefact production (Pipeline E entry-filter AUC ≥ 0.65 OR Pipeline D1 deferred-policy AUC ≥ 0.60; v2.2 §3 — no max-F1 fallback if recall ≥ 0.60 unachievable)
-5. Cross-fold stability (sign consistency, size variance, DD ceiling; v2.2 §1 — conjunctive without override)
-6. WFO truth + pass-deployable / pass-viable gate (v2.2 §7 — live-execution equivalence required)
+5. WFO truth + pass-deployable / pass-viable gate (renumbered from v2.2's Step 6 under v2.3 §2; v2.2 §7 §1a live-execution equivalence applies; full-pool measurement by construction)
 
-Arcs 1 and 2 are historical (ran under v1.x). v2.0 governed Arc 3; v2.1.2 governed Arcs 4-7; v2.2 governs Arc 8+. Calibration anchor: KH-24 K=4 archetype 3, which passes v2.0 extractability via Pipeline D1 at t=3 (RF AUC 0.638, exclusion 15.4%). Anchor not refreshed from Open-18 replays per user decision — deployed-pop reference holds. v2.1.2/v2.2 anchor preservation verified (centroid still routes to Stepwise under 5-50 local_peaks range; bimodal shape_tag passes `≠ scattered`; none of the seven v2.2 §0 items were invoked on the anchor).
+Step 5 cross-fold stability (v2.2 §9) removed under v2.3 §1 — Step 5 (WFO, was Step 6) measures full-pool by construction. Arcs 1 and 2 are historical (ran under v1.x). v2.0 governed Arc 3; v2.1.2 governed Arcs 4-7; v2.2 + v2.3 govern Arc 8+. Calibration anchor: KH-24 K=4 archetype 3, which passes Step 5 WFO via Pipeline D1 at t=3 (RF AUC 0.638, exclusion 15.4%). Anchor not refreshed from Open-18 replays per user decision — deployed-pop reference holds. v2.3 anchor preservation verified (anchor passes Step 5 WFO by deployment; Step 3 selected SL = 2.0×ATR matches v2.2 uniform pre-t SL — Open-24 spec change is a no-op).
 
-**Arc dispatch model under v2.2 (new):** one arc per CC chat session, dispatched via `prompts/cc_arc_orchestrator_template.md`. CC reads `results/ARC_QUEUE.md`, picks topmost Unrun entry, runs Steps 1-5 unattended, halts at end of Step 5 for analyst-led Step 6 WFO dispatch. Multiple arcs in parallel = multiple CC chat sessions, each on its own `phase/arc-<N>` branch. See v2.2 §15b (FIFO arc selection) and §13 (no mid-arc analyst sign-off).
+**Arc dispatch model under v2.3:** one arc per CC chat session, dispatched via `prompts/cc_arc_orchestrator_template.md` v1.1. CC reads `results/ARC_QUEUE.md`, picks topmost Unrun entry, runs Steps 1-4 unattended, halts at end of Step 4 for analyst-led Step 5 WFO dispatch. Multiple arcs in parallel = multiple CC chat sessions, each on its own `phase/arc-<N>` branch. See v2.2 §15b (FIFO arc selection) and §13 (no mid-arc analyst sign-off; halt point shifted to end of Step 4 under v2.3 §9).
 
 ### Tool assignments (unchanged)
 
@@ -126,6 +129,22 @@ The L arc is methodologically distinct from KH-24 development. It does not assum
 ## Phase History
 
 *Note: when applying SESSION_ZERO updates, preserve any pre-existing Phase History entries below this line. New entries are appended at the top. The full list is what remains in the file.*
+
+### 2026-05-18 — L_ARC_PROTOCOL v2.3 amendment landed
+
+`L_ARC_PROTOCOL_v2_3_AMENDMENT.md` (repo root), `prompts/cc_arc_orchestrator_template.md` (updated to v1.1), and new `SHELVED_ARCS.md` all landed 2026-05-18 alongside the v2.2 amendment. v2.3 is the active protocol for Arc 8+ in conjunction with v2.1.2 base + v2.2 governance. Seven §0 changes:
+
+1. **§9 (Step 5 cross-fold stability) removed.** Pipeline is now five steps: 1 plumbing, 2 clustering, 3 capturability, 4 extractability, 5 WFO. Step 5 was an admit-only proxy for Pipeline D1 that diverged from deployed-system economics (Arc 4 RERUN evidence: admit-set +1.5R vs full-pool −76.98% ROI). Step 5 WFO (renumbered) measures full-pool by construction. Closes Open-22 (full-pool gate at §9) by structural removal.
+2. **§10 retitled "Step 5 — WFO".** All internal cross-references renumbered: Step 6 → Step 5 across §1, §2, §3, §11, §12, §13, §14, §15, §16, §17, §16a, v2.2 §1a, v2.2 §3 downstream. Closure docs and CHANGELOG entries written under v2.2 or earlier keep "Step 6" verbatim — protocol-version anchoring rather than retroactive renumbering.
+3. **Orchestrator halt point: end of Step 5 → end of Step 4.** Mechanical consequence of §9 removal. Orchestrator template updated to v1.1.
+4. **v2.2 §1 sign-flip mechanisation OBSOLETED.** It mechanised the Step 5 gate 1 override; the gate no longer exists. v2.2 §2/§3/§4/§7 unchanged; v2.2 §5 (§16a) and §6 (halt point) updated for renumbering.
+5. **§16a failing-step list semantic.** Position 5 now means "Step 5 WFO" (not "Step 5 cross-fold stability"). Numeric identifier unchanged; Path A near-miss and Path B categorical-with-strong-magnitude logic unchanged.
+6. **Pipeline D1 pre-t SL per archetype (Open-24).** v2.3 §5 specifies pre-t SL = cluster's Step 3 selected SL multiplier (was uniform 2.0×ATR). Engine PR pending to expose per-archetype `pre_t_sl_atr_multiplier`; default 2.0 preserves anchor (KH-24's Step 3 selected SL = 2.0×ATR, identical to v2.2 default).
+7. **Pipeline D1 cost-language documented (Open-23).** v2.3 §4 updates §3 / §8 Pipeline D1 wording with empirical cost bounds: rejected pool ~−0.15 to −0.46R, pre-t losers ~−0.45 to −0.69R on ~10-15% of signals. Full-pool R = admit + reject + pre-t-loss contributions; evaluated at Step 5 WFO.
+
+Plus new informal SHELVED register (`SHELVED_ARCS.md`, v2.3 §6) — KILL closures with portfolio-candidate annotation, feeding §16 Open-05 (multi-signal portfolio composition). Not a formal §16a disposition. Active table starts empty; analyst decides whether Arc 5's archetypes pre-populate.
+
+Anchor preservation: KH-24 K=4 archetype 3 passes Step 5 WFO by deployment (worst-fold ROI +1.92%, worst-fold DD 6.37%, all 7 OOS folds positive). Open-24's spec change is a no-op for the anchor (Step 3 selected SL = 2.0×ATR matches v2.2 uniform pre-t SL). Per v2.3 §11 Migration: protocol-doc PR to consolidate v2.2 + v2.3 amendment text into `L_ARC_PROTOCOL.md` itself is engineering scope (PR-required); option to bundle both amendments. Engine PR for Open-24 honour can land independently. v2.3 applies to Arc 8 onward; closed arcs not re-evaluated.
 
 ### 2026-05-18 — L_ARC_PROTOCOL v2.2 amendment landed
 

--- a/SHELVED_ARCS.md
+++ b/SHELVED_ARCS.md
@@ -1,0 +1,25 @@
+# Shelved Arcs Register
+
+> Informal register of arcs that closed KILL at Step 5 WFO but whose archetypes carry structural interest as portfolio composition candidates (per L_ARC_PROTOCOL §16 Open-05).
+> SHELVED is not a formal §16a disposition. Each entry here is a KILL closure with portfolio-candidate annotation.
+> Active for arcs under L_ARC_PROTOCOL v2.3+. Pre-v2.3 closures that used SHELVED informally (Arc 5) may be added here by analyst decision.
+
+## Active shelved archetypes
+
+| Arc | Archetype | Pipeline | Closure date | Result doc | Why shelved | Portfolio review status |
+|---|---|---|---|---|---|---|
+
+## Archived (no longer candidates)
+
+| Arc | Archetype | Date moved | Reason |
+|---|---|---|---|
+
+---
+
+## Conventions
+
+- SHELVED is informal — mechanically maps to KILL for §16a disposition purposes
+- Closure doc is the record-of-truth for the arc's evaluation
+- This file is the lightweight register feeding §16 Open-05 (multi-signal portfolio composition, v2.2+ deferred)
+- Analyst adds rows when a KILL closure carries portfolio-candidate annotation
+- Analyst moves rows to Archived when portfolio composition has been reviewed and archetype dropped from consideration

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,14 +1,14 @@
 # STATUS
 
 > Tight current-state snapshot. For full context, read `SESSION_ZERO.md` first.
-> For methodology, read `L_ARC_PROTOCOL.md` (v2.2 amendment landed 2026-05-18 at `L_ARC_PROTOCOL_v2_2_AMENDMENT.md`; protocol-doc PR pending engineering pass per amendment §9).
-> Last updated: 2026-05-18 — L_ARC_PROTOCOL v2.2 amendment landed (mechanises remaining chat-judgement carve-outs, closes Step 4 max-F1 fallback, asserts live-execution equivalence). Arcs 4, 5, 6, 7 all closed (Arc 4 RERUN FAIL Step 6; Arc 5 SHELVED Step 6 FAIL; Arc 6 DIES Step 4; Arc 7 CLEAN-NULL Step 4). Arc queue currently empty pending analyst signal selection for Arc 8+. KH-24 live deployment unchanged.
+> For methodology, read `L_ARC_PROTOCOL.md` (v2.1.2 base) + `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` (v2.2) + `L_ARC_PROTOCOL_v2_3_AMENDMENT.md` (v2.3, landed 2026-05-18); protocol-doc PR pending engineering pass to consolidate v2.2 + v2.3 amendments into the protocol doc itself.
+> Last updated: 2026-05-18 — L_ARC_PROTOCOL v2.3 amendment landed (Step 5 cross-fold stability removed; Step 6 WFO renumbered as Step 5; Open-22/23/24 closed in protocol with engine PR pending for Open-24). v2.2 amendment landed earlier same day. Arcs 4, 5, 6, 7 all closed. Arc queue currently empty pending analyst signal selection for Arc 8+. KH-24 live deployment unchanged.
 
 ---
 
 ## Active protocol
 
-- Active protocol: L_ARC_PROTOCOL v2.2 (amendment landed 2026-05-18 at `L_ARC_PROTOCOL_v2_2_AMENDMENT.md`; v2.1.2 base, 2026-05-17). Companion files landed same day: `prompts/cc_arc_orchestrator_template.md`, `results/ARC_QUEUE.md`. Protocol-doc PR pending engineering pass per amendment §9.
+- Active protocol: L_ARC_PROTOCOL v2.1.2 base + v2.2 amendment + v2.3 amendment (v2.3 landed 2026-05-18 at `L_ARC_PROTOCOL_v2_3_AMENDMENT.md`; v2.2 amendment landed earlier same day at `L_ARC_PROTOCOL_v2_2_AMENDMENT.md`; v2.1.2 base, 2026-05-17). Companion files: `prompts/cc_arc_orchestrator_template.md` (updated to v1.1 for v2.3), `results/ARC_QUEUE.md`, `SHELVED_ARCS.md` (new under v2.3). Protocol-doc PR pending engineering pass to consolidate v2.2 + v2.3 amendment text into `L_ARC_PROTOCOL.md` itself.
 - Calibration anchor: KH-24 K=4 archetype 3 — v2.0 values; deployed-pop reference held (no refresh from Open-18 replays per user decision; v2.1.2/v2.2 anchor preservation verified — centroid still routes to Stepwise under 5-50 local_peaks range; none of the seven v2.2 §0 items were invoked on the anchor under v2.0 / v2.1.x).
 - Next engine PR: none currently planned. Backtester extension complete: PR #131 (D1 plumbing), PR #135 (D1 PR 2 Stepwise climber policy + per-fold classifiers), PR #138 (engine generalisation: signal adapter + TF pluggability + time-exit + spread floor). §11 rows 1, 3, 4, 5, 6, 7 exit policies deferred until an arc surfaces a Step-4 consumer needing them.
 - **Spread floor:** `configs/spread_floors_5ers.yaml` replaced 2026-05-17 with per-pair p50 values from HistData 2024-2025 audit. See `docs/calibration_decisions/SPREAD_FLOOR_CALIBRATION_DECISION_2026-05-17.md` (decision rationale, §3–§4 for the p50-over-p10 override) and `docs/SPREAD_FLOOR_AUDIT_FINDING.md` RESOLVED section.
@@ -18,7 +18,20 @@
 
 ## Current Phase
 
-**L_ARC_PROTOCOL v2.2 amendment landed 2026-05-18.** Mechanises the remaining chat-judgement carve-outs in steps 1-5, closes the Step 4 max-F1 fallback gap surfaced by Arc 7, and asserts live-execution equivalence for steps 1 and 6. Methodology unchanged. CC can now run arcs 1→5 unattended in parallel without analyst sign-off mid-arc.
+**L_ARC_PROTOCOL v2.3 amendment landed 2026-05-18.** Step 5 cross-fold stability (§9) removed — pipeline is now five steps (1 plumbing, 2 clustering, 3 capturability, 4 extractability, 5 WFO). Step 6 WFO renumbered as Step 5. Closes Open-22 (full-pool gate at §9) by structural removal; closes Open-23 (Pipeline D1 cost-language) by documentation correction in §3/§8; closes Open-24 (Pipeline D1 pre-t SL per archetype) in protocol with engine PR pending (per-archetype `pre_t_sl_atr_multiplier`, default 2.0 preserves anchor). v2.2 §1 sign-flip mechanisation OBSOLETED (Step 5 stability gate it mechanised no longer exists). Orchestrator halt point: end of Step 5 → end of Step 4. §1a live-execution equivalence: Step 1 + Step 5 (was Step 6). SHELVED informal register at new `SHELVED_ARCS.md` (not §16a). Anchor preservation verified — KH-24 K=4 archetype 3 passes Step 5 WFO by deployment; Step 3 selected SL = 2.0×ATR matches v2.2 uniform pre-t SL.
+
+**v2.3 §0 changes (seven items):**
+- §9 (Step 5 cross-fold stability) removed; pipeline is 1-2-3-4-5
+- §10 retitled "Step 5 — WFO" (was "Step 6 — WFO"); all internal cross-references renumbered
+- Orchestrator halt point: end of Step 5 → end of Step 4
+- v2.2 §1 sign-flip mechanisation OBSOLETED (mechanised the removed gate)
+- §16a failing-step list position 5 semantic now = WFO (not stability); Path A/B logic unchanged
+- Pipeline D1 pre-t SL spec: per-archetype = cluster's Step 3 selected SL multiplier (Open-24)
+- Pipeline D1 cost-language documented in §3/§8 with empirical bounds (Open-23)
+
+**v2.2 amendment landed earlier same day (2026-05-18).** Methodology unchanged. v2.2 §1 (sign-flip mechanisation) now obsoleted by v2.3 §9 removal; v2.2 §2/§3/§4/§7 stand; v2.2 §5 (§16a) Step 5 semantic updated to WFO; v2.2 §6 (halt point) updated to end of Step 4; v2.2 §7 (§1a live-execution equivalence) updated to Step 1 + Step 5.
+
+**v2.2 amendment summary (preserved for reference):** Mechanises the remaining chat-judgement carve-outs in steps 1-5, closes the Step 4 max-F1 fallback gap surfaced by Arc 7, and asserts live-execution equivalence for steps 1 and 6. (Now read as: Steps 1-4 unattended; halt point end of Step 4; Step 5 WFO is the renumbered Step 6.)
 
 **v2.2 §0 changes (seven items):**
 - §9 single-fold sign-flip mechanisation (no chat-level override; mandatory diagnostic logging)
@@ -110,17 +123,18 @@ KH-24 is locked and unchanged. No modifications without an explicit modification
 
 ## Active Research
 
-L arc signal testing under `L_ARC_PROTOCOL.md` v2.2 (Arc 8+; amendment doc landed 2026-05-18 at `L_ARC_PROTOCOL_v2_2_AMENDMENT.md`). v2.1.2 governed Arcs 4-7 (all closed); v2.0 governed Arc 3 (closed); v1.x archive at `archive/` for historical Arc 1, Arc 2 reference.
+L arc signal testing under `L_ARC_PROTOCOL.md` v2.1.2 base + v2.2 + v2.3 amendments (Arc 8+; v2.3 amendment landed 2026-05-18 at `L_ARC_PROTOCOL_v2_3_AMENDMENT.md`, v2.2 earlier same day at `L_ARC_PROTOCOL_v2_2_AMENDMENT.md`). v2.1.2 governed Arcs 4-7 (all closed); v2.0 governed Arc 3 (closed); v1.x archive at `archive/` for historical Arc 1, Arc 2 reference.
 
 | Item | Detail |
 | --- | --- |
-| Protocol | `L_ARC_PROTOCOL.md` v2.1.2 base + `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` v2.2 (active for Arc 8+) |
+| Protocol | `L_ARC_PROTOCOL.md` v2.1.2 base + `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` v2.2 + `L_ARC_PROTOCOL_v2_3_AMENDMENT.md` v2.3 (all three binding for Arc 8+) |
 | Arc queue | `results/ARC_QUEUE.md` — Active: none; Unrun: none (awaiting analyst signal selection); Closed: see file |
-| Orchestrator | `prompts/cc_arc_orchestrator_template.md` — one arc per CC chat session (unattended Steps 1-5) |
+| Orchestrator | `prompts/cc_arc_orchestrator_template.md` v1.1 — one arc per CC chat session (unattended Steps 1-4 under v2.3) |
+| Shelved register | `SHELVED_ARCS.md` — informal register for KILL closures with portfolio-candidate annotation (per v2.3 §6) |
 | Signals | LCHAR registry (`docs/LCHAR_TOPN_REGISTRY.md`) entries 1-5 all consumed (Arc 1, 2, 3, 4, 5); Arc 6+ from standalone signal-spec docs |
-| Approach | Six-step pipeline: plumbing → path-shape clustering → capturability → extractability (E or D1) → cross-fold stability → WFO |
+| Approach | Five-step pipeline: 1 plumbing → 2 path-shape clustering → 3 capturability → 4 extractability (E or D1) → 5 WFO truth (renumbered from Step 6 under v2.3 §2; Step 5 cross-fold stability removed under v2.3 §1) |
 | Current arc | None active — queue empty pending Arc 8+ signal selection |
-| Calibration anchor | KH-24 K=4 archetype 3 (passes via Pipeline D1 at t=3); v2.2 anchor preservation verified — none of the seven §0 items invoked on anchor |
+| Calibration anchor | KH-24 K=4 archetype 3 (passes Step 5 WFO via Pipeline D1 at t=3); v2.3 anchor preservation verified — Step 3 selected SL = 2.0×ATR matches v2.2 uniform pre-t SL (Open-24 no-op for anchor) |
 | Risk per trade | 0.5% × reset floor balance |
 | Pair set | All 28 FX, same as KH-24 |
 | WFO | 7 anchored expanding folds, OOS Oct 2020 – Jan 2026 |
@@ -151,7 +165,8 @@ Annualisation: `fold_raw_ROI × (365 / fold_OOS_days)`. Folds < 90 OOS days excl
 
 | Phase | Verdict | Finding |
 | --- | --- | --- |
-| L_ARC_PROTOCOL v2.2 amendment | LANDED (2026-05-18) | Seven §0 changes: §9 single-fold sign-flip mechanisation (no chat override); §12 Tier 2 lift cap ≤ 5 candidates intersection-only; §8 Step 4 threshold-sweep failure rule (no max-F1 fallback); new §15b FIFO arc selection via `results/ARC_QUEUE.md`; new §16a KILL vs HALT mechanical disposition; §13 no mid-arc analyst sign-off; new §1a live-execution equivalence assertion. Methodology unchanged. Companion files: `prompts/cc_arc_orchestrator_template.md`, `results/ARC_QUEUE.md`. Amendment doc at `L_ARC_PROTOCOL_v2_2_AMENDMENT.md`; protocol-doc PR pending engineering pass per §9. |
+| L_ARC_PROTOCOL v2.3 amendment | LANDED (2026-05-18) | Seven §0 changes: §9 (Step 5 cross-fold stability) removed — pipeline is 1-2-3-4-5; §10 retitled "Step 5 — WFO" (was Step 6); orchestrator halt at end of Step 4 (was end of Step 5); v2.2 §1 sign-flip mechanisation OBSOLETED (Step 5 gate it mechanised no longer exists); §16a failing-step list position 5 semantic = WFO (not stability), Path A/B logic unchanged; Pipeline D1 pre-t SL per archetype = cluster's Step 3 selected SL (Open-24, engine PR pending; default 2.0 preserves anchor); Pipeline D1 cost-language documented in §3/§8 (Open-23). Closes Open-22 by structural removal of §9. Companion files: `prompts/cc_arc_orchestrator_template.md` updated to v1.1, new `SHELVED_ARCS.md` register. Anchor preservation verified (KH-24 K=4 archetype 3 passes Step 5 WFO by deployment; Step 3 selected SL = 2.0×ATR matches v2.2 uniform pre-t SL). Amendment doc at `L_ARC_PROTOCOL_v2_3_AMENDMENT.md`; protocol-doc PR pending engineering pass to consolidate v2.2 + v2.3 into protocol doc proper. Engine PR pending for Open-24 honour. |
+| L_ARC_PROTOCOL v2.2 amendment | LANDED (2026-05-18) | Seven §0 changes: §9 single-fold sign-flip mechanisation (no chat override) — OBSOLETED by v2.3 §9 removal; §12 Tier 2 lift cap ≤ 5 candidates intersection-only; §8 Step 4 threshold-sweep failure rule (no max-F1 fallback); new §15b FIFO arc selection via `results/ARC_QUEUE.md`; new §16a KILL vs HALT mechanical disposition (Step 5 semantic updated to WFO under v2.3); §13 no mid-arc analyst sign-off (halt point shifted to end of Step 4 under v2.3); new §1a live-execution equivalence assertion (updated to Step 1 + Step 5 under v2.3). Methodology unchanged. Companion files: `prompts/cc_arc_orchestrator_template.md`, `results/ARC_QUEUE.md`. Amendment doc at `L_ARC_PROTOCOL_v2_2_AMENDMENT.md`; protocol-doc PR pending engineering pass per §9. |
 | Arc 4 RERUN (l_arc_4_rerun) | FAIL Step 6 (2026-05-18) | bar_range_top_decile__neg__h_001 re-run under corrected per-pair p50 spread floors. Phase 5 §9 admit-only PASS (+0.125R per trade); Phase 6 §10 full-pool deployment FAIL on every gate — reject pool (32%, −0.232R mean) + early-exit pool (11%, −0.685R mean) drag strategy to −0.076R per signal, full-data DD 76.98%, 5ers daily DD breach (5.12%) = account-closure event. Second Pipeline D1 arc (after Arc 5) to PASS §9 admit-only and FAIL §10 full-pool — cross-arc structural finding. Three open protocol items spawned: Open-22 (full-pool gate at §9 or earlier), Open-23 (§8 D1 cost-language correction), Open-24 (early-exit pool architectural cost). Disposition unchanged from prior CLEAN-NULL closure (Arc 4 closed); reason updated. `docs/arc_results/ARC_4_RERUN_RESULT.md`. |
 | Arc 7 (l_arc_7) | CLEAN-NULL at Step 4 (2026-05-17) | Liquidity sweep + reclaim long (out-of-registry, `signal_spec_liquidity_sweep_reclaim_long_v0.1.md`). First capturable-not-extractable closure of record: PASS §5/§6/§7 (3 V-shape units survive §2 conjunctively at composite > 0.37); FAIL §8 (zero unit × pipeline pairs clear AUC gate; best agg/E 0.536 vs 0.65). v2.1.2 `≠ scattered` floor validated as load-bearing — all three §7 survivors carried `shape_tag = unclassified`. §8 then killed the arc for the right reason (no predictability), not the wrong reason (overly strict shape_tag). Closure doc on `phase/l_arc_7` branch pending merge: `docs/arc_results/ARC_7_RESULT.md`. |
 | Arc 5 (l_arc_5) | SHELVED Step 6 FAIL (2026-05-17) | mtf_alignment.2_down_mixed.kijun h=120 (registry Entry 5). Steps 1-5 PASS under PR1 + old spreads; Step 6 PR2 + new spreads + full-pool WFO FAIL on all three candidate strategies (c1 alone, c3 alone, tiered ensemble). Admit-set edge confirmed (+0.14-0.21R per fold, 7/7 positive folds); Pipeline D1 rejected-pool adverse selection (~78% of trades at −0.46R/trade vs +0.025R unconditional bar-2 R) kills full-strategy expectancy. PR 2 (§11 row 2 MFE-lock + trail) fully recovers c1's §9 DD ratio 2.34 → 1.17 (mechanism works as designed). Eight cross-arc backlog items added (3 P0: P-§9-FRAMING, P-D1-VIABILITY, P-D1-REJECT-BIAS; 1 P1; 4 P2). Signal NOT permanently eliminated — Pipeline E re-evaluation with richer features reopenable. Closure doc on `arc-5-closure` branch pending merge: `docs/arc_results/ARC_5_RESULT.md`. |
@@ -195,6 +210,8 @@ Annualisation: `fold_raw_ROI × (365 / fold_OOS_days)`. Folds < 90 OOS days excl
 | MT5 vs HistData spread cross-check | MEDIUM | Dump 5 days of 5ers MT5 spread snapshots from Contabo VPS, validate audit assumptions. |
 | Governance doc consolidation | LOW | `docs/SPREAD_SEMANTICS_LOCK.md` and `docs/L6_0_METHODOLOGY_LOCK.md` overlap on spread floor governance. Resolve before next calibration cycle. (Arc 4 closure follow-up) |
 | §11 row policies for rows 1, 3, 4, 5, 6, 7 | DEFERRED | Row 2 (Stepwise climber) shipped in PR #135. Other rows added when an arc surfaces a Step-4 archetype consumer needing them. No build until concrete consumer surfaces. |
+| Engine PR for Open-24 honour (per-archetype D1 `pre_t_sl_atr_multiplier`) | PENDING | v2.3 spec lands now; engine PR follows. Default 2.0 preserves anchor (KH-24 D1 cluster pre-t SL = 2.0×ATR matches Step 3 selected). Step 3 archetype YAML emission writes `pre_t_sl_atr_multiplier = selected_sl_multiplier`. Can land independently of v2.3 protocol amendment doc. |
+| Protocol-doc PR to apply v2.2 + v2.3 amendments into `L_ARC_PROTOCOL.md` proper | PENDING | Engineering scope (PR-required). Separate from v2.2 and v2.3 amendment doc landings. Option to bundle both amendments into a single consolidation PR when convenient. |
 
 No outstanding bugs or issues against KH-24. No pending fixes against the backtester. §14 anchor refresh explicitly held (deployed-pop reference, no change).
 
@@ -210,7 +227,15 @@ No outstanding bugs or issues against KH-24. No pending fixes against the backte
 
 ## Cross-Arc Calibration Backlog (post-Arc-7 review)
 
-Items accumulating from arc closures under v2.0/v2.1.x. Per §1.8 within-arc thresholds do not move; per §12 cross-arc calibration is governed and requires a calibration document + chat-level approval. The 2026-05-17 v2.1 amendment + 2026-05-18 v2.2 amendment resolved or partially resolved most of the items below; items still requiring evidence / execution are kept under "Active backlog".
+Items accumulating from arc closures under v2.0/v2.1.x. Per §1.8 within-arc thresholds do not move; per §12 cross-arc calibration is governed and requires a calibration document + chat-level approval. The 2026-05-17 v2.1 amendment + 2026-05-18 v2.2 amendment + 2026-05-18 v2.3 amendment resolved or partially resolved most of the items below; items still requiring evidence / execution are kept under "Active backlog".
+
+### Resolved in v2.3 amendment (2026-05-18)
+
+| Item | Source arc(s) | Resolution |
+| --- | --- | --- |
+| Open-22 — Full-pool gate at §9 or earlier (admit-only framing misses deployment-fatal cost) | Arc 4 RERUN + Arc 5 | CLOSED — structural removal of §9 (Step 5 cross-fold stability) in v2.3 §1. Step 5 (WFO, was Step 6) measures full-pool by construction. No replacement gate needed. |
+| Open-23 — §8 Pipeline D1 cost-language correction | Arc 4 RERUN + Arc 5 | CLOSED — documentation correction in v2.3 §4. §3 / §8 Pipeline D1 description updated with empirical cost ranges (rejected pool ~−0.15 to −0.46R; pre-t losers ~−0.45 to −0.69R on ~10-15% of signals). |
+| Open-24 — Pipeline D1 pre-t SL per archetype | Arc 4 RERUN | CLOSED in protocol — v2.3 §5 specifies pre-t SL = cluster's Step 3 selected SL multiplier. Engine PR pending to expose per-archetype `pre_t_sl_atr_multiplier`; default 2.0 preserves anchor (Open-24 is a no-op for KH-24 K=4 archetype 3 whose Step 3 selected SL = 2.0×ATR). |
 
 ### Resolved in v2.2 amendment (2026-05-18)
 
@@ -295,6 +320,7 @@ Note: `bar_range_top_decile__neg__h_001` (Arc 4 signal) is SHELVED pending sprea
 | Arc 6 (closed DIES at Step 4) | `results/arc_6/` (on `discovery/lomega_regime_conditional`) + `docs/arc_results/ARC_6_RESULT.md` |
 | Arc 7 (closed CLEAN-NULL at Step 4; closure doc on `phase/l_arc_7` branch) | `results/l_arc_7/` + `docs/arc_results/ARC_7_RESULT.md` |
 | v2.2 amendment + companions | `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` + `prompts/cc_arc_orchestrator_template.md` + `results/ARC_QUEUE.md` |
+| v2.3 amendment + companions | `L_ARC_PROTOCOL_v2_3_AMENDMENT.md` + `prompts/cc_arc_orchestrator_template.md` (v1.1) + `SHELVED_ARCS.md` |
 
 ---
 

--- a/prompts/cc_arc_orchestrator_template.md
+++ b/prompts/cc_arc_orchestrator_template.md
@@ -1,8 +1,8 @@
-# CC Arc Orchestrator — Unattended Steps 1-5 Dispatch Template
+# CC Arc Orchestrator — Unattended Steps 1-4 Dispatch Template
 
-> Version: v1.0 (drafted 2026-05-18 for L_ARC_PROTOCOL v2.2)
-> Scope: single CC dispatch in a single CC chat session runs one L arc from arc-open through end of step 5. Halts at end of step 5, returns halt summary. Step 6 (WFO) is a separate dispatch from chat after analyst review.
-> Companion files: `L_ARC_PROTOCOL.md` (v2.2), `results/ARC_QUEUE.md`, `LCHAR_TOPN_REGISTRY.md`, `SPREAD_SEMANTICS_LOCK.md`.
+> Version: v1.1 (updated 2026-05-18 for L_ARC_PROTOCOL v2.3)
+> Scope: single CC dispatch in a single CC chat session runs one L arc from arc-open through end of step 4. Halts at end of step 4, returns halt summary. Step 5 (WFO) is a separate dispatch from chat after analyst review.
+> Companion files: `L_ARC_PROTOCOL.md` (v2.1.2 base) + `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` (v2.2 governance) + `L_ARC_PROTOCOL_v2_3_AMENDMENT.md` (v2.3 Step 5 removal + renumbering), `results/ARC_QUEUE.md`, `LCHAR_TOPN_REGISTRY.md`, `SPREAD_SEMANTICS_LOCK.md`, `SHELVED_ARCS.md`.
 
 ---
 
@@ -23,7 +23,7 @@ To run N arcs in parallel: open N CC chats, paste the template into each with th
 
 ## Read these first, in order
 
-1. `L_ARC_PROTOCOL.md` (v2.2) — methodology of record, self-contained
+1. `L_ARC_PROTOCOL.md` (v2.1.2 base) + `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` (v2.2 governance) + `L_ARC_PROTOCOL_v2_3_AMENDMENT.md` (v2.3 Step 5 removal + renumbering) — methodology of record. All three documents are binding for Arc 8+.
 2. `results/ARC_QUEUE.md` — queue state; confirm Arc <N> is the topmost Unrun entry, then transition it to Active
 3. The signal source for Arc <N>:
    - Registry-based arcs: `LCHAR_TOPN_REGISTRY.md` Entry <K>
@@ -35,19 +35,19 @@ To run N arcs in parallel: open N CC chats, paste the template into each with th
 
 ## What this dispatch does
 
-Run Arc <N> through steps 1-5 of L_ARC_PROTOCOL v2.2. Halt at end of step 5. Do NOT run step 6 WFO — that is a separate dispatch from chat.
+Run Arc <N> through steps 1-4 of L_ARC_PROTOCOL v2.3. Halt at end of step 4. Do NOT run Step 5 WFO — that is a separate dispatch from chat (Step 5 is the WFO truth gate, renumbered from v2.2's Step 6 under the v2.3 amendment's §9 removal + step renumbering).
 
-No mid-arc analyst sign-off is required or expected. Per v2.2 §6: between arc-open and end of step 5, chat does not review mid-arc state. Apply mechanical rules per the protocol. Where ambiguity exists, halt and document — do not guess.
+No mid-arc analyst sign-off is required or expected. Per v2.2 §6 (updated by v2.3 §9): between arc-open and end of step 4, chat does not review mid-arc state. Apply mechanical rules per the protocol. Where ambiguity exists, halt and document — do not guess.
 
 ## Boundaries
 
-- **You own:** arc-open doc, all step 1-5 scripts, live arc doc, closure doc on early arc death, queue state transitions, branch creation, all commits on `phase/arc-<N>`.
-- **You do NOT own:** step 6 WFO dispatch, engine PRs (`scripts/phase_kgl_v2_4h_wfo.py`, `signals/`, locked configs `configs/wfo_kh24.yaml` / `configs/spreads_5ers.yaml` / `configs/spread_floors_5ers.yaml`), `L_ARC_PROTOCOL.md` edits, ship/archive decisions on step 6 output.
+- **You own:** arc-open doc, all step 1-4 scripts, live arc doc, closure doc on early arc death, queue state transitions, branch creation, all commits on `phase/arc-<N>`.
+- **You do NOT own:** Step 5 WFO dispatch, engine PRs (`scripts/phase_kgl_v2_4h_wfo.py`, `signals/`, locked configs `configs/wfo_kh24.yaml` / `configs/spreads_5ers.yaml` / `configs/spread_floors_5ers.yaml`), `L_ARC_PROTOCOL.md` edits, ship/archive decisions on Step 5 output.
 - **One arc per session.** This session runs Arc <N> and only Arc <N>. If you finish early, end the session — do not pick up the next queue entry.
 - **If you find an engine change is needed:** halt, write the halt summary explaining what engine change is needed and why, do NOT make the change. Engine PRs are PR-required scope.
 - **If protocol applicability is ambiguous:** halt, write the halt summary citing the clause and the ambiguity. Do not interpret loosely.
 
-## Live-execution equivalence (v2.2 §7 / §1a)
+## Live-execution equivalence (v2.2 §7 / §1a — Step 1 + Step 5 per v2.3 §7)
 
 All step 1 trade construction MUST use live-equivalent execution:
 
@@ -58,7 +58,7 @@ All step 1 trade construction MUST use live-equivalent execution:
 - D1 features use one-day lag (`merge_asof` backward, pre-shifted date)
 - Volume veto: no entry, no trade row, no spread
 
-The Python backtester implements this already. The assertion here is that arc Step 1 scripts MUST use the same execution path. No synthetic mid-fills. No hardcoded spread defaults. No same-day D1 close.
+The Python backtester implements this already. The assertion here is that arc Step 1 scripts MUST use the same execution path, and Step 5 WFO inherits the same semantics. No synthetic mid-fills. No hardcoded spread defaults. No same-day D1 close.
 
 ## Pre-flight
 
@@ -73,8 +73,8 @@ The Python backtester implements this already. The assertion here is that arc St
 Write `results/arc_<N>/ARC_<N>_LIVE.md` using the template in `L_ARC_PROTOCOL.md` §13. Fill arc-open section:
 
 - Signal under test: <signal_name>, source = <registry Entry K | signal_spec_<name>.md>
-- Hypothesis: this signal carries structural edge surface-able by path-shape clustering and v2.2 capturability + extractability gates
-- Protocol version: v2.2
+- Hypothesis: this signal carries structural edge surface-able by path-shape clustering and v2.1.2 capturability + extractability gates
+- Protocol version: v2.1.2 base + v2.2 amendment + v2.3 amendment (active for Arc 8+)
 - SL sweep candidates: default `{0.5, 1.0, 1.5, 2.0, 3.0, 4.0} × ATR_signal_TF` unless signal spec overrides
 - Simulation SL (step 1 pool): default 2.0×ATR_signal_TF unless signal spec overrides
 - Forward window: default 240 bars on signal TF
@@ -82,7 +82,7 @@ Write `results/arc_<N>/ARC_<N>_LIVE.md` using the template in `L_ARC_PROTOCOL.md
 - Pair set: 28 FX (KH-24 set) unless signal spec overrides
 - Population builder: `build_ex_ante_bounded_population`
 - Risk: 0.5% per trade
-- Pre-committed step gates: per v2.2 (no overrides, no mid-arc sign-off)
+- Pre-committed step gates: per v2.2 + v2.3 (no overrides, no mid-arc sign-off; halt at end of Step 4)
 
 Commit arc-open doc.
 
@@ -140,7 +140,7 @@ Update live arc doc step 3 row. Commit.
 
 ## Step 4 — Extractability
 
-Per protocol §8, with v2.2 §3 amendment (no max-F1 fallback) and v2.2 §2 amendment (Tier 2 lift cap ≤ 5).
+Per protocol §8, with v2.2 §3 amendment (no max-F1 fallback) and v2.2 §2 amendment (Tier 2 lift cap ≤ 5). Pipeline D1 cost-language and pre-t SL per v2.3 §4/§5 (Open-23/24): D1 pre-t SL = cluster's Step 3 selected SL multiplier (engine PR pending; default 2.0×ATR is anchor-preserving). Rejected-pool / pre-t-loser empirical cost ranges per v2.3 §4 — full-pool R = admit + reject + pre-t-loss contributions, evaluated at Step 5 WFO.
 
 For each surviving archetype, in order:
 1. Angle E step A: full feature set RF + logistic at entry. If RF AUC ≥ 0.65 → lock Pipeline E, proceed to threshold sweep.
@@ -151,7 +151,7 @@ For each surviving archetype, in order:
 
 For each locked classifier (E and/or D1):
 6. **Threshold sweep:** sweep {0.40, 0.50, 0.60, 0.70}, select max precision with recall ≥ 0.60. **If no threshold satisfies recall ≥ 0.60 → archetype fails Step 4 (no max-F1 fallback, v2.2 §3). Apply §16a HALT/KILL.**
-7. Tier 2 lift: ≤ 5 candidates per archetype (v2.2 §2 cap), intersection-only, evaluated at step 6. Each lift candidate must independently pass threshold sweep per rule 6.
+7. Tier 2 lift: ≤ 5 candidates per archetype (v2.2 §2 cap), intersection-only, evaluated at Step 5 WFO. Each lift candidate must independently pass threshold sweep per rule 6.
 8. Train final classifier(s), save `archetype_<label>_E_classifier.joblib` + `archetype_<label>_E_filter.yaml` (and/or D1 equivalents).
 
 Outputs: `predictability_angle_E.csv`, `predictability_angle_D1.csv`, `extractability_pass_list.csv`, per-archetype classifier files + policy YAMLs.
@@ -159,28 +159,6 @@ Outputs: `predictability_angle_E.csv`, `predictability_angle_D1.csv`, `extractab
 Gate fail (zero archetypes clear E or D1 with valid threshold) → closure doc, apply §16a.
 
 Update live arc doc step 4 row. Commit.
-
-## Step 5 — Cross-fold stability
-
-Per protocol §9.
-
-For each surviving archetype: apply filter / D1 policy across all 7 WFO folds, compute per-fold metrics.
-
-Conjunctive gate (v2.2 §1 — no overrides):
-1. Sign consistency: `final_r_mean` positive across ALL 7 folds (gate)
-2. Size variance: max-fold / min-fold ≤ 3.0 (gate)
-3. DD ceiling: worst-fold archetype-attributable DD ≤ 2× median-fold DD (gate)
-
-Diagnostic logging (v2.2 §1 mandatory):
-- Per-fold final_r_mean, n_archetype_in_fold, t_stat, fold ROI, fold max DD
-- Flag any fold with n_archetype_in_fold < 10 as "thin-fold flip" if final_r_mean ≤ 0 (informational only, does not change disposition)
-- Per-pair concentration report (informational per §9; flag if >50% in <5 pairs)
-
-Outputs: `fold_stability_<label>.csv`, `pair_stability_<label>.csv`, `stability_pass_list.csv`.
-
-Gate fail → closure doc, apply §16a.
-
-Update live arc doc step 5 row. Commit.
 
 ## Halt summary (always produced at dispatch end)
 
@@ -190,24 +168,24 @@ Append to live arc doc + write to dispatch return:
 ## Halt Summary — Arc <N>
 
 ### Status
-- Disposition: <STEP_<N>_KILL | STEP_<N>_HALT | STEP_5_COMPLETE_READY_FOR_WFO>
-- Closure doc: <path or "n/a — proceeded to step 5">
+- Disposition: <STEP_<N>_KILL | STEP_<N>_HALT | STEP_4_COMPLETE_READY_FOR_WFO>
+- Closure doc: <path or "n/a — proceeded to end of step 4">
 - Live arc doc: results/arc_<N>/ARC_<N>_LIVE.md
 - Branch: phase/arc-<N>
-- Queue state: <transitioned Active → Closed-{KILL|HALT} | remains Active pending step 6>
+- Queue state: <transitioned Active → Closed-{KILL|HALT} | remains Active pending Step 5 WFO>
 
 ### Step pass/fail table
-[as per live arc doc]
+[as per live arc doc — rows for Steps 1, 2, 3, 4]
 
-### Surviving archetypes (if step 5 complete)
-| Label | Cluster IDs | Selected SL | Pipeline | RF AUC | Threshold | Recall | Fold pass | Notes |
-|---|---|---|---|---|---|---|---|---|
+### Surviving archetypes (primary end-of-Step-4 output)
+| Label | Cluster IDs | Selected SL | Pipeline | RF AUC | Threshold | Recall | Notes |
+|---|---|---|---|---|---|---|---|
 
 ### Cross-arc calibration candidates (HALT only)
-[per §16a]
+[per §16a; failing-step list semantic position 5 now means WFO, per v2.3 §8]
 
 ### Recommended next dispatch
-- If STEP_5_COMPLETE: chat reviews surviving archetypes, dispatches step 6 WFO on selected subset
+- If STEP_4_COMPLETE_READY_FOR_WFO: chat reviews surviving archetypes, dispatches Step 5 WFO on selected subset
 - If STEP_<N>_KILL: nothing — arc archived
 - If STEP_<N>_HALT: chat reviews calibration candidate, batches with other HALT items for next protocol amendment cycle
 ```
@@ -228,6 +206,8 @@ Append to live arc doc + write to dispatch return:
 - **Unexpected data shape (NaNs, negative spreads, missing bars):** halt with halt summary documenting the data issue.
 - **Queue write conflict:** if push of queue update fails, pull, confirm Arc <N> still topmost Unrun. If yes, retry. If another session took it, halt — dispatch was for the wrong arc number.
 
+Failure modes cover Steps 1-4 only. Step 5 WFO failures are handled by the analyst-led Step 5 dispatch, not by this orchestrator.
+
 All halts are recoverable — the live arc doc + commits on branch preserve state.
 
 ## Resume semantics
@@ -244,7 +224,7 @@ No state lives in CC memory across sessions — all state is on disk + in git.
 ## End-of-dispatch
 
 Final actions:
-1. Update `results/ARC_QUEUE.md` (Active → Closed-{KILL|HALT} OR remains Active pending step 6)
+1. Update `results/ARC_QUEUE.md` (Active → Closed-{KILL|HALT} OR remains Active pending Step 5 WFO)
 2. Commit queue update
 3. Return halt summary to dispatcher
 ```
@@ -262,8 +242,9 @@ Final actions:
 
 ## What this template does NOT cover
 
-- Step 6 WFO dispatch (separate template, future work — now that PR2 lands, §11 archetype-specific exit policies are executable in step 6)
+- Step 5 WFO dispatch (separate template, future work — now the analyst-review checkpoint at end of Step 4 under v2.3; PR2 lands §11 archetype-specific exit policies, executable in Step 5 WFO)
 - Cross-arc calibration synthesis (analyst work, per §12)
 - Engine PRs (PR-required, separate workflow)
 - Protocol amendments (PR-required, separate workflow)
 - The Open-19 engine refactor that would replace manual schema replication in step 1 (deferred; absorbed risk under §16a)
+- Engine PR for Open-24 honour (per-archetype D1 `pre_t_sl_atr_multiplier`; default 2.0 preserves anchor) — separate engineering PR, can land independently of v2.3 protocol


### PR DESCRIPTION
## Summary

Lands `L_ARC_PROTOCOL_v2_3_AMENDMENT.md` plus governance housekeeping. v2.3 removes Step 5 cross-fold stability (§9), renumbers Step 6 WFO → Step 5, and closes Open-22/23/24. v2.2 §1 sign-flip mechanisation is OBSOLETED (the gate it mechanised no longer exists); v2.2 §2/§3/§4/§7 stand unchanged; v2.2 §5/§6 updated for renumbering. Methodology unchanged. Engine PR pending for Open-24 honour (per-archetype D1 `pre_t_sl_atr_multiplier`, default 2.0 anchor-preserving). Protocol-doc PR to consolidate v2.2 + v2.3 amendment text into `L_ARC_PROTOCOL.md` itself remains pending engineering scope.

Binding spec: [L_ARC_PROTOCOL_v2_3_AMENDMENT.md](L_ARC_PROTOCOL_v2_3_AMENDMENT.md).

## Changes by file area

- **`L_ARC_PROTOCOL_v2_3_AMENDMENT.md`** — placed at repo root (matches v2.2 placement; analyst-authored content, not modified)
- **`prompts/cc_arc_orchestrator_template.md`** — updated to v1.1: Step 5 cross-fold stability section removed; Step 6 → Step 5 renumbered; halt summary disposition `STEP_5_COMPLETE_READY_FOR_WFO` → `STEP_4_COMPLETE_READY_FOR_WFO`; halt point end of Step 5 → end of Step 4; failure modes scoped to Steps 1-4; live-execution equivalence Step 1 + Step 5 (was Step 6); v2.2 §1 sign-flip references removed; Open-23/24 cost-language + pre-t SL notes added at Step 4
- **`SHELVED_ARCS.md`** — new file at repo root with v2.3 §6 format (Active table empty; Arc 5 archetype pre-population surfaced as analyst question)
- **`STATUS.md`** — active protocol line updated; v2.3 §0 seven changes summarised; Recent Closures row prepended; Open Items adds Open-24 engine PR pending + protocol-doc PR pending; Cross-Arc Calibration Backlog adds "Resolved in v2.3 amendment" subsection; pipeline narrative Six-step → Five-step
- **`SESSION_ZERO.md`** — header and Pointers updated; Current State leads with v2.3; Active Research pipeline renumbered (Step 5 cross-fold stability removed; Step 6 WFO → Step 5); Phase History new v2.3 entry prepended per file's preservation rule
- **`CHANGELOG.md`** — v2.3 amendment entry prepended at top (substantive changes; open items resolved; v2.2 items obsoleted or updated; anchor preservation; files)
- **`PROTOCOL_IMPROVEMENT_BACKLOG.md`** — summary status table updated (Closed in v2.3 row); Open-22/23/24 entries marked CLOSED with resolution pointers; new "Resolved in v2.3 amendment" section; Document control v2.3 row added

## Out of scope (explicit non-changes)

- `L_ARC_PROTOCOL.md` proper — protocol-doc PR pending (engineering scope; option to bundle v2.2 + v2.3 into a single consolidation PR)
- `L_ARC_PROTOCOL_v2_2_AMENDMENT.md` — historical record (unchanged)
- Closure docs (`results/arc_*/`, `docs/arc_results/`) — unchanged
- `results/ARC_QUEUE.md` — analyst-owned (Active/Unrun); Closed section unchanged from v2.2 housekeeping
- Engine code (`scripts/phase_kgl_v2_4h_wfo.py`, `signals/`, configs) — unchanged
- Engine PR for Open-24 honour is separate (per-archetype D1 `pre_t_sl_atr_multiplier`, default 2.0 preserves anchor; can land independently)

## Anchor preservation

KH-24 K=4 archetype 3 passes Step 5 WFO by deployment (worst-fold ROI +1.92%, worst-fold DD 6.37%, all 7 OOS folds positive). Step 3 selected SL = 2.0×ATR matches v2.2 uniform pre-t SL — Open-24 spec change is a no-op for the anchor. v2.2 §1 sign-flip mechanisation obsoletion does not affect anchor evaluation (anchor passed all 7 folds positive).

## Test plan

- [ ] Analyst reviews `L_ARC_PROTOCOL_v2_3_AMENDMENT.md` placement is correct (repo root, matches v2.2)
- [ ] Analyst confirms orchestrator template v1.1 correctly removes Step 5 cross-fold stability and renumbers Step 6 → Step 5
- [ ] Analyst decides whether Arc 5's archetypes should be pre-populated in `SHELVED_ARCS.md` Active table
- [ ] Analyst schedules engine PR for Open-24 honour (per-archetype D1 `pre_t_sl_atr_multiplier`)
- [ ] Analyst schedules consolidation PR for `L_ARC_PROTOCOL.md` proper (option to bundle v2.2 + v2.3)
- [ ] Do NOT auto-merge — surface for analyst review

🤖 Generated with [Claude Code](https://claude.com/claude-code)