### PR TITLE
Arcs 12-16 Batch 2 signal specs + queue staging

### DIFF
--- a/docs/signal_spec_asia_range_breakout_htf_trend_long_v0.1.md
+++ b/docs/signal_spec_asia_range_breakout_htf_trend_long_v0.1.md
@@ -1,0 +1,87 @@
+# signal_spec_asia_range_breakout_htf_trend_long_v0.1
+
+> Standalone signal spec. Authored by analyst, referenced by `results/ARC_QUEUE.md` Arc 13.
+
+## Identification
+
+| Field | Value |
+|---|---|
+| Name | `signal_asia_range_breakout_htf_trend_long_v0.1` |
+| Family | Session breakout × HTF trend (multi-TF, session-anchored) |
+| Direction | Long only |
+| Signal TF | 4H |
+| Anchor TF | D1 (one-day lag mandatory per L_ARC_PROTOCOL §1.4 / §1a) |
+| Pair set | 28 FX (KH-24 set) |
+| Hypothesis | Session structure (Asia compression → London/NY directional break) + HTF trend context are entry-time observable and orthogonal to swing-based price-action signals → Pipeline E should clear 0.65 AUC |
+
+## Trigger (locked at arc open — L_ARC_PROTOCOL §1.8)
+
+**Session definitions (MT5 server time = GMT+2 winter / GMT+3 summer, DST-aware):**
+- **Asia session bars (day d):** 4H bars closing at 04:00 and 08:00 server time on day d
+- **London/NY session bars (day d):** 4H bars closing at 12:00 and 16:00 server time on day d
+
+**D1 anchor (one-day lag enforced per §1.4):**
+1. **D1 trend filter:** `close_D1[d_t − 1] > close_D1[d_t − 5]` (close five D1 bars ago, strictly before bar t). Structural weak-trend filter; no MA.
+
+**Asia range identification at 4H bar t:**
+2. Let `t_asia_high` = max(high) of Asia session bars on day d_t
+3. Let `t_asia_low` = min(low) of Asia session bars on day d_t
+4. Asia range exists only if both Asia bars are present in data for day d_t (no missing bars)
+
+**Trigger at 4H bar t (must be a London/NY session bar):**
+5. Bar t closes at 12:00 or 16:00 server time on day d_t
+6. `close[t] > t_asia_high + 0.10 × ATR(14)_4H[t]` (decisive break above Asia high with buffer)
+7. `close[t] > open[t]` (bullish close)
+
+**Spacing & entry:**
+8. Max one signal per pair per day (the earlier of the two London/NY bars wins if both qualify)
+9. Entry: bar t+1 open per `docs/SPREAD_SEMANTICS_LOCK.md`
+
+## Configuration
+
+| Field | Value |
+|---|---|
+| Initial SL (Step 1 sim) | `entry − 2.0 × ATR(14)_4H[t]` |
+| SL sweep at Step 3 | Default `{0.5, 1.0, 1.5, 2.0, 3.0, 4.0} × ATR_4H` |
+| Forward window | 240 bars (4H) |
+| Exposure cap | Max 1 open position per pair |
+| Risk per trade | 0.5% × reset floor balance |
+| Spread | Real per-bar MT5 bid/ask; `configs/spread_floors_5ers.yaml` fallback only when raw = 0 |
+| Data window | 2020-10-01 → 2026-01-31 |
+| Arc config target | `configs/wfo_l_arc_13.yaml` |
+| ATR period | 14 (4H and D1 where used) |
+
+## Pool-size prior
+
+Estimate 1,500–3,000 trades / 5y / 28 pairs (one chance per pair per day × ~250 trading days × 28 pairs × ~15–30% trigger rate). If Step 1 returns < 500, arc dies on §5 floor per §16a.
+
+## Step 1 D1 lag verification (mandatory, lookahead-critical)
+
+D1 close at `d_t − 1` must reference the D1 bar closing strictly before 4H bar t's open. Same-day D1 close MUST NOT be available. Use KH-24's D1 lag convention as reference (`scripts/phase_kgl_v2_4h_wfo.py`, `merge_asof` backward).
+
+**NaN-perturbation test:** swap D1[d_t] data for NaN on 3 explicit synthetic test cases; if any signal disappears, the lag is broken → halt (engine-touching, do not patch).
+
+## Step 1 session-time alignment audit (mandatory, novel)
+
+Confirm at Step 1:
+1. All bars classified as "Asia session" have timestamps closing 04:00 or 08:00 server time
+2. All bars classified as "London/NY session" have timestamps closing 12:00 or 16:00 server time
+3. DST transitions handled correctly: 5ers MT5 server transitions GMT+2 ↔ GMT+3 on European DST schedule. Sample 5 bars from days within 7 days of a DST transition; confirm session classification is consistent
+4. Days with missing Asia bars (broker downtime, holiday) produce no signal
+
+If audit fails, halt — session boundary handling is non-trivial and must not be papered over.
+
+## Step 1 co-fire matrix (mandatory)
+
+Report co-fire %:
+- **KH-24** (`kb_exhaustion_bar`): bearish exhaustion vs ARB bullish session break — independence expected. If > 10%, flag.
+- **Arcs 8/9/10/11/12** if Step 1 landed: report each. Expected low across the board (ARB is the only session-anchored signal). Open-05 note.
+- **Arcs 14/15/16** if Step 1 landed: report each.
+
+## Hypothesis notes (informational, not gating)
+
+ARB is the highest-distance signal in the Arc 12-16 batch from the swing-based price-action family. If it clears E where Arcs 8/9/10/11/12 don't (or vice versa), that's the strongest cross-arc feature-class signal of the second batch.
+
+Time-of-day features (hour of bar close, day of week) are entry-time observable and may carry signal. Pipeline E should explore these in Step 4.
+
+Path-shape expectation: bimodal cluster split likely — clean breakouts (Stepwise climber) vs failed breakouts (early peak then reversal). The breakout-fail problem applies to ARB as much as to Arc 11 (SHB); ARB's session-anchored reference may be a better discriminator than SHB's swing-high reference because it's a more cohesive setup (range identity).

