### PR TITLE
fix(lomega): clear pre-existing Ruff debt in lomega_b1_b4.py

### DIFF
--- a/scripts/lomega/lomega_b1_b4.py
+++ b/scripts/lomega/lomega_b1_b4.py
@@ -33,8 +33,6 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import roc_auc_score
 from sklearn.model_selection import TimeSeriesSplit
-from sklearn.preprocessing import StandardScaler
-
 
 # ---------------------------------------------------------------- paths / config
 
@@ -668,11 +666,11 @@ def spot_check_no_lookahead(rows_df: pd.DataFrame, pair_dfs: dict, tf: str,
         loc = int(df.index[df["time"] == t][0])
         # Recompute atr_14 from scratch using only bars <= loc
         h = df["high"].values[: loc + 1]
-        l = df["low"].values[: loc + 1]
+        low_arr = df["low"].values[: loc + 1]
         c = df["close"].values[: loc + 1]
         if loc + 1 < 14:
             continue
-        atr_recomp = compute_atr(h, l, c, 14)[0][-1]
+        atr_recomp = compute_atr(h, low_arr, c, 14)[0][-1]
         # body_ratio
         o_t = df["open"].values[loc]
         c_t = df["close"].values[loc]
@@ -773,7 +771,6 @@ def run_timeframe(tf: str) -> dict:
 
     # DXY proxy at signal TF (after per-pair features ready)
     close_dict = {}
-    common_times = None
     for pair in PAIRS:
         s = pair_dfs[pair].set_index("time")["close"]
         close_dict[pair] = s


### PR DESCRIPTION
## Summary

Resolves pre-existing Ruff lint errors blocking CI on main since 2026-05-17 (5 consecutive failures since #138 merge).

- **I001** — sort imports
- **F401** — remove unused \`sklearn.preprocessing.StandardScaler\`
- **E741** — rename ambiguous variable \`l\` → \`low_arr\` at line 669 (used in \`compute_atr(h, low_arr, c, 14)\` call)
- **F841** — drop unused \`common_times = None\` assignment

No functional change. Unblocks CI on main so v2.3 amendment PR #143 can land cleanly.

## Test plan

- [x] \`py -m ruff check scripts/lomega/lomega_b1_b4.py\` → All checks passed
- [x] \`py -m py_compile scripts/lomega/lomega_b1_b4.py\` → compile OK
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)