### PR TITLE
[INFRA] v2.5 amendment + parallel dispatch coordination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## L_ARC_PROTOCOL v2.5 AMENDMENT LANDED | 2026-05-19 | INFRASTRUCTURE
+
+v2.5 amendment adds a parallel system-level evaluation track to the L_ARC protocol. The existing trade-classifier track (v2.0–v2.3 mechanics) is preserved unchanged for arcs using it. New arcs declare track at arc open; track is locked once Step 1 commits.
+
+The amendment is numbered v2.5 (not v2.4) to avoid collision with the existing v2.4 entry-separability proposal (Open-25). Both can coexist; the entry-separability v2.4 proposal remains in flight and is not affected by this landing.
+
+Motivation: cross-arc evidence over 11 arcs shows the trade-classifier track's Step 4 AUC gate filters against a question (predict individual trade success from entry features) that may not correspond to deployability. KH-24 base would die at Step 4 under that track. The system-level track asks the deployment question directly: does signal + filter + exposure produce worst-fold WFO pass on held-out data.
+
+System-level track step structure: Step 1 plumbing (identical to v2.3), Step 2 pool characterisation (no clustering required), Step 3 filter+exposure search on IS (2010-2019 HistData), Step 4 one-shot OOS validation per top-K config (2020-current). Pre-declared canonical filter menu (≤ 3 filters per config). Selection-bias accounting mandatory. Anchor preservation (KH-24) binding.
+
+Migration: closed Arcs 1–11 eligible for re-evaluation under system-level track. Original closure status preserved unchanged; system-level verdict added as parallel record.
+
+v2.5 does NOT close any open backlog items. v2.3 closures of Open-22/23/24 remain attributed to v2.3.
+
+- Branch: `claude/vigilant-bhabha-f5e0a8`
+- Final commit: <to be filled at PR open>
+- Amendment doc: `L_ARC_PROTOCOL_v2_5_AMENDMENT.md`
+- Conventions doc: `PARALLEL_DISPATCH_CONVENTIONS.md`
+- Parallel dispatches cleared: system-level re-eval, currency strength descriptive, t=x contamination test, free-reign discovery
+
 ## 2026-05-19 — Arc 9 closure REAFFIRMED (STEP_4_KILL after producer-leak patch)
 
 ### Closed

