### PR TITLE
[INFRA] Backtester v3 PR-A — data loader + aggregator + parquet cache

### DIFF
--- a/configs/data_v3.yaml
+++ b/configs/data_v3.yaml
@@ -1,0 +1,53 @@
+# configs/data_v3.yaml
+# v3.0 data-layer config — paths into the HistData M1 layer + parquet cache roots.
+#
+# Used by `core.data.histdata_loader.load_m1(pair, ...)` and
+# `core.data.aggregator.aggregate(pair, tf, ...)`. All paths are relative to
+# the repo root.
+#
+# CC_06 PR-A landed: data loader + aggregator + per-pair parquet caching with
+# m1_manifest.json-keyed invalidation. See docs/dispatches/backtester_reconfig_log.md.
+
+data:
+  # Root of the HistData layer. Contains:
+  #   <PAIR>/tick/<YYYY>/...zip      (canonical raw — out of scope for the loader)
+  #   <PAIR>/m1/{bid,ask}/<YYYY>/... (derived, read by load_m1)
+  #   m1_manifest.json               (cache-invalidation source)
+  histdata_root: data/histdata
+
+  # Parquet cache root. Layout under this dir:
+  #   m1/<PAIR>.parquet              (joined bid+ask M1, by load_m1)
+  #   {M5,M15,M30,H1,H4,D1,W1}/<PAIR>.parquet  (aggregated TFs, by aggregate)
+  #   *.parquet.meta.json            (sidecar with cache_key + source manifest sha256)
+  cache_root: data/cache
+
+# 28-pair universe — same set as KH-24 and the L_arc series.
+pairs:
+  - AUDCAD
+  - AUDCHF
+  - AUDJPY
+  - AUDNZD
+  - AUDUSD
+  - CADCHF
+  - CADJPY
+  - CHFJPY
+  - EURAUD
+  - EURCAD
+  - EURCHF
+  - EURGBP
+  - EURJPY
+  - EURNZD
+  - EURUSD
+  - GBPAUD
+  - GBPCAD
+  - GBPCHF
+  - GBPJPY
+  - GBPNZD
+  - GBPUSD
+  - NZDCAD
+  - NZDCHF
+  - NZDJPY
+  - NZDUSD
+  - USDCAD
+  - USDCHF
+  - USDJPY

--- a/core/data/__init__.py
+++ b/core/data/__init__.py
@@ -1,0 +1,18 @@
+"""HistData M1 bid+ask data layer.
+
+Public API:
+    load_m1(pair, ...)             # core.data.histdata_loader
+    aggregate(pair, tf, ...)       # core.data.aggregator
+    compute_cache_key(...)         # core.data.cache_keys
+
+The data layer reads HistData M1 derived CSVs from
+``data/histdata/<PAIR>/m1/{bid,ask}/<YYYY>/<PAIR>_M1_{BID,ASK}_<YYYYMM>.csv``,
+joins bid+ask into a single per-pair DataFrame, and caches the result as
+parquet under ``data/cache/m1/<PAIR>.parquet``. Higher TFs (M5..W1) are
+deterministically aggregated from the M1 cache and cached at
+``data/cache/<TF>/<PAIR>.parquet``.
+
+Cache invalidation is keyed on ``data/histdata/m1_manifest.json``: a per-pair
+cache_key is the sha256 of the sorted ``(relpath, sha256)`` pairs for that pair
+in the M1 manifest. Higher-TF cache keys derive from the upstream M1 cache_key.
+"""

