### PR TITLE
[INFRA] L_PROTOCOL Amendment 3: risk-normalised gates (template v1.1)

### DIFF
--- a/ARC_TRACKER.md
+++ b/ARC_TRACKER.md
@@ -86,13 +86,20 @@ Note: "in-cluster R" tracked as `mfe_p50_r` per template §4.E. Unclassified row
 | no_clusters_separable | 0 | — | — |
 | no_capturable_cluster | 0 | — | — |
 | entry_feature_auc_ceiling | 0 | — | — |
-| step5_wf_roi_below_gate | 0 | — | — |
-| step5_dd_above_gate | 1 | l_arc_11 | 2026-05-22 |
+| step5_not_scalable | 0 | — | — |
+| step5_chained_dd_above_gate | 0 | — | — |
+| step5_daily_dd_breach | 0 | — | — |
+| step5_wf_roi_below_gate_after_scaling | 0 | — | — |
+| step5_ratio_below_gate_after_scaling | 0 | — | — |
+| step5_negative_folds | 0 | — | — |
 | step5_sign_consistency_fail | 0 | — | — |
+| step5_trade_count_below_gate | 0 | — | — |
 | step6_causal_audit_fail | 0 | — | — |
 | selection_bias | 0 | — | — |
 | holdout_fail_after_is_pass | 0 | — | — |
 | admit_only_vs_deployment | 0 | — | — |
+| step5_dd_above_gate | 1 | l_arc_11 | 2026-05-22 |  <!-- deprecated by Amendment 3; retained for historical closures -->
+| step5_wf_roi_below_gate | 0 | — | — |  <!-- legacy (pre-Amendment-3); retained for historical closures -->
 | other | 0 | — | — |
 
 ---

--- a/L_PROTOCOL.md
+++ b/L_PROTOCOL.md
@@ -7,6 +7,7 @@
 >
 > **Amendment 1 (2026-05-22):** Step 5 search policy clarified — informed by Steps 3-4, not exhaustive. Multi-cluster handling + holdout decision rule specified. See §2 Step 5.
 > **Amendment 2 (2026-05-22):** ML architecture mechanics specified for A2, A3, A4, A6. See §2 Step 5 ML mechanics subsection.
+> **Amendment 3 (2026-05-22):** Risk-normalised gates. §3 constraints preserved 1:1; evaluation now occurs at scaled risk `r_safe` / `r_hard` rather than at the WFO base risk. Scalability bounds, per-day DD recount, and explicit evaluation order added. Full text archived at `archive/L_PROTOCOL_v3_0_AMENDMENT_3.md`. See §3.
 >
 > This protocol is the umbrella. It accepts any signal, any feature space, any architecture. Sub-protocols may layer on top to add signal-class-specific specificity. The overseer's gates and verdicts apply universally.
 
@@ -333,34 +334,150 @@ A1 (system_level_filter) and A5 (portfolio_composition) are rule-based — no ML
 
 ## §3 Gates
 
+> **Amended 2026-05-22 by Amendment 3 (Risk-Normalised Gates).** Constraint thresholds preserved 1:1 with the prior protocol. Evaluation now happens at a per-arc derived `r_safe` (DEPLOYABLE) or `r_hard` (VIABLE), not at the WFO base risk. Full amendment archived at `archive/L_PROTOCOL_v3_0_AMENDMENT_3.md`.
+
+### Risk normalisation (scaling rule)
+
+WFO runs at base risk `r_base` (typically 0.5%). Engine emits required metrics at `r_base`. Gate evaluation happens at scaled risk.
+
+```
+k_safe = 8.0 / worst_fold_dd_base
+k_hard = 10.0 / worst_fold_dd_base
+r_safe = r_base × k_safe
+r_hard = r_base × k_hard
+```
+
+Linear scaling applies to: worst-fold ROI, chained max DD, holdout ROI/DD, per-day max-DD (then re-counted for daily breaches).
+
+Linear scaling does **NOT** apply to: daily breach **counts** themselves — step function in the underlying daily P&L distribution. See §"Daily DD measurement".
+
+Constraints not affected by risk scaling (sign-consistency, trade count, fold count) remain unchanged in evaluation procedure.
+
+### Scalability bounds (locked)
+
+- **Floor:** `r_safe ≥ r_min = 0.15%`. Locked value.
+- **Ceiling:** `r_safe ≤ r_max = 2.0%`. Locked value.
+- **Edge case:** `worst_fold_dd_base = 0%` → `k = ∞` → FAIL `step5_not_scalable`.
+- **Sizing convention:** linear DD scaling holds ONLY under reset-floor sizing (L arc convention). Arcs using %-of-current-equity sizing FAIL the scalability check by default unless chat approves a separate scaling treatment.
+
+Same bounds apply to `r_hard` for VIABLE evaluation.
+
 ### PASS-DEPLOYABLE (ship)
 
 All of:
