### PR TITLE
[ARC 10 v3.0] Step 6 causal audit clean — re_evaluated_verdict PASS-DEPLOYABLE

### DIFF
--- a/ARC_TRACKER.md
+++ b/ARC_TRACKER.md
@@ -4,7 +4,7 @@
 > Schema locked at v3.0. Replaces STATUS.md, CHANGELOG.md, ARC_QUEUE.md, and ACTIVE_ARCS.md.
 > First populated on first arc open under L_PROTOCOL v3.0.
 
-Last auto-update: manual: 2026-05-22 (Amendment 3 re-evaluation: arcs 8, 10, 11 — added `re_evaluated_verdict` column to Closed arcs summary; backfilled missing rows for arcs 8 and 10. Other tracker sections for arcs 8 and 10 NOT backfilled under this dispatch — separate work item.)
+Last auto-update: manual: 2026-05-22 (Arc 10 Step 6 causal audit clean — `re_evaluated_verdict` upgraded from `PASS-DEPLOYABLE-PROVISIONAL` to `PASS-DEPLOYABLE` per Amendment 3 §"Evaluation order" item 3; see `results/l_arc_10/step_6/audit_report.md`. Prior update: 2026-05-22 Amendment 3 re-evaluation: arcs 8, 10, 11 — added `re_evaluated_verdict` column to Closed arcs summary; backfilled missing rows for arcs 8 and 10.)
 
 ---
 
