### PR TITLE
feat(d1): per-archetype pre-t SL (Open-24)

### DIFF
--- a/core/d1_pipeline.py
+++ b/core/d1_pipeline.py
@@ -130,6 +130,11 @@ class D1ArchetypeConfig:
       :func:`D1Hook.from_yaml_dict`. After loading the cache holds the
       live classifier; the path itself is kept on
       ``per_fold_classifier_paths`` for audit.
+
+    Open-24 (v2.3 §5): ``pre_t_sl_atr_multiplier`` is the ATR multiplier
+    for the pre-classification SL (bars 0..t). Default 2.0 preserves
+    v2.2 uniform behaviour and the KH-24 anchor (Step 3 selected SL =
+    2.0×ATR for archetype 3).
     """
 
     label: str
@@ -139,6 +144,7 @@ class D1ArchetypeConfig:
     per_fold_classifiers: Mapping[str, Any] = field(default_factory=dict)
     per_fold_classifier_paths: Mapping[str, str] = field(default_factory=dict)
     exit_policy: ExitPolicy | None = None
+    pre_t_sl_atr_multiplier: float = 2.0
     extras: Mapping[str, Any] = field(default_factory=dict)
 
 
@@ -169,6 +175,24 @@ class D1Hook:
                 f"got {sorted(ts)}"
             )
         self._bar_offset_t = int(next(iter(ts)))
+
+        # Open-24 (v2.3 §5): pre-t SL must be shared across archetypes in
+        # the same hook because the SL is set at trade entry, before the
+        # classifier decides which archetype wins at bar t. Multi-archetype
+        # hooks whose clusters select different SLs must run as separate
+        # WFO evaluations.
+        mults = {round(float(a.pre_t_sl_atr_multiplier), 12) for a in archetypes}
+        if len(mults) > 1:
+            raise ValueError(
+                "Open-24 constraint: all archetypes must share "
+                f"pre_t_sl_atr_multiplier; got {sorted(mults)}"
+            )
+        pre_t_mult = float(next(iter(mults)))
+        if not (pre_t_mult > 0.0):
+            raise ValueError(
+                f"pre_t_sl_atr_multiplier must be > 0; got {pre_t_mult}"
+            )
+        self._pre_t_sl_atr_multiplier = pre_t_mult
 
         known = set(ALL_FEATURE_KEYS)
         for a in archetypes:
@@ -227,6 +251,17 @@ class D1Hook:
     def bar_offset_t(self) -> int:
         """The single ``t`` shared across all archetypes."""
         return self._bar_offset_t
+
+    @property
+    def pre_t_sl_atr_multiplier(self) -> float:
+        """ATR multiplier for the pre-classification SL (bars 0..t).
+
+        Open-24 (v2.3 §5): shared across all archetypes in this hook —
+        the engine sets the SL at trade entry, before the classifier
+        decides which archetype wins. Default 2.0 when the field is
+        absent from YAML preserves v2.2 uniform behaviour.
+        """
+        return self._pre_t_sl_atr_multiplier
 
     @property
     def archetypes(self) -> tuple[D1ArchetypeConfig, ...]:
@@ -398,6 +433,13 @@ class D1Hook:
                 )
             policy = build_exit_policy(raw_policy)
 
+            # Open-24 (v2.3 §5): optional per-archetype pre-t SL ATR
+            # multiplier. Absent field → 2.0 (anchor / v2.2 behaviour).
+            if "pre_t_sl_atr_multiplier" in raw:
+                pre_t_sl_atr_multiplier = float(raw["pre_t_sl_atr_multiplier"])
+            else:
+                pre_t_sl_atr_multiplier = 2.0
+
             archetypes.append(
                 D1ArchetypeConfig(
                     label=label,
@@ -407,6 +449,7 @@ class D1Hook:
                     per_fold_classifiers=per_fold_classifiers,
                     per_fold_classifier_paths=per_fold_classifier_paths,
                     exit_policy=policy,
+                    pre_t_sl_atr_multiplier=pre_t_sl_atr_multiplier,
                     extras={
                         k: v
                         for k, v in raw.items()
@@ -418,6 +461,7 @@ class D1Hook:
                             "bar_offset_t",
                             "per_fold_classifiers",
                             "exit_policy",
+                            "pre_t_sl_atr_multiplier",
                         }
                     },
                 )

--- a/scripts/phase_kgl_v2_4h_wfo.py
+++ b/scripts/phase_kgl_v2_4h_wfo.py
@@ -3150,10 +3150,13 @@ def _write_report(
     orig_sl = [t["sl_distance_atr"] for t in orig_t]
     re_sl   = [t["sl_distance_atr"] for t in re_t]
     if orig_sl:
-        orig_exact = all(abs(d - 2.0) < 1e-6 for d in orig_sl)
+        # Open-24 (v2.3 §5): the entry-SL multiplier follows the active
+        # Pipeline D1 archetype when D1_HOOK is configured; with no D1
+        # hook ``SL_MULT`` stays at the module-scope default of 2.0.
+        orig_exact = all(abs(d - SL_MULT) < 1e-6 for d in orig_sl)
         a(f"Original trades ({len(orig_t)}):  "
           f"min sl_distance_atr={min(orig_sl):.6f}  max={max(orig_sl):.6f}  "
-          f"all exactly 2.0: **{'YES — OK' if orig_exact else 'NO — FAIL'}**")
+          f"all exactly {SL_MULT:.1f}: **{'YES — OK' if orig_exact else 'NO — FAIL'}**")
     if re_sl:
         re_exp   = REENTRY_SL_ATR_MULT
         re_exact = all(abs(d - re_exp) < 1e-6 for d in re_sl)
@@ -3795,6 +3798,7 @@ def main() -> None:
     global KH17_STATE1_SL_ATR_MULT
     global KH17_BAR6_MFE_THRESHOLD, KH17_BAR6_MAE_THRESHOLD
     global D1_HOOK
+    global SL_MULT
     global SIGNAL_ADAPTER
     global SIGNAL_TF, H1_DATA_DIR
     global TIME_EXIT_BARS
@@ -4277,9 +4281,20 @@ def main() -> None:
             D1_HOOK = D1Hook.from_yaml_dict(
                 cfg["d1_archetypes"], project_root=PROJECT_ROOT,
             )
+            # Open-24 (L_ARC_PROTOCOL v2.3 §5): pre-classification SL
+            # (bars 0..t) follows the cluster's Step 3 selected SL via
+            # the archetype's `pre_t_sl_atr_multiplier` (default 2.0
+            # preserves v2.2 uniform behaviour and the KH-24 anchor).
+            # Reassigning the module-scope ``SL_MULT`` keeps the entry
+            # SL formula (``entry_px ± SL_MULT * a``) and the position
+            # sizing formula (``risk_pp = SL_MULT * a``) byte-identical
+            # at the source level while making the multiplier runtime-
+            # configurable per archetype.
+            SL_MULT = D1_HOOK.pre_t_sl_atr_multiplier
             print(
                 f"  Pipeline D1: ENABLED — {len(D1_HOOK.archetypes)} archetype(s), "
-                f"bar_offset_t={D1_HOOK.bar_offset_t}"
+                f"bar_offset_t={D1_HOOK.bar_offset_t}, "
+                f"pre_t_sl_atr_multiplier={SL_MULT}"
             )
 
     D1_ATR_DIST_CAP = args.threshold

--- a/tests/test_d1_pipeline.py
+++ b/tests/test_d1_pipeline.py
@@ -940,5 +940,204 @@ class TestEnginePatch:
         )
 
 
+# ---------------------------------------------------------------------------
+# 11. Open-24 — per-archetype pre-t SL ATR multiplier (L_ARC_PROTOCOL v2.3 §5).
+# ---------------------------------------------------------------------------
+
+
+def _open24_yaml_block(
+    *,
+    pre_t_sl_atr_multiplier: float | None,
+    fixed_p: float = 0.99,
+    bar_offset_t: int = 1,
+    label: str = "open24_archetype",
+) -> list[dict]:
+    """Build a minimal one-archetype YAML block with the new field.
+
+    ``pre_t_sl_atr_multiplier=None`` omits the field entirely (tests the
+    default-2.0 backward-compat path).
+    """
+    order = list(ALL_FEATURE_KEYS)
+    entry: dict = {
+        "label": label,
+        "feature_order": order,
+        "decision_threshold": 0.1,
+        "bar_offset_t": bar_offset_t,
+        "per_fold_classifiers": {"F1": StubClassifier(order, fixed_p=fixed_p)},
+        "exit_policy": {
+            "type": "stepwise_climber",
+            "archetype_sl_r": 1.0,
+            "r_in_atr": 3.0,
+            "mfe_lock_r": 1.0,
+            "trail_from_high_r": 0.75,
+        },
+    }
+    if pre_t_sl_atr_multiplier is not None:
+        entry["pre_t_sl_atr_multiplier"] = pre_t_sl_atr_multiplier
+    return [entry]
+
+
+class TestPreTSLAtrMultiplier:
+    """Open-24 (v2.3 §5) — per-archetype pre-classification SL multiplier.
+
+    The field controls the SL distance for bars 0..t (before the
+    classifier fires at bar t). Default 2.0 preserves the v2.2 uniform
+    behaviour and the KH-24 anchor (Step 3 selected SL = 2.0 × ATR).
+    """
+
+    @pytest.mark.parametrize(
+        "mult", [0.5, 1.0, 1.5, 2.0, 3.0, 4.0]
+    )
+    def test_yaml_field_round_trips(self, mult: float):
+        """``D1Hook.from_yaml_dict`` reads the field at any positive value."""
+        hook = D1Hook.from_yaml_dict(
+            _open24_yaml_block(pre_t_sl_atr_multiplier=mult)
+        )
+        assert hook.pre_t_sl_atr_multiplier == pytest.approx(mult)
+        assert hook.archetypes[0].pre_t_sl_atr_multiplier == pytest.approx(mult)
+
+    def test_default_is_2_0_when_field_absent(self):
+        """Backward compat: existing per-archetype YAMLs without the new
+        field continue to behave as v2.2 uniform 2.0×ATR.
+        """
+        hook = D1Hook.from_yaml_dict(
+            _open24_yaml_block(pre_t_sl_atr_multiplier=None)
+        )
+        assert hook.pre_t_sl_atr_multiplier == 2.0
+        assert hook.archetypes[0].pre_t_sl_atr_multiplier == 2.0
+
+    @pytest.mark.parametrize("bad", [0.0, -0.1, -2.5])
+    def test_non_positive_multiplier_raises(self, bad: float):
+        with pytest.raises(ValueError, match=r"pre_t_sl_atr_multiplier must be > 0"):
+            D1Hook.from_yaml_dict(
+                _open24_yaml_block(pre_t_sl_atr_multiplier=bad)
+            )
+
+    def test_mixed_multipliers_across_archetypes_raise(self):
+        """Multi-archetype hooks must share the same multiplier — the SL
+        is set at trade entry, before the classifier picks an archetype.
+        Mirrors the existing ``bar_offset_t`` shared-across-archetypes
+        constraint (PR 1).
+        """
+        order = list(ALL_FEATURE_KEYS)
+        policy = _default_policy()
+        a = D1ArchetypeConfig(
+            label="a",
+            feature_order=tuple(order),
+            decision_threshold=0.5,
+            bar_offset_t=3,
+            per_fold_classifiers={"F1": StubClassifier(order)},
+            exit_policy=policy,
+            pre_t_sl_atr_multiplier=1.5,
+        )
+        b = D1ArchetypeConfig(
+            label="b",
+            feature_order=tuple(order),
+            decision_threshold=0.5,
+            bar_offset_t=3,
+            per_fold_classifiers={"F1": StubClassifier(order)},
+            exit_policy=policy,
+            pre_t_sl_atr_multiplier=2.5,
+        )
+        with pytest.raises(
+            ValueError,
+            match=r"Open-24.*must share pre_t_sl_atr_multiplier",
+        ):
+            D1Hook([a, b])
+
+    def test_field_is_not_collected_into_extras(self):
+        """``pre_t_sl_atr_multiplier`` is a known schema field — it must
+        not leak into the ``extras`` mapping reserved for forward-compat
+        unknown keys.
+        """
+        hook = D1Hook.from_yaml_dict(
+            _open24_yaml_block(pre_t_sl_atr_multiplier=1.25)
+        )
+        assert "pre_t_sl_atr_multiplier" not in hook.archetypes[0].extras
+
+
+class TestEnginePreTSLHookIntegration:
+    """Open-24 engine integration — source-level contract.
+
+    The runtime path is exercised end-to-end by the WFO pytest suite;
+    here we verify the static contract: ``main()`` declares ``SL_MULT``
+    global and reassigns it from ``D1_HOOK.pre_t_sl_atr_multiplier`` when
+    the hook is configured. The entry-SL formula and the position-size
+    formula are unchanged at the source level (both still read
+    ``SL_MULT``), so position size scales linearly with the new field.
+    """
+
+    def test_main_declares_sl_mult_global(self):
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        assert re.search(r"^\s+global\s+SL_MULT\b", src, re.M), (
+            "main() must declare `global SL_MULT` so the D1 hook block "
+            "can reassign it from D1_HOOK.pre_t_sl_atr_multiplier"
+        )
+
+    def test_engine_reassigns_sl_mult_from_hook(self):
+        """When ``D1_HOOK`` is configured the engine sets
+        ``SL_MULT = D1_HOOK.pre_t_sl_atr_multiplier`` so the entry-SL
+        and position-size formulas pick up the per-archetype value.
+        """
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        m = re.search(
+            r"D1_HOOK\s*=\s*D1Hook\.from_yaml_dict\([^)]*\)\s*"
+            r"(?:[^\n]*\n)*?"
+            r"\s+SL_MULT\s*=\s*D1_HOOK\.pre_t_sl_atr_multiplier",
+            src,
+            re.S,
+        )
+        assert m, (
+            "engine must set `SL_MULT = D1_HOOK.pre_t_sl_atr_multiplier` "
+            "in the same block that constructs D1_HOOK"
+        )
+
+    def test_position_size_formula_reads_sl_mult_via_risk_pp(self):
+        """Position size scales linearly with ``pre_t_sl_atr_multiplier``.
+
+        Source-level proof: ``risk_pp = SL_MULT * a`` and
+        ``pos_size = (INITIAL_BAL * effective_risk_pct) / risk_pp``.
+        Reassigning ``SL_MULT`` to the per-archetype multiplier therefore
+        scales ``pos_size`` by ``1 / multiplier`` at fixed R risk.
+        """
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        assert "risk_pp   = SL_MULT * a" in src, (
+            "risk_pp must be `SL_MULT * a` so Open-24 reassignment flows "
+            "to position sizing"
+        )
+        assert "pos_size     = (INITIAL_BAL * effective_risk_pct) / risk_pp" in src, (
+            "position-size formula must divide by risk_pp"
+        )
+
+    def test_anchor_default_keeps_sl_mult_2_0(self):
+        """KH-24 anchor preservation: with no explicit field (or
+        explicit 2.0) the hook exposes ``pre_t_sl_atr_multiplier = 2.0``
+        and the engine's reassignment is a no-op against the module-
+        scope default ``SL_MULT = 2.0``.
+        """
+        # Source-level: module-scope default remains 2.0.
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        assert re.search(r"^SL_MULT\s*=\s*2\.0", src, re.M), (
+            "module-scope SL_MULT default must remain 2.0 for the KH-24 "
+            "baseline / Pipeline-E byte-identity"
+        )
+        # Runtime: anchor's YAML (omitted or explicit 2.0) → hook 2.0.
+        for absent_or_two in (None, 2.0):
+            hook = D1Hook.from_yaml_dict(
+                _open24_yaml_block(pre_t_sl_atr_multiplier=absent_or_two)
+            )
+            assert hook.pre_t_sl_atr_multiplier == 2.0
+
+    def test_sl_audit_uses_runtime_sl_mult(self):
+        """The Section 6 SL-distance sanity check compares against the
+        active ``SL_MULT`` rather than a hardcoded 2.0 so Open-24 runs
+        with a non-default multiplier do not falsely report FAIL.
+        """
+        src = ENGINE_PATH.read_text(encoding="utf-8")
+        assert "abs(d - SL_MULT) < 1e-6 for d in orig_sl" in src, (
+            "original-trade SL audit must compare against runtime SL_MULT"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Implements Open-24 per `L_ARC_PROTOCOL_v2_3_AMENDMENT.md` §5.

## What

Pipeline D1 pre-t SL (bars 0..t, before the classifier fires at bar t) is now per-archetype, configured via a new optional YAML field `pre_t_sl_atr_multiplier` on each archetype's D1 config. Default 2.0 preserves the v2.2 uniform behaviour and the KH-24 anchor.

## Why

Per v2.3 §5: §7 SL sweep selects each cluster's SL by capturability composite. Imposing a different pre-t SL during deployment (v2.2's uniform 2.0×ATR for all archetypes) breaks the link between §7 characterisation and deployed behaviour — for tighter-selected clusters, v2.2 admitted into pre-t exposure a class of trades that would have stopped out under the cluster's characterised SL; for wider-selected clusters the inverse. v2.3 spec keys pre-t SL to the cluster's Step 3 selected SL.

## Spec source

`L_ARC_PROTOCOL_v2_3_AMENDMENT.md` §5 — Open-24.

## Anchor preservation

KH-24 K=4 archetype 3 Step 3 selected SL = 2.0×ATR. The field defaults to 2.0 when absent from YAML, so the anchor's D1 config (with or without the field) produces `D1Hook.pre_t_sl_atr_multiplier = 2.0`, the engine reassigns `SL_MULT = 2.0` → 2.0 (no-op against the module-scope default), and the entry-SL formula `entry_px - SL_MULT * a` is byte-identical to pre-change. Asserted by `TestEnginePreTSLHookIntegration.test_anchor_default_keeps_sl_mult_2_0`.

## Design — why reassign `SL_MULT` instead of branching at the call site

At trade entry (bar 0), the archetype is not yet known — the classifier picks the winning archetype at bar t. Pipeline D1 entries therefore need a single pre-t SL distance, set up-front. Two options:

1. **Branch the entry-SL formula on `D1_HOOK is not None`** — clean per call site but breaks the existing `SL_MULT * a` literal that the static contract tests (and several SL audits) lean on.
2. **Reassign the module-scope `SL_MULT` once at engine startup when `D1_HOOK` is configured** — keeps every literal in place; the entry-SL formula, the position-sizing formula, and the audits all pick up the new value automatically.

This PR takes (2). The single side effect is that the §6 SL-distance sanity audit needed to drop its hardcoded `2.0` comparison and use the runtime `SL_MULT` (otherwise it would false-FAIL on any Open-24 run with a non-default multiplier). The audit fix is included here.

Multi-archetype D1Hooks are validated to share a single `pre_t_sl_atr_multiplier` (mirrors the existing `bar_offset_t` constraint) — multi-cluster setups whose Step 3 SLs differ must run as separate WFO evaluations.

## Scope

- Engine: `scripts/phase_kgl_v2_4h_wfo.py` (D1 hook startup block + §6 SL audit)
- Core: `core/d1_pipeline.py` (`D1ArchetypeConfig` field, `D1Hook` validation + property, `from_yaml_dict` reader)
- Tests: `tests/test_d1_pipeline.py` (+10 new tests across two classes; parametrizations bring the runtime count to +17)

## Position sizing

Source-level proof: `risk_pp = SL_MULT * a` and `pos_size = (INITIAL_BAL * effective_risk_pct) / risk_pp`. Reassigning `SL_MULT` to the per-archetype multiplier scales `pos_size` by `1 / multiplier` at fixed R risk — tighter pre-t SL → larger position; wider → smaller. Asserted by `test_position_size_formula_reads_sl_mult_via_risk_pp`.

## Not in scope

- §11 post-classification exit policy (PR2 territory, unchanged).
- Pipeline E (untouched — no D1 hook means no `SL_MULT` reassignment).
- Any signal-specific or arc-specific code.
- Step 3 archetype YAML emission writing `pre_t_sl_atr_multiplier = selected_sl_multiplier` (mentioned in §5 "Engine PR scope" — that's emitter scope, downstream of this schema PR).

## Tests

- 52 existing D1 tests passing (suite had grown past the 41 noted in the dispatch).
- 17 new D1 tests (10 written, parametrizations bring the runtime count up).
- Full suite: 1135 passed, 20 skipped, 7 deselected — same as `main` pre-change.

## Test plan

- [x] `pytest -q tests/test_d1_pipeline.py` — 69 passed
- [x] `pytest -q -m "not research" --ignore=attic` — 1135 passed, 20 skipped
- [ ] CI green on the PR branch
- [ ] Analyst review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)