### PR TITLE
[CHORE] gitignore: ignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ results_history/
 .aiderignore
 
 # Claude Code runtime state (not committed)
-.claude/scheduled_tasks.lock
+.claude/
 
 # MT5 exports (machine-specific)
 mt5/**


### PR DESCRIPTION
## Summary

Broadens the existing `.claude/scheduled_tasks.lock` ignore rule to cover the entire `.claude/` directory. CC runtime state (`settings.local.json`, session `worktrees/`, scheduled-task locks) is per-machine and shouldn't be tracked.

## Why

`.claude/` has been showing as untracked on every `git status` since CC sessions started using it for local state. Surfaced today during CC_08 verification (the `1 uncommitted change` warning from `gh pr create`). Pre-existing rule was too narrow — only the `.lock` file was ignored.

## Test plan

- [x] `git status --short` no longer shows `?? .claude/`
- [x] `.claude/` contents (settings.local.json, worktrees/, scheduled_tasks.lock) all covered by the new rule
- [ ] No tracked file inside `.claude/` exists that would be silently ignored (verified — directory has never been tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)