@@ -22,7 +22,7 @@ Last auto-update: manual: 2026-05-22 (Amendment 3 re-evaluation: arcs 8, 10, 11 
 
 | Arc | Signal | TF | Sub-protocol | Best architecture | Worst-fold ratio | Verdict | Re-evaluated verdict | Failed at step | Closure doc |
 |---|---|---|---|---|---|---|---|---|---|
-| l_arc_10 | D1 swing-low rejection long (DLR, v0.1) — bullish rejection of confirmed ascending D1 swing-low, 4H entry | H4 | vanilla | A1 system_level_filter | 5.4185 | PASS-VIABLE | PASS-DEPLOYABLE-PROVISIONAL | N/A | results/l_arc_10/ARC_CLOSURE.md |
+| l_arc_10 | D1 swing-low rejection long (DLR, v0.1) — bullish rejection of confirmed ascending D1 swing-low, 4H entry | H4 | vanilla | A1 system_level_filter | 5.4185 | PASS-VIABLE | PASS-DEPLOYABLE | N/A | results/l_arc_10/ARC_CLOSURE.md |
 | l_arc_8 | pullback_resume_hhhl_long_v0.1 (HH/HL uptrend, pullback >=0.5xATR, bullish-close break of prior bar) | 4H | vanilla | A6 meta_labeling | 1.749 | FAIL | FAIL | 5 | results/l_arc_8/ARC_CLOSURE.md |
 | l_arc_11 | swing-high breakout in trend (SHB) long, 4H, causal 3-bar swing (right-edge t-4) | H4 | vanilla | A2 classifier_filter | -0.7687 | FAIL | FAIL | 5 | results/l_arc_11/ARC_CLOSURE.md |
 

--- a/results/l_arc_10/ARC_CLOSURE.md
+++ b/results/l_arc_10/ARC_CLOSURE.md
@@ -155,9 +155,10 @@ A1 (no classifier filter, full Step 1 pool of 2,162 search-window trades) with S
 ## §10 Amendment 3 re-evaluation (added 2026-05-22)
 
 **Original verdict:** PASS-VIABLE (best A1 system_level_filter, worst-fold ratio 5.42, DD 9.22% at `r_base = 0.5%`)
-**Re-evaluated verdict:** **PASS-DEPLOYABLE-PROVISIONAL** (upgrade)
-**Re-evaluation status:** provisional (missing `chained_max_dd_base_pct` and per-day max-DD series; Step 6 already PASS — carries forward)
-**Re-evaluated primary_failure_mode:** N/A (passes amended DEPLOYABLE gate provisionally)
+**Re-evaluated verdict (initial, 2026-05-22 AM):** PASS-DEPLOYABLE-PROVISIONAL (upgrade)
+**Re-evaluated verdict (finalised, 2026-05-22 PM, post-Step-6):** **PASS-DEPLOYABLE** (confirmed)
+**Re-evaluation status:** confirmed — Step 6 Amendment 3 re-evaluation audit clean ([step_6/audit_report.md](step_6/audit_report.md)). The two missing-data flags (constraints #6 daily DD breaches and #7 chained max DD) are forwarded out of Step 6 scope per Amendment 3 §"Evaluation order"; engine re-run remains recommended for definitive measurement but does not block the verdict finalisation. If a subsequent re-run surfaces a constraint #6 / #7 failure, verdict reverts per Amendment 3 §"Failure-mode priority".
+**Re-evaluated primary_failure_mode:** N/A
 
 ### Scaling derivation
 - `worst_fold_dd_base_pct`: **9.22%** (closure §1 `worst_fold_dd_pct`)

--- a/results/l_arc_10/step_6/audit_report.md
+++ b/results/l_arc_10/step_6/audit_report.md
@@ -1,0 +1,177 @@
+# Arc 10 — Step 6 Causal Audit (Amendment 3 re-evaluation)
+
+> **Protocol:** L_PROTOCOL v3.0 §2 Step 6 + Amendment 3 §"Evaluation order".
+> **Trigger:** §10 Amendment 3 re-evaluation upgraded Arc 10 (A1 Top-1) from PASS-VIABLE → PASS-DEPLOYABLE-PROVISIONAL via the risk-normalised gate (`k_safe = 0.8677`). Per Amendment 3 §"Evaluation order" item 3, Step 6 is the last gate; running it confirms or downgrades the upgraded verdict.
+> **Scope:** Top-3 candidates from `step_5/architectures_ranked.md`. Special priority on swing-detection features per dispatch (Arc 9 lesson).
+> **Companion:** the pre-amendment producer-level audit at [results/l_arc_10/step_6/causal_audit_report.md](causal_audit_report.md) is incorporated by reference. This document is the Amendment 3 re-evaluation Step 6 deliverable, with an independent byte-compare and an explicit Arc 9 invariance check.
+
+---
+
+## 1. Winning candidate inventory (carries forward from prior audit)
+
+### Top-1 — A1 `system_level_filter` (PASS-DEPLOYABLE-PROVISIONAL under Amendment 3)
+- Cluster filter: **none** (no classifier on the deployment path)
+- SL: `3.5 × Wilder ATR(14)` on mid-OHLC
+- Exit policy: `sl_partial_close_1r_runner_trail`
+- Exposure: unlimited
+- Deployment-critical features: **the signal-bar conditions themselves + the per-bar path features used by the exit policy**. No classifier feature set.
+
+### Top-2 — A6 `meta_labeling` (PASS-DEPLOYABLE under Amendment 3, but not the arc Top-1)
+- Cluster filter: LGBM classifier from Step 4 (mean OOS AUC 0.5199 — near chance)
+- SL: 3.5×ATR, exit: `sl_partial_close_1r_runner_trail`, exposure: `max_per_currency=2`
+- Sizing: prob<0.4 → 0×, 0.4–0.6 → 0.5×, ≥0.6 → 1.0×
+- Deployment-critical features: signal + Step 4 top-10 classifier inputs (see §4).
+
+### Top-3 — A6 `meta_labeling` unlimited (PASS-VIABLE) — same feature set as Top-2.
+
+The Top-1 A1 is the arc's verdict-carrying candidate per Amendment 1 holdout rule and §10 of the closure.
+
+---
+
+## 2. Producer-level causal trace — signal
+
+**Verdict: PASS.**
+
+Source: [signals/lchar_dlr_long.py](../../../signals/lchar_dlr_long.py).
+
+D1 swing-low detector ([signals/lchar_dlr_long.py:95-119](../../../signals/lchar_dlr_long.py:95)) flags index `d` iff
+`low[d] < min(low[d-3..d-1]) AND low[d] < min(low[d+1..d+3])` — bilateral 3-bar confirmation.
+
+Consumer ([signals/lchar_dlr_long.py:229-242](../../../signals/lchar_dlr_long.py:229)):
+```python
+d_search_max = d_t - right_edge_offset   # right_edge_offset = 4 (locked constant)
+pos = np.searchsorted(d1_swing_indices, d_search_max, side="right")
+l1_idx = d1_swing_indices[pos - 1]       # most recent confirmed swing-low at d_t - 4 or earlier
+```
+
+Right-edge invariant: for any confirmed swing-low at `d <= d_t - 4`, the bilateral confirmation window spans `[d-3 .. d+3]`, whose latest index is `d + 3 <= d_t - 1`. D1 bar `d_t` (the D1 bar containing 4H signal-bar `t`) is structurally unread. **Matches Arc 9 lesson form (k=3, right-edge offset = k+1 = 4).**
+
+4H signal-bar conditions (cond 6-8 at [signals/lchar_dlr_long.py:266-289](../../../signals/lchar_dlr_long.py:266)) use only bar-t OHLC; ATR(14) is Wilder-causal ([signals/lchar_dlr_long.py:67-92](../../../signals/lchar_dlr_long.py:67)) using TR values at index ≤ t.
+
+Entry at bar `t+1` open ([scripts/l_arc_10_v3/step_1.py:278](../../../scripts/l_arc_10_v3/step_1.py:278)) — strictly after bar-t close.
+
+---
+
+## 3. Producer-level causal trace — path features (exit policy inputs)
+
+**Verdict: PASS by construction.**
+
+`_simulate_pair` at [scripts/l_arc_10_v3/step_1.py:296-313](../../../scripts/l_arc_10_v3/step_1.py:296) walks bars `k` from `entry_idx` to `last_path_idx` and emits per-bar `close_r[k]`, `mfe_so_far_r[k]`, `mae_so_far_r[k]` — each computed only from bars `entry_idx..k` (running max/min on bar-`k` mid-OHLC). No forward reference.
+
+`_apply_exit_policy` at [scripts/l_arc_10_v3/step_5.py:99-253](../../../scripts/l_arc_10_v3/step_5.py:99) iterates `path_rows` in chronological order; the `sl_partial_close_1r_runner_trail` branch ([step_5.py:219-250](../../../scripts/l_arc_10_v3/step_5.py:219)) consumes only the current and prior bar's values. Causal.
+
+---
+
+## 4. Producer-level causal trace — Step 4 top-10 classifier features (Top-2 A6 path)
+
+**Verdict: PASS.** Reproduced from prior audit; cited line numbers re-verified.
+
+Top-10 from [results/l_arc_10/step_4/feature_importance.csv](../step_4/feature_importance.csv):
+
+| Rank | Feature | Producer | Lineage | Audit |
+|---|---|---|---|---|
+| 1 | `atr_14` | [core/features/price_geometry.py:19-21](../../../core/features/price_geometry.py:19) — Wilder ATR(14) mid-OHLC `.shift(1)` | CLEAN | ✓ trailing only |
+| 2 | `prior_session_low_distance` | session-anchored — prior-bar mid-close vs prior session ask-side low; `.shift(1)` | CLEAN | ✓ |
+| 3 | `prior_session_high_distance` | same, bid-side high | CLEAN | ✓ |
+| 4 | `upper_fraction` | bar-t-only `(close-low)/(high-low)` from [signals/lchar_dlr_long.py:275](../../../signals/lchar_dlr_long.py:275) | CLEAN | ✓ no forward bars |
+| 5 | `distance_to_round_number` | prior mid-close to nearest grid; `.shift(1)` | CLEAN | ✓ |
+| 6 | `atr14_at_signal` | ATR(14) at signal bar t — same Wilder producer | CLEAN | ✓ |
+| 7 | `eur_strength_index` | [core/features/cross_pair.py:82-100](../../../core/features/cross_pair.py:82) — uses `_aligned_panel_close` which applies `.reindex(...).ffill().shift(1)` ([cross_pair.py:22-29](../../../core/features/cross_pair.py:22)) | SUSPECT → audited | ✓ `.shift(1)` after `.ffill()` is the load-bearing causal guard |
+| 8 | `atr_percentile_100` | trailing-100 percentile rank of ATR(14); strictly prior bars (`percentile_rank_in_window` at [core/features/_helpers.py:57-79](../../../core/features/_helpers.py:57)) | CLEAN | ✓ |
+| 9 | `swing_low_distance_14` | [core/features/price_geometry.py:81-97](../../../core/features/price_geometry.py:81) — `mid_low.rolling(14, min_periods=14).min().shift(1)` | CLEAN | ✓ **one-sided trailing min, NOT centred ±N — NOT Arc 9 failure mode** |
+| 10 | `atr_vs_trailing_100` | ATR(14) / mean(ATR over trailing 100); all trailing | CLEAN | ✓ |
+
+**Arc 9 lesson scrutiny on rank #9 `swing_low_distance_14`:** producer is `rolling(window=14, min_periods=14).min().shift(1)` on `mid_low`. This is a **one-sided trailing min** — at bar t it reads bars `[t-14..t-1]` only. Distinct from Arc 9's pre-patch ±N centred detector that read `[t-N..t+N]`. **No future bars consumed.** Causal.
+
+---
+
+## 5. End-to-end byte-compare (5 trades, independently sampled)
+
+**Verdict: PASS — abs_diff = 0.0 on every feature in every sampled trade.**
+
+Method: load `step_1/pool.parquet`, sample 5 trades with `numpy.random.default_rng(42)`, re-run `dlr.compute_signal` on the sampled pair's HistData-derived H4+D1 frames, compare signal-bar feature columns at the matched `signal_bar_time`. Script: [scripts/l_arc_10_v3/step_6_byte_compare.py](../../../scripts/l_arc_10_v3/step_6_byte_compare.py). Raw log: [byte_compare_log.json](byte_compare_log.json).
+
+Compared features per trade: `L1_value`, `L0_value`, `L1_age_d1_bars`, `L0_age_d1_bars`, `L1_to_atr_proximity`, `reject_buffer_atr`, `upper_fraction`, `atr14_at_signal`. Plus the boolean `signal` flag is verified True at the recomputed bar index.
+
+| Trade ID | Pair | Signal-bar time | Signal flag at recompute | All features abs_diff = 0.0? |
+|---|---|---|---|---|
+| 295 | CHFJPY | 2011-07-12 08:00 UTC | True | ✓ |
+| 1430 | NZDCAD | 2017-04-03 12:00 UTC | True | ✓ |
+| 1449 | NZDJPY | 2017-05-22 16:00 UTC | True | ✓ |
+| 2160 | NZDUSD | 2020-12-21 12:00 UTC | True | ✓ |
+| 2553 | GBPJPY | 2022-11-03 20:00 UTC | True | ✓ |
+
+Tolerances: rtol=1e-9, atol=1e-9. Every comparison returned abs_diff = 0.0 (exact bit-equality on the floats — the producer is deterministic on identical input).
+
+This is a true end-to-end byte-compare: pool values originated from the same `compute_signal` invocation that produced the integrity-tested Step 1 pool; re-running the producer cold from the cached H4+D1 aggregations reproduces them exactly.
+
+---
+
+## 6. Arc 9 swing-invariance check (independent verification)
+
+**Verdict: PASS — all 5 sampled trades satisfy all three invariants.**
+
+For each sampled trade, three independent checks ([byte_compare_log.json](byte_compare_log.json) `arc9_swing_invariance` block):
+
+1. **Right-edge constraint:** `d_search_max == d_t - 4` AND `l1_idx <= d_search_max`. ✓ all 5.
+2. **Confirmation window in past:** `l1_idx + 3 <= d_t - 1` (L1's bilateral confirmation window never touches D1[d_t]). ✓ all 5.
+3. **NaN-perturbation invariance:** NaN-ing OHLC at D1[d_t] leaves `signal[t]` unchanged. ✓ all 5.
+
+| Trade | `d_t` | `d_search_max` | `l1_idx` | `confirmation_window_max` | All 3 checks |
+|---|---|---|---|---|---|
+| 295 | 476 | 472 | 469 | 472 | ✓ |
+| 1430 | 2261 | 2257 | 2253 | 2256 | ✓ |
+| 1449 | 2303 | 2299 | 2295 | 2298 | ✓ |
+| 2160 | 3422 | 3418 | **3418** | 3421 | ✓ |
+| 2553 | 4006 | 4002 | 3995 | 3998 | ✓ |
+
+Trade 2160 is the boundary case: `l1_idx == d_search_max` (L1 sits exactly at the right edge). Even there, the bilateral confirmation window's furthest forward index is `l1_idx + 3 = 3421 = d_t - 1` — strictly before `d_t = 3422`. The invariant holds at the boundary.
+
+---
+
+## 7. Kill / downgrade rule application
+
+Per L_PROTOCOL §2 Step 6 §"Mechanics" item 3:
+- A **non-critical filter feature** failure → downgrade candidate.
+- A **load-bearing feature** failure → kill candidate.
+
+Zero features failed at the producer level. Zero byte-compare mismatches. Arc 9 invariance holds on every sampled trade. **No downgrades, no kills.**
+
+The Top-1 A1 candidate uses no classifier features — its deployment-critical path is the signal conditions + SL/exit policy, all of which audit PASS at the producer level. The Top-2/Top-3 A6 candidates use the Step 4 top-10 classifier features; all 10 pass at the producer level with the load-bearing `.shift(1)` guards in place.
+
+---
+
+## 8. Verdict
+
+**Step 6: PASS.** No producer downgrades, no candidate kills.
+
+Per Amendment 3 §"Evaluation order" item 3, with the non-Step-6 constraints already cleared at provisional level in closure §10, Step 6 clean **finalises the Arc 10 verdict at PASS-DEPLOYABLE** (Top-1 A1 candidate, risk-normalised to `r_safe = 0.4339%`).
+
+The `re_evaluated_verdict` in `ARC_TRACKER.md` is updated from `PASS-DEPLOYABLE-PROVISIONAL` to `PASS-DEPLOYABLE`.
+
+### Caveats forwarded from closure §10 (unchanged by Step 6 audit)
+
+Step 6 audits causal lineage, not engine artefacts. These two missing-data flags from closure §10 remain open and were not in scope for this audit:
+
+- **Constraint #6 (daily DD breaches at `r_safe`):** per-day max-DD series not built under v3.0 pre-amendment. Closure §10 reasons that under downward scaling (`k_safe = 0.8677`), proper per-day re-evaluation can only decrease the breach count from the `r_base` count, but the `r_base` count itself was not separately stored. Status remains as flagged.
+- **Constraint #7 (chained max DD at `r_safe`):** `chained_max_dd_base_pct` not measured; Step 5 used per-fold equity reset only. Status remains as flagged.
+
+Closure §10 recommended an engine re-run of the A1 winning config (`sl_3.5x_partial_close_1r_runner_trail_unlimited`, ~12 fold-runs of low compute) with continuous-equity emission + per-day max-DD persisted to `step_5/per_day_max_dd_base.parquet`. That recommendation stands. Step 6 audit clean does not retire it; it lifts the *causal-audit* component of the PROVISIONAL flag, not the *engine-artefact* component.
+
+The verdict update from PROVISIONAL → confirmed follows the dispatch directive ("if audit clean → confirmed PASS-DEPLOYABLE"). If the engine re-run subsequently surfaces a daily DD breach or chained DD > 10% at `r_safe`, the verdict reverts per Amendment 3 §"Failure-mode priority" (`step5_daily_dd_breach` or `step5_chained_dd_above_gate`).
+
+---
+
+## 9. Audit provenance
+
+| Artefact | Path | sha256 (run-time) |
+|---|---|---|
+| Signal module | [signals/lchar_dlr_long.py](../../../signals/lchar_dlr_long.py) | recorded in [step_1/manifest.json](../step_1/manifest.json) |
+| Step 1 pool | [results/l_arc_10/step_1/pool.parquet](../step_1/pool.parquet) | recorded in [step_1/manifest.json](../step_1/manifest.json) |
+| Step 4 importance | [results/l_arc_10/step_4/feature_importance.csv](../step_4/feature_importance.csv) | recorded in [step_4/manifest.json](../step_4/manifest.json) |
+| Step 5 best | [results/l_arc_10/step_5/best_candidate.md](../step_5/best_candidate.md) | recorded in [step_5/manifest.json](../step_5/manifest.json) |
+| Byte-compare script | [scripts/l_arc_10_v3/step_6_byte_compare.py](../../../scripts/l_arc_10_v3/step_6_byte_compare.py) | this PR |
+| Byte-compare log | [byte_compare_log.json](byte_compare_log.json) | this PR |
+| Companion (prior-protocol) audit | [causal_audit_report.md](causal_audit_report.md) | preserved unchanged |
+
+Determinism: byte-compare script uses `numpy.random.default_rng(42)` for sample selection. Producer determinism is inherited from `core.determinism.RANDOM_STATE = 42`, `n_jobs=1`, `lineterminator='\n'`.

--- a/results/l_arc_10/step_6/byte_compare_log.json
+++ b/results/l_arc_10/step_6/byte_compare_log.json
@@ -1,0 +1,399 @@
+{
+  "n_samples": 5,
+  "seed": 42,
+  "rtol": 1e-09,
+  "atol": 1e-09,
+  "overall_ok": true,
+  "entries": [
+    {
+      "trade_id": 295,
+      "pair": "CHFJPY",
+      "sig_idx_4h": 2458,
+      "signal_bar_time": "2011-07-12 08:00:00+00:00",
+      "signal_flag_true_at_recompute": true,
+      "feature_comparisons": [
+        {
+          "name": "L1_value",
+          "pool": 94.82,
+          "recomputed": 94.82,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L0_value",
+          "pool": 94.11,
+          "recomputed": 94.11,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L1_age_d1_bars",
+          "pool": 7.0,
+          "recomputed": 7.0,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L0_age_d1_bars",
+          "pool": 19.0,
+          "recomputed": 19.0,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L1_to_atr_proximity",
+          "pool": -0.10026850415755231,
+          "recomputed": -0.10026850415755231,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "reject_buffer_atr",
+          "pool": 1.5290946884030112,
+          "recomputed": 1.5290946884030112,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "upper_fraction",
+          "pool": 0.6701030927835118,
+          "recomputed": 0.6701030927835118,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "atr14_at_signal",
+          "pool": 0.39892885942668377,
+          "recomputed": 0.39892885942668377,
+          "match": true,
+          "abs_diff": 0.0
+        }
+      ],
+      "all_features_match": true,
+      "arc9_swing_invariance": {
+        "d_t": 476,
+        "d_search_max": 472,
+        "l1_idx": 469,
+        "l1_age": 7.0,
+        "right_edge_constraint_ok": true,
+        "confirmation_window_in_past_ok": true,
+        "confirmation_window_max_d1_idx": 472,
+        "nan_perturbation_invariance_ok": true,
+        "all_ok": true
+      },
+      "trade_ok": true
+    },
+    {
+      "trade_id": 1430,
+      "pair": "NZDCAD",
+      "sig_idx_4h": 11656,
+      "signal_bar_time": "2017-04-03 12:00:00+00:00",
+      "signal_flag_true_at_recompute": true,
+      "feature_comparisons": [
+        {
+          "name": "L1_value",
+          "pool": 0.93507,
+          "recomputed": 0.93507,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L0_value",
+          "pool": 0.92718,
+          "recomputed": 0.92718,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L1_age_d1_bars",
+          "pool": 8.0,
+          "recomputed": 8.0,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L0_age_d1_bars",
+          "pool": 15.0,
+          "recomputed": 15.0,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L1_to_atr_proximity",
+          "pool": -0.510285306848558,
+          "recomputed": -0.510285306848558,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "reject_buffer_atr",
+          "pool": 0.6961749543434399,
+          "recomputed": 0.6961749543434399,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "upper_fraction",
+          "pool": 0.7371937639198306,
+          "recomputed": 0.7371937639198306,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "atr14_at_signal",
+          "pool": 0.002743563220830592,
+          "recomputed": 0.002743563220830592,
+          "match": true,
+          "abs_diff": 0.0
+        }
+      ],
+      "all_features_match": true,
+      "arc9_swing_invariance": {
+        "d_t": 2261,
+        "d_search_max": 2257,
+        "l1_idx": 2253,
+        "l1_age": 8.0,
+        "right_edge_constraint_ok": true,
+        "confirmation_window_in_past_ok": true,
+        "confirmation_window_max_d1_idx": 2256,
+        "nan_perturbation_invariance_ok": true,
+        "all_ok": true
+      },
+      "trade_ok": true
+    },
+    {
+      "trade_id": 1449,
+      "pair": "NZDJPY",
+      "sig_idx_4h": 11874,
+      "signal_bar_time": "2017-05-22 16:00:00+00:00",
+      "signal_flag_true_at_recompute": true,
+      "feature_comparisons": [
+        {
+          "name": "L1_value",
+          "pool": 77.54,
+          "recomputed": 77.54,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L0_value",
+          "pool": 76.975,
+          "recomputed": 76.975,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L1_age_d1_bars",
+          "pool": 8.0,
+          "recomputed": 8.0,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L0_age_d1_bars",
+          "pool": 14.0,
+          "recomputed": 14.0,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L1_to_atr_proximity",
+          "pool": 0.035238036598362936,
+          "recomputed": 0.035238036598362936,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "reject_buffer_atr",
+          "pool": 0.5432530642247063,
+          "recomputed": 0.5432530642247063,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "upper_fraction",
+          "pool": 0.6975806451612672,
+          "recomputed": 0.6975806451612672,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "atr14_at_signal",
+          "pool": 0.3405411072351841,
+          "recomputed": 0.3405411072351841,
+          "match": true,
+          "abs_diff": 0.0
+        }
+      ],
+      "all_features_match": true,
+      "arc9_swing_invariance": {
+        "d_t": 2303,
+        "d_search_max": 2299,
+        "l1_idx": 2295,
+        "l1_age": 8.0,
+        "right_edge_constraint_ok": true,
+        "confirmation_window_in_past_ok": true,
+        "confirmation_window_max_d1_idx": 2298,
+        "nan_perturbation_invariance_ok": true,
+        "all_ok": true
+      },
+      "trade_ok": true
+    },
+    {
+      "trade_id": 2160,
+      "pair": "NZDUSD",
+      "sig_idx_4h": 17635,
+      "signal_bar_time": "2020-12-21 12:00:00+00:00",
+      "signal_flag_true_at_recompute": true,
+      "feature_comparisons": [
+        {
+          "name": "L1_value",
+          "pool": 0.70536,
+          "recomputed": 0.70536,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L0_value",
+          "pool": 0.70053,
+          "recomputed": 0.70053,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L1_age_d1_bars",
+          "pool": 4.0,
+          "recomputed": 4.0,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L0_age_d1_bars",
+          "pool": 12.0,
+          "recomputed": 12.0,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L1_to_atr_proximity",
+          "pool": -0.9159819369033555,
+          "recomputed": -0.9159819369033555,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "reject_buffer_atr",
+          "pool": 0.30410600305191954,
+          "recomputed": 0.30410600305191954,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "upper_fraction",
+          "pool": 0.9596541786743429,
+          "recomputed": 0.9596541786743429,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "atr14_at_signal",
+          "pool": 0.0027293114626819543,
+          "recomputed": 0.0027293114626819543,
+          "match": true,
+          "abs_diff": 0.0
+        }
+      ],
+      "all_features_match": true,
+      "arc9_swing_invariance": {
+        "d_t": 3422,
+        "d_search_max": 3418,
+        "l1_idx": 3418,
+        "l1_age": 4.0,
+        "right_edge_constraint_ok": true,
+        "confirmation_window_in_past_ok": true,
+        "confirmation_window_max_d1_idx": 3421,
+        "nan_perturbation_invariance_ok": true,
+        "all_ok": true
+      },
+      "trade_ok": true
+    },
+    {
+      "trade_id": 2553,
+      "pair": "GBPJPY",
+      "sig_idx_4h": 20651,
+      "signal_bar_time": "2022-11-03 20:00:00+00:00",
+      "signal_flag_true_at_recompute": true,
+      "feature_comparisons": [
+        {
+          "name": "L1_value",
+          "pool": 164.939,
+          "recomputed": 164.939,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L0_value",
+          "pool": 159.72,
+          "recomputed": 159.72,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L1_age_d1_bars",
+          "pool": 11.0,
+          "recomputed": 11.0,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L0_age_d1_bars",
+          "pool": 20.0,
+          "recomputed": 20.0,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "L1_to_atr_proximity",
+          "pool": 0.22552032244449643,
+          "recomputed": 0.22552032244449643,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "reject_buffer_atr",
+          "pool": 1.007324106918715,
+          "recomputed": 1.007324106918715,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "upper_fraction",
+          "pool": 0.9826771653543372,
+          "recomputed": 0.9826771653543372,
+          "match": true,
+          "abs_diff": 0.0
+        },
+        {
+          "name": "atr14_at_signal",
+          "pool": 0.7981542330594495,
+          "recomputed": 0.7981542330594495,
+          "match": true,
+          "abs_diff": 0.0
+        }
+      ],
+      "all_features_match": true,
+      "arc9_swing_invariance": {
+        "d_t": 4006,
+        "d_search_max": 4002,
+        "l1_idx": 3995,
+        "l1_age": 11.0,
+        "right_edge_constraint_ok": true,
+        "confirmation_window_in_past_ok": true,
+        "confirmation_window_max_d1_idx": 3998,
+        "nan_perturbation_invariance_ok": true,
+        "all_ok": true
+      },
+      "trade_ok": true
+    }
+  ]
+}

--- a/results/l_arc_10/step_6/manifest.json
+++ b/results/l_arc_10/step_6/manifest.json
@@ -2,18 +2,36 @@
   "arc_name": "l_arc_10",
   "step": "step_6",
   "protocol_version": "v3.0",
-  "trigger": "Step 5 produced 1 PASS-DEPLOYABLE + 2 PASS-VIABLE candidates",
+  "trigger": "Step 5 produced 1 PASS-DEPLOYABLE + 2 PASS-VIABLE candidates; Amendment 3 re-evaluation upgraded A1 Top-1 to PASS-DEPLOYABLE-PROVISIONAL pending Step 6",
   "verdict": "PASS",
   "candidate_kills": 0,
   "feature_downgrades": 0,
+  "deliverables": {
+    "causal_audit_report_md": "causal_audit_report.md",
+    "audit_report_md": "audit_report.md",
+    "byte_compare_log_json": "byte_compare_log.json"
+  },
   "priority_audits": {
     "swing_detection_arc9_check": "PASS - producer uses confirmation-lag (right-edge offset k+1), not centred-at-signal",
     "trailing_swing_features": "PASS - swing_low_distance_14, swing_high_distance_14 use one-sided rolling min/max with shift(1)",
     "cross_pair_ffill_lookahead": "PASS - .shift(1) after .ffill() prevents future-bar leakage"
   },
-  "caveats_surfaced_to_closure": [
-    "Per-fold equity reset (no cumulative DD across folds)",
-    "Exit-policy re-simulation uses mid-price path; spread on new exits not modelled",
-    "Step 4 AUC ~0.50 → cluster classifier near chance; A1 unfiltered IS the realised edge"
+  "byte_compare": {
+    "n_samples": 5,
+    "seed": 42,
+    "rtol": 1e-09,
+    "atol": 1e-09,
+    "all_features_abs_diff_zero": true,
+    "arc9_invariance_all_ok": true
+  },
+  "verdict_update": {
+    "tracker_re_evaluated_verdict_before": "PASS-DEPLOYABLE-PROVISIONAL",
+    "tracker_re_evaluated_verdict_after": "PASS-DEPLOYABLE",
+    "rationale": "Step 6 causal audit clean; Amendment 3 evaluation order item 3 finalises verdict"
+  },
+  "caveats_forwarded_to_closure": [
+    "Constraint #6 daily DD breaches at r_safe — per-day max-DD series not built (out of Step 6 scope)",
+    "Constraint #7 chained max DD at r_safe — Step 5 per-fold equity reset only (out of Step 6 scope)",
+    "Engine re-run of A1 winning config recommended for definitive constraints #6 + #7 measurement (closure §10 missing-data flags persist)"
   ]
 }

--- a/scripts/l_arc_10_v3/step_6_byte_compare.py
+++ b/scripts/l_arc_10_v3/step_6_byte_compare.py
@@ -1,0 +1,250 @@
+"""Arc 10 v3.0 — Step 6 byte-compare verification.
+
+Samples N random trades from step_1/pool.parquet, re-runs the DLR signal
+producer on the relevant pair's H4+D1 data, and compares the recomputed
+signal-bar features to the pool values column-by-column.
+
+Verifies:
+  - L1_value, L0_value, L1_age_d1_bars, L0_age_d1_bars
+  - L1_to_atr_proximity, reject_buffer_atr, upper_fraction
+  - atr14_at_signal
+  - signal flag is True at the recomputed signal_bar_time
+
+Independently verifies Arc 9 lesson: D1 swing-low detection at signal-bar
+must obey right-edge offset = k + 1 (=4), so its confirmation window
+spans only D1 bars strictly before D1[d_t].
+
+Output:
+  results/l_arc_10/step_6/byte_compare_log.json
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_HERE = Path(__file__).resolve()
+REPO_ROOT = _HERE.parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import signals.lchar_dlr_long as dlr  # noqa: E402
+from scripts.l_arc_10_v3._common import (  # noqa: E402
+    bid_view_for_signal,
+    load_config,
+    load_pair_tf,
+    window_slice,
+)
+
+POOL_PATH = REPO_ROOT / "results" / "l_arc_10" / "step_1" / "pool.parquet"
+CONFIG_PATH = REPO_ROOT / "configs" / "l_arc_10_v3" / "arc_open.yaml"
+OUT_PATH = REPO_ROOT / "results" / "l_arc_10" / "step_6" / "byte_compare_log.json"
+
+NUM_SAMPLES = 5
+RTOL = 1e-9
+ATOL = 1e-9
+
+
+def _samples(pool: pd.DataFrame, n: int, seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    n_avail = len(pool)
+    if n_avail == 0:
+        return pool.iloc[0:0]
+    idx = rng.choice(n_avail, size=min(n, n_avail), replace=False)
+    return pool.iloc[idx].sort_values("signal_bar_time").reset_index(drop=True)
+
+
+def _compare(name: str, pool_val: float, recomputed: float) -> dict:
+    pool_v = float(pool_val) if not pd.isna(pool_val) else float("nan")
+    rec_v = float(recomputed) if not pd.isna(recomputed) else float("nan")
+    both_nan = math.isnan(pool_v) and math.isnan(rec_v)
+    if both_nan:
+        return dict(name=name, pool=pool_v, recomputed=rec_v, match=True, abs_diff=0.0)
+    if math.isnan(pool_v) or math.isnan(rec_v):
+        return dict(name=name, pool=pool_v, recomputed=rec_v, match=False, abs_diff=float("nan"))
+    diff = abs(pool_v - rec_v)
+    match = bool(diff <= ATOL + RTOL * max(abs(pool_v), abs(rec_v)))
+    return dict(name=name, pool=pool_v, recomputed=rec_v, match=match, abs_diff=diff)
+
+
+def _verify_arc9_swing_invariance(
+    df_h4_bid: pd.DataFrame,
+    df_d1_bid: pd.DataFrame,
+    sig_idx_4h: int,
+) -> dict:
+    """Independent Arc 9 lesson check.
+
+    Per producer at signals/lchar_dlr_long.py:229, d_search_max = d_t - 4.
+    Re-derive d_t for this signal-bar timestamp, then verify:
+      - The L1 D1 index used by the producer satisfies l1_idx <= d_t - 4.
+      - The L1 swing-low's confirmation window spans D1 bars
+        [l1_idx - 3 .. l1_idx + 3], all of which are <= d_t - 1
+        (strictly prior to D1[d_t]).
+      - Perturbing D1[d_t] to NaN leaves the signal output unchanged at
+        sig_idx_4h.
+    """
+    sig_row = dlr.compute_signal(df_h4_bid, df_d1_bid, signal_col="signal").reset_index(drop=True)
+    d_t = int(sig_row["d_t_idx"].iloc[sig_idx_4h])
+    d_search_max = int(sig_row["d_for_l1_search_max"].iloc[sig_idx_4h])
+    l1_age = float(sig_row["L1_age_d1_bars"].iloc[sig_idx_4h])
+    l1_idx = int(d_t - l1_age) if not math.isnan(l1_age) else -1
+
+    # Check 1: right-edge constraint
+    right_edge_ok = (d_search_max == d_t - 4) and (l1_idx <= d_search_max)
+
+    # Check 2: confirmation window stays before d_t
+    confirmation_window_max = l1_idx + 3
+    confirmation_window_ok = confirmation_window_max <= d_t - 1
+
+    # Check 3: NaN-perturbation invariance at D1[d_t]
+    bar_date = pd.Timestamp(df_h4_bid["date"].iloc[sig_idx_4h]).normalize()
+    d1_dates = pd.to_datetime(df_d1_bid["date"]).dt.normalize()
+    match = d1_dates == bar_date
+    d1_pert = df_d1_bid.copy()
+    if match.any():
+        d1_pert.loc[match, ["open", "high", "low", "close"]] = np.nan
+    pert_sig = dlr.compute_signal(df_h4_bid, d1_pert, signal_col="signal").reset_index(drop=True)
+    nan_invariance_ok = bool(pert_sig["signal"].iloc[sig_idx_4h]) == bool(sig_row["signal"].iloc[sig_idx_4h])
+
+    return dict(
+        d_t=d_t,
+        d_search_max=d_search_max,
+        l1_idx=l1_idx,
+        l1_age=l1_age,
+        right_edge_constraint_ok=bool(right_edge_ok),
+        confirmation_window_in_past_ok=bool(confirmation_window_ok),
+        confirmation_window_max_d1_idx=int(confirmation_window_max),
+        nan_perturbation_invariance_ok=bool(nan_invariance_ok),
+        all_ok=bool(right_edge_ok and confirmation_window_ok and nan_invariance_ok),
+    )
+
+
+def main() -> int:
+    cfg = load_config(CONFIG_PATH)
+    pool = pd.read_parquet(POOL_PATH)
+    pool["signal_bar_time"] = pd.to_datetime(pool["signal_bar_time"], utc=True)
+
+    samples = _samples(pool, NUM_SAMPLES, seed=42)
+    if len(samples) == 0:
+        print("[step_6_byte_compare] empty pool — nothing to verify", flush=True)
+        return 1
+
+    # Cache per-pair signal frames lazily
+    per_pair_cache: dict[str, dict] = {}
+
+    log_entries = []
+    overall_ok = True
+
+    for _, row in samples.iterrows():
+        pair = row["pair"]
+        if pair not in per_pair_cache:
+            h4_full = load_pair_tf(pair, "H4", cfg)
+            d1_full = load_pair_tf(pair, "D1", cfg)
+            h4_w = window_slice(h4_full, cfg["window"]["start"], cfg["window"]["end"])
+            pad_start = (pd.Timestamp(cfg["window"]["start"], tz="UTC") - pd.Timedelta(days=45)).strftime("%Y-%m-%d")
+            d1_w = window_slice(d1_full, pad_start, cfg["window"]["end"])
+            df_h4_bid = bid_view_for_signal(h4_w)
+            df_d1_bid = bid_view_for_signal(d1_w)
+            sig_df = dlr.compute_signal(df_h4_bid, df_d1_bid, signal_col="signal").reset_index(drop=True)
+            per_pair_cache[pair] = dict(
+                df_h4_bid=df_h4_bid,
+                df_d1_bid=df_d1_bid,
+                sig_df=sig_df,
+            )
+
+        cache = per_pair_cache[pair]
+        df_h4_bid = cache["df_h4_bid"]
+        sig_df = cache["sig_df"]
+
+        # Find sig_idx_4h matching this trade's signal_bar_time
+        target_ts = pd.Timestamp(row["signal_bar_time"]).tz_convert(None)
+        bar_dates = pd.to_datetime(df_h4_bid["date"])
+        if bar_dates.dt.tz is not None:
+            bar_dates = bar_dates.dt.tz_convert(None)
+        match_idx = np.where(bar_dates.to_numpy() == target_ts.to_datetime64())[0]
+        if match_idx.size == 0:
+            log_entries.append(dict(
+                trade_id=int(row["trade_id"]), pair=pair, status="NOT_FOUND",
+                signal_bar_time=str(row["signal_bar_time"]),
+            ))
+            overall_ok = False
+            continue
+        sig_idx_4h = int(match_idx[0])
+
+        # Verify signal flag is True
+        signal_flag = bool(sig_df["signal"].iloc[sig_idx_4h])
+
+        # Byte-compare signal-bar features
+        comparisons = []
+        for col in [
+            "L1_value",
+            "L0_value",
+            "L1_age_d1_bars",
+            "L0_age_d1_bars",
+            "L1_to_atr_proximity",
+            "reject_buffer_atr",
+            "upper_fraction",
+        ]:
+            comparisons.append(_compare(col, row[col], sig_df[col].iloc[sig_idx_4h]))
+        comparisons.append(_compare("atr14_at_signal", row["atr14_at_signal"], sig_df["atr14"].iloc[sig_idx_4h]))
+
+        all_match = all(c["match"] for c in comparisons)
+
+        # Arc 9 lesson verification
+        arc9 = _verify_arc9_swing_invariance(
+            df_h4_bid=df_h4_bid,
+            df_d1_bid=cache["df_d1_bid"],
+            sig_idx_4h=sig_idx_4h,
+        )
+
+        trade_ok = signal_flag and all_match and arc9["all_ok"]
+        overall_ok = overall_ok and trade_ok
+
+        log_entries.append(dict(
+            trade_id=int(row["trade_id"]),
+            pair=pair,
+            sig_idx_4h=sig_idx_4h,
+            signal_bar_time=str(row["signal_bar_time"]),
+            signal_flag_true_at_recompute=signal_flag,
+            feature_comparisons=comparisons,
+            all_features_match=all_match,
+            arc9_swing_invariance=arc9,
+            trade_ok=trade_ok,
+        ))
+
+        status = "OK" if trade_ok else "FAIL"
+        print(
+            f"  [{status}] trade {row['trade_id']} ({pair} @ {row['signal_bar_time']}) "
+            f"sig={signal_flag} feat={all_match} arc9={arc9['all_ok']}",
+            flush=True,
+        )
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(
+        json.dumps(
+            dict(
+                n_samples=int(len(samples)),
+                seed=42,
+                rtol=RTOL,
+                atol=ATOL,
+                overall_ok=overall_ok,
+                entries=log_entries,
+            ),
+            indent=2,
+            default=str,
+        )
+        + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    print(f"[step_6_byte_compare] overall_ok={overall_ok} wrote {OUT_PATH}", flush=True)
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Step 6 causal audit per L_PROTOCOL v3.0 §2 Step 6 + Amendment 3 §"Evaluation order"
- Producer-level traces clean for Top-1 A1 + Top-2/3 A6 candidates; 5-trade byte-compare reproduces every signal-bar feature with abs_diff = 0.0
- Arc 9 swing-invariance independently verified (right-edge offset 4, confirmation window in past, NaN-perturbation of D1[d_t] leaves signal unchanged)
- Verdict updated: `re_evaluated_verdict` PASS-DEPLOYABLE-PROVISIONAL → **PASS-DEPLOYABLE** (confirmed)

## What changed

| File | Change |
|---|---|
| `results/l_arc_10/step_6/audit_report.md` | NEW — Amendment 3 re-evaluation Step 6 deliverable |
| `results/l_arc_10/step_6/byte_compare_log.json` | NEW — raw 5-trade byte-compare evidence (abs_diff=0.0 every feature) |
| `scripts/l_arc_10_v3/step_6_byte_compare.py` | NEW — verification script (deterministic, seed=42) |
| `results/l_arc_10/step_6/manifest.json` | UPDATED — deliverable list + verdict update block |
| `results/l_arc_10/ARC_CLOSURE.md` | UPDATED — §10 finalisation note + reversion clause |
| `ARC_TRACKER.md` | UPDATED — l_arc_10 `re_evaluated_verdict` = PASS-DEPLOYABLE; Last auto-update line bumped |

## Producer-level audit highlights
- Signal: `signals/lchar_dlr_long.py:229` uses `d_search_max = d_t - 4`; bilateral 3-bar confirmation window's furthest index is `d + 3 <= d_t - 1` → D1[d_t] structurally unread (matches Arc 9 lesson form `right_edge_offset = k + 1`)
- Path features (mfe_so_far_r, mae_so_far_r, close_r): bar-k computed only from bars `entry_idx..k`
- Step 4 top-10 classifier features: cross_pair load-bearing `.shift(1)` after `.ffill()` verified; `swing_low_distance_14` is one-sided trailing min (not centred ±N — distinct from Arc 9 pre-patch failure mode)

## Byte-compare sample
5 trades from pool.parquet, sampled with `numpy.default_rng(42)`. All features reproduced with abs_diff = 0.0 (exact bit equality):
- 295 CHFJPY 2011-07-12
- 1430 NZDCAD 2017-04-03
- 1449 NZDJPY 2017-05-22
- 2160 NZDUSD 2020-12-21 (boundary case — L1 at the right edge; invariant still holds)
- 2553 GBPJPY 2022-11-03

## Caveats forwarded
Out of Step 6 scope (closure §10 missing-data flags persist):
- Constraint #6 daily DD breaches at r_safe — per-day max-DD series not built
- Constraint #7 chained max DD at r_safe — Step 5 per-fold equity reset only

Engine re-run of the A1 winning config remains recommended for definitive measurement; verdict reverts per Amendment 3 §"Failure-mode priority" if those re-runs surface a failure.

## Test plan
- [x] `py scripts/l_arc_10_v3/step_6_byte_compare.py` → `overall_ok=True` on 5 sampled trades
- [x] Re-read `audit_report.md` and cross-check producer-line citations (lchar_dlr_long.py:95-119, 229-242, 266-289; step_1.py:296-313; step_5.py:99-253; cross_pair.py:22-29; price_geometry.py:81-97; _helpers.py:57-79)
- [x] Confirm `ARC_TRACKER.md` row diff is the single cell update (PASS-DEPLOYABLE-PROVISIONAL → PASS-DEPLOYABLE)
- [x] Confirm closure §10 amendment preserves the original PROVISIONAL framing as historical record while finalising the verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)