--- a/docs/signal_spec_failed_breakdown_reversal_uptrend_long_v0.1.md
+++ b/docs/signal_spec_failed_breakdown_reversal_uptrend_long_v0.1.md
@@ -1,0 +1,106 @@
+# signal_spec_failed_breakdown_reversal_uptrend_long_v0.1
+
+> Standalone signal spec. Authored by analyst, referenced by `results/ARC_QUEUE.md` Arc 15.
+
+## Identification
+
+| Field | Value |
+|---|---|
+| Name | `signal_failed_breakdown_reversal_uptrend_long_v0.1` |
+| Family | Failed-pattern reversal (long after downside fakeout in uptrend context) |
+| Direction | Long only |
+| Signal TF | 4H |
+| Anchor TF | n/a (single-TF) |
+| Pair set | 28 FX (KH-24 set) |
+| Hypothesis | Failed-breakdown geometry (depth, retake speed, ATR-normalised metrics) is entry-time observable. Tests whether Arc 6 failed-breakout-up died for class-specific reasons or trigger-specific reasons — Arc 15 is the symmetric setup → Pipeline E should clear 0.65 AUC |
+
+## Trigger (locked at arc open — L_ARC_PROTOCOL §1.8)
+
+**Swing definitions (3-bar local extreme):**
+- Swing-high at bar k iff `high[k] > max(high[k-3..k-1])` AND `high[k] > max(high[k+1..k+3])`
+- Swing-low at bar k iff `low[k] < min(low[k-3..k-1])` AND `low[k] < min(low[k+1..k+3])`
+
+**1. Uptrend context:**
+- Identify all swing-lows in window `t-30..t-1`; require ≥ 1 swing-low exists
+- Identify all swing-highs in window `t-30..t-1`; require ≥ 1 swing-high exists
+- Require `close[t-1] > min(swing_lows in window)` — price holds above recent swing-low chain
+- Right-edge constraint: all identifiable swings at most bar `t-4`
+
+**2. Reference swing-low:**
+- Identify swing-lows in window `t-15..t-1`
+- `L_ref` = most recent identifiable swing-low in window (at most bar `t-4`)
+- Require `L_ref` exists in window
+
+**3. Failed breakdown (within last 3 bars):**
+- Require some bar `k ∈ {t-3, t-2, t-1}` such that:
+  - `low[k] < L_ref − 0.10 × ATR(14)[k]` (price broke below L_ref with buffer)
+  - `close[k] > L_ref` (closed back above L_ref on same bar)
+- Record `k_fakeout` = the most recent qualifying bar
+
+**4. Trigger at bar t:**
+- `close[t] > high[t-1]` (bullish continuation)
+- `close[t] > open[t]` (bullish close)
+- `(close[t] − low[t]) / (high[t] − low[t]) ≥ 0.5` (close in upper half)
+
+**5. Spacing & entry:**
+- ≥ 20 bars since last signal on this pair
+- Entry: bar t+1 open per `docs/SPREAD_SEMANTICS_LOCK.md`
+
+## Configuration
+
+| Field | Value |
+|---|---|
+| Initial SL (Step 1 sim) | `entry − 2.0 × ATR(14)_4H[t]` |
+| SL sweep at Step 3 | Default `{0.5, 1.0, 1.5, 2.0, 3.0, 4.0} × ATR_4H` |
+| Forward window | 240 bars (4H) |
+| Exposure cap | Max 1 open position per pair |
+| Risk per trade | 0.5% × reset floor balance |
+| Spread | Real per-bar MT5 bid/ask; `configs/spread_floors_5ers.yaml` fallback only when raw = 0 |
+| Data window | 2020-10-01 → 2026-01-31 |
+| Arc config target | `configs/wfo_l_arc_15.yaml` |
+| ATR period | 14 |
+
+## Pool-size prior
+
+Estimate 800–1,800 trades / 5y / 28 pairs. Multiple compound conditions (uptrend + reference swing-low + fakeout in last 3 bars + trigger geometry) cut pool aggressively. If Step 1 returns < 500, arc dies on §5 floor per §16a — this is the highest pool-floor-risk signal of the Arc 12-16 batch.
+
+## Smaller-pool risk
+
+With 800–1,800 trades, clusters at Step 3 may not clear `size_fraction ≥ 0.10` (requires ~80–180 per cluster). §16a handles disposition: size_fraction failure near 0.10 with strong magnitude (`fwd_mfe_p50 ≥ 3.0R`) → HALT Path B; else KILL.
+
+## Step 1 right-edge swing audit (mandatory)
+
+Both swing-high and swing-low identification use k+1..k+3 lookahead within the detection window only. Confirm at Step 1 that:
+- All swing-lows used for trend filter are at most bar `t-4`
+- All swing-highs used for trend filter are at most bar `t-4`
+- `L_ref` is at most bar `t-4`
+
+If standard 5/5 lookahead spot-check shows any future-bar dependency, halt.
+
+## Step 1 fakeout-bar validity audit (mandatory, novel)
+
+The fakeout condition allows `k ∈ {t-3, t-2, t-1}`. Confirm at Step 1:
+- `k_fakeout` is always strictly less than `t` (no same-bar fakeout)
+- For all signals, the fakeout bar has both `low[k] < L_ref` and `close[k] > L_ref` (intrabar low must be below L_ref AND close must be above — single-bar wick-and-reverse pattern)
+- L_ref is older than `k_fakeout` (the level being faked existed before the fakeout)
+
+If any of these fail, halt — fakeout definition is structurally broken.
+
+## Step 1 co-fire matrix (mandatory)
+
+Report co-fire %:
+- **KH-24** (`kb_exhaustion_bar`): bearish exhaustion vs FBR bullish failed-breakdown reversal — independence expected. If > 10%, flag.
+- **Arc 6** (closed): structural cousin. Arc 6 was failed-breakout-up reversal; Arc 15 is failed-breakdown-down reversal. Co-fire near zero by direction.
+- **Arcs 8/9/10/11/12** if Step 1 landed: report each. Expected low — FBR triggers after a fakeout, not on clean continuation. Open-05 note.
+- **Arcs 13/14/16** if Step 1 landed: report each. Expected very low with Arc 14 (MRS) despite both being non-Arc-8 family — different geometry (stretch vs fakeout).
+
+## Hypothesis notes (informational, not gating)
+
+FBR is the controlled test of Arc 6's failure mode. Arc 6 died at Step 4 with Pipeline E both clusters AUC ~0.60 (below 0.65 gate). Two interpretations:
+
+- **Class-specific:** failed-pattern reversal signals can't be discriminated on entry-time features at all. FBR will die the same way.
+- **Trigger-specific:** Arc 6's failed-breakout-up trigger had specific geometry issues (e.g., breakout was already overextended by the time it failed). FBR's failed-breakdown trigger may have cleaner geometry because the prior context is an uptrend, not an overextended breakout.
+
+If FBR clears E where Arc 6 didn't, that's a direction-asymmetry signal worth documenting in the closure doc and shelved-arcs register.
+
+Path-shape expectation: bimodal — clean continuation after fakeout (Stepwise climber) vs failed continuation (early peak then deeper decline). The bimodality risk (Open-13 / Open-14 territory) may bite at Step 2; watch silhouette scores. Aggregate evaluation may be the deciding §7 path here.