-- worst-fold ROI/DD ratio ≥ 2.0
-- worst-fold ROI > 0 at any risk size; positive at all 11 folds (WFO)
-- at chosen risk size: DD ≤ 8%
-- at chosen risk size: 0 days breaching 5% daily DD
-- at chosen risk size: max DD ≤ 10% (5ers hard limit)
-- sign-consistency: 0 negative folds
-- ≥ 25 trades per fold
-- Step 6 causal audit clean
+
+1. **Scalable to safe:** `r_safe ∈ [0.15%, 2.0%]` (added by Amendment 3).
+2. **Worst-fold ROI/DD ratio at `r_safe`:** ≥ 2.0 (ratio invariant under linear scaling).
+3. **Worst-fold ROI at `r_safe`:** > 0 (linearly scaled from `r_base`).
+4. **Per-fold positivity:** positive at all 11 IS folds, 0 negative folds (sign does not scale; holdout has its own gate).
+5. **Worst-fold DD at `r_safe`:** ≤ 8% (by construction at `k_safe`).
+6. **Daily DD breaches at `r_safe`:** exactly 0 across all IS folds + holdout (see §"Daily DD measurement").
+7. **Chained max DD at `r_safe`:** ≤ 10% (linearly scaled).
+8. **Trades per fold:** ≥ 25 per fold (trade count does not scale).
+9. **Holdout at `r_safe`:** re-run holdout simulation at `r_safe`; result clears the prior §3 holdout gate.
+10. **Step 6 causal audit clean** (evaluated last per §"Evaluation order").
+
+> The pre-amendment §3 had "positive at all 11 folds" and "0 negative folds" as separate bullets. Merged into constraint #4 here. Same meaning, no threshold change.
 
 ### PASS-VIABLE (portfolio candidate, does NOT ship alone)
 
 All of:
-- worst-fold ROI/DD ratio ≥ 2.0
-- mean-fold ROI/DD ratio ≥ 2.5
-- worst-fold ROI may be negative (single negative fold permitted)
-- at chosen risk size: max DD ≤ 10%
-- at chosen risk size: 0 days breaching 5% daily DD
-- ≥ 25 trades per fold
-- Step 6 causal audit clean (if invoked)
 
-A PASS-VIABLE strategy becomes deployable when combined with another PASS-VIABLE / PASS-DEPLOYABLE into a portfolio whose COMBINED account performance passes PASS-DEPLOYABLE gates. Portfolio composition mechanics handled within Architecture A5.
+1. **Hard-scalable:** `r_hard ∈ [0.15%, 2.0%]` (added by Amendment 3).
+2. **Worst-fold ROI/DD ratio at `r_hard`:** ≥ 2.0 (ratio invariant).
+3. **Mean-fold ROI/DD ratio at `r_hard`:** ≥ 2.5 (ratio invariant).
+4. **Per-fold positivity:** up to 1 negative fold permitted across the 11 IS folds.
+5. **Worst-fold DD at `r_hard`:** ≤ 10% (by construction at `k_hard`; matches the 5ers hard limit).
+6. **Daily DD breaches at `r_hard`:** exactly 0.
+7. **Chained max DD at `r_hard`:** ≤ 10% (linearly scaled).
+8. **Trades per fold:** ≥ 25 per fold.
+9. **Holdout at `r_hard`:** re-run at `r_hard`; clears the prior §3 holdout gate.
+10. **Step 6 causal audit clean.**
+
+A PASS-VIABLE strategy becomes deployable when combined with another PASS-VIABLE / PASS-DEPLOYABLE into an A5 portfolio whose combined account performance passes PASS-DEPLOYABLE gates. Combined-portfolio DD spec when components are at `r_hard` is open — see §"A5 follow-up flag".
 
 ### FAIL
 
 Everything else. The arc's closure doc explains why and what would help.