--- a/core/data/aggregator.py
+++ b/core/data/aggregator.py
@@ -1,0 +1,207 @@
+"""Deterministic M1→higher-TF OHLC aggregation with parquet caching.
+
+Aggregates the per-pair M1 cache (see ``core.data.histdata_loader``) into
+{M5, M15, M30, H1, H4, D1, W1} bars. Both bid and ask streams are aggregated
+independently with standard OHLC rules:
+
+    open  = first   (chronological)
+    high  = max
+    low   = min
+    close = last    (chronological)
+    volume = sum
+
+``spread_close`` and ``bid_ask_data_quality`` are recomputed from the
+aggregated ``close_ask`` / ``close_bid`` (the per-minute quality flag does not
+propagate — a 5-minute bar is its own thing).
+
+TF boundaries (UTC, fixed):
+    M5     every  5 minutes anchored to epoch (which is :00 / :05 / :10 ...)
+    M15    every 15 minutes anchored to epoch
+    M30    every 30 minutes anchored to epoch
+    H1     every hour at :00
+    H4     every 4 hours at 00:00 / 04:00 / 08:00 / 12:00 / 16:00 / 20:00 UTC
+    D1     daily at 00:00 UTC
+    W1     weekly starting Monday 00:00 UTC
+
+Determinism guarantees:
+    1. Bid and ask streams are aggregated in a fixed order with deterministic
+       ``resample`` arguments (``label='left'``, ``closed='left'``).
+    2. Output column order is fixed (``M1_COLUMNS``).
+    3. Bars where any side has all-NaN OHLC (i.e. no underlying M1 minute) are
+       dropped — these correspond to weekend gaps / market closures.
+
+Two-run byte-identical parquet output is the contract (tested in
+tests/test_aggregator.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from core.data.cache_keys import (
+    CacheMeta,
+    cache_valid,
+    load_m1_manifest,
+    m1_cache_key_for_pair,
+    manifest_self_sha256,
+    now_iso,
+    tf_cache_key,
+    write_meta,
+)
+from core.data.histdata_loader import (
+    DQ_NAN_BID_OR_ASK,
+    DQ_OK,
+    DQ_ZERO_OR_NEG_SPREAD,
+    M1_COLUMNS,
+    HistDataPaths,
+    load_m1,
+)
+
+# Mapping from TF label → pandas resample freq string. Anchoring:
+#   - sub-hourly + H1: pandas default origin (epoch, midnight UTC) is correct
+#   - H4: explicit ``origin='start_day'`` to force 00:00/04:00/... anchors
+#   - D1: ``1D`` is non-tick-like → ``origin`` is a no-op; default anchors at
+#     midnight UTC which is what we want
+#   - W1: ``W-MON`` with label='left' / closed='left' gives Monday 00:00 → Sunday
+SUPPORTED_TFS: tuple[str, ...] = ("M5", "M15", "M30", "H1", "H4", "D1", "W1")
+
+_TF_TO_FREQ: dict[str, str] = {
+    "M5": "5min",
+    "M15": "15min",
+    "M30": "30min",
+    "H1": "1h",
+    "H4": "4h",
+    "D1": "1D",
+    "W1": "W-MON",
+}
+
+# Freqs for which pandas honours the ``origin`` keyword (Tick-like).
+_TICK_LIKE_FREQS: frozenset[str] = frozenset({"5min", "15min", "30min", "1h", "4h"})
+
+# Per-side OHLC aggregation rules (column → aggregator). Identical for bid and
+# ask; rebuilt programmatically to avoid duplication.
+_OHLC_AGG: dict[str, str] = {
+    "open": "first",
+    "high": "max",
+    "low": "min",
+    "close": "last",
+}
+
+
+def _resample_kwargs(freq: str, origin: str) -> dict:
+    """Build resample kwargs; ``origin`` is only honoured for tick-like freqs."""
+    kw: dict = {"label": "left", "closed": "left"}
+    if freq in _TICK_LIKE_FREQS:
+        kw["origin"] = origin
+    return kw
+
+
+def _aggregate_side(df: pd.DataFrame, side: str, freq: str, origin: str) -> pd.DataFrame:
+    """Resample one side (bid or ask) into ``freq`` bars.
+
+    Returns a DataFrame with columns ``open_<side> high_<side> low_<side> close_<side>``
+    and the same DatetimeIndex (left-labelled) as the resample output.
+    """
+    cols = {f"{k}_{side}": f"{k}_{side}" for k in _OHLC_AGG}
+    side_df = df[list(cols)].rename(columns={f"{k}_{side}": k for k in _OHLC_AGG})
+    resampled = side_df.resample(freq, **_resample_kwargs(freq, origin)).agg(_OHLC_AGG)
+    return resampled.rename(columns={k: f"{k}_{side}" for k in _OHLC_AGG})
+
+
+def aggregate_m1_to_tf(df_m1: pd.DataFrame, tf: str) -> pd.DataFrame:
+    """Aggregate an M1 DataFrame (per ``histdata_loader.M1_COLUMNS``) to ``tf``.
+
+    Parameters
+    ----------
+    df_m1 : pd.DataFrame
+        M1 frame as returned by ``load_m1`` — DatetimeIndex (UTC), columns
+        per ``M1_COLUMNS``.
+    tf : str
+        Target TF, one of ``SUPPORTED_TFS``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Same column ordering as ``M1_COLUMNS``; DatetimeIndex left-labelled
+        at the TF boundary; bars with no underlying M1 data are dropped.
+    """
+    if tf not in SUPPORTED_TFS:
+        raise ValueError(f"Unsupported TF {tf!r}; expected one of {SUPPORTED_TFS}")
+    freq = _TF_TO_FREQ[tf]
+    origin = "start_day" if tf in ("H4",) else "epoch"
+
+    bid = _aggregate_side(df_m1, "bid", freq, origin)
+    ask = _aggregate_side(df_m1, "ask", freq, origin)
+    volume = df_m1["volume"].resample(freq, **_resample_kwargs(freq, origin)).sum()
+
+    out = pd.concat([bid, ask, volume.rename("volume")], axis=1)
+    # Drop bars where either side is entirely NaN (no underlying minutes).
+    keep = out[["open_bid", "open_ask"]].notna().all(axis=1)
+    out = out.loc[keep].copy()
+    out["volume"] = out["volume"].astype("int64")
+
+    out["spread_close"] = out["close_ask"] - out["close_bid"]
+    dq = pd.Series(DQ_OK, index=out.index, dtype="object")
+    nan_mask = out[["open_bid", "close_bid", "open_ask", "close_ask"]].isna().any(axis=1)
+    dq.loc[nan_mask] = DQ_NAN_BID_OR_ASK
+    bad_spread = (out["spread_close"] <= 0) & ~nan_mask
+    dq.loc[bad_spread] = DQ_ZERO_OR_NEG_SPREAD
+    out["bid_ask_data_quality"] = dq
+
+    return out[M1_COLUMNS]
+
+
+def _tf_cache_parquet(paths: HistDataPaths, tf: str, pair: str) -> Path:
+    return paths.cache_root / tf / f"{pair}.parquet"
+
+
+def _write_parquet(df: pd.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(path, engine="pyarrow", compression="snappy", index=True)
+
+
+def aggregate(
+    pair: str,
+    tf: str,
+    histdata_root: Path | str = "data/histdata",
+    cache_root: Path | str = "data/cache",
+    use_cache: bool = True,
+) -> pd.DataFrame:
+    """Load (or compute + cache) aggregated TF bars for ``pair``.
+
+    On a cache hit (parquet exists + sidecar cache_key matches the upstream M1
+    key for that pair), the parquet is read directly. Otherwise the M1 layer
+    is loaded (which itself may build its cache), aggregated, written to
+    ``<cache_root>/<tf>/<pair>.parquet``, and returned.
+    """
+    if tf not in SUPPORTED_TFS:
+        raise ValueError(f"Unsupported TF {tf!r}; expected one of {SUPPORTED_TFS}")
+
+    paths = HistDataPaths(Path(histdata_root), Path(cache_root))
+    manifest = load_m1_manifest(paths.m1_manifest_path)
+    m1_key = m1_cache_key_for_pair(manifest, pair)
+    key = tf_cache_key(m1_key, tf)
+    parquet_path = _tf_cache_parquet(paths, tf, pair)
+
+    if use_cache and cache_valid(parquet_path, key):
+        return pd.read_parquet(parquet_path)
+
+    df_m1 = load_m1(pair, histdata_root=histdata_root, cache_root=cache_root, use_cache=use_cache)
+    df_tf = aggregate_m1_to_tf(df_m1, tf)
+
+    _write_parquet(df_tf, parquet_path)
+    write_meta(
+        parquet_path,
+        CacheMeta(
+            pair=pair,
+            layer=tf,
+            cache_key=key,
+            source_m1_manifest_sha256=manifest_self_sha256(paths.m1_manifest_path),
+            n_rows=int(len(df_tf)),
+            columns=list(df_tf.columns),
+            created_at=now_iso(),
+        ),
+    )
+    return df_tf

--- a/core/data/cache_keys.py
+++ b/core/data/cache_keys.py
@@ -1,0 +1,123 @@
+"""Cache key derivation + meta sidecar IO for the HistData data layer.
+
+The per-pair M1 cache key is a sha256 over the sorted ``(relpath, sha256)``
+pairs of that pair's M1 CSVs as recorded in ``data/histdata/m1_manifest.json``.
+Higher-TF cache keys derive from the upstream M1 cache key plus the TF label,
+so any change to the M1 derived layer propagates through every dependent TF
+cache.
+
+Each cache parquet sits next to a sidecar ``<file>.parquet.meta.json`` that
+records the cache_key, the source manifest sha256, layer, pair, n_rows, and
+created_at timestamp. The loader checks the sidecar before trusting a cached
+parquet; sidecar absent or cache_key mismatch ⇒ rebuild.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CacheMeta:
+    pair: str
+    layer: str  # "m1" | "M5" | "M15" | "M30" | "H1" | "H4" | "D1" | "W1"
+    cache_key: str
+    source_m1_manifest_sha256: str
+    n_rows: int
+    columns: list[str]
+    created_at: str  # ISO-8601 UTC
+
+
+def sha256_file(path: Path) -> str:
+    """Streaming sha256 of a file."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sha256_bytes(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+
+def load_m1_manifest(manifest_path: Path) -> dict[str, Any]:
+    """Load m1_manifest.json. Raises FileNotFoundError if absent."""
+    if not manifest_path.exists():
+        raise FileNotFoundError(
+            f"M1 manifest not found at {manifest_path}. Run scripts/histdata_aggregate_m1.py first."
+        )
+    return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+def m1_cache_key_for_pair(manifest: dict[str, Any], pair: str) -> str:
+    """Derive a deterministic cache key for one pair's full M1 history.
+
+    Key = sha256 of the canonical newline-joined ``relpath\\tsha256`` lines,
+    sorted lexicographically by relpath. Any change to any M1 CSV (which
+    rewrites m1_manifest.json) propagates into the key.
+    """
+    pairs = manifest.get("pairs") or {}
+    if pair not in pairs:
+        raise KeyError(f"Pair {pair!r} not present in M1 manifest")
+    files = pairs[pair].get("files") or {}
+    if not files:
+        raise ValueError(f"Pair {pair!r} has no files entry in M1 manifest")
+    lines = sorted(f"{rel}\t{meta['sha256']}" for rel, meta in files.items())
+    return sha256_bytes("\n".join(lines).encode("utf-8"))
+
+
+def tf_cache_key(m1_key: str, tf: str) -> str:
+    """Cache key for an aggregated TF derives from the M1 key + TF label."""
+    return sha256_bytes(f"{m1_key}|{tf}".encode("utf-8"))
+
+
+def manifest_self_sha256(manifest_path: Path) -> str:
+    """sha256 of the m1_manifest.json file itself.
+
+    Used as a coarse "is the manifest the one I derived against" check on the
+    sidecar; the per-pair cache_key is the load-bearing invariant.
+    """
+    return sha256_file(manifest_path)
+
+
+def write_meta(parquet_path: Path, meta: CacheMeta) -> Path:
+    """Write the sidecar ``<parquet>.meta.json`` next to a cached parquet.
+
+    Uses ``\\n`` line terminator and sorted keys for cross-platform
+    reproducibility per L_PROTOCOL §1.
+    """
+    sidecar = parquet_path.with_suffix(parquet_path.suffix + ".meta.json")
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(asdict(meta), sort_keys=True, indent=2)
+    sidecar.write_text(payload + "\n", encoding="utf-8", newline="\n")
+    return sidecar
+
+
+def read_meta(parquet_path: Path) -> CacheMeta | None:
+    """Read sidecar meta if present; return None if absent or malformed."""
+    sidecar = parquet_path.with_suffix(parquet_path.suffix + ".meta.json")
+    if not sidecar.exists():
+        return None
+    try:
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+        return CacheMeta(**data)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+
+
+def cache_valid(parquet_path: Path, expected_cache_key: str) -> bool:
+    """A cache parquet is valid iff it exists and its sidecar cache_key matches."""
+    if not parquet_path.exists():
+        return False
+    meta = read_meta(parquet_path)
+    return meta is not None and meta.cache_key == expected_cache_key
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/core/data/histdata_loader.py
+++ b/core/data/histdata_loader.py
@@ -1,0 +1,283 @@
+"""HistData M1 bid+ask loader with parquet caching.
+
+Reads HistData M1 derived CSVs (one per pair-side-month) and joins them into a
+single per-pair time-indexed DataFrame with separate bid and ask OHLC columns.
+First load parses CSVs and writes a parquet cache; subsequent loads of the same
+pair read the cache directly when the upstream M1 manifest is unchanged.
+
+Layout (from docs/DATA_FOUNDATION.md):
+
+    data/histdata/<PAIR>/m1/bid/<YYYY>/<PAIR>_M1_BID_<YYYYMM>.csv
+    data/histdata/<PAIR>/m1/ask/<YYYY>/<PAIR>_M1_ASK_<YYYYMM>.csv
+    data/histdata/m1_manifest.json
+
+CSV schema (both sides):
+
+    timestamp_utc,open,high,low,close,volume
+    2010-01-03T22:00:00Z,1.4301,1.4304,1.4301,1.4304,6
+
+Output DataFrame schema:
+
+    Index: DatetimeIndex (UTC, named "timestamp_utc")
+    Columns:
+        open_bid, high_bid, low_bid, close_bid,
+        open_ask, high_ask, low_ask, close_ask,
+        volume,
+        spread_close,
+        bid_ask_data_quality
+
+``volume`` is the per-minute tick count (bid.volume == ask.volume by
+construction per DATA_FOUNDATION §Aggregation — asserted at load).
+``spread_close`` = ``close_ask - close_bid``; non-positive or NaN values
+mark the bar in ``bid_ask_data_quality`` per the §1 non-negotiable
+"zero-spread bars are a data quality flag, not silently backfilled".
+
+Determinism: rows sorted ascending by timestamp_utc; per-row column order
+fixed; parquet written with ``compression='snappy'`` and explicit schema
+ordering for two-run reproduction within a tolerance documented in
+tests/test_histdata_loader.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from core.data.cache_keys import (
+    CacheMeta,
+    cache_valid,
+    load_m1_manifest,
+    m1_cache_key_for_pair,
+    manifest_self_sha256,
+    now_iso,
+    write_meta,
+)
+
+# Canonical column order — used for output DataFrames and parquet schema.
+M1_COLUMNS: list[str] = [
+    "open_bid",
+    "high_bid",
+    "low_bid",
+    "close_bid",
+    "open_ask",
+    "high_ask",
+    "low_ask",
+    "close_ask",
+    "volume",
+    "spread_close",
+    "bid_ask_data_quality",
+]
+
+DQ_OK = "ok"
+DQ_ZERO_OR_NEG_SPREAD = "zero_or_negative_spread"
+DQ_NAN_BID_OR_ASK = "nan_bid_or_ask"
+
+
+@dataclass(frozen=True)
+class HistDataPaths:
+    """Resolved roots for the data layer."""
+
+    histdata_root: Path
+    cache_root: Path
+
+    @property
+    def m1_manifest_path(self) -> Path:
+        return self.histdata_root / "m1_manifest.json"
+
+    def m1_cache_parquet(self, pair: str) -> Path:
+        return self.cache_root / "m1" / f"{pair}.parquet"
+
+    def pair_root(self, pair: str) -> Path:
+        return self.histdata_root / pair
+
+    def side_csv(self, pair: str, side: str, yyyymm: str) -> Path:
+        year = yyyymm[:4]
+        side_upper = side.upper()
+        return (
+            self.histdata_root / pair / "m1" / side / year / f"{pair}_M1_{side_upper}_{yyyymm}.csv"
+        )
+
+
+def _enumerate_pair_months(manifest: dict[str, Any], pair: str) -> list[str]:
+    """Return sorted YYYYMM strings for which both bid and ask CSVs exist in the manifest.
+
+    The M1 manifest lists per-file entries with relpath like
+    ``<PAIR>/m1/bid/<YYYY>/<PAIR>_M1_BID_<YYYYMM>.csv``. A month is loadable iff
+    both sides are present; mismatched months (one side missing) are dropped.
+    """
+    files = manifest["pairs"][pair]["files"]
+    bid_months: set[str] = set()
+    ask_months: set[str] = set()
+    for relpath in files:
+        parts = relpath.split("/")
+        # parts: [PAIR, "m1", side, YYYY, FILENAME]
+        if len(parts) != 5 or parts[1] != "m1":
+            continue
+        side = parts[2]
+        fname = parts[4]
+        # filename: <PAIR>_M1_{BID|ASK}_<YYYYMM>.csv
+        try:
+            yyyymm = fname.split("_")[3].removesuffix(".csv")
+        except IndexError:
+            continue
+        if side == "bid":
+            bid_months.add(yyyymm)
+        elif side == "ask":
+            ask_months.add(yyyymm)
+    return sorted(bid_months & ask_months)
+
+
+def _read_side_csv(path: Path) -> pd.DataFrame:
+    """Read one side CSV with locked dtypes and UTC parsing.
+
+    Schema: timestamp_utc,open,high,low,close,volume — the
+    ``timestamp_utc`` column is ISO-8601 with a ``Z`` suffix.
+    """
+    df = pd.read_csv(
+        path,
+        dtype={
+            "open": "float64",
+            "high": "float64",
+            "low": "float64",
+            "close": "float64",
+            "volume": "int64",
+        },
+    )
+    df["timestamp_utc"] = pd.to_datetime(df["timestamp_utc"], utc=True, format="ISO8601")
+    return df
+
+
+def _read_pair_csvs(paths: HistDataPaths, pair: str, months: list[str]) -> pd.DataFrame:
+    """Read all bid+ask CSVs for a pair, join on timestamp, return canonical schema."""
+    bid_frames: list[pd.DataFrame] = []
+    ask_frames: list[pd.DataFrame] = []
+    for yyyymm in months:
+        bid_path = paths.side_csv(pair, "bid", yyyymm)
+        ask_path = paths.side_csv(pair, "ask", yyyymm)
+        if not bid_path.exists():
+            raise FileNotFoundError(f"Missing bid CSV: {bid_path}")
+        if not ask_path.exists():
+            raise FileNotFoundError(f"Missing ask CSV: {ask_path}")
+        bid_frames.append(_read_side_csv(bid_path))
+        ask_frames.append(_read_side_csv(ask_path))
+
+    bid = pd.concat(bid_frames, ignore_index=True).sort_values("timestamp_utc")
+    ask = pd.concat(ask_frames, ignore_index=True).sort_values("timestamp_utc")
+
+    # Inner-merge: keep only minutes present on both sides.
+    merged = pd.merge(
+        bid.rename(
+            columns={
+                "open": "open_bid",
+                "high": "high_bid",
+                "low": "low_bid",
+                "close": "close_bid",
+                "volume": "volume_bid",
+            }
+        ),
+        ask.rename(
+            columns={
+                "open": "open_ask",
+                "high": "high_ask",
+                "low": "low_ask",
+                "close": "close_ask",
+                "volume": "volume_ask",
+            }
+        ),
+        on="timestamp_utc",
+        how="inner",
+        validate="one_to_one",
+    )
+
+    # Volume invariant: bid and ask tick counts agree per minute by source design.
+    # Tolerance: allow tiny mismatches (e.g. file boundary edge cases) but fail
+    # loudly if widespread — would indicate aggregation drift.
+    mismatched = (merged["volume_bid"] != merged["volume_ask"]).sum()
+    if mismatched > 0:
+        frac = mismatched / len(merged)
+        if frac > 0.001:
+            raise ValueError(
+                f"bid/ask volume mismatch on {mismatched:,} of {len(merged):,} bars "
+                f"({frac:.4%}) for pair {pair!r} — aggregation drift suspected"
+            )
+    merged["volume"] = merged[["volume_bid", "volume_ask"]].max(axis=1).astype("int64")
+    merged = merged.drop(columns=["volume_bid", "volume_ask"])
+
+    merged["spread_close"] = merged["close_ask"] - merged["close_bid"]
+    dq = pd.Series(DQ_OK, index=merged.index, dtype="object")
+    nan_mask = merged[["open_bid", "close_bid", "open_ask", "close_ask"]].isna().any(axis=1)
+    dq.loc[nan_mask] = DQ_NAN_BID_OR_ASK
+    bad_spread = (merged["spread_close"] <= 0) & ~nan_mask
+    dq.loc[bad_spread] = DQ_ZERO_OR_NEG_SPREAD
+    merged["bid_ask_data_quality"] = dq
+
+    merged = merged.set_index("timestamp_utc")
+    return merged[M1_COLUMNS]
+
+
+def _write_parquet(df: pd.DataFrame, path: Path) -> None:
+    """Write a deterministic parquet file.
+
+    Snappy compression, fixed column order. pandas/pyarrow handles schema
+    introspection; column ordering is the load-bearing determinism control.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(path, engine="pyarrow", compression="snappy", index=True)
+
+
+def load_m1(
+    pair: str,
+    histdata_root: Path | str = "data/histdata",
+    cache_root: Path | str = "data/cache",
+    use_cache: bool = True,
+) -> pd.DataFrame:
+    """Load the full M1 bid+ask history for one pair.
+
+    Parameters
+    ----------
+    pair : str
+        Pair symbol, e.g. ``"EURUSD"``.
+    histdata_root : Path | str
+        Root of the HistData layer (containing ``<PAIR>/m1/...`` and
+        ``m1_manifest.json``). Defaults to ``data/histdata``.
+    cache_root : Path | str
+        Cache root. M1 cache is written to ``<cache_root>/m1/<PAIR>.parquet``.
+    use_cache : bool
+        If False, ignore any existing cache and re-parse the CSVs (cache is
+        still written on success). Default True.
+
+    Returns
+    -------
+    pd.DataFrame
+        DatetimeIndex named ``timestamp_utc`` (UTC); columns ``M1_COLUMNS``.
+    """
+    paths = HistDataPaths(Path(histdata_root), Path(cache_root))
+    manifest = load_m1_manifest(paths.m1_manifest_path)
+    cache_key = m1_cache_key_for_pair(manifest, pair)
+    parquet_path = paths.m1_cache_parquet(pair)
+
+    if use_cache and cache_valid(parquet_path, cache_key):
+        return pd.read_parquet(parquet_path)
+
+    months = _enumerate_pair_months(manifest, pair)
+    if not months:
+        raise ValueError(f"No paired bid/ask months found for {pair!r}")
+    df = _read_pair_csvs(paths, pair, months)
+
+    _write_parquet(df, parquet_path)
+    write_meta(
+        parquet_path,
+        CacheMeta(
+            pair=pair,
+            layer="m1",
+            cache_key=cache_key,
+            source_m1_manifest_sha256=manifest_self_sha256(paths.m1_manifest_path),
+            n_rows=int(len(df)),
+            columns=list(df.columns),
+            created_at=now_iso(),
+        ),
+    )
+    return df

--- a/core/manifest.py
+++ b/core/manifest.py
@@ -1,0 +1,60 @@
+"""sha256 artefact manifest writer.
+
+Used by any module that emits a result file (data cache parquets, WFO outputs,
+feature matrices, etc.) to record sha256s alongside the artefact for
+determinism audits per L_PROTOCOL §1.
+
+Conventions:
+- Manifests are JSON with sorted keys, indent=2, trailing newline.
+- Written with ``newline='\\n'`` for cross-platform byte-identical reproduction.
+- Schema:
+
+    {
+      "generated_at": "<ISO-8601 UTC>",
+      "artefacts": {
+        "<relpath>": {
+          "sha256": "<hex64>",
+          "size_bytes": <int>
+        },
+        ...
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def write_manifest(manifest_path: Path, artefacts: list[Path], root: Path | None = None) -> Path:
+    """Write a sha256 manifest covering ``artefacts``.
+
+    Paths are recorded relative to ``root`` (default: manifest_path.parent).
+    """
+    root = root or manifest_path.parent
+    entries: dict[str, dict] = {}
+    for a in artefacts:
+        rel = str(a.relative_to(root)).replace("\\", "/")
+        entries[rel] = {"sha256": _sha256_file(a), "size_bytes": a.stat().st_size}
+    payload = {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "artefacts": entries,
+    }
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return manifest_path

--- a/docs/dispatches/backtester_reconfig_intent.md
+++ b/docs/dispatches/backtester_reconfig_intent.md
@@ -1,0 +1,197 @@
+# Backtester v3.0 Reconfiguration — Intent
+
+Dispatch source: `CC_06_BACKTESTER_RECONFIG.md` (read from `~/Downloads/`).
+Branch: `claude/agitated-hellman-c92fb6` (worktree), targeting `main` via PR per DoD #11.
+Prereqs verified: HistData M1 layer in place (52 GB tick, 18 GB M1, integrity 0 mismatches per [DATA_FOUNDATION.md](docs/DATA_FOUNDATION.md)); CC_05 v3.0 landing merged (`612d3d7`); [L_PROTOCOL.md](L_PROTOCOL.md) v3.0 locked.
+
+---
+
+## Read-first findings (current state)
+
+### 1. Backtester entry points
+
+| Lineage | Path | LOC | Role |
+|---|---|---:|---|
+| KH-era engine | [core/backtester.py](core/backtester.py) | 2,011 | indicator-cache + WFO runner. Bound to MT5 OHLCV schema. |
+| KH-era helpers | [core/backtester_helpers.py](core/backtester_helpers.py) | 388 | trade row finalisation |
+| Path-D1 pipeline | [core/d1_pipeline.py](core/d1_pipeline.py) | 590 | path-so-far hook (Arc 4/5/6) |
+| Exit policies | [core/exit_policies.py](core/exit_policies.py) | 186 | trail / kijun / stop |
+| Signal logic | [core/signal_logic.py](core/signal_logic.py) | 630 | KH-era continuation logic |
+| KH-24 v2.0 step1 | [scripts/arc_kh24_v2/step1/run_step1.py](scripts/arc_kh24_v2/step1/run_step1.py) | — | newer L_ARC v2.x Step-1 runner (bare KH-24 signal, MT5 schema) |
+| KH-24 WFO runner | [scripts/phase_kgl_v2_4h_wfo.py](scripts/phase_kgl_v2_4h_wfo.py) | — | full KH-24 WFO with spread floor (MT5 schema) |
+| L_char atlas | [scripts/lchar/run_layer4.py](scripts/lchar/run_layer4.py) (+ 1/2/3/5) | — | descriptive atlas (separate lineage) |
+
+### 2. Data loader
+
+[core/utils.py:259](core/utils.py:259) — `load_pair_csv(pair, data_dir) → pd.DataFrame`. Reads a single CSV from one MT5-style directory (`data/4hr/`, `data/1hr/`, `data/daily/`). Single-side OHLC (no bid/ask separation).
+
+[scripts/arc_kh24_v2/step1/run_step1.py:43](scripts/arc_kh24_v2/step1/run_step1.py:43) — `_load_pair_csv(p)` local variant; same MT5 layout.
+
+**Critical finding:** `data/4hr/`, `data/1hr/`, `data/daily/` no longer exist under `data/` — only `data/histdata/` and a tiny `data/test/` fixture remain. The existing backtester cannot run against any current arc data without this dispatch.
+
+### 3. Spread-handling logic
+
+[core/spread_floor.py](core/spread_floor.py) — full `spread_floors_5ers.yaml` floor mechanism: load → sha256-verify against `expected_body_sha256` → cap-floor `apply_spread_floor_to_pips()`. Already feature-flagged via cfg.
+
+Integration site: [scripts/phase_kgl_v2_4h_wfo.py:60–66](scripts/phase_kgl_v2_4h_wfo.py:60) imports and threads `STATE_CFG_KEY` through the runner. `core/backtester.py` uses a different `resolve_spread_pips` path; spread floor flows in through cfg state.
+
+### 4. WFO orchestration
+
+[analytics/wfo.py](analytics/wfo.py) — generic `generate_folds(from, to, train_months, test_months, step_months)` returning `Fold(fold_id, train_start, train_end, test_start, test_end)`. Rolling windows, train_end < test_start enforced. Used by `scripts/phase_kgl_v2_4h_wfo.py` for the published KH-24 7-fold WFO (Oct 2020 → Jan 2026). Generic enough to be reused; the 11-fold expanding-IS pattern needs a new helper (anchored `train_start=2010-01-01`, 1-year OOS slices).
+
+### 5. Feature engineering
+
+No unified feature pipeline exists. Per-arc step-1 scripts compute their own feature columns inline:
+- [scripts/arc_kh24_v2_patch/emit_step1_base8_features.py](scripts/arc_kh24_v2_patch/emit_step1_base8_features.py) — base-8 set for the v2.0 self-test
+- [scripts/arc_kh24_v2/step2/_features.py](scripts/arc_kh24_v2/step2/_features.py) — path features
+- [scripts/lchar/run_layer*.py](scripts/lchar/) — L_char atlas features
+- [core/features_path_so_far.py](core/features_path_so_far.py) — Pipeline D1 path-so-far computer
+
+L_PROTOCOL §2 Step 1 lists the broader feature space (session, cross-pair, multi-TF, vol regime, distance, spread regime, causal lineage tag) as the v3.0 default. None of that currently exists as a shared module.
+
+### 6. L_PROTOCOL.md anchors confirmed
+
+§1 non-negotiables — no lookahead, ex-ante pool, D1 one-bar lag, real bid/ask, determinism, config-driven, anchor preservation.
+
+§2 Step 1 — feature space (price geometry, time, cross-pair, multi-TF, vol regime, cross-asset, distance, spread regime).
+
+§2 Step 5 — WFO structure: training/search 2010-01-01 → 2020-12-31, 11-fold 1-year folds; holdout 2021-01-01 → present one-shot; top-K (K=3) on holdout.
+
+Appendix B — architecture search space (filter sets, exposure rules, SL × ATR(14) ∈ {1.5..4.0}, exit policies, pipeline_de_n ∈ {1,3,5,8}, A1..A6 enabled).
+
+### 7. DATA_FOUNDATION.md — actual HistData layout
+
+**Dispatch path** (Task 1 prescription): `data/histdata/<pair>/{bid,ask}/<year>/DAT_ASCII_<pair>_M1_<YYYYMM>.csv`.
+
+**Actual on-disk layout** (per [docs/DATA_FOUNDATION.md](docs/DATA_FOUNDATION.md) §Location and verified):
+```
+data/histdata/<PAIR>/
+  tick/<YYYY>/DAT_ASCII_<PAIR>_T_<YYYYMM>.zip          # raw, canonical
+  m1/bid/<YYYY>/<PAIR>_M1_BID_<YYYYMM>.csv             # derived
+  m1/ask/<YYYY>/<PAIR>_M1_ASK_<YYYYMM>.csv             # derived
+data/histdata/manifest.json                            # tick zip sha256
+data/histdata/m1_manifest.json                         # derived M1 sha256
+```
+
+I will **use the actual layout** (the dispatch path string is wrong but the intent is clear). Cache invalidation will key off `m1_manifest.json` sha256 (the derived layer the loader actually reads), not the tick `manifest.json` — derivation is reproducible from tick anyway, but cache freshness is bounded by the M1 layer.
+
+Volume column: HistData tick volume is 0 by source; the M1 layer substitutes per-minute tick count (per [DATA_FOUNDATION.md](docs/DATA_FOUNDATION.md) §Aggregation). I'll preserve this.
+
+### 8. KH-24 anchor lineage (from [ARC_HISTORY.md](ARC_HISTORY.md))
+
+| Metric | Published (5ers MT5) | Real-spread reconciled (HistData expected band) | Tolerance (§8) |
+|---|---:|---:|---|
+| Worst-fold ROI | +1.92% (F7) | ~+1.28% | ±0.5pp |
+| Worst-fold DD | 6.37% (F1) | (not specifically reported; expected near 6.37%) | ±1pp |
+| Folds positive | 7/7 | unchanged at sign level | — |
+
+Per dispatch Task 8 and L_PROTOCOL §8: either within ±0.5pp/±1pp of the published 5ers numbers, OR within the documented +1.28% real-spread band, counts as anchor preserved. The KH-24 published WFO uses **7 folds** (Oct 2020 → Jan 2026, all post-2020). The v3.0 framework uses **11 folds 2010-2020 + 1-shot 2021-2025 holdout** — there is no clean 1:1 fold mapping. The natural reproduction is: run KH-24 on the 2021-2025 holdout window with the same 7-fold rolling structure as published, and compare. I will document this explicitly in Task 8's report and not silently re-map.
+
+---
+
+## Files CC will touch
+
+### New modules
+
+| Path | Purpose | Source task |
+|---|---|---|
+| `core/data/__init__.py` | package marker | infra |
+| `core/data/histdata_loader.py` | M1 bid+ask reader + parquet cache (`data/cache/m1/<pair>.parquet`) | Task 1 |
+| `core/data/aggregator.py` | deterministic M1→{M5,M15,M30,H1,H4,D1,W1} + per-TF parquet cache (`data/cache/<tf>/<pair>.parquet`) | Task 2 |
+| `core/data/cache_keys.py` | sha256 cache-key + invalidation logic (tied to `m1_manifest.json`) | Tasks 1, 2, 9b |
+| `core/spread/real_spread.py` | per-bar `ask.close − bid.close`, quality flag for bid==ask==0/NaN | Task 3 |
+| `core/sim/fill.py` | bar-level fill — entry at next-bar open, SL/TP intra-bar against bid/ask, no idealised fills | Task 3 |
+| `core/sim/multipair.py` | single account state across 28 pairs concurrently; exposure rules at account level | Task 6 |
+| `core/wfo/v3.py` | 11-fold anchored-IS WFO 2010-2020 + holdout 2021-present one-shot | Task 4 |
+| `core/features/v3.py` | broader feature space (entry point) | Task 5 |
+| `core/features/session.py` | London/NY/Tokyo/overlap/dead, hour-of-day, day-of-week | Task 5 |
+| `core/features/cross_pair.py` | signal density, dollar-bloc, currency strength ranks | Task 5 |
+| `core/features/multi_tf.py` | D1 directional state, D1 ATR percentile, W1 state | Task 5 |
+| `core/features/vol_regime.py` | 4H ATR vs trailing-100, percentile rank | Task 5 |
+| `core/features/distance.py` | from prior session HL, round numbers (.0050, .0100, .0500) | Task 5 |
+| `core/features/spread_regime.py` | current spread vs trailing 100-bar avg | Task 5 |
+| `core/features/lineage.py` | `causal_lineage ∈ {clean, suspect, unverified}` tagging | Task 5 |
+| `core/features/cache.py` | feature-matrix cache keyed by (signal_def + pool_sha + feature_set_version) | Task 9b |
+| `core/architectures/__init__.py` | architecture registry | Task 8 (interface, no impl yet) |
+| `core/architectures/base.py` | A1..A6 protocol — `run(config, pool, panel) → wfo_result` | Task 8 |
+| `core/parallel.py` | `multiprocessing.Pool` wrapper, default `min(28, cpu_count()-1)`, deterministic aggregation | Task 9c, 9d |
+| `core/manifest.py` | sha256 manifest writer per artefact | Task 7 |
+| `configs/wfo_v3.yaml` | locked WFO config (window dates, fold counts, holdout) | Task 4 |
+| `configs/features_v3.yaml` | feature set version + per-feature toggles | Task 5 |
+| `configs/parallel.yaml` | pool size override knob | Task 9c |
+| `configs/kh24_anchor.yaml` | KH-24 config for Task 8 reproduction (signal/SL/trail/filters/exposure) | Task 8 |
+
+### Modified modules
+
+| Path | Change |
+|---|---|
+| [core/backtester.py](core/backtester.py) | Route OHLCV access through `core/data/histdata_loader` + `aggregator`; route spread through `core/spread/real_spread`; deprecate MT5 schema branch (gated behind explicit `data_source: mt5_legacy` cfg flag — default `histdata`). |
+| [core/spread_floor.py](core/spread_floor.py) | Marked deprecated; kept loadable only when `data_source: mt5_legacy` (no removal yet — preserves the 5ers/spread-floors path used to publish KH-24 for reference / spot-check). |
+| [analytics/wfo.py](analytics/wfo.py) | Generic helper retained; `core/wfo/v3.py` is the new v3.0 orchestrator that calls into it. |
+| [docs/DATA_FOUNDATION.md](docs/DATA_FOUNDATION.md) | Reflect parquet cache layout + cache invalidation rules. |
+
+### New tests
+
+| Path | Purpose |
+|---|---|
+| `tests/test_histdata_loader.py` | layout parse, bid+ask alignment, missing-month tolerance, parquet roundtrip, ≥10× speedup vs CSV reparse |
+| `tests/test_aggregator.py` | OHLC rules per-side, UTC boundaries, two-run byte-identical, parquet roundtrip |
+| `tests/test_real_spread.py` | bid==ask==0 flag path, NaN handling, no spread-floor reference |
+| `tests/test_fill.py` | next-bar open entry, intra-bar SL/TP priority on bid/ask, long vs short symmetry |
+| `tests/test_multipair_sim.py` | single equity curve, exposure caps, cross-pair feature access at bar t |
+| `tests/test_wfo_v3.py` | 11 folds, anchored IS, holdout one-shot, top-K=3 |
+| `tests/test_features_v3.py` (or per-class) | lookahead-invariant spot-checks on 5 random trades per feature class; causal_lineage column present |
+| `tests/test_determinism_parallel.py` | two-run sha256 with pool=1 vs pool=8 byte-identical |
+| `tests/test_kh24_anchor.py` | wires Task 8 reproduction into CI as an opt-in (slow) marker; tolerance check |
+
+### New / updated docs
+
+| Path | Action |
+|---|---|
+| `docs/BACKTESTER_ARCHITECTURE.md` | **CREATE** — data source, TF aggregation, spread/fill, WFO, features, multi-pair, determinism, anchor results, cache layout |
+| `docs/features_reference.md` | **CREATE** — every Step-1 feature: definition, computation, causal lineage tag, inputs |
+| `docs/dispatches/backtester_reconfig_intent.md` | this file |
+| `docs/dispatches/backtester_reconfig_log.md` | created during execution — running log per task |
+
+---
+
+## Interpretive calls (flag for chat before any code lands)
+
+The dispatch is mostly literal, but four points need a chat call. **Stopping turn after this intent doc lands so these can be resolved.**
+
+1. **Scope of this PR.** Tasks 1–10 cover a multi-day to multi-week implementation surface (~25 new modules + 9 tests + 2 new docs + the KH-24 anchor compute run, which is itself many hours wall-clock on 16 years of M1 data × 28 pairs). The DoD asks for **one PR**. Two viable interpretations:
+   - **(a) One bundled PR.** Implement all 10 tasks, run the anchor, open the single PR. Long-lived branch.
+   - **(b) Staged PRs under the `infra/backtester-v3-reconfig` umbrella.** e.g. PR-1: data loader + aggregator + parquet cache + tests. PR-2: spread + fill + multi-pair sim. PR-3: WFO + features. PR-4: parallelism + determinism harness. PR-5: KH-24 anchor reproduction + docs. Each PR is reviewable in isolation; the final PR is the gate (anchor must pass).
+   - **Recommendation: (b).** The KH-24 anchor reproduction (Task 8) is the gate, and it depends on every prior task working — a single 10-task PR would be unreviewable and would conflate "infra builds" with "infra works." Staging surfaces problems at each layer.
+
+2. **MT5 legacy code path.** Existing arcs (KH-24 v2.0 self-test, Arc 4 rerun, Arc 10) ran against MT5 data that is now deleted from the repo. The reconfig defaults to HistData, but the existing `core/backtester.py` references and the `spread_floors_5ers.yaml` reconciliation logic are tightly coupled to the MT5 schema. Two options:
+   - **Hard-cut MT5.** Delete `core/spread_floor.py`, the MT5 branch in `core/backtester.py`, and the `data/4hr/` / `data/daily/` / `data/1hr/` references entirely. Cleaner but irreversible without a revert.
+   - **Soft-deprecate.** Keep MT5 paths gated behind `data_source: mt5_legacy` cfg flag (default `histdata`). Anyone re-running an old arc for forensics still can.
+   - **Recommendation: soft-deprecate**, since the dispatch says "no 5ers MT5 data path" in Task 1 but ARC_HISTORY's real-spread reconciliation table is one of the most cited cross-arc artefacts and re-running it for KH-25 / KH-27 forensics is plausible.
+
+3. **KH-24 anchor reproduction window (Task 8).** The published KH-24 numbers come from a **7-fold rolling WFO** over Oct 2020 → Jan 2026. The new v3.0 framework uses **11-fold anchored IS 2010-2020 + 1-shot holdout 2021-2025**. There is no fold-by-fold remapping. Three options:
+   - **(a) Run KH-24 through the v3.0 11-fold + holdout framework.** Worst-fold and DD across the new fold structure are compared to the published numbers within tolerance. Cleanest forward-looking — what every future arc will do.
+   - **(b) Run KH-24 with its original 7-fold rolling WFO** using the new HistData loader + real spreads. Most directly comparable to the published numbers, but it bakes the old WFO into the new engine.
+   - **(c) Both.** Worst-fold ratio on the published 7-fold window for anchor preservation; full 11-fold + holdout reported for v3.0 record.
+   - **Recommendation: (c).** Anchor preservation needs the apples-to-apples comparison (b); the v3.0 framework needs to be exercised end-to-end on a known signal (a). Reporting both is one extra config and one extra report — cheap.
+
+4. **`spread_floors_5ers.yaml` deprecation timing.** Dispatch Task 3 says "no `spread_floors_5ers.yaml` reference in the new code path" — clear. But also dispatch §"Required outputs" #3 says "If a bar has bid==ask==0 or NaN, the bar is flagged as a data quality issue in a separate log; trades are not simulated through such bars." That replaces the floor's purpose entirely. **DATA_FOUNDATION.md** still says `spread_floors_5ers.yaml` becomes a "fallback for bars with no quote activity." Two readings:
+   - **Strict dispatch reading**: zero-spread bars are dropped from simulation, no fallback ever, file is dead.
+   - **DATA_FOUNDATION reading**: zero-spread bars are filled from the floor file as a documented fallback.
+   - **Recommendation: strict dispatch reading.** Drop the bar, log it, no silent fallback. This matches L_PROTOCOL §1 non-negotiable on "Real bid/ask spreads. No fallback mechanism." If chat wants the DATA_FOUNDATION fallback restored, it's a one-line cfg toggle but L_PROTOCOL would need an amendment.
+
+---
+
+## Pre-commitments (no chat call needed — captured here for transparency)
+
+- **Parquet only.** Every tabular artefact downstream of HistData CSVs writes parquet. Manifest = JSON, closure docs = markdown, logs = text. (Dispatch Task 9a.)
+- **Determinism baseline.** `random_state=42`, `n_jobs=1` for any in-worker compute that affects results, `lineterminator='\n'` on every text/JSON/MD write, sha256 manifest per artefact. (Dispatch Task 7 + L_PROTOCOL §1.)
+- **Parallelism via `multiprocessing.Pool`**, not threading. Default pool = `min(28, cpu_count()-1)`. (Dispatch Task 9c.)
+- **Feature matrix cache key** = sha256 of `(signal_def_text + pool_sha256 + feature_set_version_string)`. Cache files at `data/cache/features/<arc_id>/<feature_set_hash>.parquet`. (Dispatch Task 9b.)
+- **No protocol logic invented.** This dispatch implements what L_PROTOCOL v3.0 specifies; it does not extend the protocol. (Dispatch §Discipline rules.)
+
+---
+
+## End of intent
+
+End turn. Awaiting chat on the four interpretive calls above (scope staging, MT5 legacy, anchor reproduction window, spread-floor deprecation) before any code or test file lands.

--- a/docs/dispatches/backtester_reconfig_log.md
+++ b/docs/dispatches/backtester_reconfig_log.md
@@ -1,0 +1,65 @@
+# Backtester v3.0 Reconfiguration — Log
+
+Running log of each staged PR under the `infra/backtester-v3-reconfig` umbrella.
+Intent doc: [`backtester_reconfig_intent.md`](backtester_reconfig_intent.md).
+
+Chat resolved the four interpretive calls on 2026-05-22:
+1. Staged 5-PR cadence (PR-A through PR-E); PR-E anchor is the critical review gate.
+2. Hard cut on MT5 — no `data_source` flag, no fallback branches. `spread_floors_5ers.yaml` deleted in PR-B.
+3. Report both the 7-fold Oct 2020–Jan 2026 (KH-24 anchor preservation) AND the 11-fold 2010-2020 + 1-shot 2021-2025 holdout in PR-E.
+4. Strict spread deprecation — zero/negative-spread bars dropped, no fallback, file deleted.
+
+---
+
+## PR-A — data loader + aggregator + parquet cache (Tasks 1, 2)
+
+**Branch:** `claude/agitated-hellman-c92fb6` (worktree).
+
+**Scope:**
+- HistData M1 bid+ask loader: per-pair, joined on `timestamp_utc`, written to `data/cache/m1/<PAIR>.parquet`.
+- Deterministic OHLC aggregation M1 → {M5, M15, M30, H1, H4, D1, W1}, cached per TF at `data/cache/<TF>/<PAIR>.parquet`.
+- sha256 cache-key derived from `data/histdata/m1_manifest.json`; sidecar `<parquet>.meta.json` records the key for cache validity checks.
+- Strict spread handling baked into the schema: `spread_close = close_ask - close_bid`, with per-bar `bid_ask_data_quality ∈ {ok, zero_or_negative_spread, nan_bid_or_ask}`. No fallback to any external floor file.
+
+**Added:**
+- [`core/data/__init__.py`](core/data/__init__.py)
+- [`core/data/cache_keys.py`](core/data/cache_keys.py)
+- [`core/data/histdata_loader.py`](core/data/histdata_loader.py)
+- [`core/data/aggregator.py`](core/data/aggregator.py)
+- [`core/manifest.py`](core/manifest.py)
+- [`configs/data_v3.yaml`](configs/data_v3.yaml)
+- [`tests/fixtures/histdata_mini/__init__.py`](tests/fixtures/histdata_mini/__init__.py) + [`build.py`](tests/fixtures/histdata_mini/build.py) — synthetic two-pair × two-month layout for test isolation
+- [`tests/test_cache_keys.py`](tests/test_cache_keys.py) — 15 tests on key derivation, sidecar IO, isolation
+- [`tests/test_histdata_loader.py`](tests/test_histdata_loader.py) — 13 tests covering schema, bid≤ask invariant, cache hit/miss, manifest-driven invalidation, data-quality flagging
+- [`tests/test_aggregator.py`](tests/test_aggregator.py) — 25 tests covering OHLC rules, TF anchoring (H4 @ 00/04/.../20, D1 @ midnight, W1 @ Monday), byte-identical two-run parquet, cache cascade from M1
+
+**Status:** 53/53 tests pass; ruff clean.
+
+**Deferred to PR-B+:**
+- Real-spread / fill mechanics integration with `core/backtester.py` (PR-B).
+- Multi-pair simultaneous simulation (PR-B).
+- Per-pair `multiprocessing.Pool` parallelism for cache warm-up (PR-D). For now, callers warm caches single-pair; serial loop over 28 pairs is the intended pattern until PR-D.
+- Feature-matrix cache (PR-C, dispatch Task 9b).
+- KH-24 anchor reproduction (PR-E, dispatch Task 8).
+
+**Notes / interpretive choices in PR-A:**
+
+1. **Cache invalidation source.** The dispatch says "Invalidate cache if HistData `manifest.json` sha256s change" but `manifest.json` is the tick-zip manifest, upstream of the M1 layer the loader actually reads. PR-A keys off `m1_manifest.json` (the directly-relevant manifest); any tick-layer change that re-derives M1 also rewrites `m1_manifest.json` and cascades through. Documented in [`core/data/__init__.py`](core/data/__init__.py) module docstring.
+
+2. **Volume column reconciliation.** Per [DATA_FOUNDATION.md §Aggregation](docs/DATA_FOUNDATION.md), bid and ask M1 CSVs both carry per-minute tick counts; they should match minute-for-minute. PR-A asserts a 0.1% tolerance and takes `max(volume_bid, volume_ask)` when they agree, raises `ValueError` on widespread mismatch (would indicate aggregation drift in the upstream M1 layer).
+
+3. **H4 anchoring.** Pandas 3 honours `origin='start_day'` only for Tick-like freqs. H4 (`4h`) is tick-like, so `start_day` anchors bars at 00:00 / 04:00 / 08:00 / 12:00 / 16:00 / 20:00 UTC. D1 (`1D`) and W1 (`W-MON`) are non-tick-like; their default anchoring (midnight UTC for D1, Monday start for W1 via `closed=left, label=left`) is correct without an `origin` argument. Asserted in three TF-anchoring tests.
+
+4. **Cache files are gitignored.** `data/cache/` is covered by the existing `data/*` exclude in `.gitignore` with no re-include. Caches are rebuilt locally on first run; the cache root structure is documented in [`configs/data_v3.yaml`](configs/data_v3.yaml).
+
+5. **Synthetic test fixture.** Real HistData is 70 GB and gitignored, so PR-A ships a [`build.py`](tests/fixtures/histdata_mini/build.py) that materialises a tiny matching layout (2 pairs × 2 months × 12 minutes) into `tmp_path` per test. Deterministic by construction; produces matching sha256s in its fixture manifest.
+
+---
+
+## PR-B — spread / fill mechanics + multi-pair sim (Tasks 3, 6) — pending
+
+## PR-C — WFO + features (Tasks 4, 5) — pending
+
+## PR-D — parallelism + determinism harness (Tasks 7, 9c, 9d) — pending
+
+## PR-E — KH-24 anchor reproduction + docs (Tasks 8, 10) — pending

--- a/docs/dispatches/pr_a_verification.md
+++ b/docs/dispatches/pr_a_verification.md
@@ -1,0 +1,261 @@
+# PR-A Pre-Merge Verification
+
+PR: [Forex-Backtester#161](https://github.com/kpanapabusiness-droid/Forex-Backtester/pull/161)
+Branch: `claude/agitated-hellman-c92fb6` (worktree)
+Date: 2026-05-22
+Mode: read-only verification per CC dispatch. No code modifications. Output is this single report file.
+
+---
+
+## Check 1 — Parquet cache works as expected
+
+**What was tested.** First and second `load_m1('EURUSD', ...)` calls timed against real HistData (5,964,931 M1 rows / 16 years × 12 months × 2 sides). First should parse CSVs; second should hit the parquet cache. Ratio target: ≥10×.
+
+**Command.**
+
+```python
+from core.data.histdata_loader import load_m1
+HISTDATA = Path('C:/Users/panap/Documents/Forex-Backtester/data/histdata')
+CACHE = Path('C:/Users/panap/AppData/Local/Temp/pr_a_check1_cache')
+shutil.rmtree(CACHE, ignore_errors=True)
+# t1: first call (cache miss); t2: second call (cache hit)
+```
+
+**Result.**
+
+| Metric | Value |
+|---|---:|
+| First run (cache miss) | **41.6207 s** |
+| Second run (cache hit) | **0.4223 s** |
+| Ratio (first / second) | **98.56×** |
+| Parquet file present | **Y** — `data/cache/m1/EURUSD.parquet`, 131.96 MB |
+| Sidecar `.meta.json` present | **Y**, 492 bytes |
+| Sidecar `cache_key` (sha256, 64 hex chars) | **Y** — `16b7daaa…7a660e96` |
+| Sidecar `source_m1_manifest_sha256` (64 hex chars) | **Y** — `a2d19a9c…2caa679d` |
+| Sidecar fields populated | `pair=EURUSD`, `layer=m1`, `n_rows=5964931`, all 11 canonical columns recorded |
+
+**Verdict: PASS.** Speedup 98.56× — almost 10× the 10× bar.
+
+**Concerns:** none.
+
+---
+
+## Check 2 — TF aggregation byte-identical (determinism)
+
+**What was tested.** Locate the byte-identical determinism test for M1→TF aggregation, run it in isolation, then manually re-confirm on real EURUSD data (not just the synthetic fixture) by aggregating to H4 twice and sha256-comparing the two parquet outputs.
+
+**Test located.** `tests/test_aggregator.py::test_aggregate_byte_identical_two_runs` — implementation aggregates twice, writes both to tmp parquets, asserts `sha256(a) == sha256(b)`.
+
+**Command (isolated test).**
+
+```bash
+py -m pytest tests/test_aggregator.py::test_aggregate_byte_identical_two_runs -v
+```
+
+**Result (isolated test).** `1 passed in 0.25s`.
+
+**Command (manual on real EURUSD H4).**
+
+```python
+df_m1 = load_m1('EURUSD', histdata_root=HISTDATA, cache_root=CACHE)
+df_h4_a = aggregate_m1_to_tf(df_m1, 'H4')
+df_h4_b = aggregate_m1_to_tf(df_m1, 'H4')
+# write each to tmp parquet, sha256 compare
+```
+
+**Result (manual).**
+
+| Metric | Value |
+|---|---|
+| H4 rows | 26,170 |
+| sha256(a) | `2d3b62ef31c35a7b417671887dd15bdd97a429e3be2f41d0980b2538451484e9` |
+| sha256(b) | `2d3b62ef31c35a7b417671887dd15bdd97a429e3be2f41d0980b2538451484e9` |
+| Byte-identical | **Y** |
+| `pd.testing.assert_frame_equal(a, b)` | **passes** |
+
+**Verdict: PASS.** Two-run byte-identical determinism holds at both fixture scale and real-data scale (16 years of EURUSD H4).
+
+**Concerns:** none.
+
+---
+
+## Check 3 — Zero `spread_floors_5ers` references in new code
+
+**Commands + results.**
+
+```
+grep -r "spread_floors_5ers" core/data/        → No matches found
+grep -r "spread_floors"       configs/data_v3.yaml → No matches found
+grep -r "spread_floor"        core/data/        → No matches found
+```
+
+All three return zero matches.
+
+**Verdict: PASS.** PR-A new code is clean of any spread-floor references. The existing `configs/spread_floors_5ers.yaml` file is untouched in PR-A and will be deleted in PR-B per the chat-resolved scope.
+
+**Concerns:** none.
+
+---
+
+## Check 4 — Legacy MT5 tests skip (not silently failing)
+
+**Command.**
+
+```bash
+py -m pytest -rs --tb=no -q
+py -m pytest -rs --tb=no -q | grep "^SKIPPED"  # for distinct reasons
+```
+
+**Result.**
+
+| Metric | Value |
+|---|---:|
+| Passed | 859 |
+| Skipped | 364 |
+| Failed | 0 |
+| Errors | 0 |
+
+All 364 skips are explicit `pytest.skip(...)` calls with informative reasons (no import errors, no setup errors masquerading as skips). Distinct skip-reason categories observed:
+
+| Category | Pattern | Notes |
+|---|---|---|
+| Missing legacy MT5 data | `data/daily missing or empty; need OHLCV CSV for <X> tests`, `data/4hr and data/daily not present` | Expected — dirs deleted with v3.0 reorg. Will be replaced by HistData-fed equivalents in PR-C+. |
+| Missing pre-built result artefacts | `No artifact at .../trades_all.csv; run <config> first`, `Step 1 + Step 2 outputs must exist; run those first.`, `results/kh24/trades_all.csv not present — run the KH-24 backtester first` | Tests guard against running without the upstream artefact; cheap and correct. |
+| Missing legacy config | `configs/wfo_phase5.yaml not found`, `configs/wfo_v2.yaml not found`, `configs/v1_system.yaml not found` | Older configs not on main. |
+| Explicit "real arc data unavailable" | `Real arc data not available in this environment` | Same as above, with a friendlier message. |
+| Logical / design skips (not data-related) | `binary does not output 0 by design`, `flip comparison is for binary vs naive`, `Full perturbation test deferred to v1.3.1 — protocol §10.1 lookahead invariant covers entry/exit decisions; per-bar invariant check is a planned follow-up extension.` | These are by-design skips, not data-availability skips. Three of these in total. |
+
+**Verdict: PASS.** Every skip is intentional and well-labelled. No silent failures, no import errors, no setup errors.
+
+**Concerns:** none. (Note for chat awareness: many of the 361 data-availability skips will need to be either rewired to the HistData layer or marked obsolete during PR-C+. That cleanup is out of scope for PR-A.)
+
+---
+
+## Check 5 — Test coverage of new code
+
+**Command (collection).**
+
+```bash
+py -m pytest tests/test_cache_keys.py tests/test_histdata_loader.py tests/test_aggregator.py --collect-only -q
+```
+
+**Result.** **53 tests collected** across the three files. Coverage summary:
+
+| File | Test count | Coverage areas |
+|---|---:|---|
+| `tests/test_cache_keys.py` | 15 | sha256 derivation (stability under dict ordering, change on file mutation, change on file added, isolation per pair), TF key cascade from M1 key, sidecar meta IO (roundtrip, missing, malformed), `cache_valid` semantics, LF line-terminator invariant, `manifest_self_sha256` content-sensitivity |
+| `tests/test_histdata_loader.py` | 13 | canonical schema, row count vs fixture, bid≤ask invariant, `spread_close` consistency, all-OK data-quality on clean fixture, parquet write, second-call cache hit, manifest-change → cache invalidation, `use_cache=False` rebuild, two-pair cache isolation, missing-pair raises, missing-manifest raises, zero-spread data-quality flag |
+| `tests/test_aggregator.py` | 25 (incl. 7-way + 7-way parametrize) | canonical schema per TF (× 7 TFs), M5 OHLC rules concrete, H4 anchoring at `:00/:04/.../:20`, D1 at midnight, W1 starting Monday, unsupported-TF error, **byte-identical two-run parquet**, DataFrame equality two-run, volume sum preserved (no dropped minutes), parquet cache per TF (× 7 TFs), cache hit avoids recompute, TF cache invalidation cascade from M1, `use_cache=False` idempotence |
+
+Areas explicitly covered per the dispatch's coverage requirement:
+- Data loader paths ✅
+- Missing-month handling ✅ (`_enumerate_pair_months` keeps only paired months; `test_load_m1_missing_pair_raises` for absent pair; `test_load_m1_missing_manifest_raises` for absent manifest)
+- Cache invalidation ✅ (`test_load_m1_cache_invalidates_on_manifest_change`, `test_aggregate_tf_cache_invalidates_with_m1`)
+- M1→TF aggregation ✅ (7 TFs × parametrize, OHLC rules, anchoring, volume preservation)
+- Bid-ask schema ✅ (canonical columns, bid≤ask invariant, spread_close consistency, data-quality flags)
+- Parquet I/O ✅ (write on miss, read on hit, mtime preserved on hit, byte-identical two-run)
+
+**Command (spot-check 5 random tests individually).**
+
+```bash
+py -m pytest \
+  "tests/test_cache_keys.py::test_m1_cache_key_isolated_per_pair" \
+  "tests/test_histdata_loader.py::test_load_m1_cache_invalidates_on_manifest_change" \
+  "tests/test_histdata_loader.py::test_load_m1_data_quality_flag_on_zero_spread" \
+  "tests/test_aggregator.py::test_aggregate_h4_anchors_to_zero_oclock" \
+  "tests/test_aggregator.py::test_aggregate_volume_sum_preserved" \
+  -v
+```
+
+**Result.** `5 passed in 0.44s`. Per-test:
+
+| # | Test | Result |
+|---|---|---|
+| 1 | `test_cache_keys.py::test_m1_cache_key_isolated_per_pair` | PASSED |
+| 2 | `test_histdata_loader.py::test_load_m1_cache_invalidates_on_manifest_change` | PASSED |
+| 3 | `test_histdata_loader.py::test_load_m1_data_quality_flag_on_zero_spread` | PASSED |
+| 4 | `test_aggregator.py::test_aggregate_h4_anchors_to_zero_oclock` | PASSED |
+| 5 | `test_aggregator.py::test_aggregate_volume_sum_preserved` | PASSED |
+
+**Verdict: PASS.** 53 tests cover every required area; spot-checks all green individually.
+
+**Concerns:** none.
+
+---
+
+## Check 6 — Manifest and meta files
+
+**Cache directory listing (after Check 1's `load_m1('EURUSD')`).**
+
+```
+data/cache/m1/
+  EURUSD.parquet            138,367,909 bytes
+  EURUSD.parquet.meta.json          492 bytes
+```
+
+One parquet + one `.meta.json` per pair attempted (one pair attempted in this check). Naming convention `<file>.parquet.meta.json` per spec.
+
+**Full sidecar contents (`EURUSD.parquet.meta.json`).**
+
+```json
+{
+  "cache_key": "16b7daaa7ee1550b826d9d0047334248552599c326c7815053bba0197a660e96",
+  "columns": [
+    "open_bid",
+    "high_bid",
+    "low_bid",
+    "close_bid",
+    "open_ask",
+    "high_ask",
+    "low_ask",
+    "close_ask",
+    "volume",
+    "spread_close",
+    "bid_ask_data_quality"
+  ],
+  "created_at": "2026-05-21T23:55:32Z",
+  "layer": "m1",
+  "n_rows": 5964931,
+  "pair": "EURUSD",
+  "source_m1_manifest_sha256": "a2d19a9cfc4c8ff2ff1e5edbb51e97b144267ccdbc019d3193cdac432caa679d"
+}
+```
+
+Both sha256 fields are 64 hex characters (well-formed). `cache_key` derives from the sorted `(relpath, sha256)` pairs of EURUSD's entries in `m1_manifest.json` per `core.data.cache_keys.m1_cache_key_for_pair`. `source_m1_manifest_sha256` is the sha256 of the full `m1_manifest.json` file itself (coarse provenance pointer; the load-bearing invariant is `cache_key`).
+
+**Cache invalidation on upstream manifest change.**
+
+Re-ran the two unit tests that exercise this directly:
+
+```bash
+py -m pytest \
+  "tests/test_histdata_loader.py::test_load_m1_cache_invalidates_on_manifest_change" \
+  "tests/test_aggregator.py::test_aggregate_tf_cache_invalidates_with_m1" -v
+```
+
+Result: `2 passed in 0.32s`. Both tests:
+1. Build a fixture, load the pair, capture the sidecar `cache_key`.
+2. Mutate one CSV's sha256 in the fixture's `m1_manifest.json` (writing the file back with the standard sort_keys + LF terminator).
+3. Reload the pair, capture the new sidecar `cache_key`.
+4. Assert old ≠ new.
+
+The aggregator test additionally proves that changing the M1 layer's manifest entry cascades into the **H1** TF cache key (because `tf_cache_key(m1_key, tf)` consumes the upstream key).
+
+**Note on manual re-confirmation on real data.** A direct manual repro (mutate a fork of the real `m1_manifest.json` and reload the real EURUSD) was attempted but blocked by Windows' lack of admin-required symlink privilege — copying the actual 5,488-row EURUSD pair-dir into tmp would have moved ~0.5 GB of CSVs which violates the "read-only" verification scope. The two unit tests above are the canonical proof; both pass.
+
+**Verdict: PASS.** Cache files present and well-formed; sidecar fields all populated with valid sha256 keys; invalidation-on-manifest-change verified via the unit tests.
+
+**Concerns:** none material. The Windows symlink limitation is environmental, not a PR-A defect.
+
+---
+
+## VERDICT: PR-A safe to merge
+
+All six checks pass. Specific highlights worth recording:
+
+- **Real-data cache speedup is 98.56×** (dispatch target: ≥10×).
+- **Real-data H4 byte-identical** across two-run aggregation (26,170 H4 bars on 16 years of EURUSD).
+- **Zero `spread_floor*` references** in any PR-A new code (modules + new config).
+- **Zero failures, zero errors, zero silent skips** across 1,223 collected tests in the full repo sweep.
+
+No anomalies, no concerns flagged. Recommending merge of PR-A; PR-B (real-spread + fill mechanics + multi-pair sim, including deletion of `configs/spread_floors_5ers.yaml`) can proceed immediately on top.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 numpy
 pandas
+pyarrow
 pytest
 ruff
 pyyaml

--- a/tests/fixtures/histdata_mini/__init__.py
+++ b/tests/fixtures/histdata_mini/__init__.py
@@ -1,0 +1,7 @@
+"""Synthetic HistData mini-fixture for the data-layer tests.
+
+A pytest fixture lives in ``tests/conftest.py`` (or per-test) that constructs
+this fixture inside a ``tmp_path``: two pairs × two months × bid+ask CSVs plus
+an ``m1_manifest.json`` referencing them. See ``tests/test_histdata_loader.py``
+for usage.
+"""

--- a/tests/fixtures/histdata_mini/build.py
+++ b/tests/fixtures/histdata_mini/build.py
@@ -1,0 +1,132 @@
+"""Builder for the synthetic HistData mini-fixture used by data-layer tests.
+
+The real HistData layer is 70 GB and gitignored; we can't ship it with the
+repo. Instead each data-layer test constructs a tiny in-tmp version of the
+exact layout the loader expects, then exercises the loader against it.
+
+Layout produced (rooted at ``root``):
+
+    root/
+      m1_manifest.json
+      <PAIR>/m1/bid/<YYYY>/<PAIR>_M1_BID_<YYYYMM>.csv
+      <PAIR>/m1/ask/<YYYY>/<PAIR>_M1_ASK_<YYYYMM>.csv
+
+CSV schema mirrors production: ``timestamp_utc,open,high,low,close,volume``.
+
+The fixture is deterministic: same ``root`` + ``pairs`` + ``months`` →
+byte-identical CSVs and identical sha256s in the manifest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class FixtureSpec:
+    pairs: tuple[str, ...] = ("EURUSD", "GBPUSD")
+    months: tuple[str, ...] = ("201001", "201002")
+    minutes_per_month: int = 12  # 12 sequential minutes — enough for OHLC tests at every TF
+    base_bid: float = 1.4300
+    spread_pips: float = 0.5  # constant 0.5-pip spread → ask = bid + 0.00005
+
+
+def _gen_side_rows(
+    pair: str, side: str, yyyymm: str, spec: FixtureSpec
+) -> list[tuple[str, float, float, float, float, int]]:
+    """Generate deterministic minute rows for one (pair, side, month).
+
+    The price walk is a simple deterministic ramp from base_bid varying with
+    pair index and month index — enough to make different pairs/months
+    distinguishable in test assertions, while keeping bid ≤ ask everywhere.
+    """
+    year = int(yyyymm[:4])
+    month = int(yyyymm[4:])
+    pair_offset = sum(ord(c) for c in pair) % 17 / 10_000  # ≤ 0.0017
+    month_offset = (month - 1) * 0.0001
+    start_bid = spec.base_bid + pair_offset + month_offset
+    spread_price = spec.spread_pips * 0.0001  # pip = 0.0001 for non-JPY pairs
+
+    rows: list[tuple[str, float, float, float, float, int]] = []
+    for i in range(spec.minutes_per_month):
+        # Bid OHLC: small zigzag — open = base, high = base + 1.5pip,
+        # low = base - 0.5pip, close = base + 1pip + i%3 * 0.1pip
+        b = start_bid + i * 0.00002
+        o = round(b, 5)
+        h = round(b + 0.00015, 5)
+        lo = round(b - 0.00005, 5)
+        c = round(b + 0.00010 + (i % 3) * 0.00001, 5)
+        if side == "ask":
+            o, h, lo, c = (round(x + spread_price, 5) for x in (o, h, lo, c))
+        ts = f"{year:04d}-{month:02d}-{i // 60 + 1:02d}T{i // 60 * 0:02d}:{i % 60:02d}:00Z"
+        # Keep timestamps in-month and unique per minute. Below we use a
+        # cleaner day-1 sequence — i ∈ [0,12), so all timestamps land on day 1.
+        ts = f"{year:04d}-{month:02d}-01T00:{i:02d}:00Z"
+        volume = 5 + (i % 4)
+        rows.append((ts, o, h, lo, c, volume))
+    return rows
+
+
+def _write_side_csv(path: Path, rows: list[tuple]) -> None:
+    """Write one side CSV with locked formatting for byte-identical reproduction."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as f:
+        f.write("timestamp_utc,open,high,low,close,volume\n")
+        for ts, o, h, lo, c, v in rows:
+            f.write(f"{ts},{o},{h},{lo},{c},{v}\n")
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_fixture(root: Path, spec: FixtureSpec | None = None) -> Path:
+    """Materialise the mini HistData layout under ``root``.
+
+    Returns the root path (same as input). After the call:
+
+        root/m1_manifest.json
+        root/<PAIR>/m1/bid/<YYYY>/<PAIR>_M1_BID_<YYYYMM>.csv  (per pair × month)
+        root/<PAIR>/m1/ask/<YYYY>/<PAIR>_M1_ASK_<YYYYMM>.csv
+    """
+    spec = spec or FixtureSpec()
+    root.mkdir(parents=True, exist_ok=True)
+
+    manifest_pairs: dict[str, dict] = {}
+    for pair in spec.pairs:
+        files: dict[str, dict] = {}
+        for yyyymm in spec.months:
+            year = yyyymm[:4]
+            for side in ("bid", "ask"):
+                rel = f"{pair}/m1/{side}/{year}/{pair}_M1_{side.upper()}_{yyyymm}.csv"
+                path = root / rel
+                rows = _gen_side_rows(pair, side, yyyymm, spec)
+                _write_side_csv(path, rows)
+                files[rel] = {
+                    "n_ticks_source": 0,
+                    "rows": len(rows),
+                    "sha256": _sha256_file(path),
+                    "size_bytes": path.stat().st_size,
+                }
+        manifest_pairs[pair] = {"files": files}
+
+    manifest = {
+        "aggregated_at": datetime(2026, 1, 1, tzinfo=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S+00:00"
+        ),
+        "pairs": manifest_pairs,
+    }
+    (root / "m1_manifest.json").write_text(
+        json.dumps(manifest, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return root

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,163 @@
+"""Tests for core/data/aggregator.py — M1→TF deterministic OHLC aggregation."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.data.aggregator import (
+    SUPPORTED_TFS,
+    aggregate,
+    aggregate_m1_to_tf,
+)
+from core.data.cache_keys import read_meta
+from core.data.histdata_loader import M1_COLUMNS, load_m1
+from tests.fixtures.histdata_mini.build import build_fixture
+
+
+@pytest.fixture
+def mini_root(tmp_path: Path) -> Path:
+    return build_fixture(tmp_path / "histdata")
+
+
+@pytest.fixture
+def cache_root(tmp_path: Path) -> Path:
+    return tmp_path / "cache"
+
+
+@pytest.fixture
+def m1_df(mini_root: Path, cache_root: Path) -> pd.DataFrame:
+    return load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+
+
+@pytest.mark.parametrize("tf", SUPPORTED_TFS)
+def test_aggregate_returns_canonical_schema(m1_df: pd.DataFrame, tf: str) -> None:
+    out = aggregate_m1_to_tf(m1_df, tf)
+    assert list(out.columns) == M1_COLUMNS
+    assert out.index.tz is not None
+    assert len(out) >= 1
+
+
+def test_aggregate_m5_ohlc_rules(m1_df: pd.DataFrame) -> None:
+    """Verify first/max/min/last/sum on a concrete 5-minute block.
+
+    Fixture has 12 minutes per month at 00:00..00:11. M5 bars: [00:00, 00:05),
+    [00:05, 00:10), [00:10, 00:15). The third bar covers minutes 10–11 only.
+    """
+    out = aggregate_m1_to_tf(m1_df, "M5")
+    # First M5 bar should aggregate minutes 0..4 of the first month
+    first_5 = m1_df.iloc[:5]
+    first_bar = out.iloc[0]
+    assert first_bar["open_bid"] == first_5["open_bid"].iloc[0]
+    assert first_bar["high_bid"] == first_5["high_bid"].max()
+    assert first_bar["low_bid"] == first_5["low_bid"].min()
+    assert first_bar["close_bid"] == first_5["close_bid"].iloc[-1]
+    assert first_bar["volume"] == first_5["volume"].sum()
+
+
+def test_aggregate_h4_anchors_to_zero_oclock(m1_df: pd.DataFrame) -> None:
+    """All H4 bar labels should be at 00, 04, 08, 12, 16, or 20 UTC."""
+    out = aggregate_m1_to_tf(m1_df, "H4")
+    assert (out.index.hour % 4 == 0).all()
+
+
+def test_aggregate_d1_anchors_to_midnight(m1_df: pd.DataFrame) -> None:
+    out = aggregate_m1_to_tf(m1_df, "D1")
+    assert (out.index.hour == 0).all()
+    assert (out.index.minute == 0).all()
+
+
+def test_aggregate_w1_anchors_to_monday(m1_df: pd.DataFrame) -> None:
+    """W1 bars start at Monday 00:00 UTC."""
+    out = aggregate_m1_to_tf(m1_df, "W1")
+    # weekday() == 0 means Monday
+    assert all(d.weekday() == 0 for d in out.index)
+
+
+def test_aggregate_unsupported_tf_raises(m1_df: pd.DataFrame) -> None:
+    with pytest.raises(ValueError, match="Unsupported TF"):
+        aggregate_m1_to_tf(m1_df, "M7")
+
+
+def test_aggregate_byte_identical_two_runs(m1_df: pd.DataFrame, tmp_path: Path) -> None:
+    """Two aggregations of the same M1 input write byte-identical parquet."""
+    out_a = aggregate_m1_to_tf(m1_df, "M5")
+    out_b = aggregate_m1_to_tf(m1_df, "M5")
+
+    p_a = tmp_path / "a.parquet"
+    p_b = tmp_path / "b.parquet"
+    out_a.to_parquet(p_a, engine="pyarrow", compression="snappy", index=True)
+    out_b.to_parquet(p_b, engine="pyarrow", compression="snappy", index=True)
+
+    sha_a = hashlib.sha256(p_a.read_bytes()).hexdigest()
+    sha_b = hashlib.sha256(p_b.read_bytes()).hexdigest()
+    assert sha_a == sha_b, "Two-run aggregation produced different parquet bytes"
+
+
+def test_aggregate_dataframe_equality_two_runs(m1_df: pd.DataFrame) -> None:
+    """Logical equality across two runs even if parquet byte equality were brittle."""
+    out_a = aggregate_m1_to_tf(m1_df, "H1")
+    out_b = aggregate_m1_to_tf(m1_df, "H1")
+    pd.testing.assert_frame_equal(out_a, out_b)
+
+
+def test_aggregate_volume_sum_preserved(m1_df: pd.DataFrame) -> None:
+    """Total volume across all bars must equal M1 total volume (no dropped minutes)."""
+    out = aggregate_m1_to_tf(m1_df, "H1")
+    assert out["volume"].sum() == m1_df["volume"].sum()
+
+
+@pytest.mark.parametrize("tf", SUPPORTED_TFS)
+def test_aggregate_writes_parquet_cache(mini_root: Path, cache_root: Path, tf: str) -> None:
+    parquet = cache_root / tf / "EURUSD.parquet"
+    assert not parquet.exists()
+    aggregate("EURUSD", tf, histdata_root=mini_root, cache_root=cache_root)
+    assert parquet.exists()
+    meta = read_meta(parquet)
+    assert meta is not None
+    assert meta.pair == "EURUSD"
+    assert meta.layer == tf
+
+
+def test_aggregate_cache_hit_avoids_recompute(mini_root: Path, cache_root: Path) -> None:
+    aggregate("EURUSD", "H1", histdata_root=mini_root, cache_root=cache_root)
+    parquet = cache_root / "H1" / "EURUSD.parquet"
+    first_mtime = parquet.stat().st_mtime_ns
+    time.sleep(0.05)
+    aggregate("EURUSD", "H1", histdata_root=mini_root, cache_root=cache_root)
+    second_mtime = parquet.stat().st_mtime_ns
+    assert second_mtime == first_mtime
+
+
+def test_aggregate_tf_cache_invalidates_with_m1(mini_root: Path, cache_root: Path) -> None:
+    """Bumping the M1 manifest sha cascades into the H1 cache key."""
+    import json
+
+    aggregate("EURUSD", "H1", histdata_root=mini_root, cache_root=cache_root)
+    parquet = cache_root / "H1" / "EURUSD.parquet"
+    first_key = read_meta(parquet).cache_key
+
+    # Bust one EURUSD M1 sha
+    manifest_path = mini_root / "m1_manifest.json"
+    mfst = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rel = next(iter(mfst["pairs"]["EURUSD"]["files"]))
+    mfst["pairs"]["EURUSD"]["files"][rel]["sha256"] = "f" * 64
+    manifest_path.write_text(
+        json.dumps(mfst, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    aggregate("EURUSD", "H1", histdata_root=mini_root, cache_root=cache_root)
+    second_key = read_meta(parquet).cache_key
+    assert first_key != second_key
+
+
+def test_aggregate_idempotent_with_use_cache_false(mini_root: Path, cache_root: Path) -> None:
+    a = aggregate("EURUSD", "M5", histdata_root=mini_root, cache_root=cache_root, use_cache=False)
+    b = aggregate("EURUSD", "M5", histdata_root=mini_root, cache_root=cache_root, use_cache=False)
+    pd.testing.assert_frame_equal(a, b)

--- a/tests/test_cache_keys.py
+++ b/tests/test_cache_keys.py
@@ -1,0 +1,201 @@
+"""Tests for core/data/cache_keys.py — sha256 derivation + sidecar meta IO."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.data.cache_keys import (
+    CacheMeta,
+    cache_valid,
+    load_m1_manifest,
+    m1_cache_key_for_pair,
+    manifest_self_sha256,
+    read_meta,
+    sha256_bytes,
+    sha256_file,
+    tf_cache_key,
+    write_meta,
+)
+
+
+def _manifest(pair_files: dict[str, dict[str, str]]) -> dict:
+    return {
+        "aggregated_at": "2026-01-01T00:00:00+00:00",
+        "pairs": {
+            pair: {
+                "files": {
+                    rel: {"sha256": sha, "rows": 1, "size_bytes": 1, "n_ticks_source": 0}
+                    for rel, sha in files.items()
+                }
+            }
+            for pair, files in pair_files.items()
+        },
+    }
+
+
+def test_m1_cache_key_stable_under_dict_ordering(tmp_path: Path) -> None:
+    """Cache key is invariant to insertion order of files in the manifest dict."""
+    files_a = {
+        "EURUSD/m1/bid/2010/X_201001.csv": "a" * 64,
+        "EURUSD/m1/ask/2010/X_201001.csv": "b" * 64,
+    }
+    files_b = dict(reversed(list(files_a.items())))
+    k_a = m1_cache_key_for_pair(_manifest({"EURUSD": files_a}), "EURUSD")
+    k_b = m1_cache_key_for_pair(_manifest({"EURUSD": files_b}), "EURUSD")
+    assert k_a == k_b
+
+
+def test_m1_cache_key_changes_on_sha256_change() -> None:
+    files = {"EURUSD/m1/bid/2010/X_201001.csv": "a" * 64}
+    k1 = m1_cache_key_for_pair(_manifest({"EURUSD": files}), "EURUSD")
+    files["EURUSD/m1/bid/2010/X_201001.csv"] = "c" * 64
+    k2 = m1_cache_key_for_pair(_manifest({"EURUSD": files}), "EURUSD")
+    assert k1 != k2
+
+
+def test_m1_cache_key_changes_on_file_added() -> None:
+    base = {"EURUSD/m1/bid/2010/X_201001.csv": "a" * 64}
+    k1 = m1_cache_key_for_pair(_manifest({"EURUSD": base}), "EURUSD")
+    extra = dict(base)
+    extra["EURUSD/m1/bid/2010/X_201002.csv"] = "b" * 64
+    k2 = m1_cache_key_for_pair(_manifest({"EURUSD": extra}), "EURUSD")
+    assert k1 != k2
+
+
+def test_m1_cache_key_isolated_per_pair() -> None:
+    """Touching EURUSD does not change GBPUSD's key."""
+    mfst = _manifest(
+        {
+            "EURUSD": {"EURUSD/m1/bid/2010/X_201001.csv": "a" * 64},
+            "GBPUSD": {"GBPUSD/m1/bid/2010/Y_201001.csv": "b" * 64},
+        }
+    )
+    k_eur_a = m1_cache_key_for_pair(mfst, "EURUSD")
+    k_gbp_a = m1_cache_key_for_pair(mfst, "GBPUSD")
+
+    # Mutate only EURUSD
+    mfst["pairs"]["EURUSD"]["files"]["EURUSD/m1/bid/2010/X_201001.csv"]["sha256"] = "c" * 64
+    k_eur_b = m1_cache_key_for_pair(mfst, "EURUSD")
+    k_gbp_b = m1_cache_key_for_pair(mfst, "GBPUSD")
+
+    assert k_eur_a != k_eur_b
+    assert k_gbp_a == k_gbp_b
+
+
+def test_tf_cache_key_differs_per_tf() -> None:
+    m1 = "a" * 64
+    assert tf_cache_key(m1, "M5") != tf_cache_key(m1, "H1")
+    assert tf_cache_key(m1, "M5") == tf_cache_key(m1, "M5")
+
+
+def test_tf_cache_key_propagates_m1_change() -> None:
+    a = tf_cache_key("a" * 64, "H1")
+    b = tf_cache_key("b" * 64, "H1")
+    assert a != b
+
+
+def test_load_m1_manifest_missing_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_m1_manifest(tmp_path / "m1_manifest.json")
+
+
+def test_meta_roundtrip(tmp_path: Path) -> None:
+    parquet = tmp_path / "EURUSD.parquet"
+    parquet.write_bytes(b"\x00")
+    meta = CacheMeta(
+        pair="EURUSD",
+        layer="m1",
+        cache_key="k" * 64,
+        source_m1_manifest_sha256="m" * 64,
+        n_rows=42,
+        columns=["open_bid", "close_ask"],
+        created_at="2026-01-01T00:00:00Z",
+    )
+    write_meta(parquet, meta)
+    loaded = read_meta(parquet)
+    assert loaded == meta
+
+
+def test_meta_missing_returns_none(tmp_path: Path) -> None:
+    parquet = tmp_path / "EURUSD.parquet"
+    parquet.write_bytes(b"\x00")
+    assert read_meta(parquet) is None
+
+
+def test_meta_malformed_returns_none(tmp_path: Path) -> None:
+    parquet = tmp_path / "EURUSD.parquet"
+    parquet.write_bytes(b"\x00")
+    sidecar = parquet.with_suffix(parquet.suffix + ".meta.json")
+    sidecar.write_text("{not valid json", encoding="utf-8")
+    assert read_meta(parquet) is None
+
+
+def test_cache_valid_requires_matching_key(tmp_path: Path) -> None:
+    parquet = tmp_path / "EURUSD.parquet"
+    parquet.write_bytes(b"\x00")
+    write_meta(
+        parquet,
+        CacheMeta(
+            pair="EURUSD",
+            layer="m1",
+            cache_key="k" * 64,
+            source_m1_manifest_sha256="m" * 64,
+            n_rows=1,
+            columns=["x"],
+            created_at="2026-01-01T00:00:00Z",
+        ),
+    )
+    assert cache_valid(parquet, "k" * 64)
+    assert not cache_valid(parquet, "other" * 16)
+
+
+def test_cache_valid_false_when_parquet_missing(tmp_path: Path) -> None:
+    parquet = tmp_path / "EURUSD.parquet"
+    # Note: no parquet on disk; sidecar may or may not exist — answer is False.
+    assert not cache_valid(parquet, "k" * 64)
+
+
+def test_sha256_helpers_match_hashlib(tmp_path: Path) -> None:
+    import hashlib
+
+    p = tmp_path / "x"
+    payload = b"the quick brown fox"
+    p.write_bytes(payload)
+    expected = hashlib.sha256(payload).hexdigest()
+    assert sha256_file(p) == expected
+    assert sha256_bytes(payload) == expected
+
+
+def test_meta_json_uses_lf_line_terminator(tmp_path: Path) -> None:
+    """L_PROTOCOL §1 determinism: cross-platform byte-identical sidecar files."""
+    parquet = tmp_path / "X.parquet"
+    parquet.write_bytes(b"\x00")
+    write_meta(
+        parquet,
+        CacheMeta(
+            pair="X",
+            layer="m1",
+            cache_key="k" * 64,
+            source_m1_manifest_sha256="m" * 64,
+            n_rows=1,
+            columns=["a"],
+            created_at="2026-01-01T00:00:00Z",
+        ),
+    )
+    raw = (parquet.with_suffix(parquet.suffix + ".meta.json")).read_bytes()
+    assert b"\r\n" not in raw
+    # Sanity: sorted JSON is stable
+    data = json.loads(raw.decode("utf-8"))
+    assert data["pair"] == "X"
+
+
+def test_manifest_self_sha256_changes_on_content_change(tmp_path: Path) -> None:
+    p = tmp_path / "m1_manifest.json"
+    p.write_text('{"v": 1}', encoding="utf-8")
+    s1 = manifest_self_sha256(p)
+    p.write_text('{"v": 2}', encoding="utf-8")
+    s2 = manifest_self_sha256(p)
+    assert s1 != s2

--- a/tests/test_histdata_loader.py
+++ b/tests/test_histdata_loader.py
@@ -1,0 +1,180 @@
+"""Tests for core/data/histdata_loader.py — M1 bid+ask loader with parquet cache."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.data.cache_keys import read_meta
+from core.data.histdata_loader import (
+    DQ_OK,
+    DQ_ZERO_OR_NEG_SPREAD,
+    M1_COLUMNS,
+    load_m1,
+)
+from tests.fixtures.histdata_mini.build import FixtureSpec, build_fixture
+
+
+@pytest.fixture
+def mini_root(tmp_path: Path) -> Path:
+    """Materialise a tiny HistData layer under tmp_path. Returns its root."""
+    return build_fixture(tmp_path / "histdata")
+
+
+@pytest.fixture
+def cache_root(tmp_path: Path) -> Path:
+    return tmp_path / "cache"
+
+
+def test_load_m1_returns_canonical_schema(mini_root: Path, cache_root: Path) -> None:
+    df = load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+
+    assert list(df.columns) == M1_COLUMNS
+    assert df.index.name == "timestamp_utc"
+    assert df.index.tz is not None  # UTC
+    assert str(df.index.tz) == "UTC"
+
+
+def test_load_m1_row_count_matches_fixture(mini_root: Path, cache_root: Path) -> None:
+    """Two months × 12 minutes each = 24 rows."""
+    df = load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    assert len(df) == 2 * FixtureSpec().minutes_per_month
+
+
+def test_load_m1_bid_le_ask(mini_root: Path, cache_root: Path) -> None:
+    df = load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    # bid ≤ ask holds at every OHLC corner by fixture construction
+    for col_b, col_a in [
+        ("open_bid", "open_ask"),
+        ("high_bid", "high_ask"),
+        ("low_bid", "low_ask"),
+        ("close_bid", "close_ask"),
+    ]:
+        assert (df[col_b] <= df[col_a]).all(), f"{col_b} > {col_a} on some row"
+
+
+def test_load_m1_spread_close_consistent(mini_root: Path, cache_root: Path) -> None:
+    df = load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    expected = df["close_ask"] - df["close_bid"]
+    pd.testing.assert_series_equal(
+        df["spread_close"], expected, check_names=False, check_dtype=False
+    )
+
+
+def test_load_m1_data_quality_all_ok(mini_root: Path, cache_root: Path) -> None:
+    """Fixture has a positive spread on every bar."""
+    df = load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    assert (df["bid_ask_data_quality"] == DQ_OK).all()
+
+
+def test_load_m1_caches_to_parquet(mini_root: Path, cache_root: Path) -> None:
+    parquet = cache_root / "m1" / "EURUSD.parquet"
+    assert not parquet.exists()
+    load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    assert parquet.exists()
+    # Sidecar meta is present and well-formed
+    meta = read_meta(parquet)
+    assert meta is not None
+    assert meta.pair == "EURUSD"
+    assert meta.layer == "m1"
+    assert meta.n_rows == 2 * FixtureSpec().minutes_per_month
+
+
+def test_load_m1_second_call_uses_cache(mini_root: Path, cache_root: Path) -> None:
+    """Second call returns same data without re-reading CSVs (mtime check)."""
+    load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    parquet = cache_root / "m1" / "EURUSD.parquet"
+    first_mtime = parquet.stat().st_mtime_ns
+    # Tiny sleep so a re-write would show a different mtime
+    time.sleep(0.05)
+    df = load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    second_mtime = parquet.stat().st_mtime_ns
+    assert second_mtime == first_mtime, "Parquet was rewritten on cache hit"
+    assert len(df) == 2 * FixtureSpec().minutes_per_month
+
+
+def test_load_m1_cache_invalidates_on_manifest_change(mini_root: Path, cache_root: Path) -> None:
+    """Mutating m1_manifest.json's sha for EURUSD forces a rebuild."""
+    load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    parquet = cache_root / "m1" / "EURUSD.parquet"
+    first_key = read_meta(parquet).cache_key
+
+    # Mutate one EURUSD file sha in the manifest
+    manifest_path = mini_root / "m1_manifest.json"
+    mfst = json.loads(manifest_path.read_text(encoding="utf-8"))
+    eur_files = mfst["pairs"]["EURUSD"]["files"]
+    first_relpath = next(iter(eur_files))
+    eur_files[first_relpath]["sha256"] = "f" * 64
+    manifest_path.write_text(
+        json.dumps(mfst, sort_keys=True, indent=2) + "\n", encoding="utf-8", newline="\n"
+    )
+
+    # Loader should detect the change and rebuild cache; new key differs
+    load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    second_key = read_meta(parquet).cache_key
+    assert first_key != second_key
+
+
+def test_load_m1_use_cache_false_rebuilds(mini_root: Path, cache_root: Path) -> None:
+    """use_cache=False ignores existing parquet and rebuilds."""
+    load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    parquet = cache_root / "m1" / "EURUSD.parquet"
+    first_mtime = parquet.stat().st_mtime_ns
+    time.sleep(0.05)
+    load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root, use_cache=False)
+    second_mtime = parquet.stat().st_mtime_ns
+    assert second_mtime > first_mtime
+
+
+def test_load_m1_two_pairs_independent(mini_root: Path, cache_root: Path) -> None:
+    """Loading EURUSD must not affect GBPUSD's cache."""
+    load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    assert (cache_root / "m1" / "EURUSD.parquet").exists()
+    assert not (cache_root / "m1" / "GBPUSD.parquet").exists()
+    load_m1("GBPUSD", histdata_root=mini_root, cache_root=cache_root)
+    assert (cache_root / "m1" / "GBPUSD.parquet").exists()
+
+
+def test_load_m1_missing_pair_raises(mini_root: Path, cache_root: Path) -> None:
+    with pytest.raises(KeyError, match="not present in M1 manifest"):
+        load_m1("XXXYYY", histdata_root=mini_root, cache_root=cache_root)
+
+
+def test_load_m1_missing_manifest_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_m1("EURUSD", histdata_root=tmp_path, cache_root=tmp_path / "cache")
+
+
+def test_load_m1_data_quality_flag_on_zero_spread(mini_root: Path, cache_root: Path) -> None:
+    """Manually inject a bad ask CSV row and verify the flag.
+
+    Rebuilds the fixture so the bad row is in the actual on-disk CSV (loader
+    re-parses on cache miss).
+    """
+    # Overwrite one ask CSV with a bad row (ask == bid) on its first minute,
+    # then bust the manifest sha to force a re-read.
+    bad = mini_root / "EURUSD/m1/ask/2010/EURUSD_M1_ASK_201001.csv"
+    bid = mini_root / "EURUSD/m1/bid/2010/EURUSD_M1_BID_201001.csv"
+    bid_lines = bid.read_text(encoding="utf-8").splitlines()
+    header = bid_lines[0]
+    bid_first_row = bid_lines[1]
+    # Replace ask first row with the bid first row → close_ask == close_bid → spread=0
+    ask_lines = bad.read_text(encoding="utf-8").splitlines()
+    ask_lines[1] = bid_first_row
+    bad.write_text("\n".join([header] + ask_lines[1:]) + "\n", encoding="utf-8", newline="\n")
+
+    # Bust the manifest sha for that file so the loader regenerates
+    manifest_path = mini_root / "m1_manifest.json"
+    mfst = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rel = "EURUSD/m1/ask/2010/EURUSD_M1_ASK_201001.csv"
+    mfst["pairs"]["EURUSD"]["files"][rel]["sha256"] = "deadbeef" + "0" * 56
+    manifest_path.write_text(
+        json.dumps(mfst, sort_keys=True, indent=2) + "\n", encoding="utf-8", newline="\n"
+    )
+
+    df = load_m1("EURUSD", histdata_root=mini_root, cache_root=cache_root)
+    assert (df["bid_ask_data_quality"] == DQ_ZERO_OR_NEG_SPREAD).sum() == 1


### PR DESCRIPTION
## Summary

PR-A of the **CC_06 backtester v3.0 reconfiguration** — the first of five staged PRs under `infra/backtester-v3-reconfig`. Adds the HistData data layer the rest of the reconfig builds on, with strict spread handling per L_PROTOCOL §1 baked in from the start.

- **`core/data/histdata_loader.py`** — per-pair M1 bid+ask reader. Joins `<PAIR>/m1/{bid,ask}/<YYYY>/...csv` into a single DatetimeIndex'd frame with `open/high/low/close_{bid,ask}` + `volume` + `spread_close` + `bid_ask_data_quality`. Caches to `data/cache/m1/<PAIR>.parquet`.
- **`core/data/aggregator.py`** — deterministic M1→{M5,M15,M30,H1,H4,D1,W1} OHLC aggregation (first/max/min/last/sum per side). Byte-identical two-run output (asserted in tests). Caches per TF at `data/cache/<TF>/<PAIR>.parquet`.
- **`core/data/cache_keys.py`** — sha256 cache keys derived from `data/histdata/m1_manifest.json`. Sidecar `<parquet>.meta.json` files for validity checks; TF cache key cascades from upstream M1 key, so any change in the M1 layer invalidates every dependent TF.
- **`core/manifest.py`** — generic sha256 artefact manifest writer (used here, will be reused by PR-C+ for WFO outputs).
- **`configs/data_v3.yaml`** — data + cache roots + 28-pair universe.

**Strict spread handling per L_PROTOCOL §1:** every row carries `bid_ask_data_quality ∈ {ok, zero_or_negative_spread, nan_bid_or_ask}`. No fallback to any external floor file. The existing `configs/spread_floors_5ers.yaml` is untouched in PR-A; **PR-B removes it** (per chat call: hard cut, no soft-deprecate).

## Test plan

- [x] 53 new tests across cache keys (15), loader (13), aggregator (25) — all green.
- [x] Full repo test sweep stays green: **859 pass, 364 skipped** (skipped are legacy tests bound to MT5 data dirs that no longer exist).
- [x] Ruff lint + format clean on PR-A files.
- [x] Byte-identical parquet on two-run aggregation (asserted).
- [x] Cache invalidation cascade: mutating one CSV sha in `m1_manifest.json` invalidates both M1 and dependent TF caches.

## Staged delivery

This is PR-A of five. The plan in [docs/dispatches/backtester_reconfig_log.md](docs/dispatches/backtester_reconfig_log.md):

- **PR-A** (this PR): data loader + aggregator + parquet cache (Tasks 1, 2).
- **PR-B**: real-spread + fill mechanics + multi-pair simultaneous simulation (Tasks 3, 6). Deletes `configs/spread_floors_5ers.yaml` and removes all references.
- **PR-C**: WFO restructuring (11-fold 2010-2020 + 1-shot holdout) + broader feature space (Tasks 4, 5).
- **PR-D**: parallelism + determinism harness (Tasks 7, 9c, 9d).
- **PR-E**: KH-24 anchor reproduction + final docs (Tasks 8, 10). **This is the critical review gate.**

Interpretive calls resolved with chat before PR-A landed are documented in [docs/dispatches/backtester_reconfig_intent.md](docs/dispatches/backtester_reconfig_intent.md) and the log.

## Notes on choices in PR-A

- **Cache invalidation source** keys off `m1_manifest.json` rather than the dispatch's literal `manifest.json` (the tick-zip one). The M1 layer is what the loader actually reads, and any tick-layer regeneration also rewrites `m1_manifest.json`. Documented in `core/data/__init__.py`.
- **H4 anchoring** uses `origin='start_day'` (pandas 3 honours this only for Tick-like freqs). D1 and W1 use defaults — midnight UTC / Monday start respectively. Three TF-anchoring tests assert this.
- **Synthetic test fixture** (`tests/fixtures/histdata_mini/`) materialises a 2-pair × 2-month layout into `tmp_path` per test, since the real HistData layer is 70 GB and gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)