--- a/docs/signal_spec_mean_reversion_stretch_long_v0.1.md
+++ b/docs/signal_spec_mean_reversion_stretch_long_v0.1.md
@@ -1,0 +1,80 @@
+# signal_spec_mean_reversion_stretch_long_v0.1
+
+> Standalone signal spec. Authored by analyst, referenced by `results/ARC_QUEUE.md` Arc 14.
+
+## Identification
+
+| Field | Value |
+|---|---|
+| Name | `signal_mean_reversion_stretch_long_v0.1` |
+| Family | Counter-trend reversion within trend (the only non-continuation signal in current batches) |
+| Direction | Long only |
+| Signal TF | 4H |
+| Anchor TF | n/a (single-TF) |
+| Pair set | 28 FX (KH-24 set) |
+| Hypothesis | Stretch magnitude (ATR-normalised distance below recent high) + recovery-bar geometry are entry-time observable → Pipeline E should clear 0.65 AUC. Diagnostic-value high: tests whether reversal-class signals can clear E at all (Arcs 5/6/7 all failed Step 3/4 in this family) |
+
+## Trigger (locked at arc open — L_ARC_PROTOCOL §1.8)
+
+**Swing-low definition (3-bar local low):**
+- Swing-low at bar k iff `low[k] < min(low[k-3..k-1])` AND `low[k] < min(low[k+1..k+3])`
+
+**1. Trend context (weaker than Arc 9/11 — admits more pullback depth):**
+- Identify all swing-lows in window `t-50..t-1`
+- Right-edge constraint: most recent identifiable swing-low at most bar `t-4`
+- Require ≥ 1 swing-low exists in window
+- Require `close[t-1] > min(swing_lows in window)` — price holds above 50-bar swing-low chain
+
+**2. Stretch condition:**
+- Let `H_10 = max(high[t-10..t-1])` (10-bar high in window strictly before signal bar)
+- Require `close[t-1] < H_10 − 1.5 × ATR(14)[t-1]` — close at least 1.5 ATR below 10-bar high
+
+**3. Reversal trigger at bar t:**
+- `close[t] > open[t]` (bullish close)
+- `close[t] > close[t-1]` (higher close than prior bar)
+- `(close[t] − low[t]) / (high[t] − low[t]) ≥ 0.6` (close in upper 40% of bar)
+
+**4. Spacing & entry:**
+- ≥ 20 bars since last signal on this pair
+- Entry: bar t+1 open per `docs/SPREAD_SEMANTICS_LOCK.md`
+
+## Configuration
+
+| Field | Value |
+|---|---|
+| Initial SL (Step 1 sim) | `entry − 2.0 × ATR(14)_4H[t]` |
+| SL sweep at Step 3 | Default `{0.5, 1.0, 1.5, 2.0, 3.0, 4.0} × ATR_4H` |
+| Forward window | 240 bars (4H) |
+| Exposure cap | Max 1 open position per pair |
+| Risk per trade | 0.5% × reset floor balance |
+| Spread | Real per-bar MT5 bid/ask; `configs/spread_floors_5ers.yaml` fallback only when raw = 0 |
+| Data window | 2020-10-01 → 2026-01-31 |
+| Arc config target | `configs/wfo_l_arc_14.yaml` |
+| ATR period | 14 |
+
+## Pool-size prior
+
+Estimate 2,000–3,500 trades / 5y / 28 pairs. Pullbacks are common; weaker trend filter admits more candidates than Arc 9/11. If Step 1 returns < 500, arc dies on §5 floor per §16a.
+
+## Step 1 right-edge swing audit (mandatory)
+
+Swing-low identification uses k+1..k+3 lookahead within the detection window only. Confirm at Step 1 that all swing-lows used for trend filter are at most bar `t-4`. If standard 5/5 lookahead spot-check shows any future-bar dependency, halt.
+
+## Step 1 co-fire matrix (mandatory)
+
+Report co-fire %:
+- **KH-24** (`kb_exhaustion_bar`): KH-24 is bearish exhaustion in trend, MRS is bullish reversal after stretch — opposite by construction. Co-fire expected very low. If > 5%, flag.
+- **Arcs 8/9/10/11/12** if Step 1 landed: report each. Expected low — MRS triggers at pullback bottoms, not continuation tops. The mechanical opposite of Arc 8/9/11/12 trigger geometry. Open-05 note.
+- **Arcs 13/15/16** if Step 1 landed: report each.
+
+## Hypothesis notes (informational, not gating)
+
+MRS is the highest-risk signal in the Arc 12-16 batch by ship-probability prior, but the highest diagnostic-value signal if it fails. Three independent reversal/recovery signals died at Step 3/4 in Arcs 5-7. MRS is the cleanest fourth test:
+
+- If MRS dies at Step 3 same way Arc 3/5 died (path quality clean but §2 fails on shape_tag) → reversal-class signals consistently produce bimodal/scattered path-shape clusters, even with clean stretch geometry. Strong methodological conclusion.
+- If MRS dies at Step 4 same way Arc 6/7 died (E fails AUC 0.65) → reversal-class signals can't be discriminated on entry-time features at all. Even stronger methodological conclusion: reversal class is dead on this protocol surface, future work goes to richer D1 or hybrid pipelines (not in this batch).
+- If MRS clears E → Arc 5-7 failures were trigger-specific, not class-specific. Reversal signals reopen as a viable line.
+
+Path-shape expectation: V-shape recovery family (Arc 7 pattern) on clean reversions; whipsaw bottom or stair-step decline on failures.
+
+Co-fire with KH-24 expected near-zero by trigger geometry; this is a deliberately complementary signal to the current live system.

