### PR TITLE
[INFRA] Closure template v1.0 + tracker schema extension

### DIFF
--- a/ARC_TRACKER.md
+++ b/ARC_TRACKER.md
@@ -1,7 +1,7 @@
 # ARC_TRACKER — Live State
 
-> **Auto-updated.** Do not edit manually. Schema locked at v3.0.
-> Replaces STATUS.md, CHANGELOG.md, ARC_QUEUE.md, and ACTIVE_ARCS.md.
+> **Auto-updated.** Do not edit manually except per `docs/templates/ARC_CLOSURE_TEMPLATE.md` Section 4 mapping (until parser ships).
+> Schema locked at v3.0. Replaces STATUS.md, CHANGELOG.md, ARC_QUEUE.md, and ACTIVE_ARCS.md.
 > First populated on first arc open under L_PROTOCOL v3.0.
 
 Last auto-update: never (empty initial state)
@@ -71,28 +71,70 @@ Schema:
 
 | Failure mode | Count | Recent example arc | Recent example date |
 |---|---|---|---|
-| Pool too small | 0 | — | — |
-| No clusters separable | 0 | — | — |
-| No cluster passes capturability | 0 | — | — |
-| Entry-feature AUC ceiling | 0 | — | — |
-| Step 5 worst-fold ROI below gate | 0 | — | — |
-| Step 5 DD above gate | 0 | — | — |
-| Step 5 sign-consistency fail | 0 | — | — |
-| Step 6 causal audit fail | 0 | — | — |
-| Selection bias not defensible | 0 | — | — |
-| Holdout fail after IS pass | 0 | — | — |
-| Other | 0 | — | — |
+| pool_too_small | 0 | — | — |
+| no_clusters_separable | 0 | — | — |
+| no_capturable_cluster | 0 | — | — |
+| entry_feature_auc_ceiling | 0 | — | — |
+| step5_wf_roi_below_gate | 0 | — | — |
+| step5_dd_above_gate | 0 | — | — |
+| step5_sign_consistency_fail | 0 | — | — |
+| step6_causal_audit_fail | 0 | — | — |
+| selection_bias | 0 | — | — |
+| holdout_fail_after_is_pass | 0 | — | — |
+| admit_only_vs_deployment | 0 | — | — |
+| other | 0 | — | — |
+
+---
+
+## Cross-arc cluster registry
+
+> Every cluster from every arc gets a row. Append-only, never deduplicated.
+> Enables cross-arc pooling queries (e.g., pooling all V-shape clusters with `step4_e_auc` near gate to test multi-arc clusterifier).
+
+| Cluster ID | Archetype | n | mfe_p50_r | ww_pp | reach_1r | step3_composite | step4_e_auc | step4_d1_auc | sl_atr | outcome |
+|---|---|---|---|---|---|---|---|---|---|---|
+
+(empty — no clusters logged yet)
+
+Schema:
+- `Cluster ID` — `<arc_name>.<cluster_id>` (e.g., `arc_07.c1`)
+- `outcome` — passed_step3 | dies_step3 | dies_step4 | wins_step5 | viable_step5 | dies_step5
+
+---
+
+## Cost-decomposition registry
+
+> One row per arc whose best architecture is classifier-based (A2 / A3 / A4 / A6).
+> Tracks admit-only-vs-deployment pattern across arcs.
+
+| Arc | Admit fraction | Admit mean R | Reject fraction | Reject mean R | Early-exit fraction | Early-exit mean R |
+|---|---|---|---|---|---|---|
+
+(empty — no classifier-based winners yet)
+
+---
+
+## Cross-arc tag registry
+
+> Tags from §1 `cross_arc_tags` in each closure doc. Used to surface recurring patterns mechanically.
+
+| Tag | Count | Arcs |
+|---|---|---|
+
+(empty — no tags logged yet)
 
 ---
 
 ## Update mechanism
 