--- a/L_ARC_PROTOCOL_v2_5_AMENDMENT.md
+++ b/L_ARC_PROTOCOL_v2_5_AMENDMENT.md
@@ -1,0 +1,287 @@
+# L_ARC_PROTOCOL v2.5 — AMENDMENT
+
+> **Version:** 2.5
+> **Predecessor:** v2.3 (Step 5 = WFO; Step 5 stability removed)
+> **Note on numbering:** This amendment is numbered v2.5, NOT v2.4, to avoid collision with the existing v2.4 proposal (entry-separability gate, Open-25). Either may land first. If both land, sequence is determined by chat at merge time; both are additive and do not conflict at the mechanical level.
+> **Effective:** on merge to `main`
+> **Status:** ADDITIVE — does not deprecate or modify v2.3 mechanics for arcs using the trade-classifier track. Coexists with any v2.4 amendment landing for entry-separability.
+
+---
+
+## What this amendment does
+
+Adds a parallel **system-level evaluation track** to the L_ARC protocol. The existing **trade-classifier track** (Steps 1–6 with cluster → capturability → extractability → WFO) is preserved unchanged for arcs that use it. Each new arc declares which track it operates under at arc open. Once declared, the track is locked for that arc.
+
+The system-level track exists because cross-arc evidence over 11 arcs has shown the trade-classifier track's Step 4 AUC gate is filtering against a question (predict individual trade success from entry features) that may not correspond to deployability. KH-24 — the only currently-deployed system — would have died at Step 4 under the trade-classifier track applied to its base signal. The system-level track asks the deployment question directly: does this signal + filter + exposure configuration produce a worst-fold WFO pass on held-out data.
+
+---
+
+## What does NOT change
+
+- v2.3 protocol remains in full force for any arc declared under the trade-classifier track.
+- v2.3 closures stand. Open-22, Open-23, Open-24 closed by v2.3 remain closed by v2.3; this amendment does NOT re-close or re-attribute them.
+- Any v2.4 amendment (entry-separability gate, Open-25) coexists with v2.5. If v2.4 lands first, v2.5 inherits any v2.4 mechanics where applicable.
+- All non-negotiables: no lookahead, no repainting, real execution only, ex-ante population construction, deterministic outputs, config-driven via YAML, Python backtester as source of truth.
+- Worst-fold WFO as the deployment gate. ROI ≥ 5% worst-fold, DD ≤ 8%, daily DD ≤ 4%, sign-consistency.
+- KH-24 deployment status. KH-24 is locked. Changes to KH-24 require an explicit modification phase opened against it, NOT a system-level re-evaluation.
+- The L0 registry as a historical artefact. New arcs are not bound to the registry.
+- Permanently eliminated items in `CLAUDE.md`. Nothing on that list returns under either track.
+- Spread floor convention (post-2026-05-17 calibration from HistData audit).
+- D1 one-bar lag rule (`iClose(D1, 1)` semantics).
+- Anchor preservation principle: cross-arc work must reproduce KH-24's worst-fold ROI (1.92%) and DD (6.37%) within tolerance as a methodology check.
+
+---
+
+## What this amendment closes from the open backlog
+
+**Nothing.** This amendment is purely additive infrastructure. It introduces a parallel track but does not resolve any open backlog item by itself. Open items remain open; their resolution is the work product of arcs run under the new track, not the track's existence.
+
+(This is an intentional departure from earlier draft text that claimed closures of Open-22, Open-04, etc. Those claims were incorrect — Open-22/23/24 were already closed by v2.3, and the others are not mechanically resolved by adding a track.)
+
+---
+
+## §A. Track declaration
+
+Every arc-open document must contain a locked field at the top:
+
+```
+track: trade-classifier | system-level
+declared_by: <author>
+declared_at: <ISO timestamp>
+amendment_version: v2.5
+```
+
+Once an arc commits a step-1 result on its branch, the track is locked. A track switch requires arc closure and a new arc-open under the alternative track.
+
+Existing closed arcs (Arcs 1–11) are eligible for re-opening under the system-level track via the migration rules in §F.
+
+---
+
+## §B. System-level track — step structure
+
+The system-level track replaces the trade-classifier track's step structure (1→6) with the following four-step structure:
+
+### Step 1 — Plumbing and pool construction
+
+Identical to the trade-classifier track Step 1. Build the trade pool using the arc's declared signal definition. All Step 1 gates from v2.3 apply unchanged:
+
+- Pool size ≥ 500 trades
+- ≥ 28 pairs
+- Smallest per-pair n ≥ 20
+- Determinism (byte-identical across re-runs)
+- Lookahead spot-check (5 randomly sampled trades, manually verified)
+- D1-lag verification (3 NaN-perturbation tests)
+- KH-24 co-fire rate < 5% (independence from anchor)
+- Cap-binding rate ≤ 20% under §5 auto-extend
+- Spread floor applied per post-2026-05-17 calibration
+
+**Pass:** all gates clean.
+**Fail:** Step 1 fails → arc closes with `STEP_1_HALT`. Same as trade-classifier track.
+
+### Step 2 — Pool characterisation
+
+Replaces the trade-classifier track's cluster → capturability → extractability sequence with a single descriptive step.
+
+The arc produces a pool characterisation document containing:
+
+- Full distribution of trade outcomes (R, bars_held, MFE, MAE, time-to-peak)
+- Per-pair trade-count and outcome distribution (small-multiples table)
+- Per-session, per-hour, per-day-of-week trade-count and outcome distribution
+- Per-vol-regime, per-D1-state outcome distribution
+- Forward-path geometry distribution (mono, peaks, ttp_rel — same metrics as trade-classifier track Step 2, but used descriptively only; no clustering required)
+- Conditional outcome distributions across the filter menu in §C (one row per filter, no combinations yet)
+
+**Pass:** the pool has at least one ≥ 5pp delta in mean R between the filtered and unfiltered cohort across at least one filter in the menu. (This is a very weak gate — it asks only "does any filter move the needle at all on this pool". If no filter moves it, the pool itself doesn't carry differential information and the search in Step 3 will not succeed.)
+**Fail:** no filter moves mean R by ≥ 5pp → `STEP_2_HALT_NULL_POOL`. Close arc.
+
+Clustering is **optional** under the system-level track. An arc may run clustering as auxiliary analysis if the candidate hypothesis benefits from it, but no gate depends on cluster quality.
+
+### Step 3 — Filter and exposure search (IS only)
+
+The arc declares its filter menu at arc-open as a subset of (or extension to) the canonical menu in §C. The complexity cap is ≤ 3 filters per config. Exposure rules are searchable independently.
+
+Search procedure:
+
+1. Enumerate the full discrete search space (filters × thresholds × exposure rules × SL multipliers).
+2. For each config, run 7-fold IS WFO on the IS window (2010-01-01 → 2019-12-31, HistData).
+3. Record per-config: worst-fold ROI, mean-fold ROI, worst-fold DD, daily DD breach count, trades per fold, sign-consistency.
+4. Rank configs by worst-fold ROI subject to: worst-fold DD ≤ 8%, daily DD ≤ 4%, trades per fold ≥ 5, sign-consistency.
+5. Keep top-K configs (K = 5 by default, declarable at arc-open up to K = 10).
+
+**Pass:** at least one config clears the IS gates with worst-fold ROI ≥ 5%.
+**Fail:** no config clears IS → `STEP_3_HALT_NO_IS_PASS`. Close arc.
+
+The IS window is searched blind. No human inspection of IS data prior to Step 3 results, no inspection of intermediate IS distributions during the search, no peek at OOS at any point during Step 3.
+
+Selection-bias log is mandatory. The total number of configs evaluated is reported in the arc closure document. This number bounds the multiple-testing exposure for the Step 4 verdict.
+
+### Step 4 — OOS validation (one-shot per config)
+
+For each of the K top-K winners from Step 3:
+
+1. Lock the config (filters, thresholds, exposure rule, SL multiplier). No further tuning.
+2. Run 7-fold OOS WFO on the OOS window (2020-01-01 → present, HistData primary).
+3. Record same metrics as Step 3.
+4. Optionally: re-run on 5ers MT5 data over the OOS window as a data-source ratification (informational, not a gate).
+
+**This is one-shot per config.** Each config gets exactly one OOS evaluation. If a config fails OOS, that config is dead. The arc may evaluate other configs from the top-K list, but no config may be re-tuned and re-validated within the same arc.
+
+**Deployable verdict** per config requires ALL of:
+
+- IS worst-fold ROI ≥ 5% (already verified in Step 3)
+- IS worst-fold DD ≤ 8%
+- IS daily DD ≤ 4% (zero breaches across IS window)
+- IS sign-consistency (no negative folds; or ≤ 1 mildly negative fold if mean-fold ≥ 8% — same convention as v2.3)
+- IS trades per fold ≥ 5
+- OOS worst-fold ROI ≥ 5%
+- OOS worst-fold DD ≤ 8%
+- OOS daily DD ≤ 4% (zero breaches across OOS window)
+- OOS sign-consistency (same convention)
+- OOS trades per fold ≥ 5
+- 5ers MT5 ratification: worst-fold ROI within ±3pp of HistData OOS, DD within ±2pp (if ratification is run)
+
+Anything short of all of the above is **NOT_DEPLOYABLE**. Per-config; an arc may produce 0, 1, or more deployable configs from its top-K.
+
+**Arc closure:**
+
+- If ≥ 1 deployable config: arc closes with `DEPLOYABLE` disposition. The deployable config(s) are flagged for chat-side review. Deployment requires explicit chat-side decision; the protocol does not auto-deploy.
+- If 0 deployable configs but ≥ 1 OOS near-miss (within 1pp of worst-fold ROI gate, ≤ 1pp over DD gate): arc closes with `STEP_4_HALT` and the near-miss is flagged for protocol calibration review.
+- If 0 deployable configs and no near-miss: arc closes with `CLEAN_NULL`.
+
+---
+
+## §C. Canonical filter menu
+
+The system-level track operates against a canonical filter menu. Arcs may use any subset, with the ≤ 3 complexity cap. Extensions require an explicit amendment to this menu, declared at arc-open.
+
+| Filter ID | Description | Grid |
+|---|---|---|
+| F-session | Session window | {London, NY, Tokyo, London∪NY, NY∪Tokyo, any} |
+| F-hod | Hour-of-day | {0-7, 8-15, 16-23, custom 4h windows} |
+| F-dow | Day-of-week | {Mon-Fri, Mon-Thu, Tue-Thu, Tue-Fri} |
+| F-d1-slope | D1 close − D1 close[N] sign | sign ∈ {+, -, any}, N ∈ {1, 3, 5} |
+| F-d1-atr-pct | D1 ATR percentile vs 100-bar trailing | {>50, >70, <30, <50, any} |
+| F-vol-regime | 4H ATR / 100-bar trailing 4H ATR ratio | {>1.0, >1.2, <0.8, <1.0, any} |
+| F-1h-close-in-range | 1H close position within 1H bar range | T ∈ {0.20, 0.28, 0.35, 0.50}, dir ∈ {top, bottom, any} |
+| F-cross-pair-density | Count of same-direction signals in trailing 24 bars across 28 pairs | {<2, <5, <8, ≥3, ≥6, any} |
+| F-dollar-bloc | Mean rank of USD pairs over trailing 24 bars | {top tercile, bottom tercile, middle, any} |
+| F-currency-strength | Rank of base or quote currency at entry | {rank ≤ 2, rank ≥ 7, diff ≥ 4, any} |
+
+Exposure rule (searched separately, applied as outermost gate):
+
+| Parameter | Grid |
+|---|---|
+| max_concurrent_per_currency | {1, 2, 3, unlimited} |
+| max_concurrent_total | {3, 5, 10, unlimited} |
+
+SL multiplier (searched as part of config):
+
+| Parameter | Grid |
+|---|---|
+| SL × ATR(14) | {1.5, 2.0, 2.5, 3.0, 3.5, 4.0} |
+
+TP and trailing policies are NOT searched under the canonical menu — they require their own amendment. Default exit policy: stop-loss only, no fixed TP, trade exits when SL is hit or when the signal's natural exit condition triggers (defined per signal at arc-open).
+
+---
+
+## §D. IS / OOS partition convention
+
+```
+IS  window:  2010-01-01 → 2019-12-31  (HistData M1 OHLC, harmonised)
+OOS window:  2020-01-01 → present     (HistData primary)
+Ratification (optional, informational): 5ers MT5 over the OOS window
+```
+
+The IS window is searched. The OOS window is one-shot per config. No exceptions.
+
+If HistData 2010-2019 is unavailable for any reason (build failure, data gap), the fallback is:
+
+```
+IS  (interim):  2020-01-01 → 2024-12-31, 7-fold WFO
+OOS (interim): 2025-01-01 → present
+```
+
+Arcs run on the interim partition must be flagged as `INTERIM_PARTITION` in their closure. Such results are not deployment-deciding; they are exploratory. A `DEPLOYABLE` verdict requires the full partition.
+
+---
+
+## §E. Selection-bias and multiple-testing accounting
+
+System-level Step 3 searches discrete config spaces that may contain hundreds or thousands of candidates. The Step 4 one-shot OOS rule is the primary defence against in-sample overfitting, but multiple-testing exposure remains via the K = 5 (or up to 10) top-K promoted to OOS.
+
+The arc closure document must include a selection-bias section reporting:
+
+- Total configs evaluated in Step 3
+- Number of configs passing IS gates
+- Number of configs promoted to OOS (= top-K)
+- Number of configs passing OOS gates
+- Bonferroni-corrected significance threshold for the OOS pass rate, given K trials
+
+A pass rate at K trials that is statistically indistinguishable from random is grounds for `STEP_4_HALT_SELECTION_BIAS` rather than `DEPLOYABLE`, even if individual configs pass the per-config criteria. This rule prevents a single noise-driven OOS pass from being treated as deployment evidence.
+
+Concretely: if K = 5 and only 1 of 5 passes OOS, the binomial P(≥1 random pass | per-config null rate p₀) must be small (Bonferroni-style threshold: P ≤ 0.05 after correction for the implicit null rate). If P > 0.05 after correction, the pass is logged as `OOS_PASS_NOT_BIAS_DEFENSIBLE` and the arc closes with `STEP_4_HALT`.
+
+---
+
+## §F. Migration of closed arcs
+
+Arcs 1–11 closed under v2.0–v2.3 (trade-classifier track) are eligible for re-evaluation under the system-level track. The procedure:
+
+1. Open a re-evaluation dispatch (not a new arc) targeting one or more closed arcs.
+2. Reuse the original arc's Step 1 trade pool. **Do not rebuild.** Extend backward to 2010 using the same signal definition for the IS window.
+3. Run system-level Steps 2 → 3 → 4 as defined above.
+4. Closure of the re-evaluation produces:
+   - For each closed arc: a verdict (`DEPLOYABLE` / `STEP_4_HALT` / `CLEAN_NULL`) under the system-level track.
+   - The original closure status (trade-classifier track) is preserved unchanged. The system-level verdict is added as a parallel record.
+
+A `DEPLOYABLE` verdict from a re-evaluation does NOT automatically reopen the arc as live. It produces a deployable config that is then flagged for chat-side deployment decision.
+
+The system-level re-evaluation of closed arcs is the canonical first use of v2.5. See `CC_SYSTEM_LEVEL_TRACK_REEVAL.md` for the dispatch.
+
+---
+
+## §G. Anchor preservation
+
+Under either track, any cross-arc evaluation framework must reproduce KH-24's deployed worst-fold ROI (1.92%) and worst-fold DD (6.37%) within tolerance (±0.5pp on ROI, ±1pp on DD) when KH-24 is run through the framework. If reproduction fails, the framework has a methodology bug and any results from that framework are suspect.
+
+KH-24 itself is locked. Re-evaluation of KH-24 base under the system-level track is permitted for benchmarking purposes only — it does NOT authorise modifications to the deployed KH-24 configuration. Changes to the deployed KH-24 require a dedicated modification phase opened against KH-24, separate from any L-arc work.
+
+---
+
+## §H. Discipline rules (track-agnostic)
+
+- Track declaration is binding. An arc may not switch tracks mid-flight.
+- Locked thresholds within an arc do not move. Calibration adjustments are cross-arc.
+- The selection-bias log is mandatory and material.
+- The one-shot OOS rule binds at the config level, not the arc level. An arc may evaluate multiple configs on OOS as long as each is locked before its single OOS evaluation.
+- Cross-arc findings raised by a system-level arc are logged to `PROTOCOL_IMPROVEMENT_BACKLOG.md`. Resolution is cross-arc, never mid-arc.
+- The system-level track does NOT lower the deployment bar. All gates from v2.3 (worst-fold ROI, DD, daily DD, sign-consistency) apply equally. What changes is the path to those gates, not their stringency.
+
+---
+
+## §I. What this amendment does NOT permit
+
+- Lowering the worst-fold ROI gate (≥ 5%) or DD gate (≤ 8%).
+- Lowering the daily DD breach threshold (no breaches above 4% permitted).
+- Skipping the OOS validation step.
+- Iterating on OOS after seeing OOS results.
+- Lookahead in any feature, anywhere.
+- Outcome-aware filters in population construction.
+- Modifying KH-24 deployment without an explicit modification phase.
+- Treating clustering as required for the system-level track.
+- Treating an interim-partition pass as deployment-deciding.
+- Re-using an OOS block for a re-tuned config.
+- Closing existing open backlog items by reference to v2.5 mechanics. v2.5 is additive; closures of existing items require their own work.
+
+---
+
+## §J. Cross-reference
+
+This amendment is consumed by the following parallel dispatches:
+
+- `CC_SYSTEM_LEVEL_TRACK_REEVAL.md` — re-evaluation of closed arcs 6, 7, 8, 10, 11 under the system-level track
+- `CC_FREE_REIGN_STRATEGY_DISCOVERY.md` — free-reign discovery operates under system-level track conventions for any candidate it promotes to OOS validation
+- `CC_CURRENCY_STRENGTH_DESCRIPTIVE.md` — descriptive phase; gates an eventual system-level arc on currency strength
+- `CC_TX_CONTAMINATION_TEST.md` — diagnostic probe informing Pipeline D (trade-classifier track feature design); independent of v2.5 mechanics
+
+The infrastructure dispatch `CC_PARALLEL_COORDINATION.md` lands this amendment on `main` before the substantive dispatches launch.

--- a/PARALLEL_DISPATCH_CONVENTIONS.md
+++ b/PARALLEL_DISPATCH_CONVENTIONS.md
@@ -1,0 +1,132 @@
+# Parallel Dispatch Conventions
+
+This document governs the four substantive CC dispatches running in parallel after the v2.5 amendment landed on `main`. Each dispatch reads this file as part of its read-first sequence.
+
+## Branches and file ownership
+
+| Dispatch | Branch | Owns (read+write) | Reads only |
+|---|---|---|---|
+| System-level re-eval | `system-level/closed-arc-reeval` | `results/system_level_track/**` | All canonical refs below |
+| Currency strength descriptive | `analysis/currency-strength-descriptive` | `results/currency_strength/**` | All canonical refs below |
+| t=x contamination test | `probe/tx-contamination-test` | `results/tx_contamination/**` | All canonical refs below |
+| Free-reign discovery | `discovery/free-reign-v1` | `results/free_reign/**`, `scripts/free_reign/**` | All canonical refs below |
+
+**Canonical references (read-only across all parallel dispatches):**
+
+- `L_ARC_PROTOCOL.md`
+- `L_ARC_PROTOCOL_v2_3_AMENDMENT.md`
+- `L_ARC_PROTOCOL_v2_5_AMENDMENT.md`
+- `L_ARC_PROTOCOL_v2_x_AMENDMENT_PROPOSAL.md` (if present)
+- `docs/KH24_SYSTEM_LOCK.md`
+- `docs/SPREAD_SEMANTICS_LOCK.md`
+- `docs/calibration_decisions/SPREAD_FLOOR_CALIBRATION_DECISION_2026-05-17.md`
+- `configs/spread_floors_5ers.yaml`
+- `CLAUDE.md`
+- `project_brief.md`
+- `PARALLEL_DISPATCH_CONVENTIONS.md` (this file)
+
+**No parallel dispatch modifies a canonical reference.** If a parallel dispatch believes a canonical reference needs to change, it logs the concern to `PROTOCOL_IMPROVEMENT_BACKLOG.md` (NEW item only, never modify existing) and continues without the change.
+
+## Shared meta-files (write-coordinated)
+
+These files may be touched by parallel dispatches, but writes are append-only and section-scoped:
+
+- `STATUS.md` — each parallel dispatch appends a status entry under its own dated section when it begins, when it produces a meaningful milestone, and when it closes. Format below.
+- `CHANGELOG.md` — each parallel dispatch appends a top-of-file entry on closure (PR open). Format below.
+- `PROTOCOL_IMPROVEMENT_BACKLOG.md` — each parallel dispatch may append NEW items under "Open" with unique IDs. Existing items (open or closed) are NOT modified by parallel dispatches under any circumstances.
+- `results/ARC_QUEUE.md` — owned by main chat / coordination dispatch only. Parallel dispatches do NOT modify this file.
+
+If two parallel dispatches need to modify the same meta-file, the later merge resolves the conflict by appending both entries in chronological order. No content from either dispatch is dropped.
+
+## STATUS.md entry format (append-only by parallel dispatches)
+
+```
+### YYYY-MM-DD — <dispatch short name> — <milestone>
+
+<one-paragraph description of what was done or completed, with commit hash and result file pointer>
+```
+
+## CHANGELOG.md entry format (append-only by parallel dispatches at PR open)
+
+```
+## <DISPATCH NAME> | YYYY-MM-DD | <verdict>
+
+<two-paragraph summary: what was done, headline result, any cross-arc items raised>
+
+- Branch: <branch name>
+- Final commit: <commit hash>
+- PR: <PR URL>
+- Result document: <path>
+```
+
+## Anchor preservation rule (binding on all parallel dispatches)
+
+KH-24 deployed configuration is locked. No parallel dispatch may:
+
+- Modify `docs/KH24_SYSTEM_LOCK.md` (wherever it lives)
+- Modify the deployed `KH24_EA.mq5` EA code
+- Modify the live KH-24 spread floor, exposure cap, or 1H filter configuration
+- Recommend deployment changes to KH-24 directly (recommendations go to chat via the dispatch's closure document)
+
+Parallel dispatches MAY:
+
+- Evaluate KH-24 base or KH-24 full as benchmark / anchor checks (read-only on KH-24 config)
+- Recommend modifications to KH-24 in their closure documents for chat-side review
+- Compare candidates against KH-24's worst-fold ROI / DD numbers
+
+## Spread floor and data source rules (binding)
+
+All parallel dispatches use:
+
+- `configs/spread_floors_5ers.yaml` at the version on `main` at branch-cut time (do not update mid-dispatch)
+- HistData M1 OHLC as primary data source for any 2010-2019 IS work (depends on separate HistData pipeline being on `main`; if not present, dispatches falling back to the interim partition per v2.5 §D are permitted)
+- 5ers MT5 data as secondary / ratification source for OOS
+
+If a parallel dispatch finds a spread floor or data source issue, it logs to `PROTOCOL_IMPROVEMENT_BACKLOG.md` (new item) and continues using the existing config. It does NOT change the config mid-dispatch.
+
+## Determinism rule (binding)
+
+All result files produced by parallel dispatches must:
+
+- Be reproducible from seed
+- Carry a sha256 in the result manifest
+- Use `lineterminator='\n'` on any `to_csv()` call for cross-platform reproducibility
+
+## Cross-dispatch communication
+
+Parallel dispatches do not communicate with each other during execution. Cross-dispatch findings (e.g. free-reign discovery finds something that informs the system-level re-eval) are surfaced via:
+
+1. The dispatch's closure document and CHANGELOG entry
+2. New items in `PROTOCOL_IMPROVEMENT_BACKLOG.md`
+
+Chat reviews findings after all four dispatches close and decides next steps (which may include a follow-up coordination dispatch).
+
+## PR merge order (recommended)
+
+When the four parallel dispatches close and open PRs, the recommended merge order is:
+
+1. `CC_TX_CONTAMINATION_TEST.md` — smallest, fastest, informs Pipeline D design downstream
+2. `CC_CURRENCY_STRENGTH_DESCRIPTIVE.md` — descriptive only, no protocol mutation
+3. `CC_SYSTEM_LEVEL_TRACK_REEVAL.md` — substantive, references v2.5
+4. `CC_FREE_REIGN_STRATEGY_DISCOVERY.md` — largest, most likely to surface cross-cutting findings
+
+This order is a recommendation, not a constraint. PRs may be merged as they pass review.
+
+## Dispatch halt conditions
+
+A parallel dispatch HALTS and ends turn (no PR merge attempt) if any of:
+
+- A canonical reference is found to be inconsistent with the dispatch's needs
+- Lookahead is detected in any feature or pipeline component
+- A determinism failure is encountered that cannot be resolved within the dispatch scope
+- The HistData 2010-2019 pipeline dependency is required but not satisfied AND the interim partition fallback is not permitted for the work in question
+- KH-24 anchor reproduction check fails (worst-fold ROI / DD drift beyond tolerance)
+
+On halt, the dispatch:
+
+1. Writes a HALT entry in its result document explaining what triggered the halt
+2. Adds a new entry to `PROTOCOL_IMPROVEMENT_BACKLOG.md`
+3. Opens a PR (do-not-merge) with title `[HALT] <dispatch name> — <reason>`
+4. Ends turn
+
+## End of file

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,6 +6,23 @@
 
 ---
 
+### 2026-05-19 — Parallel dispatch wave launched — v2.5 amendment in effect
+
+L_ARC_PROTOCOL v2.5 amendment landed on main. Adds parallel system-level evaluation track alongside the existing trade-classifier track. Each new arc declares which track at arc open; track locked once Step 1 commits. Existing closed arcs eligible for re-evaluation under system-level track per §F.
+
+v2.5 numbering note: the existing v2.4 entry-separability proposal (Open-25) is unaffected and remains in flight. v2.5 lands as an additive parallel amendment. v2.3 closures of Open-22/23/24 stand unchanged; v2.5 does NOT close any existing backlog items.
+
+Four parallel CC dispatches cleared to launch:
+
+1. **System-level re-eval** (`system-level/closed-arc-reeval`): re-evaluate closed Arcs 6, 7, 8, 10, 11 under system-level track. Depends on HistData 2010-2019 pipeline (separate work). Optional Phase 0 sanity on 2020-2025 runs immediately under interim partition.
+2. **Currency strength descriptive** (`analysis/currency-strength-descriptive`): Phase 0 descriptive analysis of cross-sectional currency strength on 2020-2025 data. Gates whether to open a formal arc.
+3. **t=x contamination test** (`probe/tx-contamination-test`): diagnostic probe testing whether post-entry AUC lift in prior arcs is genuine forward signal or contamination from observing the move. Informs Pipeline D feature design.
+4. **Free-reign strategy discovery** (`discovery/free-reign-v1`): open-ended discovery dispatch. No fixed signal, no prescribed methodology beyond core non-negotiables. Continuously updated live discovery doc.
+
+Parallel conventions doc landed at `PARALLEL_DISPATCH_CONVENTIONS.md`. KH-24 anchor preservation rule binding across all four. All four read v2.5 amendment as canonical. Landed via worktree branch `claude/vigilant-bhabha-f5e0a8` (HEAD == origin/main at cut time).
+
+---
+
 ## Active protocol
 
 - Active protocol: L_ARC_PROTOCOL v2.1.2 base + v2.2 amendment + v2.3 amendment (v2.3 landed 2026-05-18 at `L_ARC_PROTOCOL_v2_3_AMENDMENT.md`; v2.2 amendment landed earlier same day at `L_ARC_PROTOCOL_v2_2_AMENDMENT.md`; v2.1.2 base, 2026-05-17). Companion files: `prompts/cc_arc_orchestrator_template.md` (updated to v1.1 for v2.3), `results/ARC_QUEUE.md`, `SHELVED_ARCS.md` (new under v2.3). Protocol-doc PR pending engineering pass to consolidate v2.2 + v2.3 amendment text into `L_ARC_PROTOCOL.md` itself.


### PR DESCRIPTION
## Summary

Infrastructure-only dispatch landing `L_ARC_PROTOCOL_v2_5_AMENDMENT.md` and the parallel-dispatch conventions doc on `main`. This PR is the precondition for the four substantive parallel CC dispatches that chat dispatches separately after merge.

- **v2.5 amendment:** adds a parallel system-level evaluation track alongside the existing trade-classifier track. Additive — does not modify v2.3 mechanics or re-attribute v2.3 closures (Open-22/23/24 stay v2.3). Numbered v2.5 to avoid collision with the in-flight v2.4 entry-separability proposal (Open-25), which remains untouched.
- **PARALLEL_DISPATCH_CONVENTIONS.md:** branch + ownership table for the four parallel dispatches, canonical-ref read-only list with paths resolved against the actual repo layout, shared meta-file append-only rules, KH-24 anchor-preservation binding, determinism rule, halt conditions.
- **STATUS + CHANGELOG updates** per dispatch text.

## Files changed

| File | Change |
|---|---|
| `L_ARC_PROTOCOL_v2_5_AMENDMENT.md` | new — verbatim from dispatch source |
| `PARALLEL_DISPATCH_CONVENTIONS.md` | new — canonical-ref paths resolved |
| `STATUS.md` | append dated dispatch-wave entry |
| `CHANGELOG.md` | prepend top-of-file v2.5 entry |

## Files explicitly NOT touched

- `L_ARC_PROTOCOL.md` (v2.5 is additive, not a rewrite)
- `L_ARC_PROTOCOL_v2_3_AMENDMENT.md`
- `L_ARC_PROTOCOL_v2_x_AMENDMENT_PROPOSAL.md` (existing v2.4 proposal stays in flight)
- `PROTOCOL_IMPROVEMENT_BACKLOG.md` (v2.5 closes nothing; Task 5 removed from dispatch)
- `results/ARC_QUEUE.md` (chat-owned)
- `docs/KH24_SYSTEM_LOCK.md` (KH-24 deployment locked)

## Branch note

Worktree HEAD at branch cut was identical to `origin/main` (`d527c59`). Dispatch header allows proceeding on the existing worktree branch in this case; `claude/vigilant-bhabha-f5e0a8` is used in lieu of `infra/v2.5-amendment-and-parallel-coord`. Branch name is not load-bearing per dispatch.

## Four substantive dispatches cleared

Chat dispatches these to separate CC sessions after merge. They are NOT in this repo and are NOT touched by this PR:

1. `CC_SYSTEM_LEVEL_TRACK_REEVAL.md` → `system-level/closed-arc-reeval`
2. `CC_CURRENCY_STRENGTH_DESCRIPTIVE.md` → `analysis/currency-strength-descriptive`
3. `CC_TX_CONTAMINATION_TEST.md` → `probe/tx-contamination-test`
4. `CC_FREE_REIGN_STRATEGY_DISCOVERY.md` → `discovery/free-reign-v1`

## Test plan

- [ ] `git diff main --stat` shows exactly 4 files (CHANGELOG, v2.5 amendment, conventions doc, STATUS)
- [ ] `L_ARC_PROTOCOL_v2_5_AMENDMENT.md` byte-identical to dispatch source
- [ ] `PARALLEL_DISPATCH_CONVENTIONS.md` canonical-ref paths exist in repo (`docs/KH24_SYSTEM_LOCK.md`, `docs/SPREAD_SEMANTICS_LOCK.md`, `docs/calibration_decisions/SPREAD_FLOOR_CALIBRATION_DECISION_2026-05-17.md`, `configs/spread_floors_5ers.yaml`, repo-root protocol + amendment files)
- [ ] Untouched files unchanged: `L_ARC_PROTOCOL.md`, `L_ARC_PROTOCOL_v2_3_AMENDMENT.md`, `L_ARC_PROTOCOL_v2_x_AMENDMENT_PROPOSAL.md`, `PROTOCOL_IMPROVEMENT_BACKLOG.md`, `results/ARC_QUEUE.md`, `docs/KH24_SYSTEM_LOCK.md`
- [ ] Ready for immediate merge so the four substantive dispatches can cut their branches from updated `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)