--- a/docs/signal_spec_persistent_momentum_continuation_long_v0.1.md
+++ b/docs/signal_spec_persistent_momentum_continuation_long_v0.1.md
@@ -1,0 +1,79 @@
+# signal_spec_persistent_momentum_continuation_long_v0.1
+
+> Standalone signal spec. Authored by analyst, referenced by `results/ARC_QUEUE.md` Arc 16.
+
+## Identification
+
+| Field | Value |
+|---|---|
+| Name | `signal_persistent_momentum_continuation_long_v0.1` |
+| Family | Trend continuation conditioned on ascent quality (no swing definitions, pure bar-statistics) |
+| Direction | Long only |
+| Signal TF | 4H |
+| Anchor TF | n/a (single-TF) |
+| Pair set | 28 FX (KH-24 set) |
+| Hypothesis | Persistence count + ascent slope + clean-ascent constraint (drawdown bound) are entry-time observable geometry, fundamentally different from swing-based feature sets in Arcs 8/9/11/12 → Pipeline E should clear 0.65 AUC |
+
+## Trigger (locked at arc open — L_ARC_PROTOCOL §1.8)
+
+**1. Persistence window:** examine bars `t-10..t-1` (10 bars strictly before signal bar)
+
+**2. Persistence count:**
+- Let `bullish_count` = count of bars k ∈ {t-10..t-1} where `close[k] > open[k]`
+- Require `bullish_count ≥ 7`
+
+**3. Drawdown bound (clean-ascent constraint):**
+- Let `window_high = max(close[t-10..t-1])`
+- Let `window_low = min(close[t-10..t-1])`
+- Require `window_high − window_low ≤ 2.0 × ATR(14)[t-1]` — close-range across window is bounded
+
+**4. Trigger at bar t:**
+- `close[t] > high[t-1]` (breaks prior bar high)
+- `close[t] > open[t]` (bullish close)
+
+**5. Spacing & entry:**
+- ≥ 20 bars since last signal on this pair
+- Entry: bar t+1 open per `docs/SPREAD_SEMANTICS_LOCK.md`
+
+## Configuration
+
+| Field | Value |
+|---|---|
+| Initial SL (Step 1 sim) | `entry − 2.0 × ATR(14)_4H[t]` |
+| SL sweep at Step 3 | Default `{0.5, 1.0, 1.5, 2.0, 3.0, 4.0} × ATR_4H` |
+| Forward window | 240 bars (4H) |
+| Exposure cap | Max 1 open position per pair |
+| Risk per trade | 0.5% × reset floor balance |
+| Spread | Real per-bar MT5 bid/ask; `configs/spread_floors_5ers.yaml` fallback only when raw = 0 |
+| Data window | 2020-10-01 → 2026-01-31 |
+| Arc config target | `configs/wfo_l_arc_16.yaml` |
+| ATR period | 14 |
+
+## Pool-size prior
+
+Estimate 1,200–2,200 trades / 5y / 28 pairs. Persistence + drawdown bound is moderately restrictive. If Step 1 returns < 500, arc dies on §5 floor per §16a.
+
+## Step 1 lookahead audit (mandatory)
+
+No swing definitions used → no right-edge swing audit needed. Standard 5/5 lookahead spot-check sufficient. Confirm all features computed from bars ≤ signal bar; entry bar t+1 open uses next-bar data only at execution time.
+
+## Step 1 co-fire matrix (mandatory)
+
+Report co-fire %:
+- **KH-24** (`kb_exhaustion_bar`): bearish exhaustion in trend vs PMC bullish continuation — independence expected. KH-24 selects single-bar exhaustion; PMC selects after sustained ascent. Possible co-fire if KH-24 fires near top of clean ascent (overlap moderate). Report and Open-05 note.
+- **Arcs 8/9/11/12** if Step 1 landed: report each. PMC's no-swing-definition trigger geometry may overlap with Arc 9 (IB-break — both bullish bar-prior break) and Arc 12 (3BR — bullish multi-bar break). Open-05 note.
+- **Arc 10/13/14/15** if Step 1 landed: report each. Expected low.
+
+## Hypothesis notes (informational, not gating)
+
+PMC is the only Arc 12-16 candidate without swing definitions. Tests whether "ascent quality" — measured by bar-statistics alone — carries predictive signal independent of structural levels.
+
+Two informative outcomes:
+- **PMC clears E + swing-based arcs (8/9/11/12) clear E:** ascent quality and structural levels both work; portfolio diversification possible.
+- **PMC clears E + swing-based arcs fail:** structural-levels framing was the wrong feature lens for entry-time. Diagnostic win for future signal design.
+- **PMC fails + swing-based arcs clear:** ascent-quality is reducible to structural geometry, no extra signal.
+- **All fail:** trend-continuation feature class is dead at entry-time across all geometries tested.
+
+Path-shape expectation: Stepwise climber on continuation; whipsaw or early peak on failed breaks. The drawdown bound at signal time should reduce whipsaw mass compared to Arc 8 (PR-HHHL) which admits deeper pullbacks before resume.
+
+**Risk:** persistence may be exactly the wrong filter — by the time you have 7/10 bullish closes with bounded drawdown, you may be selecting peak-trend entries that are about to mean-revert. If clusters at Step 2 are dominated by early-peak archetype (instead of Stepwise climber), that's the signal — informative, but kills extractability.