-Overseer parses sections 1-3 of every `ARC_CLOSURE.md` and updates this tracker on arc close:
-- Active arcs: row removed
-- Closed arcs summary: row appended
-- Per-feature contribution: rolling averages updated for features in the winning config
-- Per-architecture win rate: incremented if architecture won; ratio averaged
-- Per-archetype recurrence: cluster archetype labels parsed and counted
-- Per-failure-mode count: failure mode parsed from closure doc; counted
+Until parser ships:
+- Manual updates per `docs/templates/ARC_CLOSURE_TEMPLATE.md` Section 4 mapping (steps A through K).
+- Each closure doc's `§1 tracker_payload` YAML block is the source of truth — copy fields verbatim.
+- "Last auto-update" line bumped to `manual: YYYY-MM-DD` after each update.
+
+Once parser ships (`scripts/update_tracker_from_closure.py`):
+- Parser ingests `§1 tracker_payload` YAML.
+- Applies same Section 4 mapping mechanically.
+- "Last auto-update" line bumped to `parser: YYYY-MM-DD HH:MM:SS`.
 
 Tracker is APPEND-ONLY at the row level. Bad rows can be flagged with a `⚠️` prefix but cannot be deleted (history matters). Schema changes require explicit chat-side redesign event documented in the closure doc that introduced them.