+
+### Daily DD measurement
+
+Linear scaling of breach **counts** is mathematically wrong. Correct procedure:
+
+**Engine emits at `r_base`:** for each trading day in the IS + holdout trajectory, the maximum intraday drawdown percentage of that day's starting equity. Full per-day series persisted to a separate parquet artefact (NOT only summary stats).
+
+**Day-start equity definition:** account equity at 00:00 broker-day (the equity at the start of that calendar trading day in broker timezone), NOT the reset-floor sizing baseline. Under reset-floor sizing the two values are distinct: reset-floor is the per-trade sizing reference; day-start equity is the daily-DD reference. Engine must use day-start equity for daily DD measurement.
+
+**Engine artefact:** `step_5/per_day_max_dd_base.parquet`. Columns: `date`, `pair_set`, `day_max_dd_base_pct`, `n_trades_open_start_of_day`.
+
+**At gate evaluation:** for each day in the series, compute `day_max_dd_scaled = day_max_dd_base × k`. Count days where `day_max_dd_scaled ≥ 5%`. This is per-day re-evaluation, not count scaling.
+
+**Boundary:** UTC broker-day. Locked value.
+
+**Tolerance:** exactly 0 breaches in both tiers. No safety margin on the daily limit.
+
+### Chained max DD measurement
+
+Computed across the full IS + holdout trajectory: folds concatenated chronologically into one continuous equity curve, peak-to-trough across the whole curve.
+
+Scales linearly with `k`. Threshold preserved from the prior §3 chained-DD spec — only the risk at which evaluated changes.
+
+### Evaluation order
+
+Step 6 is lazy per §2. Amendment 3 specifies order explicitly:
+
+1. Constraints #1-#9 (all non-Step-6 constraints, both tiers) evaluated in priority order.
+2. If ALL clear → Step 6 causal audit dispatched.
+3. Step 6 clean → PASS-DEPLOYABLE / PASS-VIABLE finalised.
+4. Step 6 fails → FAIL with `primary_failure_mode = step6_causal_audit_fail`.
+
+Step 6 is the LAST gate, not concurrent with the others.
+
+### Failure-mode priority (tie-break)
+
+When multiple constraints fail simultaneously, `primary_failure_mode` is assigned by first-fail in this order:
+
+1. `pool_too_small` (Step 1 failure — encountered before Step 5 evaluation)
+2. `step5_not_scalable`
+3. `step5_dd_above_gate` (defensive — should not occur by construction)
+4. `step5_chained_dd_above_gate`
+5. `step5_daily_dd_breach`
+6. `holdout_fail_after_is_pass`
+7. `step5_sign_consistency_fail` / `step5_negative_folds`
+8. `step5_trade_count_below_gate`
+9. `step5_wf_roi_below_gate_after_scaling`
+10. `step5_ratio_below_gate_after_scaling`
+11. `step6_causal_audit_fail`
+
+Other §3 failure modes not listed (no clusters separable, no capturable cluster, etc.) remain ordered per the wider protocol.
+
+### Failure-mode taxonomy
+
+Added by Amendment 3:
+
+- `step5_not_scalable`
+- `step5_daily_dd_breach`
+- `step5_chained_dd_above_gate`
+- `step5_wf_roi_below_gate_after_scaling`
+- `step5_ratio_below_gate_after_scaling`
+- `step5_trade_count_below_gate`
+- `step5_negative_folds`
+
+Deprecated but retained for historical closures:
+
+- `step5_dd_above_gate` (replaced by scalability check + scaled gates)
+
+### A5 follow-up flag (deferred)
+
+Combined A5 portfolio DD when each component is independently scaled to `r_hard` (worst-fold DD = 10%) can produce combined account-wide DD > 10%. The current §2 Step 5 A5 spec does not address this; Amendment 3 does not either. A separate amendment will specify combined-portfolio DD constraints for VIABLE components. Deferred until the first VIABLE candidate emerges and A5 deployment is concretely on the table.
+
+### Holdout window
+
+Holdout = "2021-01-01 to present at time of arc closure" — matches §2 Step 5 and Appendix B. Moving target by design.
+
+### r_max note
+
+`r_max = 2.0%` is the gate ceiling. Locked value.
 
 ---
 