--- a/docs/signal_spec_three_bar_reversal_trend_long_v0.1.md
+++ b/docs/signal_spec_three_bar_reversal_trend_long_v0.1.md
@@ -1,0 +1,77 @@
+# signal_spec_three_bar_reversal_trend_long_v0.1
+
+> Standalone signal spec. Authored by analyst, referenced by `results/ARC_QUEUE.md` Arc 12.
+
+## Identification
+
+| Field | Value |
+|---|---|
+| Name | `signal_three_bar_reversal_trend_long_v0.1` |
+| Family | Trend continuation (multi-bar sequence) |
+| Direction | Long only |
+| Signal TF | 4H |
+| Anchor TF | n/a (single-TF) |
+| Pair set | 28 FX (KH-24 set) |
+| Hypothesis | 3-bar sequence geometry (pullback bar → recovery bar → break bar) carries entry-time information that single-bar triggers (Arc 8/9) miss → Pipeline E should clear 0.65 AUC |
+
+## Trigger (locked at arc open — L_ARC_PROTOCOL §1.8)
+
+**Swing-low definition (3-bar local low):**
+- Swing-low at bar k iff `low[k] < min(low[k-3..k-1])` AND `low[k] < min(low[k+1..k+3])`
+
+**1. Trend filter (pure structural, no MA — same as Arc 9):**
+- Identify all swing-lows in window `t-30..t-1`
+- Right-edge constraint: most recent identifiable swing-low at most bar `t-4`
+- Require ≥ 1 swing-low exists in window
+- Require `close[t-1] > min(swing_lows in window)`
+
+**2. Bar t-2 (pullback bar):**
+- `close[t-2] < open[t-2]` (bearish close)
+
+**3. Bar t-1 (recovery bar):**
+- `low[t-1] > low[t-2]` (higher low than pullback bar)
+- `close[t-1] > close[t-2]` (higher close than pullback bar)
+
+**4. Bar t (break trigger):**
+- `close[t] > high[t-1]` (breaks recovery bar high)
+- `close[t] > open[t]` (bullish close)
+- `(close[t] − low[t]) / (high[t] − low[t]) ≥ 0.5` (close in upper half)
+
+**5. Spacing & entry:**
+- ≥ 20 bars since last signal on this pair
+- Entry: bar t+1 open per `docs/SPREAD_SEMANTICS_LOCK.md`
+
+## Configuration
+
+| Field | Value |
+|---|---|
+| Initial SL (Step 1 sim) | `entry − 2.0 × ATR(14)_4H[t]` |
+| SL sweep at Step 3 | Default `{0.5, 1.0, 1.5, 2.0, 3.0, 4.0} × ATR_4H` |
+| Forward window | 240 bars (4H) |
+| Exposure cap | Max 1 open position per pair |
+| Risk per trade | 0.5% × reset floor balance |
+| Spread | Real per-bar MT5 bid/ask; `configs/spread_floors_5ers.yaml` fallback only when raw = 0 |
+| Data window | 2020-10-01 → 2026-01-31 |
+| Arc config target | `configs/wfo_l_arc_12.yaml` |
+| ATR period | 14 |
+
+## Pool-size prior
+
+Estimate 1,500–2,500 trades / 5y / 28 pairs. The 3-bar sequence is more restrictive than Arc 9's inside-bar pattern but the trend filter is identical. If Step 1 returns < 500, arc dies on §5 floor per §16a.
+
+## Step 1 right-edge swing audit (mandatory)
+
+Swing-low identification uses k+1..k+3 lookahead within the detection window only. Confirm at Step 1 that all swing-lows used for trend filter are at most bar `t-4`. If standard 5/5 lookahead spot-check shows any future-bar dependency, halt.
+
+## Step 1 co-fire matrix (mandatory)
+
+Report co-fire %:
+- **KH-24** (`kb_exhaustion_bar`): bearish exhaustion vs 3BR bullish break — independence expected. If > 10%, flag.
+- **Arcs 8/9/10/11** if Step 1 landed: report each. Expected highest with Arc 9 (both use same trend filter + bullish break geometry). Open-05 note.
+- **Arcs 13/14/15/16** if Step 1 landed: report each. Expected lower (different families).
+
+## Hypothesis notes (informational, not gating)
+
+3BR is the cleanest test of "multi-bar sequence vs single-bar trigger." If it clears E where Arc 8 (PR-HHHL) fails — or vice versa — that's a concrete signal-design lesson. If both clear, the 3-bar sequence is redundant complexity over PR-HHHL. If both fail, the trend-continuation feature class is dead at 4H regardless of trigger granularity.
+
+Path-shape expectation: Stepwise climber on clean continuation; whipsaw on failed break. Cluster heterogeneity at Step 2 expected.

--- a/results/ARC_QUEUE.md
+++ b/results/ARC_QUEUE.md
@@ -1,8 +1,8 @@
 # Arc Queue
 
-> State file for L arc parallel execution under L_ARC_PROTOCOL v2.2.
+> State file for L arc parallel execution under L_ARC_PROTOCOL v2.3 (base v2.1.2 + v2.2 amendment + v2.3 amendment).
 > Read by CC at arc-open. Updated by CC at queue transitions. Analyst owns Unrun ordering and signal source selection.