--- a/L_PROTOCOL.md
+++ b/L_PROTOCOL.md
@@ -441,27 +441,27 @@ hypothesis: <one paragraph what this arc tests>
 expected_failure_modes: <if any anticipated>
 ```
 
-### ARC_CLOSURE.md required sections
+### ARC_CLOSURE.md format
 
-1. Headline — verdict + one-sentence summary
-2. Best architecture — which won, ratio, key metrics, vs Oracle
-3. All architectures tested — full ranked table
-4. Step-by-step results — what each step produced, failure diagnostics where applicable
-5. Why it failed (or succeeded) — specific, actionable
-6. Improvements to try — concrete next experiments
-7. What else worth investigating — adjacent ideas this arc surfaced
+All arc closure docs MUST follow `docs/templates/ARC_CLOSURE_TEMPLATE.md` v1.0.
 
-### ARC_TRACKER.md auto-update
+The template has three required sections:
 
-Overseer parses Sections 1-3 of every closure doc and updates the tracker mechanically. Sections updated:
-- Active arcs (row removed)
-- Closed arcs summary (row added)
-- Per-feature contribution (rolling avg updated)
-- Per-architecture win rate (updated)
-- Per-archetype recurrence (updated)
-- Per-failure-mode count (updated)
+1. **§1 tracker_payload** — machine-parseable YAML block. Source of truth for ARC_TRACKER updates. Field names and structure are locked.
+2. **§2 Why <failed | succeeded>** — required prose, 100-300 words. Preserves cross-arc synthesis quality.
+3. **§3 Cross-arc observations** — required bullet list. What does this arc add to cumulative findings?
 
-Tracker is append-only. Bad rows flagged not deleted. Schema locked at v3.0.
+Closure docs not conforming to the template are invalid. Tracker updates cannot be applied until the closure is repaired (per template Section 4-K).
+
+### ARC_TRACKER.md update mechanism
+
+ARC_TRACKER updates are driven by each closure doc's `§1 tracker_payload` YAML block.
+
+Until parser ships: manual updates per `docs/templates/ARC_CLOSURE_TEMPLATE.md` Section 4 (steps A through K).
+
+Once parser ships (`scripts/update_tracker_from_closure.py`): same Section 4 mapping applied mechanically. Parser specification in template Section 5.
+
+Tracker is append-only at the row level. Bad rows flagged with ⚠️ prefix, never deleted. Schema changes require explicit chat-side redesign event documented in the closure doc that introduced them.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 > The operational todo list. Append, check off, delete as work completes.
 > Distinct from `ARC_TRACKER.md` (which is auto-updated arc state) and `ARC_HISTORY.md` (frozen pre-v3.0 record).
-> Last updated: 2026-05-22 (PR-E.1.7 closure of CC_06 dispatch chain)
+> Last updated: 2026-05-22 (CC_08 closure template + tracker schema extension)
 
 ---
 
@@ -51,7 +51,7 @@
 | Land `L_PROTOCOL.md` on main | 🔴 |
 | Draft `docs/sub_protocols/heavy_ml_probe.md` | 🔴 |
 | Draft `docs/sub_protocols/signal_discovery_probe.md` | 🔴 |
-| Draft `ARC_TRACKER.md` skeleton (empty schema) | 🔴 |
+| Draft `ARC_TRACKER.md` skeleton (empty schema) | 🟢 |
 | Lock Wave 1 / Wave 2 arc composition | 🔴 |
 | Backup destination for HistData (separate folder off-repo) | 🟡 user pending |
 
@@ -77,6 +77,15 @@
 | Review `/mnt/project/` against new repo state | 🔴 |
 | Remove pre-reset docs (v2.x amendments, dispatch handovers, etc.) | 🔴 |
 | Sync currently-active docs (L_PROTOCOL, ARC_HISTORY, etc.) into project | 🔴 |
+
+### Round 5 — Closure infrastructure
+
+| Task | Status |
+|---|---|
+| Lock `docs/templates/ARC_CLOSURE_TEMPLATE.md` v1.0 | 🟢 |
+| Extend `ARC_TRACKER.md` schema (cluster registry, cost-decomp registry, tag registry) | 🟢 |
+| Land L_PROTOCOL §6 update referencing template | 🟢 |
+| Build tracker parser `scripts/update_tracker_from_closure.py` | ⚪ deferred until 2-3 Wave 1 closures land |
 
 ---
 
@@ -203,6 +212,7 @@ Triggered after: Phase 1 closes (all 11 arcs).
 |---|---|
 | `L_PROTOCOL.md` | Only at major redesign events |
 | `docs/sub_protocols/*` | When sub-protocol is amended |
+| `docs/templates/ARC_CLOSURE_TEMPLATE.md` | Only at major redesign events (template version bump) |
 | `ARC_TRACKER.md` | Auto on arc open/close |
 | `ARC_HISTORY.md` | Never (frozen at v3.0 start) |
 | `TODO.md` (this file) | Manually as work progresses |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -106,6 +106,7 @@ Chat decides next step from the diagnostic.
 |---|---|
 | `L_PROTOCOL.md` | Only at major redesign events |
 | `docs/sub_protocols/*` | When sub-protocol is amended |
+| `docs/templates/ARC_CLOSURE_TEMPLATE.md` | Only at major redesign events (template version bump) |
 | `WORKFLOW.md` (this file) | When operational conventions evolve |
 | `ARC_TRACKER.md` | Auto on arc open / close per L_PROTOCOL §6 |
 | `ARC_HISTORY.md` | Never (frozen at v3.0 start) |

--- a/docs/dispatches/closure_template_intent.md
+++ b/docs/dispatches/closure_template_intent.md
@@ -1,0 +1,93 @@
+# closure_template_intent.md
+
+> **Dispatch:** `CC_08_CLOSURE_TEMPLATE_LAND.md`
+> **Branch:** `infra/closure-template-v1` (cut from main, this commit forward)
+> **Scope:** docs-only. No engine, no arc, no backtester.
+> **Stage:** Read-first complete. Awaiting chat review before executing Tasks 1-7.
+
+---
+
+## Reads completed
+
+1. `L_PROTOCOL.md` §6 — current "ARC_CLOSURE.md required sections" subsection (lines 444-452) and "ARC_TRACKER.md auto-update" subsection (lines 454-464). Both to be replaced verbatim per Task 3.
+2. `WORKFLOW.md` §7 — cadence table at lines 103-117. `docs/sub_protocols/*` row is at line 109. Template row inserts immediately after.
+3. `ARC_TRACKER.md` — confirmed **empty initial state**. No active arcs, no closed-arc rows, no per-feature rows, all counter tables zeroed. `Last auto-update: never (empty initial state)`. **Safe to overwrite per Task 2** — HALT clause does not trigger.
+4. `TODO.md` — Round 2 row `Draft 'ARC_TRACKER.md' skeleton (empty schema)` is at line 54, status 🔴 (matches dispatch precondition). Round 4 ends at line 80; Phase 0 header begins line 83 — Round 5 inserts between these. `Last updated:` line at line 5 currently reads `2026-05-22 (PR-E.1.7 closure of CC_06 dispatch chain)`.
+
+---
+
+## File paths CC will touch (in execution order)
+
+| Order | Path | Action | Source |
+|---|---|---|---|
+| T1 | `docs/templates/` | Create directory | — |
+| T1 | `docs/templates/ARC_CLOSURE_TEMPLATE.md` | Create (verbatim) | Attached `ARC_CLOSURE_TEMPLATE.md` |
+| T2 | `ARC_TRACKER.md` | Overwrite (verbatim) | Attached `ARC_TRACKER (1).md` |
+| T3 | `L_PROTOCOL.md` | Edit §6 — replace 2 subsections | Dispatch text (Task 3) |
+| T4 | `WORKFLOW.md` | Edit §7 — insert 1 cadence row | Dispatch text (Task 4) |
+| T5 | `TODO.md` | Edit — flip Round 2 row to 🟢, insert Round 5 block, bump `Last updated` | Dispatch text (Task 5) |
+| T7 | PR `[INFRA] Closure template v1.0 + tracker schema extension` | gh pr create | — |
+
+Plus this intent doc + a `closure_template_log.md` at the end (per WORKFLOW §2 pattern).
+
+Net: 5 files modified, 1 directory created, 2 dispatch artefacts (intent + log). All edits verifiable via `git diff`.
+
+---
+
+## Verbatim-source diffs (pre-execution sanity)
+
+- Template file: 239 lines as provided. Contains nested fences (outer ```markdown wraps inner ```yaml at L27-114, then closes at L138). Lands as-is per dispatch ("CC does not edit their content").
+- ARC_TRACKER replacement: 141 lines as provided. New sections vs current:
+  - Cross-arc cluster registry (NEW)
+  - Cost-decomposition registry (NEW)
+  - Cross-arc tag registry (NEW)
+  - Per-failure-mode table — enum keys now snake_case (`pool_too_small`, etc.) matching template §1 `tracker_payload.primary_failure_mode` enum; row count expands from 11 → 12 (adds `admit_only_vs_deployment`, splits `step5_*` into three rows, etc.)
+  - Per-archetype table unchanged in shape
+  - Per-architecture table unchanged in shape (still 6 rows A1-A6)
+  - Update mechanism rewritten to reference template Section 4 mapping + parser path
+
+---
+
+## Interpretive calls flagged for chat
+
+Three items where the dispatch is ambiguous or where I noticed something worth surfacing before execution:
+
+### 1. `TODO.md` "Last updated" — today is already 2026-05-22
+
+The dispatch line is `Bump the file's 'Last updated' line at the top to today's date`. The file already shows `2026-05-22`. Same calendar day. Default plan: rewrite the parenthetical to reference this dispatch — `2026-05-22 (CC_08 closure template + tracker schema extension)` — replacing the prior `(PR-E.1.7 closure of CC_06 dispatch chain)` annotation. Flag if chat prefers verbatim-no-change or a different annotation.
+
+### 2. TODO.md has a duplicate cadence table at §"Reminder — what gets updated when" (lines 200-213)
+
+This duplicate mirrors WORKFLOW §7. Task 4 updates WORKFLOW §7 only; it does not mention this mirror. Default plan: **leave the TODO mirror untouched** (dispatch scope is explicit, and the discipline rules say "All edits verifiable via git diff" — i.e. only the specified edits). Consistency cleanup can be a separate trivial follow-up. Flag if chat wants the mirror synced in this dispatch.
+
+### 3. Failure-mode enum row split — historical-counter implication is zero (no prior arcs under v3.0)
+
+The new tracker's failure-mode table replaces 11 human-readable rows with 12 snake_case enum rows. Since the tracker is empty initial state, no counts are lost. Flagging only because the change is semantically a schema break — but the dispatch explicitly authorises verbatim replacement, and the tracker is empty, so this is in-scope and zero-risk.
+
+---
+
+## What CC will NOT do (boundaries)
+
+- Will not modify content of the two attached files (template + tracker). Verbatim only.
+- Will not edit any §6 content beyond the two specified subsections.
+- Will not touch the TODO duplicate cadence table without explicit go-ahead.
+- Will not touch any engine code, config YAML, or backtester artefact.
+- Will not delete or restructure pre-existing tracker rows if they appear (they don't — verified empty).
+- Will not open the PR until Tasks 1-6 are complete and `git diff` is clean.
+
+---
+
+## Halt-conditions during execution
+
+CC will HALT and surface to chat if:
+- Either verbatim-source file fails byte-identical write (e.g. line-ending corruption on Windows).
+- §6 subsection match fails (heading drift since this read).
+- WORKFLOW §7 `docs/sub_protocols/*` row not findable.
+- TODO Round 2 row text drifts from the read snapshot.
+- Any other unexpected file state.
+
+---
+
+## Ready for chat review
+
+Standing by. On chat approval, execute Tasks 1-7 in sequence, write `closure_template_log.md`, open PR, end turn.

--- a/docs/dispatches/closure_template_log.md
+++ b/docs/dispatches/closure_template_log.md
@@ -1,0 +1,68 @@
+# closure_template_log.md
+
+> **Dispatch:** `CC_08_CLOSURE_TEMPLATE_LAND.md`
+> **Branch:** `infra/closure-template-v1`
+> **Status:** Tasks 1-6 complete. PR pending.
+
+---
+
+## Execution summary
+
+All 7 tasks executed in order per dispatch. No HALT conditions triggered.
+
+| Task | Outcome |
+|---|---|
+| T1 — Create `docs/templates/` + land template | ✅ written; sha256 `efa4eea0…44055a` matches source |
+| T2 — Replace `ARC_TRACKER.md` | ✅ overwritten; sha256 `4c08bcbb…01ea560` matches source. Pre-overwrite state confirmed empty (no closed-arc rows, all counters at 0) — HALT clause did not trigger |
+| T3 — `L_PROTOCOL.md` §6 (two subsections) | ✅ both subsections replaced verbatim per dispatch text. All other §6 content unchanged (verified by diff scope) |
+| T4 — `WORKFLOW.md` §7 (one row) | ✅ row inserted immediately after `docs/sub_protocols/*` |
+| T5 — `TODO.md` (4 edits) | ✅ Round 2 row `Draft 'ARC_TRACKER.md' skeleton (empty schema)` → 🟢; Round 5 block inserted before Phase 0; `Last updated` annotation swapped to CC_08; mirror cadence table at §"Reminder" also synced with template row (per chat confirmation) |
+| T6 — Verification | ✅ see checklist below |
+| T7 — PR | pending (next step) |
+
+---
+
+## Verification checklist
+
+Per dispatch Task 6:
+
+- [x] `docs/templates/ARC_CLOSURE_TEMPLATE.md` exists, byte-identical to source provided (sha256 match)
+- [x] `ARC_TRACKER.md` updated, byte-identical to source provided (sha256 match)
+- [x] `L_PROTOCOL.md` §6 references the template (`docs/templates/ARC_CLOSURE_TEMPLATE.md v1.0` named; Section 4-K + Section 5 referenced)
+- [x] `WORKFLOW.md` §7 cadence table includes the template row (inserted after `docs/sub_protocols/*`)
+- [x] `TODO.md` updated with Round 5 + bumped date annotation
+- [x] TODO mirror cadence table synced (chat-approved scope extension to original Task 4)
+- [x] No other files modified (`git status` confirms: 4 modified, 2 untracked — template dir + this dispatch artefact pair only)
+- [x] All edits verifiable via `git diff`
+
+`git diff --stat HEAD`:
+```
+ARC_TRACKER.md | 82 ++++++++++++++++++++++++++++++++++++++++++++--------------
+L_PROTOCOL.md  | 42 +++++++++++++++---------------
+TODO.md        | 14 ++++++++--
+WORKFLOW.md    |  1 +
+4 files changed, 96 insertions(+), 43 deletions(-)
+```
+Plus new files: `docs/templates/ARC_CLOSURE_TEMPLATE.md`, `docs/dispatches/closure_template_intent.md`, this log.
+
+---
+
+## Deviations from dispatch
+
+One scope extension, chat-approved before execution:
+
+- **TODO §"Reminder — what gets updated when" mirror table also synced** with the template row. Original Task 4 only specified WORKFLOW §7. Chat confirmed in the intent-review reply: "sync it in this dispatch. Add the docs/templates/ARC_CLOSURE_TEMPLATE.md row matching the WORKFLOW §7 edit. Two tables in lockstep."
+
+No other deviations. All other edits adhere to dispatch text exactly.
+
+---
+
+## Flags for chat
+
+None. Verification clean across all six items. Ready for PR review.
+
+---
+
+## Next step
+
+Open PR `[INFRA] Closure template v1.0 + tracker schema extension` per Task 7, end turn.

--- a/docs/templates/ARC_CLOSURE_TEMPLATE.md
+++ b/docs/templates/ARC_CLOSURE_TEMPLATE.md
@@ -1,0 +1,238 @@
+# ARC_CLOSURE.md Template (Locked v1.0)
+
+> **Location:** `docs/templates/ARC_CLOSURE_TEMPLATE.md`
+> **Status:** locked. Every arc closure MUST follow this template.
+> **Referenced by:** `L_PROTOCOL.md` §6.
+> **Parser status:** spec-only. Manual updates per Section 4 mapping until parser ships.
+>
+> Section headings are LITERAL — do not rephrase. Field names inside `§1 tracker_payload` are LITERAL — parser depends on exact spelling.
+>
+> **Design priority:** machine-parseability over human readability. §1 YAML is the source of truth for the tracker. §2 + §3 exist only to preserve cross-arc synthesis quality that prose enables and YAML doesn't.
+
+---
+
+## Template
+
+```markdown
+# ARC_<N>_CLOSURE — <arc_name>
+
+> **Closed:** <ISO timestamp>
+> **Branch:** arc/<arc_name>
+> **Closure doc path:** results/<arc_name>/ARC_CLOSURE.md
+
+---
+
+## §1 tracker_payload
+
+```yaml
+tracker_payload:
+
+  # ────── Identity ──────
+  arc_name: <arc_name>
+  signal: <signal description, terse, ≤80 char>
+  tf: <timeframe>
+  sub_protocol: vanilla | heavy_ml_probe | signal_discovery_probe | <other>
+  closed_timestamp: <ISO>
+  closure_doc_link: results/<arc_name>/ARC_CLOSURE.md
+
+  # ────── Verdict ──────
+  verdict: PASS-DEPLOYABLE | PASS-VIABLE | FAIL | HALT | DISCOVERY_COMPLETE
+  one_line: <≤140 char summary>
+  failed_at_step: 1 | 2 | 3 | 4 | 5 | 6 | N/A
+  primary_failure_mode: <enum: pool_too_small | no_clusters_separable | no_capturable_cluster | entry_feature_auc_ceiling | step5_wf_roi_below_gate | step5_dd_above_gate | step5_sign_consistency_fail | step6_causal_audit_fail | selection_bias | holdout_fail_after_is_pass | admit_only_vs_deployment | other | N/A>
+
+  # ────── Pool metadata ──────
+  pool_metadata:
+    total_n: <int>
+    window_start: <ISO date>
+    window_end: <ISO date>
+    kh24_co_fire_pct: <float>
+    configs_evaluated_step5: <int>
+    search_scope_flag: thin | normal | broad   # thin <50, normal 50-99, broad 100+
+
+  # ────── Best architecture (null block if no winner) ──────
+  best_architecture:
+    name: A1 system_level_filter | A2 classifier_filter | A3 pipeline_de | A4 pipeline_d_exits | A5 portfolio_composition | A6 meta_labeling | null
+    cluster: <cluster_id> | aggregate | null
+    archetype: V-shape | Stepwise | Bimodal | Monotonic_up | Monotonic_down | Choppy | Unclassified | null
+    config: <config name / descriptor> | null
+    sl_atr: <float or null>
+    exit_policy: <policy name or null>
+    exposure_cap: <int or unlimited or null>
+    worst_fold_ratio: <float or null>
+    worst_fold_roi_pct: <float or null>
+    worst_fold_dd_pct: <float or null>
+    mean_fold_ratio: <float or null>
+    mean_fold_roi_pct: <float or null>
+    sign_pos_folds: <"X/N" string or null>
+    n_trades_total: <int or null>
+    holdout_roi_pct: <float or null>
+    holdout_dd_pct: <float or null>
+    holdout_passed: <bool or null>
+    oracle_worst_ratio: <float or null>
+    oracle_real_gap_sharpe: <float or null>
+    features_in_winning_config: [<feature_1>, <feature_2>, ...]   # empty list if no winner
+
+  # ────── Cost decomposition (null if winning arch is not classifier-based) ──────
+  cost_decomposition:
+    admit_pool:      {n_fraction: <float>, mean_r: <float>}
+    reject_pool:     {n_fraction: <float>, mean_r: <float>}
+    early_exit_pool: {n_fraction: <float>, mean_r: <float>}
+    # or:
+    # cost_decomposition: null
+
+  # ────── Per-cluster results (every cluster from Step 2) ──────
+  clusters:
+    c0:
+      n: <int>
+      archetype: <archetype>
+      sl_atr: <float>
+      step3_composite: <float>
+      mfe_p50_r: <float>
+      ww_pp: <float>
+      reach_1r: <float>
+      step4_e_auc: <float or null>
+      step4_d1_auc: <float or null>
+      outcome: passed_step3 | dies_step3 | dies_step4 | wins_step5 | viable_step5 | dies_step5
+    c1:
+      # same fields
+    # repeat per cluster
+
+  # ────── Architecture results (every arch tested in Step 5) ──────
+  architectures_tested: [A1, A2, A3, A4, A5, A6]   # subset that ran
+  architecture_results:
+    A1: {tested: true, won: false, worst_fold_ratio: <float or null>}
+    A2: {tested: true, won: true,  worst_fold_ratio: <float>}
+    # repeat per architecture tested
+
+  # ────── Archetypes observed ──────
+  archetypes_observed: [<archetype_1>, <archetype_2>, ...]   # union across clusters
+
+  # ────── Cross-arc observation tags (terse, one-line each) ──────
+  cross_arc_tags: [<tag_1>, <tag_2>]
+  # Examples: "v_shape_auc_ceiling", "pipeline_d1_admit_vs_deployment", "co_fire_with_arc_7"
+```
+
+---
+
+## §2 Why <failed | succeeded>
+
+(Required prose. 100-300 words. Specific and actionable.)
+
+What was the proximate cause? What was the structural cause behind it? What does this tell us about the signal class or the methodology? Reference specific clusters, architectures, or features by name.
+
+---
+
+## §3 Cross-arc observations
+
+(Required bullet list. What does THIS arc add to the project's cumulative findings?)
+
+- <observation 1>
+- <observation 2>
+
+Examples of useful cross-arc observations:
+- "Third V-shape cohort with Step 4 AUC < 0.55 — confirms entry-feature ceiling pattern"
+- "Pipeline D1 admit/reject pools mirror Arc 5 within ±10% on all metrics — fourth instance"
+- "Cross-arc co-fire with Arc 7 = 5.4% on c1 trades — worth EXP-05 style pooling"
+
+```
+
+---
+
+## Section 4 — Closure → ARC_TRACKER mapping (manual update checklist)
+
+Until parser ships, manual updates follow this exact sequence on each arc close. Every action sources fields from the closure doc's `§1 tracker_payload` block.
+
+### A. Active arcs section
+Action: REMOVE the row matching `arc_name`.
+
+### B. Closed arcs summary section
+Action: APPEND a row with these fields:
+
+| Tracker column | Source field |
+|---|---|
+| Arc | `arc_name` |
+| Signal | `signal` |
+| TF | `tf` |
+| Sub-protocol | `sub_protocol` |
+| Best architecture | `best_architecture.name` |
+| Worst-fold ratio | `best_architecture.worst_fold_ratio` |
+| Verdict | `verdict` |
+| Failed at step | `failed_at_step` |
+| Closure doc | `closure_doc_link` |
+
+### C. Per-feature contribution section
+For each feature in `best_architecture.features_in_winning_config`:
+1. Find or create row matching feature name.
+2. Increment `Arcs used`.
+3. Update rolling avg `Avg WFO ratio with` using `best_architecture.worst_fold_ratio`.
+
+For each feature in any tracker row but NOT in `features_in_winning_config`:
+1. Update rolling avg `Avg WFO ratio without` using this arc's `worst_fold_ratio`.
+
+Re-derive `Verdict` per schema (LIFTS / HURTS / NEUTRAL / INSUFFICIENT).
+
+### D. Per-architecture win rate section
+For each architecture in `architectures_tested`:
+1. Increment `Arcs tested`.
+2. If `architecture_results.<arch>.won == true`: increment `Won (best in arc)`, append `worst_fold_ratio` to rolling avg `Avg ratio when won`.
+
+### E. Per-archetype recurrence section
+For each archetype in `archetypes_observed`:
+1. Find or create row, increment `Arcs where appeared`.
+2. Update rolling avgs `Avg in-cluster R` and `Avg in-cluster reach_1R` using `clusters.<cid>.mfe_p50_r` and `clusters.<cid>.reach_1r` for clusters whose archetype matches.
+
+### F. Per-failure-mode count section
+Find row matching `primary_failure_mode`:
+1. Increment `Count`.
+2. Update `Recent example arc` to `arc_name`.
+3. Update `Recent example date` to `closed_timestamp`.
+
+### G. Cross-arc cluster registry
+For each cluster in `clusters`:
+1. APPEND row: `<arc_name>.<cluster_id>`, archetype, n, mfe_p50_r, ww_pp, reach_1r, step3_composite, step4_e_auc, step4_d1_auc, sl_atr, outcome.
+2. Never deduplicate — every cluster across every arc gets a row. Enables cross-arc pooling queries (EXP-05 style).
+
+### H. Cost-decomposition registry
+If `cost_decomposition` is non-null:
+1. APPEND row: `arc_name`, admit_pool_fraction, admit_mean_r, reject_pool_fraction, reject_mean_r, early_exit_fraction, early_exit_mean_r.
+2. Used to track admit-only-vs-deployment pattern across arcs.
+
+### I. Cross-arc tag registry
+For each tag in `cross_arc_tags`:
+1. Find or create row, increment `Count`, append `arc_name` to `Arcs`.
+
+### J. Update "Last auto-update" line
+- Manual: `Last auto-update: manual: YYYY-MM-DD`
+- Parser: `Last auto-update: parser: YYYY-MM-DD HH:MM:SS`
+
+### K. Bad-payload handling
+If `§1 tracker_payload` block is missing or malformed:
+1. DO NOT update the tracker.
+2. Flag closure doc in `TODO.md` as needing repair.
+3. After repair, apply update.
+
+If a tracker row is suspected wrong post-update:
+1. Prepend `⚠️` to the row (do not delete).
+2. Add footnote describing suspected issue.
+3. Resolve in next protocol calibration review.
+
+---
+
+## Section 5 — Parser implementation notes (deferred)
+
+Parser not yet built. Recommendation: build after 2-3 Wave 1 closures land — gives real golden inputs to validate against.
+
+Parser specification:
+- Input: any `results/<arc_name>/ARC_CLOSURE.md` file.
+- Extract: `§1 tracker_payload` YAML block (everything between the fenced ` ```yaml ` and the closing ` ``` `).
+- Validate: schema match against this template's §1 spec; fail loudly on missing required fields.
+- Output: append-only updates to `ARC_TRACKER.md` per Section 4 A-J above.
+- Idempotency: parsing the same closure doc twice produces identical tracker (no double-append).
+- Determinism: same closure doc → same tracker delta byte-for-byte.
+
+Suggested implementation: single Python script `scripts/update_tracker_from_closure.py`. Invoked manually post-PR-merge, or via post-merge git hook (bundles with WORKFLOW §3 auto-cleanup hook trigger point).
+
+---
+
+End of template.


### PR DESCRIPTION
## Summary

CC_08 dispatch — locks the `ARC_CLOSURE.md` format and extends the `ARC_TRACKER.md` schema before Wave 1's first closure lands. Docs-only. No engine, no arc, no backtester touch.

## Why

Wave 1 is in flight and its first closure is imminent. Without a locked template, each arc would close in its own shape — re-blocking cross-arc synthesis and breaking any future parser. This dispatch lands the template + schema NOW so all 11 Wave 1/2 closures pour into a single source-of-truth structure.

## Files changed (5 + 2 dispatch artefacts)

- `docs/templates/ARC_CLOSURE_TEMPLATE.md` — new, v1.0, verbatim from chat (sha256-verified byte-identical)
- `ARC_TRACKER.md` — replaced verbatim with extended schema (sha256-verified); pre-overwrite confirmed empty so HALT clause did not trigger
  - NEW sections: cross-arc cluster registry, cost-decomposition registry, cross-arc tag registry
  - Failure-mode enum migrated to snake_case matching template payload spec (`pool_too_small`, `entry_feature_auc_ceiling`, `admit_only_vs_deployment`, …)
- `L_PROTOCOL.md` §6 — two subsections replaced. `ARC_CLOSURE.md format` now references the template v1.0 + Section 4-K bad-payload rule; `ARC_TRACKER.md update mechanism` references Section 4 manual mapping + parser path
- `WORKFLOW.md` §7 — cadence row added: `docs/templates/ARC_CLOSURE_TEMPLATE.md` → only at template version bumps
- `TODO.md` — Round 2 `Draft 'ARC_TRACKER.md' skeleton` flipped 🔴 → 🟢; Round 5 closure-infra block added before Phase 0; mirror cadence table at §"Reminder" also synced with template row (chat-approved scope extension); `Last updated` annotation swapped to CC_08

Plus dispatch artefact pair under `docs/dispatches/`:
- `closure_template_intent.md` — pre-execution intent doc
- `closure_template_log.md` — execution log + verification checklist

## Parser status

`scripts/update_tracker_from_closure.py` deferred until 2-3 Wave 1 closures land — gives real golden inputs to validate against. Manual updates per template Section 4 in the meantime.

## Verification

- [x] Template + tracker SHA256-identical to chat-provided source
- [x] §6 replacement scope limited to two specified subsections; all other §6 content unchanged
- [x] WORKFLOW §7 row inserted at correct table position
- [x] TODO edits match dispatch exactly + chat-approved mirror sync
- [x] No engine/config/backtester files touched (verified by `git diff --stat`)
- [x] Pre-overwrite ARC_TRACKER state confirmed empty (no closed-arc data loss)

## Test plan

- [ ] Chat reviews diff
- [ ] Chat merges to main
- [ ] Phase 1 dispatches Wave 1 first closure against the new template

🤖 Generated with [Claude Code](https://claude.com/claude-code)