--- a/archive/L_PROTOCOL_v3_0_AMENDMENT_3.md
+++ b/archive/L_PROTOCOL_v3_0_AMENDMENT_3.md
@@ -1,0 +1,282 @@
+# L_PROTOCOL Amendment 3 — Risk-Normalised Gates (v5, locked)
+
+> **Date:** 2026-05-22
+> **Status:** locked and landed into `L_PROTOCOL.md` §3 on 2026-05-22.
+> **Triggered by:** Protocol failed configs with high raw DD but linearly-scalable risk.
+> **Replaces:** v1, v2, v3, v4 drafts (all superseded by this v5; no historical drafts preserved).
+> **Scope:** PURE risk-normalisation. Adds scaling, scalability bounds, daily/chained DD evaluation at scaled risk. Does NOT redesign §3 gate constraints — every constraint matched 1:1 to current §3 wording; only the risk at which constraints are evaluated changes.
+> **Supersedes within §3:** the procedure by which DD constraints are evaluated. Constraint thresholds preserved.
+
+---
+
+## Core principle
+
+A config passes if it can be **scaled to a per-trade risk** at which all current §3 constraints hold. Evaluation happens at the scaled risk, not the base risk used in the WFO run.
+
+Two tiers preserved: PASS-DEPLOYABLE (single-strategy ship) and PASS-VIABLE (A5 portfolio composition eligible).
+
+---
+
+## Scaling rule
+
+WFO runs at base risk `r_base` (typically 0.5%). Engine emits required metrics at `r_base`.
+
+Compute:
+
+```
+k_safe = 8.0 / worst_fold_dd_base
+k_hard = 10.0 / worst_fold_dd_base
+r_safe = r_base × k_safe
+r_hard = r_base × k_hard
+```
+
+Linear scaling applies to: worst-fold ROI, chained max DD, holdout ROI/DD, per-day max-DD (then re-counted for daily breaches).
+
+Linear scaling does **NOT** apply to: daily breach **counts** themselves (step function — see §"Daily DD measurement").
+
+Constraints that are not affected by risk scaling (sign-consistency, trade count, fold count): unchanged from current §3.
+
+---
+
+## Scalability bounds (locked)
+
+- **Floor:** `r_safe ≥ r_min = 0.15%`. Locked value.
+- **Ceiling:** `r_safe ≤ r_max = 2.0%`. Locked value.
+- **Edge case:** `worst_fold_dd_base = 0%` → `k = ∞` → FAIL `step5_not_scalable` (no DD information to anchor scaling).
+- **Sizing convention:** linear DD scaling holds ONLY under reset-floor sizing (the L arc convention). Arcs using %-of-current-equity sizing FAIL the scalability check by default unless chat approves a separate scaling treatment for that arc.
+
+Same bounds apply to `r_hard` for VIABLE evaluation.
+
+---
+
+## PASS-DEPLOYABLE gate (matched 1:1 to current §3 PASS-DEPLOYABLE)
+
+All of:
+
+1. **Scalable to safe:** `r_safe ∈ [0.15%, 2.0%]` (NEW constraint added by this amendment — required for scaled evaluation).
+2. **Worst-fold ROI/DD ratio at `r_safe`:** ≥ 2.0 (ratio invariant under linear scaling; same value as at `r_base`; constraint unchanged in threshold).
+3. **Worst-fold ROI at `r_safe`:** > 0 (linearly scaled from `r_base`).
+4. **Per-fold positivity:** positive at all 11 IS folds, 0 negative folds (matches current §3; sign does not scale; holdout has separate gate).
+5. **Worst-fold DD at `r_safe`:** ≤ 8% (by construction at `k_safe`; matches current §3 "at chosen risk: DD ≤ 8%").
+6. **Daily DD breaches at `r_safe`:** exactly 0 across all IS folds + holdout (matches current §3 "0 days breaching 5% daily"; see §"Daily DD measurement" for evaluation).
+7. **Chained max DD at `r_safe`:** ≤ 10% (matches current §3 "at chosen risk: max DD ≤ 10%"; linearly scaled).
+8. **Trades per fold:** ≥ 25 per fold (trade count does not scale; unchanged from current §3).
+9. **Holdout at `r_safe`:** re-run holdout sim at `r_safe`; result clears existing §3 holdout gate (unchanged thresholds).
+10. **Step 6 causal audit clean** (evaluated last per §"Evaluation order").
+
+> Note: current §3 DEPLOYABLE has a known internal duplicate ("positive at all 11 folds" + "0 negative folds" as separate bullets). Preserved here for 1:1 mapping fidelity; flagged as §3 housekeeping for a future protocol clean-up, not this amendment.
+
+Every constraint references current §3 wording. The only change is "evaluated at `r_safe`" replacing "at chosen risk" or "at `r_base`" depending on the constraint.
+
+## PASS-VIABLE gate (matched 1:1 to current §3 PASS-VIABLE; A5 portfolio composition eligible)
+
+All of:
+
+1. **Hard-scalable:** `r_hard ∈ [0.15%, 2.0%]` (NEW).
+2. **Worst-fold ROI/DD ratio at `r_hard`:** ≥ 2.0 (ratio invariant under linear scaling; unchanged threshold).
+3. **Mean-fold ROI/DD ratio at `r_hard`:** ≥ 2.5 (ratio invariant under linear scaling; unchanged threshold).
+4. **Per-fold positivity:** up to 1 negative fold permitted across the 11 IS folds (matches current §3 VIABLE per-fold rule; sign-related, does not scale).
+5. **Worst-fold DD at `r_hard`:** ≤ 10% (by construction at `k_hard`; matches 5ers hard limit).
+6. **Daily DD breaches at `r_hard`:** exactly 0.
+7. **Chained max DD at `r_hard`:** clears existing §3 VIABLE chained-DD gate (unchanged threshold; linearly scaled).
+8. **Trades per fold:** clears existing §3 VIABLE trade-count gate (unchanged).
+9. **Holdout at `r_hard`:** re-run at `r_hard`; clears existing holdout gate.
+10. **Step 6 causal audit clean.**
+
+A config can be VIABLE without being DEPLOYABLE if it scales into 5ers-hard compliance but not in-system safety compliance. VIABLE strategies enter A5 portfolio composition per existing §3 A5 spec (subject to follow-up — see §"A5 follow-up flag").
+
+---
+
+## Daily DD measurement (handles step-function correctly)
+
+Linear scaling of breach **counts** is mathematically wrong. Correct procedure:
+
+**Engine emits at `r_base`:** for each trading day in the IS + holdout trajectory, the maximum intraday drawdown percentage of that day's starting equity. Full per-day series persisted to a separate parquet artefact (NOT only summary stats in the payload).
+
+**Day-start equity definition:** the account equity at 00:00 broker-day (i.e., the equity at the start of that calendar trading day in broker timezone), NOT the reset-floor sizing baseline. Under reset-floor sizing the two values are distinct: reset-floor is the per-trade sizing reference; day-start equity is the daily-DD reference. Engine must use day-start equity for daily DD measurement.
+
+**Engine artefact:** `step_5/per_day_max_dd_base.parquet`. Columns: `date`, `pair_set`, `day_max_dd_base_pct`, `n_trades_open_start_of_day`.
+
+**At gate evaluation:** for each day in the series, compute `day_max_dd_scaled = day_max_dd_base × k`. Count days where `day_max_dd_scaled ≥ 5%`.
+
+This is per-day re-evaluation, not count scaling — correct under linear-scaling assumption.
+
+**Boundary:** UTC broker-day. Locked value.
+
+**Tolerance:** exactly 0 breaches in both tiers. No safety margin on the daily limit.
+
+---
+
+## Chained max DD measurement
+
+Computed across the full IS + holdout trajectory (folds concatenated chronologically into one continuous equity curve, peak-to-trough across the whole curve).
+
+Scales linearly with `k`. Threshold preserved from current §3 chained-DD spec — only the risk at which evaluated changes.
+
+---
+
+## Evaluation order (Step 6 ordering)
+
+Step 6 is lazy per current protocol §2. This amendment specifies order explicitly:
+
+1. Constraints #1-#9 (all non-Step-6 constraints, both tiers) evaluated in priority order.
+2. If ALL clear → Step 6 causal audit dispatched.
+3. Step 6 clean → PASS-DEPLOYABLE / PASS-VIABLE finalised.
+4. Step 6 fails → FAIL with `primary_failure_mode = step6_causal_audit_fail`.
+
+Step 6 is the LAST gate.
+
+---
+
+## Failure-mode priority (tie-break)
+
+When multiple constraints fail simultaneously, `primary_failure_mode` is assigned by first-fail in this order:
+
+1. `pool_too_small` (Step 1 failure — encountered before Step 5 evaluation)
+2. `step5_not_scalable` (scalability bounds)
+3. `step5_dd_above_gate` (defensive — should not occur by construction)
+4. `step5_chained_dd_above_gate`
+5. `step5_daily_dd_breach`
+6. `holdout_fail_after_is_pass`
+7. `step5_sign_consistency_fail` / `step5_negative_folds`
+8. `step5_trade_count_below_gate`
+9. `step5_wf_roi_below_gate_after_scaling`
+10. `step5_ratio_below_gate_after_scaling`
+11. `step6_causal_audit_fail`
+
+Other §3 failure modes not listed (no clusters separable, no capturable cluster, etc.) remain ordered per current protocol.
+
+---
+
+## Failure mode taxonomy update
+
+Add to `primary_failure_mode` enum:
+
+- `step5_not_scalable`
+- `step5_daily_dd_breach`
+- `step5_chained_dd_above_gate`
+- `step5_wf_roi_below_gate_after_scaling`
+- `step5_ratio_below_gate_after_scaling`
+- `step5_trade_count_below_gate`
+- `step5_negative_folds`
+
+Deprecate but retain for historical closures:
+
+- `step5_dd_above_gate` (replaced by scalability check + scaled gates)
+
+---
+
+## A5 follow-up flag (NOT in scope of this amendment)
+
+Combined A5 portfolio DD when each component is independently scaled to `r_hard` (worst-fold DD = 10%) can produce combined account-wide DD > 10%. Current §3 A5 spec does not address this; current amendment does not either.
+
+**Follow-up required:** separate A5 amendment specifying combined-portfolio DD constraint when components are VIABLE-tier. Candidate approaches: cap combined `r_hard` allocation; require pairwise correlation analysis; require combined-portfolio chained-DD simulation at proposed allocation. Defer until first VIABLE candidate emerges and A5 deployment is concretely on the table.
+
+---
+
+## Engine-side changes
+
+Scoped:
+
+1. **Per-day max-DD emission.** Full per-day series to `step_5/per_day_max_dd_base.parquet` at `r_base`. Required for daily DD evaluation at scaled risk.
+2. **Chained max DD emission.** Across IS + holdout trajectory at `r_base`. (Likely partially implemented for sign-consistency already.)
+3. **Verdict logic.** Step 5 closure-writer reads per-day artefact, computes `k_safe`, `k_hard`, `r_safe`, `r_hard`, scaled metrics, applies gate per priority order.
+4. **Holdout re-run.** For each candidate reaching gate stage, re-run holdout sim at `r_safe` (for DEPLOYABLE) and `r_hard` (for VIABLE if separately evaluated). 1-2 additional sims per candidate.
+5. **Determinism.** Each holdout re-run produces its own sha256 manifest entry. Two holdout re-runs (one at `r_safe`, one at `r_hard`) produce two separate manifest entries. Same seed, same data → same output bytes.
+
+---
+
+## Why holdout re-runs but IS doesn't
+
+IS is the scaling input — linear-scaling assumption applied analytically to per-fold metrics is the foundation. Holdout is the one-shot deployment proxy and must match deployment risk exactly for the verdict to be honest. Re-running holdout at scaled risk costs little (1-2 sims) and removes the strongest assumption from the most consequential gate.
+
+---
+
+## Tracker payload additions
+
+`§1 tracker_payload.best_architecture` in `ARC_CLOSURE_TEMPLATE.md` v1.0 → v1.1.
+
+### Field rename map
+
+| Old field (v1.0) | New field (v1.1) |
+|---|---|
+| `worst_fold_dd_pct` | `worst_fold_dd_base_pct` |
+| `worst_fold_roi_pct` | `worst_fold_roi_base_pct` |
+
+Closures landed before this amendment retain v1.0 field names. Parser handles both schemas via version detection on the closure doc's template version reference.
+
+### New fields
+
+```yaml
+  best_architecture:
+    # ── renamed fields above ──
+    chained_max_dd_base_pct: <float>            # NEW — IS+holdout chained at base risk
+    per_day_max_dd_artefact_path: <path>        # NEW — relative path to per-day series parquet
+    per_day_max_dd_base_summary:                # NEW — summary for human inspection only
+      n_days: <int>
+      p50_pct: <float>
+      p95_pct: <float>
+      p99_pct: <float>
+      max_pct: <float>
+    k_safe: <float>                             # NEW
+    k_hard: <float>                             # NEW
+    r_safe_pct: <float>                         # NEW
+    r_hard_pct: <float>                         # NEW
+    scalable_to_safe: <bool>                    # NEW
+    scalable_to_hard: <bool>                    # NEW
+    worst_fold_roi_at_r_safe_pct: <float>       # NEW
+    worst_fold_roi_at_r_hard_pct: <float>       # NEW
+    chained_max_dd_at_r_safe_pct: <float>       # NEW
+    chained_max_dd_at_r_hard_pct: <float>       # NEW
+    daily_dd_breaches_at_r_safe: <int>          # NEW (recounted per-day, not count-scaled)
+    daily_dd_breaches_at_r_hard: <int>          # NEW
+    holdout_roi_at_r_safe_pct: <float or null>  # NEW (from re-run; null if not re-run)
+    holdout_dd_at_r_safe_pct: <float or null>   # NEW
+    holdout_roi_at_r_hard_pct: <float or null>  # NEW
+    holdout_dd_at_r_hard_pct: <float or null>   # NEW
+    sizing_convention: reset_floor | equity_pct # NEW — gate FAILs equity_pct unless chat approves
+```
+
+---
+
+## Holdout window
+
+Holdout = "2021-01-01 to present at time of arc closure" — matches current §2 Step 5 and Appendix B definition. Moving target by design.
+
+---
+
+## r_max note
+
+`r_max = 2.0%` is the gate ceiling. Locked value.
+
+---
+
+## Application to in-flight work
+
+Forward arcs use amended gate from first run. Closures produced before this amendment lands are re-evaluated at chat discretion — none currently in scope.
+
+---
+
+## Action items
+
+1. Land amendment into `L_PROTOCOL.md` §3. **[DONE 2026-05-22]**
+2. Update `ARC_CLOSURE_TEMPLATE.md` v1.0 → v1.1 with rename map + new fields. **[DONE 2026-05-22]**
+3. Update parser for v1.0/v1.1 schema detection. (Parser not yet built — spec updated in template §5.)
+4. Update Step 5 closure-writer + verdict logic with priority-ordered gate evaluation.
+5. Add per-day max-DD parquet emission to engine.
+6. Add chained max DD emission to engine if not already present.
+7. Add holdout re-run at scaled risk(s) to candidate evaluation pipeline, with separate manifest entries.
+8. Add sizing-convention check to gate (FAIL if `equity_pct` without chat-approved alternative scaling).
+9. **A5 follow-up amendment** — separate amendment defining combined-portfolio DD constraints for VIABLE components. Deferred until first VIABLE candidate emerges.
+
+---
+
+## Risks
+
+1. **Per-day max-DD granularity.** Engine must compute per-day at M1 simulation tick (or finer); verify no coarser aggregation.
+2. **Sizing-convention silent invalidation.** Future arcs switching to equity-pct must FAIL by default at the gate.
+3. **A5 portfolio combined DD.** Open follow-up item, not blocker for this amendment.
+
+---
+
+End of v5.