-> Coordination: git-level. Queue file is the only shared state between concurrent CC sessions. Each session pulls before edit; on push conflict, pulls and retries.
+> Coordination: per-arc worktrees. Each CC session runs in its own worktree directory pinned to `phase/l_arc_<N>`; commits push to `origin/phase/l_arc_<N>`. Analyst reconciles queue across branches at chat level.
 
 ---
 
@@ -16,41 +16,55 @@ _None._
 
 In FIFO order. Topmost is next. Analyst adds entries here as signals become ready.
 
-- [ ] **Arc 9** — Inside-bar break in trend (IB-trend, long)
-  - Spec: `signal_spec_inside_bar_break_trend_long_v0.1.md`
-  - Handover: `arc_9_handover_IB_trend.md`
-  - Family: Trend continuation (compression-and-break). Signal TF 4H, long-only, 28 FX. Pool prior 1,500–2,500.
+### Batch 2 — feature-class diversification
 
-- [ ] **Arc 10** — D1 swing-low rejection in D1 uptrend (DLR, long)
-  - Spec: `signal_spec_d1_swing_low_rejection_long_v0.1.md`
-  - Handover: `arc_10_handover_DLR.md`
-  - Family: Multi-TF trend continuation (HTF-anchored level rejection). Signal TF 4H, anchor TF D1 (one-day lag), long-only, 28 FX. Pool prior 1,000–2,000.
+Second batch testing distinct feature classes from Batch 1. **Recommend dispatch only after ≥ 2 Batch 1 halts return** — pre-staged in Unrun, not pre-committed to immediate dispatch.
 
-### Batch note
+- [ ] **Arc 12** — Three-bar bullish reversal in trend (3BR, long)
+  - Spec: `docs/signal_spec_three_bar_reversal_trend_long_v0.1.md`
+  - Family: Trend continuation (multi-bar sequence). Signal TF 4H, long-only, 28 FX. Pool prior 1,500–2,500.
+  - Tests: multi-bar sequence vs single-bar trigger (vs Arc 8/9).
 
-Arcs 8-11 are a coordinated parallel batch testing the entry-time-features hypothesis across four distinct trend-continuation feature classes:
-- Arc 8: rich entry-time features (trend strength + pullback geometry + trigger geometry)
-- Arc 9: narrow entry-time features (compression geometry + break geometry)
-- Arc 10: HTF entry-time features (D1 anchor identity + LTF rejection geometry)
-- Arc 11: structural reference break magnitude (swing-high freshness + break magnitude)
+- [ ] **Arc 13** — Asia-range breakout in HTF trend (ARB, long)
+  - Spec: `docs/signal_spec_asia_range_breakout_htf_trend_long_v0.1.md`
+  - Family: Session breakout × HTF trend (multi-TF, session-anchored). Signal TF 4H, anchor TF D1 (one-day lag), long-only, 28 FX. Pool prior 1,500–3,000.
+  - Tests: session-anchored signal class (orthogonal to swing-based price-action). Novel session-time alignment audit at Step 1.
 
-Co-fire matrix between the four is measured at each arc's Step 1 closure (handover specs). Cross-arc synthesis is analyst work at Step 5 halt-summary review.
+- [ ] **Arc 14** — Mean-reversion stretch (MRS, long)
+  - Spec: `docs/signal_spec_mean_reversion_stretch_long_v0.1.md`
+  - Family: Counter-trend reversion within trend (the only non-continuation candidate). Signal TF 4H, long-only, 28 FX. Pool prior 2,000–3,500.
+  - Tests: reversal-class viability after Arc 5/6/7 family deaths. Highest diagnostic value if it fails.
+
+- [ ] **Arc 15** — Failed-breakdown reversal in uptrend (FBR, long)
+  - Spec: `docs/signal_spec_failed_breakdown_reversal_uptrend_long_v0.1.md`
+  - Family: Failed-pattern reversal (symmetric to closed Arc 6). Signal TF 4H, long-only, 28 FX. Pool prior 800–1,800.
+  - Tests: whether Arc 6 died for class-specific or trigger-specific reasons. Smallest pool of Batch 2 — highest §16a-trigger risk.
+
+- [ ] **Arc 16** — Persistent-momentum continuation (PMC, long)
+  - Spec: `docs/signal_spec_persistent_momentum_continuation_long_v0.1.md`
+  - Family: Trend continuation conditioned on ascent quality (no swing definitions, pure bar-statistics). Signal TF 4H, long-only, 28 FX. Pool prior 1,200–2,200.
+  - Tests: bar-statistics feature class vs swing-based feature class.
+
+### Batch dispatch staging
+
+- **Batch 1 (Arcs 8-11):** ready for dispatch under v2.3 + per-arc worktree arrangement.
+- **Batch 2 (Arcs 12-16):** staged for dispatch after ≥ 2 Batch 1 halts return. Rationale: 8 concurrent CC sessions exceeds reasonable analyst review bandwidth; cross-arc synthesis benefits from staggered halt summaries; failure modes from Batch 1 may inform Batch 2 trigger refinements before commitment.
+- **If Batch 1 returns multiple early KILLs (Step 1-2):** dispatch Batch 2 onto freed worktrees.
+- **If Batch 1 returns STEP_4_COMPLETE on multiple:** prioritize Step 5 WFO dispatches over Batch 2 launches.
 
 ### Entry format
-
-Each Unrun entry references either a registry entry or a standalone signal spec:
 
 ```markdown
 - [ ] **Arc <N>** — <signal name>
   - Spec: `LCHAR_TOPN_REGISTRY.md` Entry <K>     # for registry-derived signals
-  - Spec: `signal_spec_<name>_v<version>.md`     # for analyst-designed signals
+  - Spec: `docs/signal_spec_<name>_v<version>.md`  # for analyst-designed signals
 ```
 
 ---
 
 ## Closed
 
-Most recent first. Populated from actual closure docs in `results/arc_<N>/` and `docs/arc_results/`.
+Most recent first. Populated from actual closure docs in `results/l_arc_<N>/` and `docs/arc_results/`.
 
 - [x] **Arc 8** — Pullback-and-resume in HH/HL uptrend (PR-HHHL, long) — HALT_DEPLOYMENT (Step 5 WFO §10 FAIL) 2026-05-18; `results/l_arc_8/ARC_8_CLOSURE.md`
   - Spec: `docs/signal_spec_pullback_resume_hhhl_long_v0.1.md`
@@ -63,27 +77,27 @@ Most recent first. Populated from actual closure docs in `results/arc_<N>/` and 
   - Note: second confirmed capturable-not-extractable closure (pairs with Arc 6). 3 Step 3 V-shape units survived; 0/3 cleared Step 4 disjunctive AUC gate (best agg_c1_c3 D1 t=5 AUC 0.5728 vs 0.60, margin 0.027). §16a Path A near-miss. 4 post-closure experimental sessions (~125s compute) retired 8 directions and proposed Pipeline DE + `min_observation_bars` as v2.4 amendment candidates.
 
 - [x] **Arc 7** — Liquidity sweep + reclaim (long) — CLEAN-NULL 2026-05-17 (Step 4); `docs/arc_results/ARC_7_RESULT.md`
-  - Spec: `signal_spec_liquidity_sweep_reclaim_long_v0.1.md`
-  - Closure branch: `phase/l_arc_7` (closure doc pending merge to main)
+  - Spec: `docs/signal_spec_liquidity_sweep_reclaim_long_v0.1.md`
+  - Closure branch: `phase/l_arc_7`
   - Note: first capturable-not-extractable closure of record. PASS §7 with 3 V-shape units; FAIL §8 with 0/6 unit × pipeline AUCs clearing gate (best 0.536 vs 0.65). Max-F1 fallback case that v2.2 §3 closes mechanically going forward.
 
 - [x] **Arc 4 RERUN** — `bar_range_top_decile__neg__h_001` — KILL (Step 6 FAIL) 2026-05-18; `docs/arc_results/ARC_4_RERUN_RESULT.md`
   - Spec: `LCHAR_TOPN_REGISTRY.md` Entry 4 (re-run from Step 1 under corrected per-pair p50 spread floors)
   - Closure branch: `calibration/spread-floor-p50-2026-05-17`
-  - Note: §10 full-pool deployment FAIL on every gate. Admit-pool edge +0.125R per trade swamped by reject pool (32%, −0.232R) + early-exit pool (11%, −0.685R). Open-22/23/24 spawned. Supersedes prior CLEAN-NULL closure (disposition unchanged, reason updated).
+  - Note: §10 full-pool deployment FAIL on every gate. Admit-pool edge +0.125R per trade swamped by reject pool (32%, −0.232R) + early-exit pool (11%, −0.685R). Open-22/23/24 spawned; v2.3 closes Open-22 by structural removal of Step 5 (was cross-fold stability), closes Open-23 by documentation correction. Supersedes prior CLEAN-NULL closure. Closed under v2.2 numbering ("Step 6 = WFO"); under v2.3 the equivalent step is renumbered to Step 5.
 
 - [x] **Arc 5** — `mtf_alignment.2_down_mixed.kijun` (h=120) — KILL (SHELVED Step 6 FAIL) 2026-05-17; `docs/arc_results/ARC_5_RESULT.md`
   - Spec: `LCHAR_TOPN_REGISTRY.md` Entry 5
-  - Closure branch: `arc-5-closure` (closure doc pending merge to main)
-  - Note: all three strategy candidates FAIL at every risk level. Pipeline D1 rejected-pool adverse selection (~78%, −0.46R mean) kills full-strategy expectancy despite admit-set edge. Signal NOT permanently eliminated — Pipeline E re-evaluation reopenable.
+  - Closure branch: `arc-5-closure`
+  - Note: all three strategy candidates FAIL at every risk level. Pipeline D1 rejected-pool adverse selection (~78%, −0.46R mean) kills full-strategy expectancy despite admit-set edge. Signal NOT permanently eliminated — Pipeline E re-evaluation reopenable. Closed under v2.2 numbering; under v2.3 the equivalent step is Step 5 (was Step 6).
 
 - [x] **Arc 6** — Failed-breakout reversal (long) — KILL (DIES Step 4) 2026-05-17; `docs/arc_results/ARC_6_RESULT.md`
-  - Spec: `signal_spec_failed_breakout_long_v0.2.md` (out-of-registry insertion on `discovery/lomega_regime_conditional`)
-  - Note: Pipeline E both clusters fail (best AUC 0.600 / 0.590 vs 0.65); Pipeline D1 clears AUC ≥ 0.60 mechanically but threshold sweep collapses to max-F1 fallback at sub-1% recall. Signal NOT permanently eliminated — path quality clean (c2 mfe_p50 4.47R, ww_pp 0.000); may return under richer feature regime / multi-TF / ensemble. v2.2 §3 closes the max-F1 fallback path mechanically.
+  - Spec: `docs/signal_spec_failed_breakout_long_v0.2.md` (out-of-registry insertion on `discovery/lomega_regime_conditional`)
+  - Note: Pipeline E both clusters fail (best AUC 0.600 / 0.590 vs 0.65); Pipeline D1 clears AUC ≥ 0.60 mechanically but threshold sweep collapses to max-F1 fallback at sub-1% recall. Signal NOT permanently eliminated — path quality clean (c2 mfe_p50 4.47R, ww_pp 0.000); may return under richer feature regime / multi-TF / ensemble. v2.2 §3 closes the max-F1 fallback path mechanically. **Cross-reference Arc 15** — symmetric failed-pattern test.
 
 - [x] **Arc 4** (original closure) — `bar_range_top_decile__neg__h_001` — KILL (CLEAN-NULL on transaction-cost truth) 2026-05-17; `docs/arc_results/ARC_4_RESULT.md`
   - Spec: `LCHAR_TOPN_REGISTRY.md` Entry 4