--- a/docs/templates/ARC_CLOSURE_TEMPLATE.md
+++ b/docs/templates/ARC_CLOSURE_TEMPLATE.md
@@ -1,4 +1,4 @@
-# ARC_CLOSURE.md Template (Locked v1.0)
+# ARC_CLOSURE.md Template (Locked v1.1)
 
 > **Location:** `docs/templates/ARC_CLOSURE_TEMPLATE.md`
 > **Status:** locked. Every arc closure MUST follow this template.
@@ -8,6 +8,8 @@
 > Section headings are LITERAL — do not rephrase. Field names inside `§1 tracker_payload` are LITERAL — parser depends on exact spelling.
 >
 > **Design priority:** machine-parseability over human readability. §1 YAML is the source of truth for the tracker. §2 + §3 exist only to preserve cross-arc synthesis quality that prose enables and YAML doesn't.
+>
+> **v1.1 (2026-05-22, L_PROTOCOL Amendment 3):** risk-normalised gate fields added to `best_architecture` block. Two fields renamed (see §"Schema versioning" at end of template). `primary_failure_mode` enum extended.
 
 ---
 
@@ -27,6 +29,8 @@
 ```yaml
 tracker_payload:
 
+  template_version: v1.1   # NEW in v1.1 — parser uses this to dispatch schema. Omit or set to v1.0 for legacy closures.
+
   # ────── Identity ──────
   arc_name: <arc_name>
   signal: <signal description, terse, ≤80 char>
@@ -39,7 +43,7 @@ tracker_payload:
   verdict: PASS-DEPLOYABLE | PASS-VIABLE | FAIL | HALT | DISCOVERY_COMPLETE
   one_line: <≤140 char summary>
   failed_at_step: 1 | 2 | 3 | 4 | 5 | 6 | N/A
-  primary_failure_mode: <enum: pool_too_small | no_clusters_separable | no_capturable_cluster | entry_feature_auc_ceiling | step5_wf_roi_below_gate | step5_dd_above_gate | step5_sign_consistency_fail | step6_causal_audit_fail | selection_bias | holdout_fail_after_is_pass | admit_only_vs_deployment | other | N/A>
+  primary_failure_mode: <enum: pool_too_small | no_clusters_separable | no_capturable_cluster | entry_feature_auc_ceiling | step5_not_scalable | step5_wf_roi_below_gate_after_scaling | step5_ratio_below_gate_after_scaling | step5_chained_dd_above_gate | step5_daily_dd_breach | step5_negative_folds | step5_sign_consistency_fail | step5_trade_count_below_gate | step6_causal_audit_fail | selection_bias | holdout_fail_after_is_pass | admit_only_vs_deployment | step5_dd_above_gate | step5_wf_roi_below_gate | other | N/A>
 
   # ────── Pool metadata ──────
   pool_metadata:
@@ -51,6 +55,9 @@ tracker_payload:
     search_scope_flag: thin | normal | broad   # thin <50, normal 50-99, broad 100+
 
   # ────── Best architecture (null block if no winner) ──────
+  # v1.1 (Amendment 3): two fields renamed — worst_fold_roi_pct → worst_fold_roi_base_pct,
+  # worst_fold_dd_pct → worst_fold_dd_base_pct. Risk-normalised fields added below.
+  # Closures landed before v1.1 retain v1.0 field names; parser detects via template version.
   best_architecture:
     name: A1 system_level_filter | A2 classifier_filter | A3 pipeline_de | A4 pipeline_d_exits | A5 portfolio_composition | A6 meta_labeling | null
     cluster: <cluster_id> | aggregate | null
@@ -60,8 +67,8 @@ tracker_payload:
     exit_policy: <policy name or null>
     exposure_cap: <int or unlimited or null>
     worst_fold_ratio: <float or null>
-    worst_fold_roi_pct: <float or null>
-    worst_fold_dd_pct: <float or null>
+    worst_fold_roi_base_pct: <float or null>     # v1.1 renamed from worst_fold_roi_pct
+    worst_fold_dd_base_pct: <float or null>      # v1.1 renamed from worst_fold_dd_pct
     mean_fold_ratio: <float or null>
     mean_fold_roi_pct: <float or null>
     sign_pos_folds: <"X/N" string or null>
@@ -72,6 +79,33 @@ tracker_payload:
     oracle_worst_ratio: <float or null>
     oracle_real_gap_sharpe: <float or null>
     features_in_winning_config: [<feature_1>, <feature_2>, ...]   # empty list if no winner
+
+    # ── Amendment 3 risk-normalised fields ──
+    chained_max_dd_base_pct: <float or null>     # IS + holdout chained at r_base
+    per_day_max_dd_artefact_path: <path or null> # relative path to per-day series parquet
+    per_day_max_dd_base_summary:                 # summary for human inspection only
+      n_days: <int or null>
+      p50_pct: <float or null>
+      p95_pct: <float or null>
+      p99_pct: <float or null>
+      max_pct: <float or null>
+    k_safe: <float or null>
+    k_hard: <float or null>
+    r_safe_pct: <float or null>
+    r_hard_pct: <float or null>
+    scalable_to_safe: <bool or null>
+    scalable_to_hard: <bool or null>
+    worst_fold_roi_at_r_safe_pct: <float or null>
+    worst_fold_roi_at_r_hard_pct: <float or null>
+    chained_max_dd_at_r_safe_pct: <float or null>
+    chained_max_dd_at_r_hard_pct: <float or null>
+    daily_dd_breaches_at_r_safe: <int or null>   # recounted per-day, not count-scaled
+    daily_dd_breaches_at_r_hard: <int or null>
+    holdout_roi_at_r_safe_pct: <float or null>   # from holdout re-run; null if not re-run
+    holdout_dd_at_r_safe_pct: <float or null>
+    holdout_roi_at_r_hard_pct: <float or null>
+    holdout_dd_at_r_hard_pct: <float or null>
+    sizing_convention: reset_floor | equity_pct  # gate FAILs equity_pct unless chat approves
 
   # ────── Cost decomposition (null if winning arch is not classifier-based) ──────
   cost_decomposition:
@@ -230,8 +264,20 @@ Parser specification:
 - Output: append-only updates to `ARC_TRACKER.md` per Section 4 A-J above.
 - Idempotency: parsing the same closure doc twice produces identical tracker (no double-append).
 - Determinism: same closure doc → same tracker delta byte-for-byte.
+- **Schema version detection (v1.1+):** parser inspects the closure doc's referenced template version. v1.0 closures use legacy field names (`worst_fold_roi_pct`, `worst_fold_dd_pct`); v1.1+ closures use the renamed fields (`worst_fold_roi_base_pct`, `worst_fold_dd_base_pct`) and may populate Amendment 3 risk-normalised fields. Parser MUST accept both schemas — never rewrite historical closures.
 
 Suggested implementation: single Python script `scripts/update_tracker_from_closure.py`. Invoked manually post-PR-merge, or via post-merge git hook (bundles with WORKFLOW §3 auto-cleanup hook trigger point).
+
+---
+
+## Schema versioning
+
+| Template version | Date | Change |
+|---|---|---|
+| v1.0 | 2026-05-13 | Initial locked template. |
+| v1.1 | 2026-05-22 | L_PROTOCOL Amendment 3. Risk-normalised fields added to `best_architecture`. Two fields renamed: `worst_fold_roi_pct` → `worst_fold_roi_base_pct`, `worst_fold_dd_pct` → `worst_fold_dd_base_pct`. `primary_failure_mode` enum extended. Pre-v1.1 closures retain v1.0 field names; parser handles both via version detection. |
+
+Closures MUST reference the template version they were written against (e.g., `template_version: v1.1` near the top of `§1 tracker_payload` is the convention going forward — pre-v1.1 closures without this field are assumed v1.0).
 
 ---
 


### PR DESCRIPTION
## Summary

Locks **L_PROTOCOL Amendment 3 (Risk-Normalised Gates)** into `L_PROTOCOL.md` §3 and bumps the closure template to v1.1.

**Scope: doc-only.** Engine work (per-day max-DD parquet emission, chained max DD emission, holdout re-run at scaled risk, verdict logic, sizing-convention check) is out of scope for this PR and will land in subsequent engine PRs per the action items in the archived amendment.

## What changed

- **`L_PROTOCOL.md`** — Amendment 3 header line added; §3 fully replaced with the amended gates. Constraint thresholds preserved 1:1 with the prior §3; the only change is that evaluation now happens at a per-arc derived `r_safe` (DEPLOYABLE) or `r_hard` (VIABLE), not at the WFO base risk. Added: scaling rule, scalability bounds (`r_min=0.15%`, `r_max=2.0%`, both locked), per-day DD measurement procedure, chained DD measurement, explicit evaluation order, failure-mode priority, failure-mode taxonomy update, A5 follow-up flag (deferred), holdout window definition.
- **`docs/templates/ARC_CLOSURE_TEMPLATE.md`** — bumped v1.0 → v1.1. Two fields renamed (`worst_fold_roi_pct` → `worst_fold_roi_base_pct`, `worst_fold_dd_pct` → `worst_fold_dd_base_pct`). Amendment 3 risk-normalised fields added to `best_architecture` block. `primary_failure_mode` enum extended with the seven new modes. `template_version` field added; parser dispatch convention documented in §5. Schema versioning table added.
- **`ARC_TRACKER.md`** — per-failure-mode count table extended with the seven new Amendment 3 modes. `step5_dd_above_gate` retained as deprecated; `step5_wf_roi_below_gate` retained as legacy.
- **`archive/L_PROTOCOL_v3_0_AMENDMENT_3.md`** (new) — full Amendment 3 v5 text archived, including the engine-side action items deferred to follow-up PRs.

## What's preserved

Every constraint in the new §3 gates maps 1:1 to a constraint in the prior §3. No threshold moved. The pre-amendment redundancy ("positive at all 11 folds" + "0 negative folds" as two bullets) is flagged in §3 as housekeeping for a future protocol clean-up, not changed here.

## Test plan

- [ ] Read-through of `L_PROTOCOL.md` §3 — all amended subsections coherent
- [ ] Read-through of `docs/templates/ARC_CLOSURE_TEMPLATE.md` — v1.1 schema additions consistent with archived amendment text
- [ ] `ARC_TRACKER.md` failure-mode table — no row deleted, new rows added, deprecated rows annotated

🤖 Generated with [Claude Code](https://claude.com/claude-code)