-  - Note: first L arc to reach Step 5 PASS; cluster 1 D1 AUC 0.667; killed by HistData spread audit showing floor file under-models real spreads 3-48x per pair. Superseded 2026-05-18 by Arc 4 RERUN (above) — disposition unchanged, reason updated.
+  - Note: first L arc to reach Step 5 PASS; cluster 1 D1 AUC 0.667; killed by HistData spread audit. Superseded 2026-05-18 by Arc 4 RERUN (above).
 
 - [x] **Arc 3** — `TRIAL__volatility_regime__d1_atr_top_decile__any__h_120` — KILL (CLEAN-NULL Step 3) 2026-05-16; `docs/arc_results/ARC_3_RESULT.md`
   - Spec: `LCHAR_TOPN_REGISTRY.md` Entry 3
@@ -91,14 +105,12 @@ Most recent first. Populated from actual closure docs in `results/arc_<N>/` and 
 
 ### Pre-v2.2 closures (registered for completeness)
 
-The following closed pre-v2.2 (when arc selection was implicit and queue did not exist). Listed for historical record:
-
 - **Arc 2 redo / redo2** — `mtf_alignment.2_down_mixed.kijun` (h=24/120 variants) — SHELVED 2026-05-16 (KILL at Step 3, then redo2 PASS at Steps 1-2-3 under v2.1.1). See `results/l_arc_2_redo/ARC_2_REDO_RESULT.md` + `results/l_arc_2_redo2/`. Byte-identical entry trigger to Arc 5 Entry 5.
 - **Arc 2** — original under v1.x protocol — FAIL verbatim WFO. See archive.
 - **Arc 1** — original under v1.x protocol — FAIL verbatim WFO; Arc 1 P2 (CH-001 concurrent_signals filter) PASS under L6.0 framing. See archive.
 - **KH-24 v2.0 self-test (arc_kh24_v2)** — HALT at Step 3 2026-05-16. Protocol self-test on bare `kb_exhaustion_bar`. See `results/arc_kh24_v2/ARC_KH24_V2_RESULT.md`.
 
-Note on disposition naming under v2.2: KILL and HALT are the mechanical dispositions per §16a; SHIPPED is reserved for step 6 WFO pass-deployable + analyst ship decision. Pre-v2.2 closures used SHELVED for some KILL-equivalent outcomes; preserved verbatim from closure docs for traceability.
+Note on disposition naming under v2.3: KILL and HALT are the mechanical dispositions per §16a; SHIPPED is reserved for Step 5 (WFO, was Step 6 pre-v2.3) pass-deployable + analyst ship decision. Pre-v2.3 closures used "Step 6" for WFO; under v2.3 that's "Step 5". Closure docs are not retroactively renumbered.
 
 ---
 
@@ -119,18 +131,16 @@ Each Unrun entry must reference either a registry entry or a standalone signal s
 
 ### Parallel arcs
 
-Multiple Active entries permitted. Each on its own `phase/arc-<N>` branch, own `results/arc_<N>/` folder. One Active entry per CC chat session.
-
-To run N arcs in parallel: open N CC chats. Each session reads this queue file, picks the topmost Unrun, and proceeds.
+Multiple Active entries permitted. Each on its own `phase/l_arc_<N>` branch in its own worktree directory, own `results/l_arc_<N>/` folder per `WORKFLOW.md`. One Active entry per CC chat session per worktree.
 
 ### Concurrency
 
-Git-level coordination. Each session pulls before queue edit; on push conflict, pulls and retries with whatever Unrun entry is now topmost. Sufficient for dispatch cadences of minutes apart.
+Per-arc worktrees. Each session sees its own working tree; commits push to `origin/phase/l_arc_<N>`. Queue file updates land on each session's branch; analyst reconciles at chat level after halt summaries return.
 
 ### Re-runs
 
-A closed arc re-evaluated under a new protocol version gets a new Unrun entry (`Arc K redo`), not by mutating the existing Closed entry. Closed entries are historical record.
+A closed arc re-evaluated under a new protocol version gets a new Unrun entry (`Arc K redo`), not by mutating the existing Closed entry.
 
 ### SHIPPED disposition
 
-Only assigned after step 6 WFO pass-deployable + analyst ship decision (per §10). Steps 1-5 dispatches never produce SHIPPED — only KILL, HALT, or step-5-complete-pending-WFO (Active remains).
+Only assigned after Step 5 (WFO, was Step 6 pre-v2.3) pass-deployable + analyst ship decision (per §10). Steps 1-4 dispatches never produce SHIPPED — only KILL, HALT, or step-4-complete-pending-Step-5 (Active remains).


### PR DESCRIPTION
## Summary

Squash-merge of `claude/laughing-pare-79b036` adding Batch 2 (feature-class diversification) signal specs:

- **Arc 12** — Three-bar bullish reversal in trend (3BR, long)
- **Arc 13** — Asia-range breakout in HTF trend (ARB, long)
- **Arc 14** — Mean-reversion stretch (MRS, long)
- **Arc 15** — Failed-breakdown reversal in uptrend (FBR, long; symmetric to closed Arc 6)
- **Arc 16** — Persistent-momentum continuation (PMC, long)

Updates `results/ARC_QUEUE.md` with Batch 2 staging notes (dispatched only after ≥ 2 Batch 1 halts return) and per-arc worktree coordination model.

## Test plan

- [x] `results/ARC_QUEUE.md` conflict resolved by dropping Arcs 8/11 entries from laughing-pare's stale Batch 1 section (already moved to Closed in main during parallel Arc 8/9/10/11 closure batch)
- [x] No conflict markers remain in tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)