### PR TITLE
[INFRA] Closure template v1.2 + Arc 8/10/11 deployment spec retrofit

### DIFF
--- a/L_PROTOCOL.md
+++ b/L_PROTOCOL.md
@@ -560,15 +560,16 @@ expected_failure_modes: <if any anticipated>
 
 ### ARC_CLOSURE.md format
 
-All arc closure docs MUST follow `docs/templates/ARC_CLOSURE_TEMPLATE.md` v1.0.
+All arc closure docs MUST follow `docs/templates/ARC_CLOSURE_TEMPLATE.md` v1.2.
 
-The template has three required sections:
+Required sections:
 
 1. **§1 tracker_payload** — machine-parseable YAML block. Source of truth for ARC_TRACKER updates. Field names and structure are locked.
-2. **§2 Why <failed | succeeded>** — required prose, 100-300 words. Preserves cross-arc synthesis quality.
-3. **§3 Cross-arc observations** — required bullet list. What does this arc add to cumulative findings?
+2. **§2 Why <failed | succeeded>** — required prose, 100-300 words.
+3. **§3 Cross-arc observations** — required bullet list.
+4. **§4 deployment_spec** — REQUIRED for any verdict in {PASS-DEPLOYABLE, PASS-VIABLE, PASS-*-PROVISIONAL, PASS-*-PENDING-STEP6}. Self-contained porting specification. OPTIONAL for FAIL / HALT / DISCOVERY_COMPLETE verdicts.
 
-Closure docs not conforming to the template are invalid. Tracker updates cannot be applied until the closure is repaired (per template Section 4-K).
+Closure docs not conforming are invalid. Tracker updates blocked until repaired.
 
 ### ARC_TRACKER.md update mechanism
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -46,6 +46,10 @@ When the work is an arc closure, the artefact set on the arc branch includes the
 
 The parser invocation is pre-PR, not post-merge — so reviewers see the tracker change in the same diff as the closure. See `scripts/tracker_parser/README.md` for full usage.
 
+**For PASS verdicts (DEPLOYABLE / VIABLE / *-PROVISIONAL / *-PENDING-STEP6)** the artefact set additionally includes:
+- `§4 deployment_spec` in the closure doc per template v1.2 §4 — self-contained porting specification.
+- `best_architecture.config_artefact_path` populated in §1 tracker_payload and the referenced YAML file present at that path (relative to repo root). The parser HALTs at exit code 1 if either is missing or the file does not exist (template Section 4-L). Reconstruct the YAML from artefacts if it does not exist, document reconstruction in §4.10.
+
 ---
 
 ## §3 Branch + worktree conventions
@@ -117,7 +121,7 @@ Chat decides next step from the diagnostic.
 |---|---|
 | `L_PROTOCOL.md` | Only at major redesign events |
 | `docs/sub_protocols/*` | When sub-protocol is amended |
-| `docs/templates/ARC_CLOSURE_TEMPLATE.md` | Only at major redesign events (template version bump) |
+| `docs/templates/ARC_CLOSURE_TEMPLATE.md` | Only at major redesign events (template version bump). Current: v1.2 (2026-05-23, deployment_spec addition). |
 | `WORKFLOW.md` (this file) | When operational conventions evolve |
 | `ARC_TRACKER.md` | Auto on arc open / close per L_PROTOCOL §6 |
 | `ARC_HISTORY.md` | Never (frozen at v3.0 start) |

--- a/configs/l_arc_10/winning_config.yaml
+++ b/configs/l_arc_10/winning_config.yaml
@@ -1,0 +1,140 @@
+# Arc 10 winning_config — A1 system_level_filter
+#
+# RECONSTRUCTED RETROSPECTIVELY at 2026-05-23 from:
+#   - results/l_arc_10/ARC_CLOSURE.md §1 tracker_payload (best_architecture block)
+#   - results/l_arc_10/step_5/wfo_results.csv row 2 (winning candidate)
+#   - configs/l_arc_10_v3/arc_open.yaml (Step-1 signal + pair set + window)
+#   - scripts/l_arc_10_v3/step_5.py constants (RISK_PER_TRADE, INITIAL_BAL, fold windows)
+#   - results/l_arc_10/step_6/causal_audit_report.md (audit verdict)
+#
+# Original engine ran from inline driver script at scripts/l_arc_10_v3/step_5.py with these
+# parameters. Reconstructed file is the source of truth going forward but pre-retrofit
+# deployment would require source verification against the driver script.
+#
+# Verdict (closure §1): PASS-VIABLE (worst-fold ratio 5.4185, worst-fold DD 9.22% at r_base 0.5%).
+# Amendment 3 re-evaluation (closure §10): PASS-DEPLOYABLE-PROVISIONAL — chained DD + per-day DD
+# series still pending engine re-run with continuous-equity tracking.
+
+arc_name: l_arc_10
+template_version: v1.2
+protocol_version: L_PROTOCOL.md v3.0
+architecture: A1 system_level_filter
+
+# ── Signal (closure §1.signal + configs/l_arc_10_v3/arc_open.yaml signal block) ──
+signal:
+  name: D1 swing-low rejection long
+  short_name: DLR
+  version: v0.1
+  spec_doc: docs/archive/signal_specs/signal_spec_d1_swing_low_rejection_long_v0.1.md
+  module: signals.lchar_dlr_long
+  # Source: configs/l_arc_10_v3/arc_open.yaml lines 64-71
+  d1_swing_window_k: 3
+  d1_right_edge_offset: 4               # confirmation-lag right-edge offset (Arc 9 lesson)
+  d1_structure_lookback_bars: 30
+  d1_l1_freshness_max_bars: 20
+  atr_period_4h: 14
+  proximity_atr_mult: 0.25
+  reject_buffer_atr_mult: 0.10
+  upper_fraction_min: 0.6
+  refractory_bars_4h: 20
+
+# ── Pair set + window (configs/l_arc_10_v3/arc_open.yaml lines 26-55, 17-19) ──
+pairs:
+  - AUDCAD
+  - AUDCHF
+  - AUDJPY
+  - AUDNZD
+  - AUDUSD
+  - CADCHF
+  - CADJPY
+  - CHFJPY
+  - EURAUD
+  - EURCAD
+  - EURCHF
+  - EURGBP
+  - EURJPY
+  - EURNZD
+  - EURUSD
+  - GBPAUD
+  - GBPCAD
+  - GBPCHF
+  - GBPJPY
+  - GBPNZD
+  - GBPUSD
+  - NZDCAD
+  - NZDCHF
+  - NZDJPY
+  - NZDUSD
+  - USDCAD
+  - USDCHF
+  - USDJPY
+
+tf:
+  primary: H4
+  anchor: D1
+  cross_pair_aux: [D1, W1]
+
+window:
+  start: 2010-01-01
+  end: 2026-04-30                       # closure §1 pool_metadata.window_end
+
+# ── Entry + exit (closure §1 best_architecture + wfo_results.csv row 2) ──
+entry:
+  trigger_bar: signal_bar               # bar N close → enter bar N+1 open
+  fill: next_bar_open
+  order_type: market
+
+sl:
+  anchor: entry_price                   # L_PROTOCOL §2 Step 1 convention
+  atr_multiplier: 3.5                   # closure §1 best_architecture.sl_atr; wfo_results.csv col sl_multiplier
+  atr_period_4h: 14
+
+exit:
+  policy: sl_partial_close_1r_runner_trail   # closure §1 best_architecture.exit_policy
+  # Mechanics — close 50% at +1R; trail remaining 50% at 1R below subsequent peak.
+  partial_close_at_r: 1.0
+  partial_close_fraction: 0.5
+  runner_trail_distance_r: 1.0
+  runner_trail_reference: peak_high      # high-since-entry; bar-close updates
+  time_exit_bars: 240                    # signal's natural 4H horizon; carried from Step 1
+
+# ── Exposure cap (closure §1 best_architecture.exposure_cap; wfo_results.csv col exposure) ──
+exposure:
+  cap_mode: unlimited                    # closure §1 best_architecture.exposure_cap = "unlimited"
+  max_concurrent_per_pair: 1             # mirror of L_PROTOCOL §2 Step 1 (per-pair invariant)
+  max_concurrent_per_currency: null      # unlimited
+  max_concurrent_total: null             # unlimited
+
+# ── Risk sizing (scripts/l_arc_10_v3/step_5.py constants + closure §10 amendment-3 fields) ──
+risk:
+  sizing_convention: reset_floor         # L arc convention; locked v3.0 default
+  r_base_pct: 0.5                        # base risk (per L_PROTOCOL §2 Step 5 r_base)
+  r_safe_pct: 0.4339                     # closure §10: k_safe = 8.0 / 9.22 = 0.8677; 0.5 × 0.8677
+  r_hard_pct: 0.5423                     # closure §10: k_hard = 10.0 / 9.22 = 1.0846
+  scalable_to_safe: true
+  scalable_to_hard: true
+  starting_balance: 100000.0             # scripts/l_arc_10_v3/step_5.py INITIAL_BAL
+  floor_reset_condition: per_arc_engine_default
+
+# ── WFO structure (scripts/l_arc_10_v3/step_5.py SEARCH_*/HOLDOUT_*/N_SEARCH_FOLDS) ──
+wfo:
+  search_window:
+    start: 2010-01-01
+    end: 2020-12-31
+  n_search_folds: 11
+  holdout_window:
+    start: 2021-01-01
+    end: 2026-04-30
+  holdout_evaluation: one_shot_per_candidate
+
+# ── Verdict + audit lineage (closure §1, §10, step_6/causal_audit_report.md) ──
+verdict:
+  baseline: PASS-VIABLE                  # closure §1 verdict (pre-Amendment-3)
+  amendment_3_re_evaluation: PASS-DEPLOYABLE-PROVISIONAL   # closure §10
+  step_6_causal_audit: PASS              # results/l_arc_10/step_6/causal_audit_report.md §7
+
+# ── Caveats (closure §2 + §10 missing-data flags) ──
+caveats:
+  - chained_max_dd_base_pct not measured (per-fold equity reset only)
+  - per_day_max_dd_base series not built (Amendment 3 spec requires)
+  - oracle WFO locked to sl_only exit policy, not sl_partial_close_1r_runner_trail — not a fair upper bound

--- a/configs/l_arc_11/winning_config.yaml
+++ b/configs/l_arc_11/winning_config.yaml
@@ -1,0 +1,156 @@
+# Arc 11 winning_config — A2 classifier_filter (FAIL arc, retained for documentation parity)
+#
+# RECONSTRUCTED RETROSPECTIVELY at 2026-05-23 from:
+#   - results/l_arc_11/ARC_CLOSURE.md §1 tracker_payload (best_architecture block)
+#   - results/l_arc_11/step_5/wfo_results.csv row 3 (config_id=a2_shb_cluster0)
+#   - results/l_arc_11/run_summary.json (primary_classifier, primary_threshold, top features)
+#   - scripts/l_arc_11/run.py constants (lines 78-98 + A2Config builder lines 360-371)
+#   - results/l_arc_11/ARC_OPEN.md (pair set, window, signal class)
+#
+# Original engine ran from inline driver script at scripts/l_arc_11/run.py with these
+# parameters. Reconstructed file is the source of truth going forward but pre-retrofit
+# deployment would require source verification against the driver script.
+#
+# Verdict (closure §1): FAIL — best A2 worst-fold ratio -0.769; 4/10 negative folds; worst-fold
+# DD 38.4% / ROI -24.0%; holdout 1.30%/57.5%.
+#
+# FAIL ARC — not for deployment.
+
+arc_name: l_arc_11
+template_version: v1.2
+protocol_version: L_PROTOCOL.md v3.0
+architecture: A2 classifier_filter
+
+# ── Signal (closure §1.signal + results/l_arc_11/ARC_OPEN.md) ──
+signal:
+  name: Swing-high breakout in trend long
+  short_name: SHB
+  module: signals.lchar_swing_high_breakout_trend
+  # 3-bar swing detection with causal right-edge offset; structural trend filter;
+  # decisive break + bullish close + upper-half close + 0.10×ATR buffer; 20-bar refractory.
+  # Source: scripts/l_arc_11/run.py SHBSignalModule + ARC_OPEN.md
+  swing_window_k: 3
+  right_edge_offset: 4                  # confirmation-lag right-edge offset (Arc 9 lesson, closure §3)
+  refractory_bars: 20
+
+# ── Pair set + window (results/l_arc_11/ARC_OPEN.md line 11 + scripts/l_arc_11/run.py lines 79-86) ──
+pairs:
+  - AUDCAD
+  - AUDCHF
+  - AUDJPY
+  - AUDNZD
+  - AUDUSD
+  - CADCHF
+  - CADJPY
+  - CHFJPY
+  - EURAUD
+  - EURCAD
+  - EURCHF
+  - EURGBP
+  - EURJPY
+  - EURNZD
+  - EURUSD
+  - GBPAUD
+  - GBPCAD
+  - GBPCHF
+  - GBPJPY
+  - GBPNZD
+  - GBPUSD
+  - NZDCAD
+  - NZDCHF
+  - NZDJPY
+  - NZDUSD
+  - USDCAD
+  - USDCHF
+  - USDJPY
+
+tf:
+  primary: H4
+  anchor: D1
+  cross_pair_aux: [D1, W1]
+
+window:
+  start: 2010-01-01                     # scripts/l_arc_11/run.py WINDOW_START line 89
+  end: 2026-04-30                       # scripts/l_arc_11/run.py WINDOW_END line 90
+
+# ── Entry + exit (closure §1 + scripts/l_arc_11/run.py A2Config lines 360-371) ──
+entry:
+  trigger_bar: signal_bar
+  fill: next_bar_open
+  order_type: market
+
+sl:
+  anchor: entry_price
+  atr_multiplier: 2.0                   # closure §1 best_architecture.sl_atr; scripts/l_arc_11/run.py SL_ATR_MULT line 93
+  atr_period_4h: 14
+
+exit:
+  policy: sl_only                       # closure §1 best_architecture.exit_policy
+  trail_enabled: false                  # scripts/l_arc_11/run.py A2Config.trail_enabled
+  time_exit_bars: 240                   # scripts/l_arc_11/run.py HOLD_BARS line 94
+
+# ── Exposure cap (closure §1 best_architecture.exposure_cap = 2; scripts/l_arc_11/run.py A2Config) ──
+exposure:
+  cap_mode: per_pair_and_per_currency
+  max_concurrent_per_pair: 1            # scripts/l_arc_11/run.py A2Config.max_concurrent_per_pair
+  max_concurrent_per_currency: 2        # scripts/l_arc_11/run.py A2Config.max_concurrent_per_currency
+  max_concurrent_total: null
+
+# ── A2 classifier filter (closure §1 + run_summary.json primary_classifier / primary_threshold) ──
+a2_classifier_filter:
+  classifier: rf                        # results/l_arc_11/run_summary.json primary_classifier
+  classifier_hyperparameters:           # L_PROTOCOL Appendix A defaults
+    n_estimators: 200
+    max_depth: 6
+    min_samples_leaf: 50
+    random_state: 42
+  target: cluster_membership_c0          # closure §1 best_architecture.cluster = 0 (Bimodal)
+  training_window_end: 2020-12-31        # scripts/l_arc_11/run.py TRAIN_END line 91
+  threshold: 0.11937665572820917         # run_summary.json primary_threshold (AUC-best at training)
+  step4_e_auc: 0.6543                    # closure §1 clusters.c0.step4_e_auc
+  features_in_winning_config:            # closure §1 best_architecture.features_in_winning_config
+    - w1_close_slope_sign
+    - d1_atr_percentile_100
+    - prior_session_low_distance
+    - day_of_week
+    - session_london
+    - d1_close_slope_magnitude
+    - distance_to_round_number
+    - atr_percentile_100
+    - usd_strength_index
+    - spread_vs_trailing_100
+
+# ── Risk sizing (scripts/l_arc_11/run.py RISK_PCT line 95 + closure §10 amendment-3 fields) ──
+risk:
+  sizing_convention: reset_floor
+  r_base_pct: 0.5                       # base risk
+  r_safe_pct: 0.1043                    # closure §10 — below r_min 0.15% floor (FAIL scalability)
+  r_hard_pct: 0.1303                    # closure §10 — also below floor
+  scalable_to_safe: false               # closure §10 — primary FAIL constraint
+  scalable_to_hard: false
+  starting_balance: 100000.0            # scripts/l_arc_11/run.py STARTING_BALANCE line 96
+  floor_reset_condition: per_arc_engine_default
+
+# ── WFO structure (scripts/l_arc_11/run.py + L_PROTOCOL §2 Step 5) ──
+wfo:
+  search_window:
+    start: 2010-01-01
+    end: 2020-12-31
+  n_search_folds: 11                     # note: orchestrator returned 10 folds — see closure §3 canonical_orchestrator_step5_run_context_gap
+  holdout_window:
+    start: 2021-01-01
+    end: 2026-04-30
+  holdout_evaluation: one_shot_per_candidate
+
+# ── Verdict (closure §1 + §10) ──
+verdict:
+  baseline: FAIL                         # closure §1 verdict
+  amendment_3_re_evaluation: FAIL        # closure §10 — primary mode step5_not_scalable
+  step_6_causal_audit: not_run
+
+# ── Caveats (closure §2 + §3) ──
+caveats:
+  - canonical_orchestrator_step5_run_context_gap — ArcOrchestrator._run_step_5 did not thread per_trade_features through ArcFoldRunner; this driver constructed A1RunContext manually
+  - n_folds returned = 10 not 11 (same gap; see closure §1 sign_pos_folds "6/10")
+  - per_day_max_dd_base series not built; chained_max_dd_base_pct not measured
+  - FAIL arc — config not for deployment

--- a/configs/l_arc_8/winning_config.yaml
+++ b/configs/l_arc_8/winning_config.yaml
@@ -1,0 +1,169 @@
+# Arc 8 winning_config — A6 meta_labeling (FAIL arc, retained for documentation parity)
+#
+# RECONSTRUCTED RETROSPECTIVELY at 2026-05-23 from:
+#   - results/l_arc_8/ARC_CLOSURE.md §1 tracker_payload (best_architecture block)
+#   - results/l_arc_8/step_5/wfo_results.csv row 2 (config_id=30, A6, sl_atr=1.5, sl_plus_tp_3r, unlimited)
+#   - scripts/l_arc_8/shared.py (pair set, window, risk, SL Step 1 default, signal params)
+#   - scripts/l_arc_8/run_step5_wfo.py constants (A6 threshold pairs, exposure axis)
+#   - core/signals/pullback_resume_hhhl.py PullbackResumeParams (lines 46-55)
+#
+# Original engine ran from inline driver script at scripts/l_arc_8/run_step5_wfo.py with these
+# parameters. Reconstructed file is the source of truth going forward but pre-retrofit
+# deployment would require source verification against the driver script.
+#
+# Verdict (closure §1): FAIL — search WFO worst-fold ratio 1.749 below 2.0 §3 gate; holdout PASS-
+# DEPLOYABLE on top-3 (insufficient by L_PROTOCOL §2 Step 5 BOTH-gates rule).
+#
+# FAIL ARC — not for deployment. §4 deployment_spec retained for portfolio-eligibility audit only.
+
+arc_name: l_arc_8
+template_version: v1.2
+protocol_version: L_PROTOCOL.md v3.0
+architecture: A6 meta_labeling
+
+# ── Signal (closure §1.signal + scripts/l_arc_8/shared.py SIGNAL_PARAMS) ──
+signal:
+  name: Pullback-resume HHHL long
+  short_name: PR-HHHL
+  version: v0.1
+  module: core.signals.pullback_resume_hhhl
+  # Source: core/signals/pullback_resume_hhhl.py PullbackResumeParams lines 46-55
+  swing_lookback: 3
+  trend_window_bars: 30
+  right_edge_lag: 4                      # causal right-edge offset (Arc 9 lesson)
+  pullback_atr_mult: 0.5
+  upper_half_threshold: 0.5
+  spacing_bars: 20
+  atr_period: 14
+
+# ── Pair set + window (scripts/l_arc_8/shared.py lines 18-25, 31-32) ──
+pairs:
+  - AUDCAD
+  - AUDCHF
+  - AUDJPY
+  - AUDNZD
+  - AUDUSD
+  - CADCHF
+  - CADJPY
+  - CHFJPY
+  - EURAUD
+  - EURCAD
+  - EURCHF
+  - EURGBP
+  - EURJPY
+  - EURNZD
+  - EURUSD
+  - GBPAUD
+  - GBPCAD
+  - GBPCHF
+  - GBPJPY
+  - GBPNZD
+  - GBPUSD
+  - NZDCAD
+  - NZDCHF
+  - NZDJPY
+  - NZDUSD
+  - USDCAD
+  - USDCHF
+  - USDJPY
+
+tf:
+  primary: H4
+  anchor: D1
+  cross_pair_aux: [D1, W1]               # closure §2 caveat: aux-panel fix staged but not re-run
+
+window:
+  start: 2010-01-01                      # scripts/l_arc_8/shared.py WINDOW_START
+  end: 2026-04-10                        # closure §1 pool_metadata.window_end (data-limited)
+
+# ── Step 1 (closure §2 caveat) ──
+step_1:
+  sl_atr_mult: 2.0                       # scripts/l_arc_8/shared.py SL_ATR_MULT_STEP1
+  forward_bars: 240                      # scripts/l_arc_8/shared.py FORWARD_BARS
+  multi_tf_features_present: false       # closure §2 caveat — d1/w1 aux features all-NaN at Step 1
+
+# ── Entry + exit (closure §1 best_architecture + wfo_results.csv config_id=30 row) ──
+entry:
+  trigger_bar: signal_bar
+  fill: next_bar_open
+  order_type: market
+
+sl:
+  anchor: entry_price
+  atr_multiplier: 1.5                    # closure §1 best_architecture.sl_atr
+  atr_period_4h: 14
+
+exit:
+  policy: sl_plus_tp_3r                  # closure §1 best_architecture.exit_policy
+  tp_at_r: 3.0                           # +3R take-profit
+  time_exit_bars: 240                    # carried from Step 1
+
+# ── Exposure cap (closure §1 best_architecture.exposure_cap = "unlimited") ──
+exposure:
+  cap_mode: unlimited
+  max_concurrent_per_pair: null
+  max_concurrent_per_currency: null
+  max_concurrent_total: null
+
+# ── A6 meta-labeling classifier (closure §1 + run_step5_wfo.py A6_THRESHOLDS line 67) ──
+a6_meta_labeling:
+  classifier: rf                          # RandomForest (Step 4 best AUC 0.530)
+  classifier_hyperparameters:             # L_PROTOCOL Appendix A defaults
+    n_estimators: 200
+    max_depth: 6
+    min_samples_leaf: 50
+    random_state: 42
+  training_window_end: 2020-12-31         # L_PROTOCOL §2 Step 5 — no retrain at Step 5
+  thresholds:
+    lower: 0.3                            # config_id=30 extra.lo
+    upper: 0.5                            # config_id=30 extra.hi
+  sizing_map:
+    below_lower: 0.0                      # skip
+    between: 0.5                          # 0.5× risk
+    above_upper: 1.0                      # 1.0× risk
+  features_in_winning_config:             # closure §1 best_architecture.features_in_winning_config
+    - swing_low_distance_14
+    - prior_session_low_distance
+    - atr_vs_trailing_100
+    - kijun_26_distance
+    - dollar_bloc_state
+    - atr_percentile_100
+    - spread_vs_trailing_100
+    - spread_percentile_100
+    - usd_strength_index
+    - distance_to_round_number
+
+# ── Risk sizing (scripts/l_arc_8/shared.py RISK_PCT + closure §10 amendment-3 fields) ──
+risk:
+  sizing_convention: reset_floor
+  r_base_pct: 0.5                         # base risk
+  r_safe_pct: 2.0176                      # closure §10 — scalability FAILs by 0.018pp (>r_max 2.0%)
+  r_hard_pct: 2.5219                      # closure §10 — also exceeds r_max
+  scalable_to_safe: false                 # closure §10 — primary FAIL constraint
+  scalable_to_hard: false
+  starting_balance: 100000.0
+  floor_reset_condition: per_arc_engine_default
+
+# ── WFO structure (run_step5_wfo.py + L_PROTOCOL §2 Step 5) ──
+wfo:
+  search_window:
+    start: 2010-01-01
+    end: 2020-12-31
+  n_search_folds: 11
+  holdout_window:
+    start: 2021-04-01                     # data-limited
+    end: 2026-04-10
+  holdout_evaluation: one_shot_per_candidate
+
+# ── Verdict (closure §1 + §10) ──
+verdict:
+  baseline: FAIL                          # closure §1 verdict
+  amendment_3_re_evaluation: FAIL         # closure §10 — primary mode shifts to step5_ratio_below_gate_after_scaling
+  step_6_causal_audit: not_run            # Step 6 lazy — not triggered (no PASS candidate)
+
+# ── Caveats (closure §2 + §10) ──
+caveats:
+  - Step 1 multi_tf features (d1/w1 slope, d1 ATR percentile) all-NaN due to aux-panel integration gap
+  - pool-level WFO approximation (not bar-by-bar multipair backtester) — understates intraday DD timing
+  - per_day_max_dd_base series not built; chained_max_dd_base_pct not measured
+  - FAIL arc — config retained for portfolio-eligibility audit (see closure §10 portfolio-eligibility-pending-a5-spec)

--- a/docs/dispatches/closure_template_v12_intent.md
+++ b/docs/dispatches/closure_template_v12_intent.md
@@ -1,0 +1,156 @@
+# closure_template_v12_intent.md
+
+> **Dispatch:** `CC Dispatch — Closure Template v1.2 (deployment spec) + Retrofit Arcs 8, 10, 11`
+> **Branch:** `claude/romantic-nash-219b96` (running in a worktree cut from main; dispatch names `infra/closure-template-v1.2` — will rename / open PR from this branch unless chat directs otherwise).
+> **Scope:** template + parser + 3 closure retrofits + WORKFLOW.md + parser README. No engine changes. No verdict logic changes.
+> **Stage:** Read-first complete. Awaiting chat answers to three open questions before executing Tasks 1-7.
+
+---
+
+## Reads completed
+
+1. **`docs/templates/ARC_CLOSURE_TEMPLATE.md` v1.1 (284 lines)** — current schema. §1 YAML block lives inside an outer `markdown` fence with an inner `yaml` fence; the parser opens the inner one. `best_architecture:` block already carries 19+ Amendment-3 risk-normalised fields. Section 4 A-K mapping checklist is the parser contract; Section 5 references `scripts/update_tracker_from_closure.py`. Schema-versioning table at the foot already anticipates `template_version` as a per-closure declaration.
+2. **`L_PROTOCOL.md` §3, §6.** §3 (gates) is unchanged by this dispatch — Amendment 3 risk-normalised gate language stays untouched. §6 has an "ARC_CLOSURE.md format" subsection (lines 561-571) that needs to be replaced with the v1.2 spec (4 sections + §4 conditional REQUIRED rule). The §6 subsection currently reads "All arc closure docs MUST follow `docs/templates/ARC_CLOSURE_TEMPLATE.md` v1.0" — bumps to v1.2 and gains the §4 conditional rule.
+3. **The three closure docs** (`results/l_arc_{8,10,11}/ARC_CLOSURE.md`). Confirmed each currently has §1 / §2 / §3, then a `## §10 Amendment 3 re-evaluation` section. No §4 sections present. `template_version` field is absent in all three closures' §1 YAML (parser infers v1.1 from Amendment-3 fields under v1.1-exclusive-field detection, then normalises). All three are written under the v1.1 schema effectively.
+4. **`scripts/update_tracker_from_closure.py` + `scripts/tracker_parser/{schema,extract,mapping,registry,rolling_state,tracker_io}.py`.** Detection precedence: `template_version` field → v1.1-exclusive-field presence → default v1.0 (schema.py:70-92). Extraction is regex on `## §1 tracker_payload` heading + the next fenced `yaml` block (extract.py:21-77). Schema validation is Pydantic; current `parse_payload` returns a v1.1-normalised dict and rejects unknown verdict / failure_mode / architecture enums.
+5. **Canonical config YAML for each arc's winning architecture.** This is where the **load-bearing finding** sits — see "Interpretive call 2" below.
+6. **`WORKFLOW.md`** — §2 has an "Arc-close artefact set" subsection (lines 38-47). §7 cadence table includes a row for `docs/templates/ARC_CLOSURE_TEMPLATE.md` (line 120). Both touched.
+7. **`scripts/tracker_parser/README.md`** — Schema versioning section at lines 46-56 explicitly enumerates the v1.0/v1.1 rules; v1.2 row needs adding. README references `tests/tracker_parser/` test set count (currently 41 tests per line 137).
+8. **`tests/tracker_parser/`** — 10 existing test files. `conftest.py` exposes `closure_arc_8`, `closure_arc_10`, `closure_arc_11` fixtures pointing at the live closure docs. The three new test files (Task 3d) drop alongside existing ones.
+
+---
+
+## File paths CC will create / modify (in execution order)
+
+| Order | Path | Action | Source |
+|---|---|---|---|
+| T1 | `docs/templates/ARC_CLOSURE_TEMPLATE.md` | Edit — bump v1.1→v1.2, add 3 `best_architecture` fields, insert §4 deployment_spec template block, update Section 4 mapping checklist, update Section 5 parser notes, add schema-versioning row | Dispatch Task 1a-1e |
+| T2 | `L_PROTOCOL.md` | Edit §6 — replace "ARC_CLOSURE.md format" subsection verbatim with the v1.2 spec | Dispatch Task 2 |
+| T3a | `scripts/tracker_parser/schema.py` | Add v1.2 detection, add `BestArchitectureV12` model (extends v1.1 with 3 new fields), add `TrackerPayloadV12`, extend `parse_payload` dispatcher, extend `normalize_to_v11` → `normalize_to_v12` semantics | Dispatch Task 3a-3c |
+| T3a | `scripts/tracker_parser/extract.py` | Add `verify_deployment_spec_section(closure_path)` helper that scans for `## §4 deployment_spec` heading | Dispatch Task 3b |
+| T3a | `scripts/update_tracker_from_closure.py` | Wire PASS-verdict validation step between schema validation and tracker mutation: if v1.2 + PASS-verdict → run config_artefact_path + §4-heading + flag-true checks | Dispatch Task 3b |
+| T3b | `tests/tracker_parser/test_schema_v12.py` | NEW | Dispatch Task 3d |
+| T3b | `tests/tracker_parser/test_pass_verdict_validation.py` | NEW | Dispatch Task 3d |
+| T3b | `tests/tracker_parser/test_v12_golden_arc10.py` | NEW (Arc 10 retrofit idempotency vs current tracker state) | Dispatch Task 3d |
+| T4a | `configs/l_arc_8/winning_config.yaml` | CREATE (per Q2 chat direction; reconstructed from `step_5/wfo_results.csv` + closure §1 + driver script) | Dispatch Task 4 |
+| T4a | `configs/l_arc_10/winning_config.yaml` | CREATE (per Q2 chat direction) | Dispatch Task 4 |
+| T4a | `configs/l_arc_11/winning_config.yaml` | CREATE (per Q2 chat direction) | Dispatch Task 4 |
+| T4b | `results/l_arc_8/ARC_CLOSURE.md` | Edit — insert §4 deployment_spec (marked FAIL-consistency), update §1 tracker_payload (add `template_version: 1.2`, `config_artefact_path`, `deployment_spec_section_present: true`) | Dispatch Task 4 |
+| T4b | `results/l_arc_10/ARC_CLOSURE.md` | Edit — insert §4 deployment_spec (primary deployment spec; PROVISIONAL caveats), update §1 tracker_payload | Dispatch Task 4 |
+| T4b | `results/l_arc_11/ARC_CLOSURE.md` | Edit — insert §4 deployment_spec (marked FAIL-consistency), update §1 tracker_payload | Dispatch Task 4 |
+| T5 | `WORKFLOW.md` | Edit §2 arc-close artefact set — add 2 bullets (PASS verdicts require §4 deployment_spec + populated `config_artefact_path`) | Dispatch Task 5 |
+| T6 | (parser dry-run, no file write) | Run on all 3 retrofitted closures | Dispatch Task 6 |
+| T7a | `scripts/tracker_parser/README.md` | Edit Schema-versioning section — add v1.2 row; update HALT error modes; update test count | Dispatch Task 7 |
+| T7b | `WORKFLOW.md` | Edit §7 cadence table — update template-row note to reference v1.2 (`docs/templates/ARC_CLOSURE_TEMPLATE.md` line is already there) | Dispatch Task 7 |
+
+Plus this intent doc + a `closure_template_v12_log.md` at end (per WORKFLOW §2 pattern).
+
+**Net:** 13 files modified, 3 files created in `configs/`, 3 test files created, 2 dispatch artefacts. Sequence is mostly serialisable — only T6 (dry-run validation) depends on T3+T4 finishing first.
+
+---
+
+## Interpretive calls flagged for chat
+
+Three items where the dispatch needs an explicit chat decision before execution. **Items 1 + 3 are restatements of the dispatch's "Open questions for chat" with my recommendation. Item 2 is a load-bearing finding that affects whether the dispatch can execute as written.**
+
+### 1. Section numbering of retrofitted closures (dispatch Q1)
+
+The three closure docs currently use `## §1` / `## §2` / `## §3` / `## §10 Amendment 3 re-evaluation`. Inserting `## §4 deployment_spec` between §3 and §10 leaves a 5..9 gap.
+
+- **Option A — insert with gap.** Numbering becomes 1, 2, 3, 4, 10. Preserves §10 as the universal "Amendment 3 re-evaluation" cross-arc anchor — Arc 8 / 10 / 11 / 5 / 7 (re-eval pending) all keep §10 = Amendment 3 re-eval. Dispatch's recommendation.
+- **Option B — renumber.** Numbering becomes 1, 2, 3, 4, 5 (renaming §10 → §5 "Amendment 3 re-evaluation"). Clean numerical order but breaks any prose / cross-doc references to `§10` (CLAUDE.md references arc closure §10 indirectly via "Amendment 3 re-evaluation"; the existing arc-closure-content references §10 internally).
+
+**Recommendation: Option A (insert with gap), per dispatch's own suggestion.** Confirm before Task 4 retrofit.
+
+### 2. Canonical config YAML availability is uneven across the three arcs — load-bearing finding (dispatch Q2)
+
+I expected each arc's winning architecture to be backed by a canonical config YAML file referenced by the engine. That is partly true for Arc 8 and false for Arcs 10 and 11.
+
+**Arc 8.** `configs/l_arc_8/step5.yaml` exists but is **v2.3-era** (`phase: L_ARC_8_STEP_5_WFO`, references `results/l_arc_8/step1_verbatim/...`, talks about Pipeline E / Pipeline D1 — pre-v3.0 framing). The Arc 8 v3 re-run that produced the closure's `A6_SL1.5_TP3R_unlimited_thr_0.3_0.5` winning config was driven by `scripts/l_arc_8/run_step5_wfo.py` with inline parameters; no v3-era YAML lives in repo for it.
+
+**Arc 10.** No `configs/l_arc_10/winning_config.yaml` exists. The v3 winning config (`sl_3.5x_partial_close_1r_runner_trail_unlimited`) lives entirely as constants + a config table inside `scripts/l_arc_10_v3/step_5.py` (lines 73-91 + the per-arch config builders). The arc_open YAML at `configs/l_arc_10_v3/arc_open.yaml` covers Step 1 only; Step 5 parameters are inline in the driver.
+
+**Arc 11.** No `configs/l_arc_11/winning_config.yaml` exists. The v3 winning config (`a2_shb_cluster0`, A2 classifier_filter with primary_threshold ≈ 0.119) lives inline in `scripts/l_arc_11/run.py` (lines 346-388 — A1Config / A2Config / A6Config builders).
+
+**What the dispatch says (Q2):** "if no canonical YAML exists at retrofit time, create one at `configs/<arc>/winning_config.yaml` matching the parameters the engine actually ran, then reference it. Document in the retrofit's §4.10 caveats that the YAML was reconstructed from artefacts."
+
+**Recommendation: take the dispatch's option — reconstruct 3 YAMLs from artefacts.** Reconstruction sources for each arc would be:
+
+- Arc 8: closure §1 `best_architecture` block + `results/l_arc_8/step_5/wfo_results.csv` (winning config row) + the existing v2.3 `configs/l_arc_8/step5.yaml` for the Step-1 signal definition (re-stated under v3.0 framing) + `scripts/l_arc_8/run_step5_wfo.py` for inline parameter values.
+- Arc 10: closure §1 + `results/l_arc_10/step_5/wfo_results.csv` + `scripts/l_arc_10_v3/step_5.py` constants + `configs/l_arc_10_v3/arc_open.yaml` for the signal-side fields.
+- Arc 11: closure §1 + `results/l_arc_11/run_summary.json` (winning-config primary_threshold ≈ 0.11937665572820917) + `scripts/l_arc_11/run.py` constants + `results/l_arc_11/ARC_OPEN.md` for signal-side fields.
+
+Each reconstructed YAML will have a header comment: `# Reconstructed retrospectively from artefacts (closure §1, step_5/wfo_results.csv, driver script). Not the live file the engine consumed at run time.` and the §4.10 caveat will mirror this.
+
+**Confirm reconstruction is acceptable before Task 4.** Alternative is to leave `config_artefact_path: null` for all three and explicitly mark the v1.2 retrofit as "schema-compliant but config-pointer-empty" — but that defeats the purpose of the field for the one arc (Arc 10) that's PASS-track and would actually benefit from EA portability foundation.
+
+### 3. FAIL arc §4 strictness (dispatch Q3)
+
+Arcs 8 and 11 are FAIL verdicts. Dispatch says §4 is "technically optional but write it anyway for consistency." Three readings:
+
+- **Full spec** — write §4.1 through §4.11 in full, same depth as Arc 10. Cost: ~250-400 lines per FAIL closure. Benefit: full structural symmetry.
+- **Abbreviated** — sub-sections present; concrete content where applicable; `N/A` or 1-line "FAIL arc — not deployment-relevant" where not. Dispatch's recommendation.
+- **Heading-only stub** — single line under each sub-heading saying "FAIL arc — not deployment-relevant." Cheapest; least useful.
+
+**Recommendation: abbreviated.** §4.1 / 4.2 / 4.3 / 4.5 / 4.6 / 4.7 / 4.8 / 4.9 written normally (these are observable from artefacts regardless of verdict). §4.4 (filter chain) written for A2/A6 winners but tagged "FAIL — not deployed." §4.10 caveats written normally. §4.11 deployment-readiness checklist marked "N/A — FAIL verdict, not for deployment."
+
+---
+
+## Parser implementation sketch (Task 3 preview)
+
+Schema detection (T3a): extend `detect_schema_version()` to return `'1.2'` when `template_version` is `'v1.2'` / `'1.2'` OR when `config_artefact_path` or `deployment_spec_section_present` fields are present in `best_architecture`. Detection order becomes 1.2 → 1.1 → 1.0 → error. The existing v1.0/v1.1 codepaths are untouched.
+
+PASS-verdict validation (T3a, wired into `update_tracker_from_closure.py` between step 2 (`schema.parse_payload`) and step 3 (`tracker_io.read_tracker`)):
+
+```python
+# After payload validated; before tracker mutations
+verdict_starts_with_pass = payload["verdict"].startswith("PASS-")
+if payload.get("template_version") == "1.2" and verdict_starts_with_pass:
+    ba = payload.get("best_architecture") or {}
+    config_path = ba.get("config_artefact_path")
+    if not config_path:
+        logging.error(...)  # HALT
+        return 1
+    if not (_REPO_ROOT / config_path).exists():
+        logging.error(...)  # HALT
+        return 1
+    if not _closure_has_deployment_spec_heading(closure_path):
+        logging.error(...)  # HALT
+        return 1
+    if ba.get("deployment_spec_section_present") is not True:
+        logging.error(...)  # HALT
+        return 1
+```
+
+Backwards compat (T3c): v1.0 and v1.1 closures skip the v1.2-only validation block. Tracker-mutation logic is unchanged across versions — the three new fields are tracked in the v1.2 schema model but **not** written to tracker columns (per dispatch: "this column is NOT in the tracker schema; do NOT add it to the tracker. It's read by the parser for validation only").
+
+Idempotency contract: re-running the parser on a retrofitted closure produces the same tracker bytes as the pre-retrofit run because the three new fields don't affect any tracker A-J mapping. This is the test `test_v12_golden_arc10.py` confirms.
+
+---
+
+## What I will NOT do without further direction
+
+- Bump the `template_version` from `v1.1` to `v1.2` in any closure beyond Arcs 8/10/11 (no Wave 1 arc 5 / 7 / 9 closures touched).
+- Add `config_artefact_path` to the tracker schema (dispatch explicitly forbids this).
+- Modify any verdict / failure_mode / amendment-3 metric in §1 of the three closures (dispatch: "Do NOT modify §2, §3, or §10/Amendment 3 content").
+- Run the engine, re-fit any classifier, or recompute any per-fold metric.
+- Open the closure PR on a branch named `infra/closure-template-v1.2` — current branch is `claude/romantic-nash-219b96`; will rename / cherry-pick if chat directs.
+
+---
+
+## Pre-execution checklist (after chat green-light)
+
+- [ ] Q1 answered (section numbering: Option A insert-with-gap)
+- [ ] Q2 answered (config YAML reconstruction: take dispatch's option; create 3 YAMLs)
+- [ ] Q3 answered (FAIL arc §4 strictness: abbreviated)
+- [ ] T1 template v1.1 → v1.2
+- [ ] T2 L_PROTOCOL §6 patch
+- [ ] T3 parser v1.2 + tests
+- [ ] T4 retrofit 3 closures (+ 3 reconstructed config YAMLs)
+- [ ] T5 WORKFLOW.md §2
+- [ ] T6 parser dry-run on all 3 — expects exit 0 × 3
+- [ ] T7 README + WORKFLOW §7
+- [ ] Log doc at `docs/dispatches/closure_template_v12_log.md`
+- [ ] PR `[INFRA] Closure template v1.2 + Arc 8/10/11 deployment spec retrofit`
+
+End of intent. Ending turn for chat review.

--- a/docs/dispatches/closure_template_v12_log.md
+++ b/docs/dispatches/closure_template_v12_log.md
@@ -1,0 +1,121 @@
+# closure_template_v12_log.md
+
+> **Dispatch:** `CC Dispatch — Closure Template v1.2 (deployment spec) + Retrofit Arcs 8, 10, 11`
+> **Branch (worktree):** `claude/romantic-nash-219b96` — to be renamed `infra/closure-template-v1.2` at PR time per chat direction.
+> **Intent doc:** [closure_template_v12_intent.md](closure_template_v12_intent.md)
+> **Outcome:** all 7 tasks executed; parser dry-run on all three retrofitted closures exit 0; full tracker_parser test suite passes (60/60).
+
+---
+
+## Task-by-task summary
+
+### Task 1 — Template v1.1 → v1.2
+
+`docs/templates/ARC_CLOSURE_TEMPLATE.md` updated:
+- Version header bumped v1.1 → v1.2 with the dispatch's verbatim summary line.
+- Added `config_artefact_path` + `deployment_spec_section_present` fields to the `best_architecture` block in §1 YAML. Bumped `template_version` placeholder to `v1.2`.
+- Inserted **§4 deployment_spec** template (4.1-4.11) verbatim from the dispatch between §3 and the Section 4 closure-→-tracker mapping checklist.
+- Added **Section 4-L** mapping entry: parser-enforced PASS-verdict validation (config path + file + heading + flag).
+- Section 5 parser notes updated to describe v1.2 detection precedence (1.2 → 1.1 → 1.0 → error).
+- Schema-versioning table extended with the v1.2 row (date 2026-05-23, deployment-spec rationale).
+
+### Task 2 — L_PROTOCOL.md §6 patch
+
+`L_PROTOCOL.md` §6 "ARC_CLOSURE.md format" subsection replaced verbatim with the dispatch's 4-section spec (§1 / §2 / §3 / §4 conditional). v1.0 reference bumped to v1.2.
+
+### Task 3 — Parser v1.2 support + tests
+
+`scripts/tracker_parser/schema.py`:
+- Module docstring updated to describe v1.2.
+- `SchemaVersion` extended to `Literal["1.0", "1.1", "1.2"]`.
+- Added `V12_EXCLUSIVE_FIELDS = {"config_artefact_path", "deployment_spec_section_present"}`.
+- `detect_schema_version()` now returns `"1.2"` for `template_version v1.2/1.2` OR presence of v1.2-exclusive fields. Detection order 1.2 → 1.1 → 1.0.
+- `VALID_VERDICTS` extended with `PASS-VIABLE-PROVISIONAL`, `PASS-DEPLOYABLE-PENDING-STEP6`, `PASS-VIABLE-PENDING-STEP6` (anticipating §4 trigger cases).
+- New `BestArchitectureV12` (extends V11 with the two deployment-spec fields) + `TrackerPayloadV12` + `normalize_to_v12()`.
+- Added `_coerce_legacy_field_names()` helper called from `parse_payload` when version detected is v1.2 — handles the retrofit case where a v1.2 closure retains v1.0-style `worst_fold_roi_pct` / `worst_fold_dd_pct` field names. Idempotent.
+- `parse_payload()` extended with v1.2 dispatch branch.
+
+`scripts/tracker_parser/extract.py`:
+- Added `DEPLOYMENT_SPEC_HEADING_RE` and `has_deployment_spec_heading(closure_path)` helper for Section 4-L item 3.
+
+`scripts/update_tracker_from_closure.py`:
+- Added `_validate_v12_pass_verdict(payload, closure_path)` — runs the four Section 4-L checks in priority order, returns 0 on pass / 1 on any failure.
+- Wired between schema validation and tracker mutations: if `template_version == "1.2"` AND `verdict` starts with `PASS-`, validation runs and HALTs before any tracker IO if it fails.
+
+**New tests:**
+- `tests/tracker_parser/test_schema_v12.py` — 9 tests covering v1.2 detection (by template_version, by exclusive field), preservation of deployment-spec fields through normalisation, backwards-compat for v1.0/v1.1, unknown template_version rejection, new verdict enum acceptance.
+- `tests/tracker_parser/test_pass_verdict_validation.py` — 6 tests covering each Section 4-L failure mode (null config path → HALT, missing config file → HALT, missing §4 heading → HALT, flag false → HALT), full PASS case, FAIL-verdict skip-validation case.
+- `tests/tracker_parser/test_v12_golden_arc10.py` — 4 tests: Arc 10 retrofit parses as v1.2, §4 heading present, §1 metric fields unchanged from v1.1 (idempotency), full CLI validation passes against live repo.
+
+Test results: **60/60 pass**. No regressions in existing 41 tests.
+
+### Task 4 — Retrofit Arcs 8, 10, 11
+
+**Three reconstructed config YAMLs** (per chat Q2):
+
+- [configs/l_arc_8/winning_config.yaml](configs/l_arc_8/winning_config.yaml) — A6 meta_labeling, SL=1.5×ATR, sl_plus_tp_3r, unlimited exposure, RF classifier with thresholds (0.3, 0.5). Reconstructed from closure §1 + wfo_results.csv row 2 (config_id=30) + scripts/l_arc_8/{shared.py, run_step5_wfo.py}.
+- [configs/l_arc_10/winning_config.yaml](configs/l_arc_10/winning_config.yaml) — A1 system_level_filter, SL=3.5×ATR, sl_partial_close_1r_runner_trail, unlimited exposure. Reconstructed from closure §1 + wfo_results.csv row 2 + scripts/l_arc_10_v3/step_5.py + configs/l_arc_10_v3/arc_open.yaml.
+- [configs/l_arc_11/winning_config.yaml](configs/l_arc_11/winning_config.yaml) — A2 classifier_filter, SL=2.0×ATR, sl_only, per-pair-1 + per-currency-2, RF classifier with threshold 0.11937665572820917 (cluster 0). Reconstructed from closure §1 + wfo_results.csv row 3 + run_summary.json + scripts/l_arc_11/run.py.
+
+All three carry the required header block per chat Q2: "RECONSTRUCTED RETROSPECTIVELY at 2026-05-23 from <sources>. Original engine ran from driver script at <path> with these parameters." Each parameter annotated with its source.
+
+**Three closure retrofits** (per chat Q1 — section numbering insert-with-gap; per chat Q3 — abbreviated §4 for FAIL arcs):
+
+- [results/l_arc_8/ARC_CLOSURE.md](results/l_arc_8/ARC_CLOSURE.md) — added `template_version: v1.2` + `config_artefact_path: configs/l_arc_8/winning_config.yaml` + `deployment_spec_section_present: true` to §1. Inserted §4 deployment_spec (FAIL arc — abbreviated, §4.4 and §4.11 marked "FAIL arc — not applicable for deployment"; §4.10 includes the chat-required config-YAML-reconstruction caveat). §2 / §3 / §10 untouched.
+- [results/l_arc_10/ARC_CLOSURE.md](results/l_arc_10/ARC_CLOSURE.md) — same §1 additions. Inserted §4 deployment_spec as primary spec (PASS-VIABLE / PASS-DEPLOYABLE-PROVISIONAL). All sub-sections written fully; §4.10 caveats include chat-required config-YAML-reconstruction language + Step 6 PROVISIONAL flag. §2 / §3 / §10 untouched.
+- [results/l_arc_11/ARC_CLOSURE.md](results/l_arc_11/ARC_CLOSURE.md) — same §1 additions. Inserted §4 deployment_spec (FAIL arc — abbreviated, same convention as Arc 8). §2 / §3 / §10 untouched.
+
+Numbering: §1, §2, §3, §4, §10 (insert-with-gap per chat Q1). §10 "Amendment 3 re-evaluation" preserved as universal cross-arc anchor.
+
+### Task 5 — WORKFLOW.md
+
+`WORKFLOW.md` §2 arc-close artefact set extended with 2 bullets for PASS verdicts: §4 deployment_spec requirement + populated `config_artefact_path` with file presence. §7 cadence-table template row updated to reference v1.2.
+
+### Task 6 — Parser dry-run re-validation
+
+```
+py scripts/update_tracker_from_closure.py results/l_arc_8/ARC_CLOSURE.md  --dry-run  → exit 0
+py scripts/update_tracker_from_closure.py results/l_arc_10/ARC_CLOSURE.md --dry-run  → exit 0
+py scripts/update_tracker_from_closure.py results/l_arc_11/ARC_CLOSURE.md --dry-run  → exit 0
+```
+
+**Arc 10 specifically:** v1.2 PASS-verdict validation runs (verdict `PASS-VIABLE` triggers it) and passes all four Section 4-L checks. No error emitted; tracker diff content is the (expected) re-application of Arc 10's contributions per the rolling-state seeding state documented in `scripts/tracker_parser/README.md` (Arcs 8 and 10 not seeded into rolling state during the prior backfill — separate work item out of scope here).
+
+**Arcs 8 and 11 (FAIL):** v1.2 PASS-verdict validation is skipped per spec (template Section 4-L last paragraph). Both parse cleanly and emit a dry-run diff matching pre-retrofit behaviour.
+
+### Task 7 — Documentation
+
+`scripts/tracker_parser/README.md`:
+- Schema-versioning section extended with v1.2 detection rule + precedence note.
+- New "v1.2 PASS-verdict validation" subsection mirroring template Section 4-L.
+- Error-modes (HALT) list extended with the v1.2-specific failures.
+- File-layout block updated to include the three new test files.
+- Test count updated from 41 → 60.
+
+---
+
+## Anything I want to flag for chat
+
+1. **Tracker diff in the v1.2 dry-run is expected, not a regression.** The dispatch said "Tracker state should be unchanged from current — these retrofits do NOT add tracker rows." Arc 11's pre-retrofit sha256 is in `parsed.log`, so pre-retrofit Arc 11 was a no-op; the retrofit changes the sha256 so on a real (non-dry-run) invocation, the parser would re-apply Arc 11's contributions to the tracker. Arcs 8 and 10 were never seeded into rolling state (per README "Bootstrap state (2026-05-22)" — `Arcs 8 and 10 are NOT seeded`), so they would also re-apply. **This is a pre-existing condition; the dispatch's expectation does not hold because rolling state ≠ tracker rows.** If chat wants the tracker bytes truly unchanged post-retrofit, the cleanup path is to seed Arcs 8 and 10 into rolling state alongside this PR — but that's the `results/re_evaluation_2026_05/SUMMARY.md §"Tracker work surfaced"` work item the README already flags as out of scope. Recommend leaving as-is and addressing in the separate cleanup PR; the v1.2 retrofit is structurally correct regardless.
+
+2. **Verdict enum extended.** Added `PASS-VIABLE-PROVISIONAL`, `PASS-DEPLOYABLE-PENDING-STEP6`, `PASS-VIABLE-PENDING-STEP6` to `VALID_VERDICTS` to match the template v1.2 §4 trigger spec ("REQUIRED if verdict ∈ {PASS-DEPLOYABLE, PASS-VIABLE, PASS-DEPLOYABLE-PROVISIONAL, PASS-VIABLE-PROVISIONAL, PASS-*-PENDING-STEP6}"). The schema rejects unknown verdicts; without this extension, future closures using the new variants would HALT in schema validation. Chat may want to track this as a v3.0 schema-versioning note — though materially it's a forward extension, not a breaking change.
+
+3. **Section 4-L specifically prohibits adding `config_artefact_path` to the tracker schema** ("this column is NOT in the tracker schema; do NOT add it to the tracker. It's read by the parser for validation only"). Implemented exactly: the v1.2 field is read by the new CLI helper but never written to any tracker cell. The `mapping` module is unchanged.
+
+4. **Branch rename pending.** Current worktree branch is `claude/romantic-nash-219b96`. Per chat direction, will rename to `infra/closure-template-v1.2` at PR open time.
+
+5. **Rebase onto main mid-dispatch — Arc 10 §10 finalisation reconciled.** Mid-dispatch, `origin/main` advanced by one commit ([#178](https://github.com/kpanapabusiness-droid/Forex-Backtester/pull/178)) which finalised Arc 10's §10 Amendment 3 re-evaluation from `PASS-DEPLOYABLE-PROVISIONAL` to `PASS-DEPLOYABLE (confirmed)` after Step 6 audit clean. I stashed the v1.2 retrofit, fast-forwarded the worktree to main (cleanly — no merge), restored the stash (no conflicts — main's edits in §10 / my edits in §1 + §4 touch different file regions), and updated three Arc 10 §4 references to reflect the post-finalisation state: §4 header (PASS-DEPLOYABLE instead of PASS-DEPLOYABLE-PROVISIONAL), §4.10 caveats (chained DD + per-day DD missing-data flags now framed as "forwarded out of Step 6 scope per main #178" with revert clause), §4.11 Step-6 checklist row (checked, points to `step_6/audit_report.md` from #178). §10 itself was not modified by me — that's main's content, preserved per dispatch rule. The v1.2 golden test for Arc 10 + the full 60-test suite + all three parser dry-runs (exit 0) re-validated post-reconciliation.
+
+---
+
+## Definition-of-done checklist
+
+- [x] `docs/templates/ARC_CLOSURE_TEMPLATE.md` at v1.2 with §4 deployment_spec template + `config_artefact_path` field.
+- [x] `L_PROTOCOL.md` §6 patched.
+- [x] Parser updated with v1.2 schema detection + PASS-verdict validations + test coverage (60/60).
+- [x] Arcs 8, 10, 11 retrofitted with §4 deployment_spec + updated §1 tracker_payload.
+- [x] Parser dry-run exits 0 on all three retrofitted closures.
+- [x] `WORKFLOW.md` updated (§2 arc-close artefact set + §7 cadence table).
+- [x] `scripts/tracker_parser/README.md` updated.
+
+End of log. Ready for PR.

--- a/docs/templates/ARC_CLOSURE_TEMPLATE.md
+++ b/docs/templates/ARC_CLOSURE_TEMPLATE.md
@@ -1,4 +1,4 @@
-# ARC_CLOSURE.md Template (Locked v1.1)
+# ARC_CLOSURE.md Template (Locked v1.2)
 
 > **Location:** `docs/templates/ARC_CLOSURE_TEMPLATE.md`
 > **Status:** locked. Every arc closure MUST follow this template.
@@ -10,6 +10,7 @@
 > **Design priority:** machine-parseability over human readability. §1 YAML is the source of truth for the tracker. §2 + §3 exist only to preserve cross-arc synthesis quality that prose enables and YAML doesn't.
 >
 > **v1.1 (2026-05-22, L_PROTOCOL Amendment 3):** risk-normalised gate fields added to `best_architecture` block. Two fields renamed (see §"Schema versioning" at end of template). `primary_failure_mode` enum extended.
+> **v1.2 (2026-05-23, deployment-spec addition):** `config_artefact_path`, `deployment_spec_section_present`, `template_version` fields added to `best_architecture` block. New §4 deployment_spec section: REQUIRED for any PASS verdict, OPTIONAL for FAIL / HALT / DISCOVERY_COMPLETE. Parser enforces config path + §4 presence for PASS verdicts.
 
 ---
 
@@ -29,7 +30,7 @@
 ```yaml
 tracker_payload:
 
-  template_version: v1.1   # NEW in v1.1 — parser uses this to dispatch schema. Omit or set to v1.0 for legacy closures.
+  template_version: v1.2   # Schema dispatch. Accepts v1.0, v1.1, v1.2 (parser detects via this field OR v1.1/v1.2-exclusive fields).
 
   # ────── Identity ──────
   arc_name: <arc_name>
@@ -107,6 +108,10 @@ tracker_payload:
     holdout_dd_at_r_hard_pct: <float or null>
     sizing_convention: reset_floor | equity_pct  # gate FAILs equity_pct unless chat approves
 
+    # ── v1.2 deployment-spec fields ──
+    config_artefact_path: <relative path to canonical config YAML from repo root, or null for non-PASS verdicts>
+    deployment_spec_section_present: <bool>   # parser sanity-check — must be true if verdict starts with PASS-
+
   # ────── Cost decomposition (null if winning arch is not classifier-based) ──────
   cost_decomposition:
     admit_pool:      {n_fraction: <float>, mean_r: <float>}
@@ -168,6 +173,76 @@ Examples of useful cross-arc observations:
 - "Third V-shape cohort with Step 4 AUC < 0.55 — confirms entry-feature ceiling pattern"
 - "Pipeline D1 admit/reject pools mirror Arc 5 within ±10% on all metrics — fourth instance"
 - "Cross-arc co-fire with Arc 7 = 5.4% on c1 trades — worth EXP-05 style pooling"
+
+---
+
+## §4 deployment_spec
+
+> REQUIRED if verdict ∈ {PASS-DEPLOYABLE, PASS-VIABLE, PASS-DEPLOYABLE-PROVISIONAL, PASS-VIABLE-PROVISIONAL, PASS-*-PENDING-STEP6}. OPTIONAL for FAIL / HALT / DISCOVERY_COMPLETE.
+>
+> Self-contained porting specification. An EA developer must be able to implement this strategy on MT5 (or any platform) using ONLY this section + the YAML at `best_architecture.config_artefact_path`. No reverse-engineering from other artefacts required.
+
+### 4.1 Pair set
+
+- **Pairs:** <explicit list>
+- **Timeframe:** <primary TF>
+- **Higher-TF references:** <D1 lagged, W1, etc.>
+
+### 4.2 Signal definition
+
+Pseudocode of the entry trigger logic. Concrete enough to translate to MT5 line-by-line. Cite feature names matching `best_architecture.features_in_winning_config`. All thresholds numeric, no symbolic placeholders.
+
+### 4.3 Feature computation specs
+
+For each feature in `best_architecture.features_in_winning_config`:
+- **`<feature_name>`** — source bars, formula, lag rule, output type
+
+### 4.4 Filter chain (A1 / A2 / A6 architectures only)
+
+Ordered filter list applied AFTER signal generation, BEFORE entry. For each: type (hard veto / soft score / classifier admit), threshold, on-reject behaviour. For A2/A6 include classifier type, training-window definition, top features by importance, decision threshold.
+
+### 4.5 Entry mechanics
+
+- Trigger bar / fill bar / fill price / order type / slippage assumption
+
+### 4.6 Exit mechanics
+
+- Initial SL anchor, distance, update rule
+- Trail activation condition (incl. close/high reference)
+- Trail distance (incl. close/high reference for trail level)
+- Trail update frequency
+- TP, time exit if any
+- Bar-by-bar evaluation order
+
+### 4.7 Exposure cap
+
+- Type (unlimited / per-pair-N / per-currency-N / global-N / custom)
+- Counter logic, behaviour at cap
+
+### 4.8 Risk sizing
+
+- `r_safe` value from §1
+- Risk basis (reset-floor / equity-pct / other)
+- Floor reset condition
+- Position size formula
+- Lot rounding
+
+### 4.9 Session / time-of-day rules
+
+- Trading hours, day-of-week filter, news-window filter, holiday handling
+
+### 4.10 Discrepancies and caveats
+
+Known differences between backtest and expected live deployment.
+
+### 4.11 Deployment readiness checklist
+
+- [ ] Config YAML at `config_artefact_path` exists and is self-contained
+- [ ] All features in §4.3 reproduce against KH-24 live MT5 data within tolerance
+- [ ] Risk sizing at `r_safe` confirmed feasible against 5ers broker minimums
+- [ ] EA implementation matches §4.2-4.9 line-by-line
+- [ ] Backtest-vs-EA byte-identical pre-deployment shadow run on 30 days of data
+- [ ] Step 6 causal audit clean
 
 ```
 
@@ -251,6 +326,21 @@ If a tracker row is suspected wrong post-update:
 2. Add footnote describing suspected issue.
 3. Resolve in next protocol calibration review.
 
+### L. v1.2 PASS-verdict validation (parser-enforced)
+
+When `template_version == 1.2` AND `verdict` starts with `PASS-`, the parser additionally enforces (before applying any A-J mapping):
+
+1. `best_architecture.config_artefact_path` MUST be non-null.
+2. The file at `config_artefact_path` (interpreted relative to repo root) MUST exist.
+3. The closure doc MUST contain a `## §4 deployment_spec` heading.
+4. `best_architecture.deployment_spec_section_present` MUST be `true`.
+
+Any of (1)-(4) failing → parser HALTs with exit code 1, no tracker write. Fix the closure doc and re-run.
+
+Note: `config_artefact_path` is read by the parser for validation only — it is NOT written to any tracker column. The tracker schema is unchanged at v1.2.
+
+For non-PASS verdicts in v1.2, (L) is skipped; §4 is optional. For v1.0 / v1.1 closures, (L) is not evaluated.
+
 ---
 
 ## Section 5 — Parser implementation
@@ -266,7 +356,7 @@ Parser specification (preserved here for reference):
 - Output: append-only updates to `ARC_TRACKER.md` per Section 4 A-J above.
 - Idempotency: parsing the same closure doc twice produces identical tracker (no double-append). Tracked via sha256 in `scripts/tracker_parser/parsed.log`.
 - Determinism: same closure doc + same starting state → byte-identical output tracker.
-- **Schema version detection (v1.1+):** parser inspects the closure doc's referenced template version. v1.0 closures use legacy field names (`worst_fold_roi_pct`, `worst_fold_dd_pct`); v1.1+ closures use the renamed fields (`worst_fold_roi_base_pct`, `worst_fold_dd_base_pct`) and may populate Amendment 3 risk-normalised fields. Parser accepts both schemas — never rewrites historical closures.
+- **Schema version detection (v1.1+):** parser inspects the closure doc's referenced template version. v1.0 closures use legacy field names (`worst_fold_roi_pct`, `worst_fold_dd_pct`); v1.1+ closures use the renamed fields (`worst_fold_roi_base_pct`, `worst_fold_dd_base_pct`) and may populate Amendment 3 risk-normalised fields. v1.2 closures additionally carry `config_artefact_path`, `deployment_spec_section_present` in `best_architecture` and trigger PASS-verdict validation per Section 4-L. Detection order: 1.2 → 1.1 → 1.0 → error. Parser accepts all three schemas — never rewrites historical closures.
 
 ---
 
@@ -276,8 +366,9 @@ Parser specification (preserved here for reference):
 |---|---|---|
 | v1.0 | 2026-05-13 | Initial locked template. |
 | v1.1 | 2026-05-22 | L_PROTOCOL Amendment 3. Risk-normalised fields added to `best_architecture`. Two fields renamed: `worst_fold_roi_pct` → `worst_fold_roi_base_pct`, `worst_fold_dd_pct` → `worst_fold_dd_base_pct`. `primary_failure_mode` enum extended. Pre-v1.1 closures retain v1.0 field names; parser handles both via version detection. |
+| v1.2 | 2026-05-23 | Deployment-spec addition. Three new fields in `best_architecture`: `config_artefact_path`, `deployment_spec_section_present`, `template_version` (the last was conventional in v1.1; locked at v1.2). New §4 deployment_spec section: REQUIRED for PASS-* verdicts (DEPLOYABLE, VIABLE, *-PROVISIONAL, *-PENDING-STEP6), OPTIONAL otherwise. Parser HALTs on PASS verdict if config path missing / file absent / §4 heading missing (Section 4-L). Pre-v1.2 closures unaffected. |
 
-Closures MUST reference the template version they were written against (e.g., `template_version: v1.1` near the top of `§1 tracker_payload` is the convention going forward — pre-v1.1 closures without this field are assumed v1.0).
+Closures MUST reference the template version they were written against (e.g., `template_version: v1.2` near the top of `§1 tracker_payload` is the convention going forward — pre-v1.1 closures without this field are assumed v1.0; pre-v1.2 closures without `config_artefact_path` are assumed v1.1).
 
 ---
 

--- a/results/l_arc_10/ARC_CLOSURE.md
+++ b/results/l_arc_10/ARC_CLOSURE.md
@@ -11,6 +11,8 @@
 ```yaml
 tracker_payload:
 
+  template_version: v1.2
+
   # ────── Identity ──────
   arc_name: l_arc_10
   signal: D1 swing-low rejection long (DLR, v0.1) — bullish rejection of confirmed ascending D1 swing-low, 4H entry
@@ -56,6 +58,10 @@ tracker_payload:
     oracle_worst_ratio: -1.1896   # caveat: oracle was locked to sl_only exit, not the partial-close policy — not a fair upper bound
     oracle_real_gap_sharpe: null   # not computed; oracle exit-policy mismatch makes the gap non-comparable
     features_in_winning_config: []   # A1 uses no classifier features — the signal conditions + SL/exit policy ARE the architecture
+
+    # ── v1.2 deployment-spec fields (added 2026-05-23 retrofit) ──
+    config_artefact_path: configs/l_arc_10/winning_config.yaml
+    deployment_spec_section_present: true
 
   # ────── Cost decomposition ──────
   cost_decomposition: null   # A1 is unfiltered — no admit/reject pools
@@ -149,6 +155,146 @@ A1 (no classifier filter, full Step 1 pool of 2,162 search-window trades) with S
 
 - **Oracle-WFO comparison pattern broken when oracle exit policy ≠ winning architecture exit policy.** Step 5's oracle locked to `sl_only` at SL=4.0 (the Step 3 best); winning A1 used `sl_partial_close_1r_runner_trail` at SL=3.5. Oracle reports -11.74% worst ROI while A1 reports +26.49% — implying A1 BEATS the oracle, which is structurally impossible if both used the same exit. The lesson: oracle WFO must sweep the same architecture × config grid as the realised candidates, or be reported only as "cluster-filter true-label upper bound CONDITIONAL on identical exit policy." Recommendation for protocol §2 Step 5 Amendment 2's oracle WFO definition: lock oracle to the WINNING architecture's config sans cluster-filter, not to a fixed (best_sl, sl_only).
 ```
+
+---
+
+## §4 deployment_spec (added 2026-05-23 retrofit)
+
+> PASS-VIABLE verdict (baseline) / PASS-DEPLOYABLE (Amendment 3 re-eval §10, finalised post-Step-6 audit). Self-contained porting spec for the A1 winning candidate. EA developer can implement this strategy on MT5 using ONLY this section + `configs/l_arc_10/winning_config.yaml`.
+
+### 4.1 Pair set
+
+- **Pairs:** AUDCAD, AUDCHF, AUDJPY, AUDNZD, AUDUSD, CADCHF, CADJPY, CHFJPY, EURAUD, EURCAD, EURCHF, EURGBP, EURJPY, EURNZD, EURUSD, GBPAUD, GBPCAD, GBPCHF, GBPJPY, GBPNZD, GBPUSD, NZDCAD, NZDCHF, NZDJPY, NZDUSD, USDCAD, USDCHF, USDJPY (28 FX pairs, KH-24 set)
+- **Timeframe:** H4 primary
+- **Higher-TF references:** D1 (anchor, one-bar-lagged per L_PROTOCOL §1 non-negotiable); W1 (aux, used for cross-pair feature context at Step 1 — does NOT feed entry trigger since A1 carries no classifier features)
+
+### 4.2 Signal definition
+
+D1 swing-low rejection long (DLR v0.1) — bullish rejection of a confirmed ascending D1 swing-low, evaluated on the H4 bar that closes during that D1 day.
+
+Pseudocode (translates line-by-line to MT5 EA):
+
+```
+# Setup: maintain a rolling list of ascending D1 swing-lows on the D1 series.
+# A swing-low is "confirmed" when the right-edge offset rule holds:
+#   d1_right_edge_offset = 4         # the swing-low bar k satisfies k <= t_eval - 4 on D1
+#   d1_swing_window_k    = 3         # k-3..k-1 strictly above L[k]; k+1..k+3 also above
+#                                    # (3-bar window each side; L[k] is the lowest of 7 bars)
+
+# At each H4 bar close on pair P:
+#   t       = bar close timestamp (UTC)
+#   atr14   = ATR(14) on H4 at bar t (Wilder, computed from H4 bars only)
+#   d1_bars = D1 series up to t with one-bar-lag (most recent D1 bar available = D1[t-1d])
+#
+#   # Identify candidate swing-low Ls:
+#   #   most recent ASCENDING swing-low on the D1 series with confirmation lag >= 4 bars
+#   #   AND the prior swing-low (one back) is BELOW Ls (ascending structure)
+#   Ls = most_recent_ascending_confirmed_swing_low(d1_bars,
+#                                                  k=d1_swing_window_k,
+#                                                  right_edge_offset=d1_right_edge_offset,
+#                                                  lookback_bars=d1_structure_lookback_bars=30)
+#   if Ls is null: skip
+#
+#   # Freshness check: Ls must be no older than 20 D1 bars
+#   age_d1 = (most_recent_d1_bar_index - Ls.bar_index)
+#   if age_d1 > d1_l1_freshness_max_bars=20: skip
+#
+#   # Proximity test: the H4 bar's low must be within 0.25 ATR_4H of Ls.value
+#   if (Ls.value - bar_low) > proximity_atr_mult=0.25 * atr14: skip
+#
+#   # Rejection geometry: H4 bar closes back above Ls.value with a buffer
+#   if bar_close < Ls.value + reject_buffer_atr_mult=0.10 * atr14: skip
+#
+#   # Bar quality: close in the upper 60% of the bar's range
+#   bar_range = bar_high - bar_low
+#   if bar_range == 0: skip
+#   if (bar_close - bar_low) / bar_range < upper_fraction_min=0.6: skip
+#
+#   # Refractory: at least 20 H4 bars since the last signal on this pair
+#   if h4_bars_since_last_signal[P] < refractory_bars_4h=20: skip
+#
+#   EMIT signal (long) at t. Entry fills at the next H4 bar's open.
+```
+
+All thresholds numeric, no symbolic placeholders. Per-pair state required: H4 ATR(14), per-pair last-signal-time, the D1 series with confirmation-lag swing detection.
+
+### 4.3 Feature computation specs
+
+A1 (system_level_filter) uses NO classifier features. The signal definition itself + SL + exit policy constitute the architecture. The `features_in_winning_config` list in §1 is empty by design.
+
+For Step 1 pool construction (used for clustering / characterization only — NOT consumed at entry time by A1), the standard L_PROTOCOL §2 Step 1 27-feature default catalogue was computed. Those features do NOT need to exist in the EA implementation since A1 doesn't filter on them. The EA only needs to compute ATR(14)_H4 + the D1 swing detection state described in §4.2.
+
+### 4.4 Filter chain (A1 / A2 / A6 architectures only)
+
+**A1 architecture — no filter chain.** A1 admits every signal that passes §4.2's trigger. No classifier admit-step, no soft-score, no rule-based hard veto downstream of the signal.
+
+The signal definition's own conditions (Ls freshness, proximity, rejection geometry, upper-fraction, refractory) constitute the entire filter chain — they are evaluated AT signal-bar close, not as a separate post-signal step.
+
+### 4.5 Entry mechanics
+
+- **Trigger bar:** H4 bar that satisfies §4.2's predicate (the "signal bar").
+- **Fill bar:** the next H4 bar after the trigger bar (i.e., bar N+1 where N is the signal bar).
+- **Fill price:** open of bar N+1.
+- **Order type:** market on bar N+1 open.
+- **Slippage assumption:** real bid/ask spread from MT5 broker feed (L_PROTOCOL §1 non-negotiable). No spread modelling for backtesting beyond what HistData M1 bid+ask provides.
+
+### 4.6 Exit mechanics
+
+- **Initial SL anchor:** entry price.
+- **Initial SL distance:** `2.0 × ATR(14)_H4` measured at the signal bar (NOT recomputed at fill).
+- **SL update rule:** static until the partial-close milestone.
+- **Partial close trigger:** when running PnL ≥ +1R (where R = the initial SL distance in price units), close 50% of position at next H4 bar's open. The +1R condition is evaluated bar-close, not intra-bar.
+- **Runner trail activation:** the remaining 50% trails from the partial-close moment forward.
+- **Trail distance:** 1R below the highest H4 close-since-entry (bar-close updates only, no intra-bar trail updates).
+- **Trail reference:** peak H4 close (high-since-entry). Bar-close updates only.
+- **Trail update frequency:** once per H4 bar close.
+- **TP:** none (the partial close + trail handles the upside).
+- **Time exit:** 240 H4 bars after entry (≈ 40 calendar days), regardless of PnL state. Force-closes any remaining size at the H4 open of bar N+240+1.
+- **Bar-by-bar evaluation order on each H4 bar:** (1) check SL hit; (2) if SL hit, exit at SL price; (3) else if pre-partial-close and close ≥ +1R, schedule partial close at next bar open; (4) else if post-partial-close, update trail level; (5) check trail hit; (6) check time exit. Stops and trail use the H4 close as the reference for "hit" — intra-bar wicks are NOT a trigger.
+
+### 4.7 Exposure cap
+
+- **Type:** unlimited (closure §1 `best_architecture.exposure_cap: unlimited`).
+- **Per-pair invariant:** max 1 open position per pair (L_PROTOCOL §2 Step 1 default; preserved at A1).
+- **Per-currency cap:** none.
+- **Global concurrent cap:** none.
+- **Behaviour at cap:** N/A — exposure is unlimited globally, and per-pair-1 means a new signal on a pair with an open position is simply skipped (no queue).
+
+### 4.8 Risk sizing
+
+- **`r_safe` value:** 0.4339% (closure §10: `k_safe = 8.0 / 9.22 = 0.8677`; `r_safe = 0.5% × 0.8677 = 0.4339%`).
+- **`r_hard` value:** 0.5423% (closure §10: `k_hard = 10.0 / 9.22 = 1.0846`).
+- **Risk basis:** reset-floor (L arc convention).
+- **Floor reset condition:** engine default — typically per-arc starting balance or last-reset-to-floor marker; see engine spec for the exact rule.
+- **Position size formula:** `lots = floor( (current_reset_floor × r_safe_pct / 100) / (sl_distance_in_price × pip_value × contract_size) , 0.01 )` (round down to the 0.01 lot step).
+- **Lot rounding:** down to the broker's minimum lot step (0.01 on 5ers).
+- **Starting balance assumption (backtest):** $100,000.
+
+### 4.9 Session / time-of-day rules
+
+- **Trading hours:** 24/5 (Sun 22:00 UTC open → Fri 22:00 UTC close, MT5 broker convention). No intraday session filter — the signal is evaluated at every H4 bar close.
+- **Day-of-week filter:** none beyond the standard weekend break.
+- **News-window filter:** none (no news-proximity exclusion; per L_PROTOCOL convention and KH-24 baseline).
+- **Holiday handling:** broker calendar — bars that don't exist in the H4 series are skipped naturally.
+
+### 4.10 Discrepancies and caveats
+
+- **Config YAML reconstruction.** `configs/l_arc_10/winning_config.yaml` was reconstructed retrospectively from closure §1, `step_5/wfo_results.csv`, and `scripts/l_arc_10_v3/step_5.py`. Original engine ran from the inline driver script. Reconstructed file is the source of truth going forward; pre-retrofit deployment would require source verification against `scripts/l_arc_10_v3/step_5.py`.
+- **Chained DD not measured (forwarded out of Step 6 scope per main #178).** Per-fold equity reset means cumulative cross-fold DD is unknown. The §10 PASS-DEPLOYABLE finalisation depends on `chained_max_dd_base_pct ≤ 11.52%` (which would scale to ≤ 10% at `k_safe = 0.87`). Plausible but unverified. Engine re-run with continuous-equity tracking still recommended for definitive measurement; verdict reverts to PROVISIONAL if a re-run surfaces a constraint #7 failure per §10 finalisation clause.
+- **Per-day max-DD series not built (forwarded out of Step 6 scope per main #178).** §10 constraint #6 (daily breaches at `r_safe` = 0) carries a missing-data flag because the per-day series under v3.0 pre-amendment wasn't emitted. Under `k_safe < 1`, the per-day breach count can only decrease relative to `r_base` count — but the `r_base` count itself wasn't stored. Verdict reverts per §10 finalisation clause if a re-run surfaces a constraint #6 failure.
+- **Oracle WFO not a fair upper bound.** Oracle was locked to `sl_only` at SL=4.0; winning A1 uses `sl_partial_close_1r_runner_trail` at SL=3.5. Oracle reports −11.74% worst ROI vs A1 +26.49%, which is structurally impossible if both used the same exit. Treat oracle as informational only.
+- **Pool-size drift from v2 engine.** v2→v3 produced +312% pool size (802 → 3,301 trades). Path features (mid-based) are spread-independent; pool size + exposure-derived metrics are not. Forward arcs need not reproduce v2 numbers.
+- **Spread floor source.** Per L_PROTOCOL §1 — real bid/ask from HistData M1; no fallback. Live EA must use MT5 broker spreads, not a synthetic floor.
+
+### 4.11 Deployment readiness checklist
+
+- [ ] Config YAML at `configs/l_arc_10/winning_config.yaml` exists and is self-contained. (✓ exists; ⚠️ reconstructed retrospectively — verify against `scripts/l_arc_10_v3/step_5.py` before deploying)
+- [ ] All features in §4.3 reproduce against KH-24 live MT5 data within tolerance. (N/A — A1 carries no classifier features)
+- [ ] Risk sizing at `r_safe = 0.4339%` confirmed feasible against 5ers broker minimums. (PENDING — minimum-lot feasibility check at small-balance accounts)
+- [ ] EA implementation matches §4.2-4.9 line-by-line. (PENDING — EA not yet implemented for Arc 10)
+- [ ] Backtest-vs-EA byte-identical pre-deployment shadow run on 30 days of data. (PENDING)
+- [x] Step 6 causal audit clean. (✓ — `results/l_arc_10/step_6/audit_report.md` PASS per main #178; verdict finalised PASS-DEPLOYABLE)
+- [ ] **Engine re-run with continuous-equity tracking + per-day max-DD emission still recommended for definitive measurement of constraints #6 / #7 (see §10 finalisation clause — verdict reverts on failure).**
 
 ---
 

--- a/results/l_arc_11/ARC_CLOSURE.md
+++ b/results/l_arc_11/ARC_CLOSURE.md
@@ -10,6 +10,7 @@
 
 ```yaml
 tracker_payload:
+  template_version: v1.2
   arc_name: l_arc_11
   signal: swing-high breakout in trend (SHB) long, 4H, causal 3-bar swing (right-edge t-4)
   tf: H4
@@ -58,6 +59,9 @@ tracker_payload:
     - atr_percentile_100
     - usd_strength_index
     - spread_vs_trailing_100
+    # ── v1.2 deployment-spec fields (added 2026-05-23 retrofit; FAIL arc — for documentation parity) ──
+    config_artefact_path: configs/l_arc_11/winning_config.yaml
+    deployment_spec_section_present: true
   cost_decomposition:
     admit_pool:
       n_fraction: 0.125
@@ -164,6 +168,142 @@ The worst-fold ratio -0.769 is below the §3 PASS-VIABLE/DEPLOYABLE threshold of
 - Canonical orchestrator (`core/arc/arc_orchestrator.py::_run_step_5`) does not plumb `run_context` through `ArcFoldRunner`. Result: A2 / A3 / A4 / A6 — all architectures requiring `per_trade_features` — silently produce 0-trade folds when invoked via `ArcOrchestrator.run()`. This driver bypassed `_run_step_5` and constructed `A1RunContext(per_trade_features=...)` manually before `ArcFoldRunner`. Surface this gap to master chat as a v3 infra blocker for any arc using classifier-based architectures via the orchestrator. Fix is a one-line change in `_run_step_5` to thread `run_context` through; the runner already accepts it.
 - First v3.0 arc to clear Step 4 entry-feature gate (RF AUC ≥ 0.65) on 1 candidate cluster(s). Confirms the v3 27-feature default envelope CAN extract for the SHB signal class with the right cluster geometry.
 - Swing-detection producer-level causal audit (Arc 9 lesson) PASS by construction: the producer `signals/lchar_swing_high_breakout_trend.py` uses `RIGHT_EDGE_OFFSET=4` to constrain 3-bar swing consumption to k ≤ t-4, making right-side detection bars k+1..k+3 ≤ t-1 — strictly prior to signal-bar open. Confirmation-lag idiom is causally clean; whitelisted by dispatch.
+
+---
+
+## §4 deployment_spec (FAIL arc — included for consistency, NOT for deployment)
+
+> Abbreviated per dispatch — sub-sections 4.1-4.3 and 4.5-4.10 written from artefacts; §4.4 and §4.11 marked "FAIL arc — not applicable for deployment."
+>
+> FAIL verdict (closure §1 + §10).
+
+### 4.1 Pair set
+
+- **Pairs:** AUDCAD, AUDCHF, AUDJPY, AUDNZD, AUDUSD, CADCHF, CADJPY, CHFJPY, EURAUD, EURCAD, EURCHF, EURGBP, EURJPY, EURNZD, EURUSD, GBPAUD, GBPCAD, GBPCHF, GBPJPY, GBPNZD, GBPUSD, NZDCAD, NZDCHF, NZDJPY, NZDUSD, USDCAD, USDCHF, USDJPY (28 FX pairs, KH-24 set)
+- **Timeframe:** H4 primary
+- **Higher-TF references:** D1 anchor (one-bar-lagged); W1 aux (for `w1_close_slope_sign` feature). D1 + W1 panels were built and passed via the manual A1RunContext path (driver bypassed orchestrator due to the `canonical_orchestrator_step5_run_context_gap` flagged in closure §3).
+
+### 4.2 Signal definition
+
+Swing-high breakout in trend (SHB) long — causal 3-bar swing-high breakout with structural trend filter, decisive break + bullish close + upper-half close + 0.10×ATR buffer, 20-bar refractory.
+
+Pseudocode:
+
+```
+# Maintain rolling 3-bar swing-highs on H4 with causal right-edge offset.
+# A swing-high at bar k is "confirmed" when bar k satisfies k <= t_eval - 4
+# (RIGHT_EDGE_OFFSET=4) — meaning 3 confirmation bars must close strictly
+# below H[k] AND those confirmation bars must close strictly prior to t_eval.
+# This makes the right-side detection causal: k+1..k+3 are all at t_eval-1 or earlier.
+#
+# At each H4 bar close on pair P:
+#   t       = bar close timestamp (UTC)
+#   atr14   = ATR(14) on H4 at bar t (Wilder)
+#
+#   # Trend filter: structural uptrend (HH/HL with right-edge causal lag)
+#   if not structural_uptrend(h4_bars, t, swing_window_k=3): skip
+#
+#   # Find the most recent confirmed swing-high prior to t
+#   Hs = most_recent_confirmed_swing_high(h4_bars,
+#                                          k=3, right_edge_offset=4)
+#   if Hs is null: skip
+#
+#   # Decisive break: bar close strictly above Hs.value + 0.10×ATR buffer
+#   if close[t] < Hs.value + 0.10 * atr14: skip
+#
+#   # Upper-half close: (close - low) / (high - low) >= 0.5
+#   bar_range = high[t] - low[t]
+#   if bar_range == 0: skip
+#   if (close[t] - low[t]) / bar_range < 0.5: skip
+#
+#   # Refractory: 20 H4 bars since last signal on this pair
+#   if h4_bars_since_last_signal[P] < 20: skip
+#
+#   EMIT signal (long) at t. Entry fills at next H4 bar's open.
+```
+
+Causal-clean per closure §3: confirmation-lag idiom whitelisted by dispatch.
+
+### 4.3 Feature computation specs
+
+The 10 features in the winning A2 config (closure §1 `best_architecture.features_in_winning_config`):
+
+- **`w1_close_slope_sign`** — sign of the W1 close-slope (linear-fit slope over the last N W1 bars). Categorical {-1, 0, +1}. Computed at signal-bar close from the W1 panel.
+- **`d1_atr_percentile_100`** — percentile rank of current D1 ATR(14) within the trailing 100 D1 bars. One-bar-lagged.
+- **`prior_session_low_distance`** — H4 close distance to prior session low, in ATR units.
+- **`day_of_week`** — categorical {0..4}, signal-bar UTC weekday.
+- **`session_london`** — boolean: is the signal bar within the London session (08:00-16:00 UTC, broker-day convention)?
+- **`d1_close_slope_magnitude`** — magnitude of the D1 close-slope over the last N D1 bars. One-bar-lagged.
+- **`distance_to_round_number`** — H4 close distance to nearest round-number level (00/50 pips), in ATR units.
+- **`atr_percentile_100`** — percentile rank of current H4 ATR(14) within trailing 100 bars.
+- **`usd_strength_index`** — cross-pair USD strength composite at signal-bar close.
+- **`spread_vs_trailing_100`** — current bid/ask spread relative to trailing 100-bar mean.
+
+Step 1 used the L_PROTOCOL §2 Step 1 27-feature default; Step 4 RF picked these 10 as top by permutation importance.
+
+### 4.4 Filter chain (A1 / A2 / A6 architectures only)
+
+**FAIL arc — not applicable for deployment.** A2 classifier_filter uses Step 4's best classifier (RF, AUC 0.6543) with AUC-best threshold 0.119 to admit/reject signals for cluster-0 (Bimodal, n=2,192 in Step 1 pool). Section retained for documentation parity only. Winning-fold metrics: ratio -0.769, ROI -24%, DD 38%, 4 negative folds — closure §10 finds FAIL on 7+ independent constraints under Amendment 3.
+
+### 4.5 Entry mechanics
+
+- **Trigger bar:** H4 bar satisfying §4.2 AND classifier admit at threshold 0.119.
+- **Fill bar:** next H4 bar (N+1).
+- **Fill price:** open of bar N+1.
+- **Order type:** market.
+- **Slippage assumption:** real bid/ask spreads.
+
+### 4.6 Exit mechanics
+
+- **Initial SL anchor:** entry price.
+- **Initial SL distance:** `2.0 × ATR(14)_H4` at signal bar (closure §1 `sl_atr: 2.0`).
+- **SL update rule:** static.
+- **Trail activation:** N/A (`trail_enabled: false`).
+- **Trail distance / reference / frequency:** N/A.
+- **TP:** none (`sl_only` exit policy).
+- **Time exit:** 240 H4 bars after entry.
+- **Bar-by-bar evaluation order:** (1) SL hit → exit at SL price; (2) time exit at bar 240.
+
+### 4.7 Exposure cap
+
+- **Type:** per-pair-1 + per-currency-2 (closure §1 `exposure_cap: 2`; driver's `max_concurrent_per_pair: 1`, `max_concurrent_per_currency: 2`).
+- **Counter logic:** independent counters per pair (max 1) and per currency (max 2 — counted across both base and quote currency exposure). New signal admitted only if both counters below cap.
+- **Behaviour at cap:** signal skipped (no queue).
+
+### 4.8 Risk sizing
+
+- **`r_safe` value:** 0.1043% — **below** locked `r_min = 0.15%` floor (closure §10: `scalable_to_safe: false`).
+- **`r_hard` value:** 0.1303% — also below floor.
+- **Risk basis:** reset-floor.
+- **Note (closure §10):** the `r_safe < r_min` scenario is the symmetric inverse of Arc 8's `r_safe > r_max` failure — both are scalability failures. Documented as `scalability_floor_failure_high_dd`.
+- **Starting balance:** $100,000.
+
+### 4.9 Session / time-of-day rules
+
+- **Trading hours:** 24/5 standard FX session. Signal evaluation per H4 bar close; classifier ingests `session_london` feature (boolean) so the model learns session preference rather than the engine hard-filtering by session.
+- **Day-of-week filter:** none beyond weekend break (model uses `day_of_week` as a categorical feature).
+- **News-window filter:** none.
+- **Holiday handling:** broker calendar.
+
+### 4.10 Discrepancies and caveats
+
+- **Config YAML reconstruction.** `configs/l_arc_11/winning_config.yaml` was reconstructed retrospectively from closure §1, `step_5/wfo_results.csv` row 3, `run_summary.json`, and `scripts/l_arc_11/run.py` constants. Original engine ran from the inline driver script. Reconstructed file is the source of truth going forward but pre-retrofit deployment would require source verification against `scripts/l_arc_11/run.py`.
+- **`canonical_orchestrator_step5_run_context_gap`.** `ArcOrchestrator._run_step_5` did not thread `per_trade_features` through `ArcFoldRunner`; A2/A3/A4/A6 architectures requiring `per_trade_features` silently produce 0-trade folds when invoked via `ArcOrchestrator.run()`. This driver constructed `A1RunContext(per_trade_features=...)` manually before `ArcFoldRunner`. Surface as v3 infra blocker for any arc using classifier-based architectures via the orchestrator. Fix is a one-line change in `_run_step_5` to thread `run_context` through; the runner already accepts it.
+- **Fold count 10 not 11.** Same orchestrator gap consequence — `sign_pos_folds: "6/10"` in §1. The full 11-fold sweep was not completed; downstream §10 evaluation treats the 10 reported folds as the basis.
+- **Pool size canonical vs hand-rolled.** Canonical Step 1 pool is 17,533 trades vs hand-rolled 7,149 (2.5× delta). Canonical builder correctly applies exposure caps at Step 5, not Step 1 — hand-rolled was biased toward signals the cap admitted first. Closure §3 cross-arc tag.
+- **Per-day max-DD series + chained DD not measured.** PROVISIONAL on those constraints; verdict DEFINITIVE because multiple independent constraints fail (ratio, scalability, sign-consistency, trade count, holdout DD).
+- **Step 4 AUC ≥ 0.65 was met (0.6543).** First v3.0 arc to clear the entry-feature gate. Architecture-side failures dominate — the classifier extraction is genuinely capturing some signal but the WFO outcome under chained-fold realism is FAIL.
+
+### 4.11 Deployment readiness checklist
+
+**FAIL arc — not applicable for deployment.**
+
+- [ ] N/A — FAIL verdict; not for deployment.
+- [ ] N/A
+- [ ] N/A
+- [ ] N/A
+- [ ] N/A
+- [ ] N/A (Step 6 not run — lazy dispatch only on PASS candidates)
 
 ---
 

--- a/results/l_arc_8/ARC_CLOSURE.md
+++ b/results/l_arc_8/ARC_CLOSURE.md
@@ -11,6 +11,8 @@
 ```yaml
 tracker_payload:
 
+  template_version: v1.2
+
   # ────── Identity ──────
   arc_name: l_arc_8
   signal: pullback_resume_hhhl_long_v0.1 (HH/HL uptrend, pullback >=0.5xATR, bullish-close break of prior bar)
@@ -56,6 +58,10 @@ tracker_payload:
     oracle_worst_ratio: 999.0
     oracle_real_gap_sharpe: null
     features_in_winning_config: [swing_low_distance_14, prior_session_low_distance, atr_vs_trailing_100, kijun_26_distance, dollar_bloc_state, atr_percentile_100, spread_vs_trailing_100, spread_percentile_100, usd_strength_index, distance_to_round_number]
+
+    # ── v1.2 deployment-spec fields (added 2026-05-23 retrofit; FAIL arc — for documentation parity) ──
+    config_artefact_path: configs/l_arc_8/winning_config.yaml
+    deployment_spec_section_present: true
 
   # ────── Cost decomposition ──────
   # A6 is sizing-based, not binary admit/reject — the admit/reject framing
@@ -143,6 +149,139 @@ Two methodology caveats noted in the closure for cross-arc context: (1) the pool
 - **Search WFO FAIL + holdout PASS-DEPLOYABLE is a new pattern** — Top-3 holdout all clear the deployable gate (worst holdout ratio 19.4) while search WFO worst ratio is 1.749. Per §2 Step 5 the arc verdict is FAIL (both gates required). But the asymmetry is worth tagging: 2021-2025 holdout had a more favourable market regime for V-shape pullback-resume than 2010-2020 search. Cross-arc question: do other v3 arcs show this asymmetry? If yes, the 11-fold 2010-2020 search WFO may be biased toward a different regime than the deployment-window holdout.
 - **A6 with chance-AUC classifier still adds value** — A6 best (ratio 1.749) is 10× A1 best (ratio 0.171). Even at AUC 0.53, sizing differentiation moves the needle. This argues for A6-style sizing being a useful default architecture regardless of classifier strength, provided sizes are bounded (here: 0x/0.5x/1.0x mapping). Worth a v2.4 calibration thought.
 - **KH-24 co-fire on PR-HHHL: 0.000% across 6,757 signals** — Confirms the spec's "independence expected" prior. PR-HHHL bullish-resume and KH-24 bearish-exhaustion are structurally orthogonal. This frees PR-HHHL from any portfolio-overlap accounting if it's ever resurrected.
+
+---
+
+## §4 deployment_spec (FAIL arc — included for consistency, NOT for deployment; portfolio-eligibility flagged for Arc 8)
+
+> Abbreviated per dispatch — sub-sections 4.1-4.3 and 4.5-4.10 written from artefacts; §4.4 and §4.11 marked "FAIL arc — not applicable for deployment."
+>
+> FAIL verdict (closure §1 + §10). Config retained for portfolio-eligibility audit only (see closure §10 `portfolio_eligibility_pending_a5_spec`).
+
+### 4.1 Pair set
+
+- **Pairs:** AUDCAD, AUDCHF, AUDJPY, AUDNZD, AUDUSD, CADCHF, CADJPY, CHFJPY, EURAUD, EURCAD, EURCHF, EURGBP, EURJPY, EURNZD, EURUSD, GBPAUD, GBPCAD, GBPCHF, GBPJPY, GBPNZD, GBPUSD, NZDCAD, NZDCHF, NZDJPY, NZDUSD, USDCAD, USDCHF, USDJPY (28 FX pairs, KH-24 set)
+- **Timeframe:** H4 primary
+- **Higher-TF references:** D1 anchor (one-bar-lagged); W1 aux (Step 1 feature engineering only — Step 1 d1/w1 features came back all-NaN per closure §2 caveat, so the deployed-version feature catalogue was 23 features rather than the v3 27-feature default)
+
+### 4.2 Signal definition
+
+Pullback-resume HHHL long (PR-HHHL v0.1) — pullback within a confirmed HH/HL uptrend, with bullish close breaking the prior bar's high.
+
+Pseudocode:
+
+```
+# Maintain a rolling list of confirmed swing-highs (k=3, right_edge_lag=4) on H4.
+# Uptrend test: within the last trend_window_bars=30, the swing-highs are ascending
+# (each higher than the prior); same for swing-lows.
+#
+# At each H4 bar close on pair P:
+#   t       = bar close timestamp (UTC)
+#   atr14   = ATR(14) on H4 at bar t (Wilder)
+#
+#   # Trend filter: HH/HL uptrend confirmed
+#   if not hhhl_uptrend_confirmed(h4_bars, trend_window_bars=30,
+#                                  swing_lookback=3, right_edge_lag=4): skip
+#
+#   # Pullback: prior bar's close is at least 0.5×ATR below the most recent swing-high
+#   if close[t-1] > most_recent_swing_high - pullback_atr_mult=0.5 * atr14: skip
+#
+#   # Resume: current bar's close breaks prior bar's high AND closes in upper half of range
+#   if close[t] <= high[t-1]: skip
+#   bar_range = high[t] - low[t]
+#   if bar_range == 0: skip
+#   if (close[t] - low[t]) / bar_range < upper_half_threshold=0.5: skip
+#
+#   # Refractory: at least 20 H4 bars since last signal on this pair
+#   if h4_bars_since_last_signal[P] < spacing_bars=20: skip
+#
+#   EMIT signal (long) at t. Entry fills at next H4 bar's open.
+```
+
+Locked params per signal spec v0.1: swing_lookback=3, trend_window_bars=30, right_edge_lag=4, pullback_atr_mult=0.5, upper_half_threshold=0.5, spacing_bars=20, atr_period=14.
+
+### 4.3 Feature computation specs
+
+A6 meta-labeling uses the Step 1 27-feature default catalogue minus the 4 multi-TF features that came back all-NaN under the closure §2 aux-panel-integration gap. The 10 features in the winning config (closure §1 `best_architecture.features_in_winning_config`):
+
+- **`swing_low_distance_14`** — H4 bars, distance from current close to the most recent 14-bar swing-low low, as a fraction of ATR(14). Computed at signal-bar close.
+- **`prior_session_low_distance`** — H4 bars, distance from current close to the prior trading session's low, in ATR units. Session boundary is broker-day UTC.
+- **`atr_vs_trailing_100`** — current ATR(14) divided by the trailing-100-bar mean ATR(14). Vol-regime context.
+- **`kijun_26_distance`** — distance from current close to the H4 Ichimoku kijun-sen (26-bar midpoint), in ATR units.
+- **`dollar_bloc_state`** — categorical state of the dollar bloc (AUD/CAD/NZD vs USD). Computed cross-pair at signal-bar close.
+- **`atr_percentile_100`** — percentile rank of current ATR(14) within the trailing 100 bars.
+- **`spread_vs_trailing_100`** — current bid/ask spread relative to trailing 100-bar mean.
+- **`spread_percentile_100`** — percentile rank of current spread within trailing 100 bars.
+- **`usd_strength_index`** — cross-pair USD strength score at signal-bar close (composite over the 7 USD pairs in the set).
+- **`distance_to_round_number`** — H4 close distance to the nearest round-number level (00 / 50 pips), in ATR units.
+
+All features tagged with provisional causal lineage at Step 1; the A6 winning config does NOT trigger Step 6 (lazy — not dispatched because no PASS candidate).
+
+### 4.4 Filter chain (A1 / A2 / A6 architectures only)
+
+**FAIL arc — not applicable for deployment.** A6 meta-labeling uses the Step 4 RF classifier (AUC 0.530) to map per-signal classifier probability → sizing tier (0× / 0.5× / 1×) with lower/upper thresholds (0.3, 0.5). At AUC ≈ chance, the sizing differentiation does some work (A6 worst-ratio 1.75 vs A1 0.17) but cannot lift worst-fold ratio above the 2.0 PASS-VIABLE gate. Closure §10 finds the same FAIL under Amendment 3 with `step5_ratio_below_gate_after_scaling` as primary mode. Section retained for documentation parity only.
+
+### 4.5 Entry mechanics
+
+- **Trigger bar:** H4 bar satisfying §4.2.
+- **Fill bar:** next H4 bar (N+1).
+- **Fill price:** open of bar N+1.
+- **Order type:** market.
+- **Slippage assumption:** real bid/ask spreads (HistData M1 in backtest; broker feed in live).
+
+### 4.6 Exit mechanics
+
+- **Initial SL anchor:** entry price.
+- **Initial SL distance:** `1.5 × ATR(14)_H4` at signal bar (closure §1 `best_architecture.sl_atr: 1.5`).
+- **SL update rule:** static.
+- **Trail activation condition:** N/A (exit policy `sl_plus_tp_3r` has no trail).
+- **Trail distance / reference / frequency:** N/A.
+- **TP:** +3R take-profit (closure §1 `exit_policy: sl_plus_tp_3r`). Triggers when running PnL reaches 3× initial SL distance — closes 100% at next H4 bar's open (bar-close evaluation).
+- **Time exit:** 240 H4 bars after entry, force-close at bar N+241 open.
+- **Bar-by-bar evaluation order:** (1) SL hit → exit; (2) TP hit at +3R close → exit at next bar open; (3) time exit at bar 240.
+
+### 4.7 Exposure cap
+
+- **Type:** unlimited (closure §1 `best_architecture.exposure_cap: unlimited`).
+- **Per-pair invariant:** max 1 open per pair.
+- **Per-currency / global caps:** none.
+- **Behaviour at cap:** N/A.
+
+### 4.8 Risk sizing
+
+- **`r_safe` value:** 2.0176% — **above** locked `r_max = 2.0%` ceiling by 0.018pp (closure §10: `scalable_to_safe: false`).
+- **`r_hard` value:** 2.5219% — also above ceiling.
+- **Risk basis:** reset-floor (L arc convention).
+- **Position size formula:** standard reset-floor × r_pct sizing; capped at broker minimums.
+- **Note (closure §10):** the `r_safe > r_max` scenario is the symmetric inverse of Arc 11's `r_safe < r_min` failure — both are scalability failures, opposite ends of the DD distribution. Documented as `scalability_cap_low_dd_ceiling` cross-arc tag.
+- **Starting balance:** $100,000.
+
+### 4.9 Session / time-of-day rules
+
+- **Trading hours:** 24/5 standard FX session.
+- **Day-of-week filter:** none beyond weekend break.
+- **News-window filter:** none.
+- **Holiday handling:** broker calendar.
+
+### 4.10 Discrepancies and caveats
+
+- **Config YAML reconstruction.** `configs/l_arc_8/winning_config.yaml` was reconstructed retrospectively from closure §1, `step_5/wfo_results.csv` row 2 (config_id=30), and `scripts/l_arc_8/run_step5_wfo.py` + `scripts/l_arc_8/shared.py`. Original engine ran from the inline driver script. Reconstructed file is the source of truth going forward but pre-retrofit deployment would require source verification against the driver script.
+- **Step 1 multi-TF features all-NaN.** `compute_feature_matrix` requires `panel.aux={"d1":..., "w1":...}` but the Step 1 driver only passed an H4 panel. The 4 multi_tf features (`d1_close_slope_*`, `w1_close_slope_sign`, `d1_atr_percentile_100`) came back NaN. Effective Step 4 feature catalogue was 23 features instead of 27. Fix is staged but not re-run (engine PR scope).
+- **Pool-level WFO approximation.** Per-trade R outcomes from Step 1 carry through with exit-policy approximation. NOT a bar-by-bar multipair backtester. Understates intraday DD timing; ignores cross-pair concurrency interactions.
+- **Per-day max-DD series + chained DD not measured.** PROVISIONAL on those constraints, but the §10 verdict is DEFINITIVE because the ratio (0.882) and scalability (2.018% > 2.0%) failures are independent of those gaps.
+- **Engine ratio vs §3 ratio convention divergence.** Engine reports `worst_fold_ratio: 1.749` (per-fold ROI/DD inside the worst-ROI fold); §3 math reads 0.882 (cross-fold worst_ROI / worst_DD). Both fail the 2.0 gate. Same outcome.
+- **Holdout PASS-DEPLOYABLE vs Search FAIL asymmetry.** Top-3 holdout (2021-04 → 2026-04) shows ROI +19% to +43%, DD ≤ 1.7%, ratios 19-35 — comfortably above the gate. §2 Step 5 requires BOTH gates pass; search WFO doesn't, so arc verdict is FAIL despite holdout strength. Worth tracking as a cross-arc pattern.
+
+### 4.11 Deployment readiness checklist
+
+**FAIL arc — not applicable for deployment.**
+
+- [ ] N/A — FAIL verdict; not for deployment.
+- [ ] N/A — config retained for portfolio-eligibility audit only; A5 spec pending.
+- [ ] N/A
+- [ ] N/A
+- [ ] N/A
+- [ ] N/A (Step 6 not run — lazy dispatch only on PASS candidates)
 
 ---
 

--- a/scripts/tracker_parser/README.md
+++ b/scripts/tracker_parser/README.md
@@ -49,11 +49,33 @@ The parser detects the closure doc's template version automatically:
 
 | Detection rule | Outcome |
 |---|---|
-| `template_version` field present in `§1 tracker_payload` | Use it (accepts `v1.0`, `v1.1`, `1.0`, `1.1`). |
+| `template_version` field present in `§1 tracker_payload` | Use it (accepts `v1.0`, `v1.1`, `v1.2`, `1.0`, `1.1`, `1.2`). |
+| Any v1.2-exclusive field present in `best_architecture` (`config_artefact_path`, `deployment_spec_section_present`) | Infer v1.2. |
 | Any v1.1-exclusive field present (`worst_fold_dd_base_pct`, `k_safe`, etc.) | Infer v1.1. |
 | Otherwise | v1.0. |
 
-v1.0 closures use legacy field names (`worst_fold_roi_pct`, `worst_fold_dd_pct`). The parser internally renames them to v1.1 names (`*_base_pct`) and fills v1.1-exclusive Amendment 3 fields with `null`. v1.1+ closures are passed through. Either way, the mapping logic operates on a unified v1.1-shaped dict — historical closures are never rewritten.
+Detection precedence: 1.2 → 1.1 → 1.0 → error.
+
+v1.0 closures use legacy field names (`worst_fold_roi_pct`, `worst_fold_dd_pct`). The parser internally renames them to v1.1 names (`*_base_pct`) and fills v1.1-exclusive Amendment 3 fields with `null`. v1.1 closures are passed through.
+
+v1.2 closures add `config_artefact_path` + `deployment_spec_section_present` to the `best_architecture` block plus a new `§4 deployment_spec` section in the closure doc. Retrofitted v1.2 closures may retain v1.0-style field names (`worst_fold_roi_pct`); the parser renames them pre-validation via `_coerce_legacy_field_names` — purely additive on §1, no manual rewrite required.
+
+Either way, the mapping logic operates on a unified v1.1+-shaped dict — historical closures are never rewritten.
+
+## v1.2 PASS-verdict validation
+
+When `template_version == 1.2` AND `verdict` starts with `PASS-`, the parser enforces (after schema validation, BEFORE any tracker mutation):
+
+1. `best_architecture.config_artefact_path` MUST be non-null.
+2. The file at that path (resolved relative to repo root) MUST exist.
+3. The closure doc MUST contain a `## §4 deployment_spec` heading.
+4. `best_architecture.deployment_spec_section_present` MUST be `true`.
+
+Any failure → HALT exit code 1, no tracker write, no rolling-state update. Fix the closure (re-create the missing config YAML, add the §4 section, set the flag) and re-run.
+
+For non-PASS verdicts in v1.2 (FAIL / HALT / DISCOVERY_COMPLETE), the validation block is skipped — §4 is optional and `config_artefact_path` may be `null`.
+
+For v1.0 and v1.1 closures, the validation block is not evaluated.
 
 ## Idempotency
 
@@ -85,6 +107,7 @@ The parser exits with code 1 on any of:
 - `architectures_tested` entry not in `{A1, A2, A3, A4, A5, A6}`.
 - Archetype label not in the normalisation map (closures use varying casing; new archetypes require an explicit map update before the parser will accept them).
 - A `per_failure_mode_count` or `per_archetype_recurrence` row referenced in the closure does not exist in the tracker — parser will not create these rows; add them manually first.
+- **v1.2 PASS-verdict only:** `best_architecture.config_artefact_path` is null OR the file at that path does not exist OR the closure doc lacks a `## §4 deployment_spec` heading OR `best_architecture.deployment_spec_section_present` is not `true` (template Section 4-L).
 
 ## Determinism
 
@@ -119,13 +142,16 @@ tests/tracker_parser/
 │   ├── tracker_blank_state.md
 │   └── tracker_after_arc_11.md
 ├── test_schema_detection.py
+├── test_schema_v12.py
+├── test_pass_verdict_validation.py
 ├── test_yaml_extraction.py
 ├── test_mapping_A_through_K.py
 ├── test_idempotency.py
 ├── test_determinism.py
 ├── test_golden_arc8.py
 ├── test_golden_arc10.py
-└── test_golden_arc11.py
+├── test_golden_arc11.py
+└── test_v12_golden_arc10.py
 ```
 
 ## Testing
@@ -134,4 +160,4 @@ tests/tracker_parser/
 python -m pytest tests/tracker_parser/ -v
 ```
 
-41 tests cover: schema detection + normalisation, YAML extraction HALT cases, every Section 4 A-K mapping, idempotency, determinism, and three golden closures (Arc 11 full A-K; Arcs 8 & 10 Closed arcs summary row only — per the dispatch's Q-3 scope decision).
+60 tests cover: schema detection + normalisation (v1.0 / v1.1 / v1.2), YAML extraction HALT cases, every Section 4 A-K mapping, v1.2 PASS-verdict validation (Section 4-L), idempotency, determinism, and four golden closures (Arc 11 full A-K; Arcs 8 & 10 Closed arcs summary row only per Q-3; Arc 10 v1.2-retrofit metric-invariance + Section 4-L pass).

--- a/scripts/tracker_parser/extract.py
+++ b/scripts/tracker_parser/extract.py
@@ -20,6 +20,7 @@ import yaml
 
 SECTION_HEADING_RE = re.compile(r"^## §1 tracker_payload\s*$", re.MULTILINE)
 FENCE_OPEN_RE = re.compile(r"^```yaml\s*$", re.MULTILINE)
+DEPLOYMENT_SPEC_HEADING_RE = re.compile(r"^## §4 deployment_spec\b", re.MULTILINE)
 
 
 class ClosureExtractionError(Exception):
@@ -83,3 +84,12 @@ def sha256_bytes(data: bytes) -> str:
 
 def closure_sha256(closure_path: Path) -> str:
     return sha256_bytes(closure_path.read_bytes())
+
+
+def has_deployment_spec_heading(closure_path: Path) -> bool:
+    """Return True if the closure doc contains a `## §4 deployment_spec` heading.
+
+    Used by the CLI for v1.2 PASS-verdict validation (template Section 4-L).
+    """
+    text = closure_path.read_text(encoding="utf-8")
+    return DEPLOYMENT_SPEC_HEADING_RE.search(text) is not None

--- a/scripts/tracker_parser/schema.py
+++ b/scripts/tracker_parser/schema.py
@@ -1,15 +1,21 @@
-"""Pydantic models for ARC_CLOSURE.md §1 tracker_payload — v1.0 and v1.1 schemas + normalisation.
+"""Pydantic models for ARC_CLOSURE.md §1 tracker_payload — v1.0, v1.1, and v1.2 schemas + normalisation.
 
 Schema versions:
 - v1.0 — pre-Amendment 3 (legacy field names `worst_fold_roi_pct`, `worst_fold_dd_pct`)
 - v1.1 — post-Amendment 3 (renamed to `*_base_pct`, plus risk-normalised fields)
+- v1.2 — deployment-spec addition (adds `config_artefact_path`, `deployment_spec_section_present` to
+  `best_architecture`). PASS-verdict closures must point to a canonical config YAML; the parser CLI
+  enforces the file's existence + §4 heading presence before applying tracker mappings.
 
 Detection precedence (see `detect_schema_version`):
 1. `template_version` field present → use that
-2. Any v1.1-exclusive field present → v1.1
-3. Else → v1.0
+2. Any v1.2-exclusive field present → v1.2
+3. Any v1.1-exclusive field present → v1.1
+4. Else → v1.0
 
-`normalize_to_v11()` returns a v1.1-shaped dict that mapping logic consumes uniformly.
+`normalize_to_v12()` returns a v1.2-shaped dict that mapping logic consumes uniformly. The mapping
+layer only reads v1.0/v1.1-era fields, so v1.2-exclusive fields are not consumed downstream — they
+are validated at the CLI layer before tracker mutations begin.
 """
 
 from __future__ import annotations
@@ -18,7 +24,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-SchemaVersion = Literal["1.0", "1.1"]
+SchemaVersion = Literal["1.0", "1.1", "1.2"]
 
 V11_EXCLUSIVE_FIELDS = {
     "worst_fold_dd_base_pct",
@@ -30,6 +36,11 @@ V11_EXCLUSIVE_FIELDS = {
     "r_hard_pct",
     "scalable_to_safe",
     "scalable_to_hard",
+}
+
+V12_EXCLUSIVE_FIELDS = {
+    "config_artefact_path",
+    "deployment_spec_section_present",
 }
 
 VALID_FAILURE_MODES = {
@@ -62,30 +73,37 @@ VALID_VERDICTS = {
     "HALT",
     "DISCOVERY_COMPLETE",
     "PASS-DEPLOYABLE-PROVISIONAL",
+    "PASS-VIABLE-PROVISIONAL",
+    "PASS-DEPLOYABLE-PENDING-STEP6",
+    "PASS-VIABLE-PENDING-STEP6",
 }
 
 VALID_ARCHITECTURES = {"A1", "A2", "A3", "A4", "A5", "A6"}
 
 
 def detect_schema_version(payload: dict[str, Any]) -> SchemaVersion:
-    """Return '1.0' or '1.1' based on the rules in the module docstring.
+    """Return '1.0', '1.1', or '1.2' based on the rules in the module docstring.
 
-    Accepts `template_version` values: 'v1.0', 'v1.1', '1.0', '1.1'.
+    Accepts `template_version` values: 'v1.0', 'v1.1', 'v1.2', '1.0', '1.1', '1.2'.
     """
     raw = payload.get("template_version")
     if raw is not None:
         s = str(raw).lstrip("v").lstrip("V").strip()
+        if s == "1.2":
+            return "1.2"
         if s == "1.1":
             return "1.1"
         if s == "1.0":
             return "1.0"
         raise ValueError(
-            f"Unknown template_version {raw!r} — expected one of v1.0, v1.1, 1.0, 1.1"
+            f"Unknown template_version {raw!r} — expected one of v1.0, v1.1, v1.2, 1.0, 1.1, 1.2"
         )
 
     best_arch = payload.get("best_architecture") or {}
     if not isinstance(best_arch, dict):
         best_arch = {}
+    if any(k in best_arch for k in V12_EXCLUSIVE_FIELDS):
+        return "1.2"
     if any(k in best_arch for k in V11_EXCLUSIVE_FIELDS):
         return "1.1"
 
@@ -293,15 +311,76 @@ class TrackerPayloadV11(_TrackerPayloadBase):
         return d
 
 
+class BestArchitectureV12(BestArchitectureV11):
+    """v1.2 best_architecture block — adds deployment-spec pointer + flag.
+
+    `config_artefact_path` MUST be non-null for PASS-verdict closures and MUST point to a file
+    that exists relative to the repo root. `deployment_spec_section_present` MUST be true for
+    PASS-verdict closures. Both validations are enforced at the CLI layer
+    (`update_tracker_from_closure.py`), not in Pydantic — the validation needs a closure-doc-path
+    + repo-root context that the model doesn't have.
+    """
+
+    config_artefact_path: str | None = None
+    deployment_spec_section_present: bool | None = None
+
+
+class TrackerPayloadV12(_TrackerPayloadBase):
+    """v1.2 payload — deployment-spec addition."""
+
+    best_architecture: BestArchitectureV12 | None = None
+
+    def normalize_to_v12(self) -> dict[str, Any]:
+        d = self.model_dump()
+        d["template_version"] = "1.2"
+        return d
+
+
+def _coerce_legacy_field_names(payload: dict[str, Any]) -> dict[str, Any]:
+    """Rename v1.0 best_architecture fields to v1.1 names if present.
+
+    Used when a v1.2 closure retains the legacy `worst_fold_roi_pct` / `worst_fold_dd_pct` names
+    (retrofit pattern — §1 changes restricted to additive v1.2 fields). Idempotent and a no-op
+    if v1.1 names are already in place.
+    """
+    ba = payload.get("best_architecture")
+    if not isinstance(ba, dict):
+        return payload
+    if "worst_fold_roi_pct" in ba and "worst_fold_roi_base_pct" not in ba:
+        ba["worst_fold_roi_base_pct"] = ba.pop("worst_fold_roi_pct")
+    elif "worst_fold_roi_pct" in ba and "worst_fold_roi_base_pct" in ba:
+        # Both present — base_pct wins; legacy dropped (rare; retrofit edge case).
+        ba.pop("worst_fold_roi_pct")
+    if "worst_fold_dd_pct" in ba and "worst_fold_dd_base_pct" not in ba:
+        ba["worst_fold_dd_base_pct"] = ba.pop("worst_fold_dd_pct")
+    elif "worst_fold_dd_pct" in ba and "worst_fold_dd_base_pct" in ba:
+        ba.pop("worst_fold_dd_pct")
+    return payload
+
+
 def parse_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    """Detect schema version, validate via the matching model, return v1.1-normalised dict.
+    """Detect schema version, validate via the matching model, return a normalised dict.
+
+    Returns a v1.1-shaped dict for v1.0/v1.1 closures (legacy compatibility — mapping logic
+    consumes a unified v1.1 shape). For v1.2 closures, returns a v1.2-shaped dict (a superset
+    of v1.1; mapping logic ignores the two extra fields).
+
+    For v1.2 closures that retain v1.0-style field names in `best_architecture` (the retrofit
+    pattern — see `_coerce_legacy_field_names`), legacy names are renamed pre-validation.
 
     Raises pydantic.ValidationError on schema violations and ValueError on unknown enum values.
     """
     version = detect_schema_version(payload)
-    model = TrackerPayloadV11 if version == "1.1" else TrackerPayloadV10
-    validated = model.model_validate(payload)
-    norm = validated.normalize_to_v11()
+    if version == "1.2":
+        payload = _coerce_legacy_field_names(payload)
+        validated = TrackerPayloadV12.model_validate(payload)
+        norm = validated.normalize_to_v12()
+    elif version == "1.1":
+        validated = TrackerPayloadV11.model_validate(payload)
+        norm = validated.normalize_to_v11()
+    else:
+        validated = TrackerPayloadV10.model_validate(payload)
+        norm = validated.normalize_to_v11()
 
     failure_mode = norm.get("primary_failure_mode")
     if failure_mode not in VALID_FAILURE_MODES:

--- a/scripts/update_tracker_from_closure.py
+++ b/scripts/update_tracker_from_closure.py
@@ -70,6 +70,59 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _validate_v12_pass_verdict(payload: dict, closure_path: Path) -> int:
+    """v1.2 PASS-verdict validation per template Section 4-L.
+
+    Checks (all must pass):
+      1. `best_architecture.config_artefact_path` is non-null.
+      2. The file at that path (relative to repo root) exists.
+      3. The closure doc contains a `## §4 deployment_spec` heading.
+      4. `best_architecture.deployment_spec_section_present` is true.
+
+    Returns 0 on pass, 1 on any failure (with logged error). No tracker writes happen if any
+    check fails — the caller short-circuits before the mapping layer.
+    """
+    ba = payload.get("best_architecture") or {}
+    config_path_str = ba.get("config_artefact_path")
+    if not config_path_str:
+        logging.error(
+            "v1.2 PASS-verdict validation: best_architecture.config_artefact_path is null or missing. "
+            "Closure %s has verdict %r — config_artefact_path is REQUIRED for PASS verdicts. "
+            "(template Section 4-L, item 1)",
+            closure_path,
+            payload.get("verdict"),
+        )
+        return 1
+
+    config_path = (_REPO_ROOT / config_path_str).resolve()
+    if not config_path.exists():
+        logging.error(
+            "v1.2 PASS-verdict validation: config_artefact_path %r does not exist (resolved to %s). "
+            "(template Section 4-L, item 2)",
+            config_path_str,
+            config_path,
+        )
+        return 1
+
+    if not extract.has_deployment_spec_heading(closure_path):
+        logging.error(
+            "v1.2 PASS-verdict validation: closure doc %s is missing the `## §4 deployment_spec` "
+            "heading. (template Section 4-L, item 3)",
+            closure_path,
+        )
+        return 1
+
+    if ba.get("deployment_spec_section_present") is not True:
+        logging.error(
+            "v1.2 PASS-verdict validation: best_architecture.deployment_spec_section_present is "
+            "%r — must be true for PASS verdicts. (template Section 4-L, item 4)",
+            ba.get("deployment_spec_section_present"),
+        )
+        return 1
+
+    return 0
+
+
 def _diff_tracker(before: bytes, after: bytes) -> str:
     """Return a human-readable summary of changes between two tracker byte sequences."""
     if before == after:
@@ -116,6 +169,15 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:  # pydantic.ValidationError, ValueError
         logging.error("schema validation failed: %s", exc)
         return 1
+
+    # v1.2 PASS-verdict validation (template Section 4-L). Runs BEFORE tracker mutation so a
+    # missing config artefact or missing §4 section blocks the write atomically.
+    if payload.get("template_version") == "1.2" and str(payload.get("verdict", "")).startswith(
+        "PASS-"
+    ):
+        rc = _validate_v12_pass_verdict(payload, closure_path)
+        if rc != 0:
+            return rc
 
     if args.verbose:
         print("--- Parsed payload (v1.1-normalised) ---")

--- a/tests/tracker_parser/test_pass_verdict_validation.py
+++ b/tests/tracker_parser/test_pass_verdict_validation.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.update_tracker_from_closure import _validate_v12_pass_verdict, main as cli_main
+from scripts.update_tracker_from_closure import _validate_v12_pass_verdict
+from scripts.update_tracker_from_closure import main as cli_main
 
 
 def _valid_closure_text(

--- a/tests/tracker_parser/test_pass_verdict_validation.py
+++ b/tests/tracker_parser/test_pass_verdict_validation.py
@@ -1,0 +1,268 @@
+"""v1.2 PASS-verdict validation — template Section 4-L.
+
+Exercises `_validate_v12_pass_verdict` in `scripts/update_tracker_from_closure.py` directly,
+plus the full CLI on synthetic closures, to confirm HALT behaviour on each failure mode.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.update_tracker_from_closure import _validate_v12_pass_verdict, main as cli_main
+
+
+def _valid_closure_text(
+    *,
+    arc_name: str = "l_arc_z",
+    verdict: str = "PASS-VIABLE",
+    template_version: str | None = "v1.2",
+    config_path: str | None = "configs/l_arc_z/winning_config.yaml",
+    section_present: bool | None = True,
+    include_section_4: bool = True,
+) -> str:
+    tv_line = f"  template_version: {template_version}\n" if template_version else ""
+    config_line = (
+        f"    config_artefact_path: {config_path}\n"
+        if config_path is not None
+        else "    config_artefact_path: null\n"
+    )
+    flag_line = (
+        f"    deployment_spec_section_present: {'true' if section_present else 'false'}\n"
+        if section_present is not None
+        else "    deployment_spec_section_present: null\n"
+    )
+    body = f"""# ARC_Z_CLOSURE — {arc_name}
+
+---
+
+## §1 tracker_payload
+
+```yaml
+tracker_payload:
+{tv_line}  arc_name: {arc_name}
+  signal: stub signal
+  tf: H4
+  sub_protocol: vanilla
+  closed_timestamp: 2026-05-23T00:00:00Z
+  closure_doc_link: results/{arc_name}/ARC_CLOSURE.md
+  verdict: {verdict}
+  one_line: stub
+  failed_at_step: N/A
+  primary_failure_mode: N/A
+  pool_metadata:
+    total_n: 100
+    window_start: 2010-01-01
+    window_end: 2026-04-30
+    kh24_co_fire_pct: null
+    configs_evaluated_step5: 1
+    search_scope_flag: thin
+  best_architecture:
+    name: A1 system_level_filter
+    worst_fold_ratio: 5.0
+    worst_fold_roi_base_pct: 20.0
+    worst_fold_dd_base_pct: 4.0
+    features_in_winning_config: []
+{config_line}{flag_line}  cost_decomposition: null
+  clusters:
+    c0:
+      n: 50
+      archetype: V-shape
+      sl_atr: 3.5
+      step3_composite: 1.0
+      mfe_p50_r: 5.0
+      ww_pp: 0.5
+      reach_1r: 0.95
+      step4_e_auc: null
+      step4_d1_auc: null
+      outcome: wins_step5
+  architectures_tested: [A1]
+  architecture_results:
+    A1: {{tested: true, won: true, worst_fold_ratio: 5.0}}
+  archetypes_observed: [V-shape]
+  cross_arc_tags: []
+```
+
+---
+
+## §2 Why succeeded
+
+Stub.
+
+---
+
+## §3 Cross-arc observations
+
+- stub
+"""
+    if include_section_4:
+        body += """
+---
+
+## §4 deployment_spec
+
+Stub.
+"""
+    return body
+
+
+def test_validation_pass(tmp_path: Path) -> None:
+    """All four checks pass — returns 0."""
+    closure = tmp_path / "ARC_CLOSURE.md"
+    closure.write_text(_valid_closure_text(), encoding="utf-8")
+    config = tmp_path / "configs" / "l_arc_z" / "winning_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("# stub", encoding="utf-8")
+
+    payload = {
+        "verdict": "PASS-VIABLE",
+        "best_architecture": {
+            "config_artefact_path": "configs/l_arc_z/winning_config.yaml",
+            "deployment_spec_section_present": True,
+        },
+    }
+
+    import scripts.update_tracker_from_closure as cli
+    original_root = cli._REPO_ROOT
+    cli._REPO_ROOT = tmp_path
+    try:
+        rc = _validate_v12_pass_verdict(payload, closure)
+    finally:
+        cli._REPO_ROOT = original_root
+    assert rc == 0
+
+
+def test_validation_halt_on_null_config_path(tmp_path: Path) -> None:
+    """Item 1 — config_artefact_path null → HALT."""
+    closure = tmp_path / "ARC_CLOSURE.md"
+    closure.write_text(_valid_closure_text(config_path=None), encoding="utf-8")
+    payload = {
+        "verdict": "PASS-VIABLE",
+        "best_architecture": {
+            "config_artefact_path": None,
+            "deployment_spec_section_present": True,
+        },
+    }
+    rc = _validate_v12_pass_verdict(payload, closure)
+    assert rc == 1
+
+
+def test_validation_halt_on_missing_config_file(tmp_path: Path) -> None:
+    """Item 2 — file at config_artefact_path does not exist → HALT."""
+    closure = tmp_path / "ARC_CLOSURE.md"
+    closure.write_text(_valid_closure_text(), encoding="utf-8")
+    payload = {
+        "verdict": "PASS-VIABLE",
+        "best_architecture": {
+            "config_artefact_path": "configs/does_not_exist/x.yaml",
+            "deployment_spec_section_present": True,
+        },
+    }
+    import scripts.update_tracker_from_closure as cli
+    original_root = cli._REPO_ROOT
+    cli._REPO_ROOT = tmp_path
+    try:
+        rc = _validate_v12_pass_verdict(payload, closure)
+    finally:
+        cli._REPO_ROOT = original_root
+    assert rc == 1
+
+
+def test_validation_halt_on_missing_section_4(tmp_path: Path) -> None:
+    """Item 3 — closure lacks `## §4 deployment_spec` heading → HALT."""
+    closure = tmp_path / "ARC_CLOSURE.md"
+    closure.write_text(_valid_closure_text(include_section_4=False), encoding="utf-8")
+    config = tmp_path / "configs" / "l_arc_z" / "winning_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("# stub", encoding="utf-8")
+    payload = {
+        "verdict": "PASS-VIABLE",
+        "best_architecture": {
+            "config_artefact_path": "configs/l_arc_z/winning_config.yaml",
+            "deployment_spec_section_present": True,
+        },
+    }
+    import scripts.update_tracker_from_closure as cli
+    original_root = cli._REPO_ROOT
+    cli._REPO_ROOT = tmp_path
+    try:
+        rc = _validate_v12_pass_verdict(payload, closure)
+    finally:
+        cli._REPO_ROOT = original_root
+    assert rc == 1
+
+
+def test_validation_halt_on_flag_false(tmp_path: Path) -> None:
+    """Item 4 — deployment_spec_section_present false → HALT."""
+    closure = tmp_path / "ARC_CLOSURE.md"
+    closure.write_text(_valid_closure_text(section_present=False), encoding="utf-8")
+    config = tmp_path / "configs" / "l_arc_z" / "winning_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("# stub", encoding="utf-8")
+    payload = {
+        "verdict": "PASS-VIABLE",
+        "best_architecture": {
+            "config_artefact_path": "configs/l_arc_z/winning_config.yaml",
+            "deployment_spec_section_present": False,
+        },
+    }
+    import scripts.update_tracker_from_closure as cli
+    original_root = cli._REPO_ROOT
+    cli._REPO_ROOT = tmp_path
+    try:
+        rc = _validate_v12_pass_verdict(payload, closure)
+    finally:
+        cli._REPO_ROOT = original_root
+    assert rc == 1
+
+
+def test_v12_fail_verdict_skips_validation(tmp_path: Path) -> None:
+    """FAIL verdicts in v1.2 skip the PASS-verdict block — validation never runs."""
+    closure = tmp_path / "ARC_CLOSURE.md"
+    closure.write_text(
+        _valid_closure_text(
+            verdict="FAIL", config_path=None, section_present=None, include_section_4=False
+        ),
+        encoding="utf-8",
+    )
+    # The validation helper itself is only called for PASS-* verdicts in the CLI;
+    # this test confirms the closure parses without invoking validation. We invoke the
+    # full CLI in dry-run mode against a synthetic tracker to exercise the gate.
+
+    tracker = tmp_path / "ARC_TRACKER.md"
+    # Minimal tracker the parser can read without touching the v1.2 path.
+    tracker.write_text(
+        "# ARC_TRACKER\n\nLast auto-update: never\n",
+        encoding="utf-8",
+    )
+    # CLI returns 1 here because the synthetic tracker doesn't satisfy the mapping layer's
+    # row-existence checks, but the v1.2 validation block must NOT be reached for a FAIL
+    # verdict — proven by absence of the v1.2 error string. We assert exit-non-zero is
+    # caused by tracker-shape, not v1.2 validation, by checking for the v1.2 error pattern.
+    import logging
+    records: list[str] = []
+
+    class _CaptureHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(self.format(record))
+
+    handler = _CaptureHandler()
+    logging.getLogger().addHandler(handler)
+    try:
+        cli_main(
+            [
+                str(closure),
+                "--dry-run",
+                "--tracker-path",
+                str(tracker),
+                "--rolling-state",
+                str(tmp_path / "rolling_state.json"),
+                "--registry",
+                str(tmp_path / "parsed.log"),
+            ]
+        )
+    finally:
+        logging.getLogger().removeHandler(handler)
+
+    # The v1.2 validation strings (which would be emitted on PASS-verdict failure) must not appear.
+    joined = "\n".join(records)
+    assert "v1.2 PASS-verdict validation" not in joined

--- a/tests/tracker_parser/test_schema_v12.py
+++ b/tests/tracker_parser/test_schema_v12.py
@@ -1,0 +1,130 @@
+"""v1.2 schema detection + normalisation."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.tracker_parser import schema
+
+
+def _minimal_v11_payload_passlike() -> dict:
+    return {
+        "arc_name": "l_arc_y",
+        "signal": "sig",
+        "tf": "H4",
+        "sub_protocol": "vanilla",
+        "closed_timestamp": "2026-05-23T00:00:00Z",
+        "closure_doc_link": "results/l_arc_y/ARC_CLOSURE.md",
+        "verdict": "PASS-VIABLE",
+        "one_line": "stub",
+        "failed_at_step": "N/A",
+        "primary_failure_mode": "N/A",
+        "pool_metadata": {
+            "total_n": 100,
+            "window_start": "2010-01-01",
+            "window_end": "2026-04-30",
+            "kh24_co_fire_pct": None,
+            "configs_evaluated_step5": 1,
+            "search_scope_flag": "thin",
+        },
+        "best_architecture": {
+            "name": "A1 system_level_filter",
+            "worst_fold_ratio": 5.0,
+            "worst_fold_roi_base_pct": 20.0,
+            "worst_fold_dd_base_pct": 4.0,
+            "features_in_winning_config": [],
+            "k_safe": 2.0,
+        },
+        "cost_decomposition": None,
+        "clusters": {
+            "c0": {
+                "n": 50,
+                "archetype": "V-shape",
+                "sl_atr": 3.5,
+                "step3_composite": 1.0,
+                "mfe_p50_r": 5.0,
+                "ww_pp": 0.5,
+                "reach_1r": 0.95,
+                "step4_e_auc": None,
+                "step4_d1_auc": None,
+                "outcome": "wins_step5",
+            }
+        },
+        "architectures_tested": ["A1"],
+        "architecture_results": {
+            "A1": {"tested": True, "won": True, "worst_fold_ratio": 5.0}
+        },
+        "archetypes_observed": ["V-shape"],
+        "cross_arc_tags": [],
+    }
+
+
+def test_detect_v12_by_template_version_string():
+    payload = _minimal_v11_payload_passlike()
+    payload["template_version"] = "v1.2"
+    assert schema.detect_schema_version(payload) == "1.2"
+
+
+def test_detect_v12_by_numeric_template_version():
+    payload = _minimal_v11_payload_passlike()
+    payload["template_version"] = "1.2"
+    assert schema.detect_schema_version(payload) == "1.2"
+
+
+def test_detect_v12_by_exclusive_field_config_path():
+    """`config_artefact_path` presence (even null) infers v1.2 when template_version absent."""
+    payload = _minimal_v11_payload_passlike()
+    payload["best_architecture"]["config_artefact_path"] = "configs/l_arc_y/winning_config.yaml"
+    assert schema.detect_schema_version(payload) == "1.2"
+
+
+def test_detect_v12_by_exclusive_field_section_flag():
+    payload = _minimal_v11_payload_passlike()
+    payload["best_architecture"]["deployment_spec_section_present"] = True
+    assert schema.detect_schema_version(payload) == "1.2"
+
+
+def test_detect_v11_when_only_amendment3_fields_present():
+    """Sanity — v1.1 detection unchanged when v1.2 fields absent."""
+    payload = _minimal_v11_payload_passlike()
+    assert schema.detect_schema_version(payload) == "1.1"
+
+
+def test_v12_payload_preserves_deployment_spec_fields():
+    payload = _minimal_v11_payload_passlike()
+    payload["template_version"] = "v1.2"
+    payload["best_architecture"]["config_artefact_path"] = "configs/l_arc_y/winning_config.yaml"
+    payload["best_architecture"]["deployment_spec_section_present"] = True
+    normalised = schema.parse_payload(payload)
+    assert normalised["template_version"] == "1.2"
+    assert (
+        normalised["best_architecture"]["config_artefact_path"]
+        == "configs/l_arc_y/winning_config.yaml"
+    )
+    assert normalised["best_architecture"]["deployment_spec_section_present"] is True
+
+
+def test_v10_v11_payloads_still_normalise():
+    """Backwards-compat — v1.0 and v1.1 closures parse unchanged."""
+    payload = _minimal_v11_payload_passlike()
+    payload["template_version"] = "v1.1"
+    norm = schema.parse_payload(payload)
+    assert norm["template_version"] == "1.1"
+
+
+def test_unknown_template_version_v2_raises():
+    payload = _minimal_v11_payload_passlike()
+    payload["template_version"] = "v2.0"
+    with pytest.raises(ValueError, match="Unknown template_version"):
+        schema.detect_schema_version(payload)
+
+
+def test_v12_verdict_pass_viable_provisional_accepted():
+    """PASS-VIABLE-PROVISIONAL added to the verdict set in v1.2."""
+    payload = _minimal_v11_payload_passlike()
+    payload["template_version"] = "v1.2"
+    payload["verdict"] = "PASS-VIABLE-PROVISIONAL"
+    payload["best_architecture"]["config_artefact_path"] = "configs/x.yaml"
+    payload["best_architecture"]["deployment_spec_section_present"] = True
+    norm = schema.parse_payload(payload)
+    assert norm["verdict"] == "PASS-VIABLE-PROVISIONAL"

--- a/tests/tracker_parser/test_v12_golden_arc10.py
+++ b/tests/tracker_parser/test_v12_golden_arc10.py
@@ -1,0 +1,75 @@
+"""Golden test for Arc 10 retrofit — parser is idempotent across v1.1→v1.2 retrofit.
+
+The §1 metric data is unchanged by the retrofit (only template_version, config_artefact_path,
+deployment_spec_section_present are added). All tracker A-J mapping inputs are unchanged, so
+parsing the retrofitted closure must produce the same v1.2-normalised payload up to those three
+new fields.
+
+This test runs against the live closure post-retrofit (Task 4). It complements the existing
+`test_golden_arc10.py` which exercises the v1.0/v1.1 paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.tracker_parser import extract, schema
+
+
+@pytest.fixture
+def closure_arc_10(request: pytest.FixtureRequest) -> Path:
+    return request.config.rootpath / "results" / "l_arc_10" / "ARC_CLOSURE.md"
+
+
+def test_v12_payload_parses(closure_arc_10: Path) -> None:
+    """Arc 10 retrofit closure parses as v1.2 with deployment-spec fields populated."""
+    payload = extract.extract_payload(closure_arc_10)
+    normalised = schema.parse_payload(payload)
+    assert normalised["template_version"] == "1.2"
+    ba = normalised["best_architecture"]
+    assert ba["config_artefact_path"] == "configs/l_arc_10/winning_config.yaml"
+    assert ba["deployment_spec_section_present"] is True
+
+
+def test_v12_deployment_spec_heading_present(closure_arc_10: Path) -> None:
+    """`## §4 deployment_spec` heading present on Arc 10's retrofit."""
+    assert extract.has_deployment_spec_heading(closure_arc_10) is True
+
+
+def test_v12_metric_fields_unchanged_from_v11(closure_arc_10: Path) -> None:
+    """The §1 metric data (verdict, ratios, ROI/DD, cluster outcomes) is identical to the
+    pre-retrofit closure. Asserts the retrofit was purely additive — no metric mutations.
+
+    Anchored to the documented Arc 10 winning numbers from the closure §1 (PASS-VIABLE,
+    worst_fold_ratio 5.4185, A1 system_level_filter winner).
+    """
+    payload = extract.extract_payload(closure_arc_10)
+    normalised = schema.parse_payload(payload)
+    assert normalised["verdict"] == "PASS-VIABLE"
+    ba = normalised["best_architecture"]
+    assert ba["name"] == "A1 system_level_filter"
+    assert abs(ba["worst_fold_ratio"] - 5.4185) < 1e-4
+    assert abs(ba["worst_fold_roi_base_pct"] - 26.49) < 1e-3
+    assert abs(ba["worst_fold_dd_base_pct"] - 9.22) < 1e-3
+    assert ba["sign_pos_folds"] == "11/11"
+
+
+def test_v12_pass_verdict_validation_passes_against_live_repo(
+    closure_arc_10: Path, request: pytest.FixtureRequest
+) -> None:
+    """Full CLI validation gate runs clean — config file exists, §4 present, flag true."""
+    from scripts.update_tracker_from_closure import _validate_v12_pass_verdict
+    import scripts.update_tracker_from_closure as cli
+
+    payload = extract.extract_payload(closure_arc_10)
+    normalised = schema.parse_payload(payload)
+    repo_root = Path(request.config.rootpath)
+    original_root = cli._REPO_ROOT
+    cli._REPO_ROOT = repo_root
+    try:
+        rc = _validate_v12_pass_verdict(normalised, closure_arc_10)
+    finally:
+        cli._REPO_ROOT = original_root
+    assert rc == 0

--- a/tests/tracker_parser/test_v12_golden_arc10.py
+++ b/tests/tracker_parser/test_v12_golden_arc10.py
@@ -60,8 +60,8 @@ def test_v12_pass_verdict_validation_passes_against_live_repo(
     closure_arc_10: Path, request: pytest.FixtureRequest
 ) -> None:
     """Full CLI validation gate runs clean — config file exists, §4 present, flag true."""
-    from scripts.update_tracker_from_closure import _validate_v12_pass_verdict
     import scripts.update_tracker_from_closure as cli
+    from scripts.update_tracker_from_closure import _validate_v12_pass_verdict
 
     payload = extract.extract_payload(closure_arc_10)
     normalised = schema.parse_payload(payload)


### PR DESCRIPTION
## Summary

- **Template v1.1 → v1.2.** New `§4 deployment_spec` section (REQUIRED for PASS-* verdicts; OPTIONAL otherwise). Three additive fields in `§1 best_architecture`: `config_artefact_path`, `deployment_spec_section_present`, `template_version v1.2`. Parser-enforced PASS-verdict validation (Section 4-L). `L_PROTOCOL.md` §6 updated to reference v1.2 + the §4 conditional.
- **Parser support.** `schema.py` adds v1.2 detection (1.2 → 1.1 → 1.0 precedence), `BestArchitectureV12`, `_coerce_legacy_field_names` for retrofit closures keeping v1.0 field names. CLI `_validate_v12_pass_verdict` HALTs pre-mutation on any of: null/missing config path, missing file, missing §4 heading, flag-not-true. 19 new tests (60/60 pass).
- **Arc 8/10/11 retrofits.** §1 + §4 additions per template v1.2. Arc 10 §4 = full deployment spec (PASS-VIABLE baseline / PASS-DEPLOYABLE finalised post-Step-6 via main #178). Arcs 8 and 11 §4 = abbreviated FAIL-arc form (4.4 + 4.11 marked N/A). Three reconstructed `configs/<arc>/winning_config.yaml` files with full "RECONSTRUCTED RETROSPECTIVELY" header + per-parameter source annotations per chat Q2. Section numbering 1,2,3,4,10 (insert-with-gap per chat Q1; §10 preserved as Amendment 3 anchor).

## Decisions taken

- Q1 — section numbering: **insert-with-gap** (1,2,3,4,10). Preserves §10 as the universal Amendment 3 re-evaluation anchor across all retroactive closures.
- Q2 — canonical config YAML availability uneven across arcs: **reconstruct three YAMLs** from closure §1 + `step_5/wfo_results.csv` + driver-script constants. Each carries chat-required header block and per-parameter source annotations.
- Q3 — FAIL arc §4 strictness: **abbreviated**. 4.1-4.3 + 4.5-4.10 concrete from artefacts; 4.4 + 4.11 marked "FAIL arc — not applicable for deployment."

## Files changed (10 modified + 8 new = 18)

Modified: `L_PROTOCOL.md`, `WORKFLOW.md`, `docs/templates/ARC_CLOSURE_TEMPLATE.md`, `results/l_arc_{8,10,11}/ARC_CLOSURE.md`, `scripts/tracker_parser/{README.md, schema.py, extract.py}`, `scripts/update_tracker_from_closure.py`.

New: `configs/l_arc_{8,10,11}/winning_config.yaml`, `docs/dispatches/closure_template_v12_{intent,log}.md`, `tests/tracker_parser/test_{schema_v12, pass_verdict_validation, v12_golden_arc10}.py`.

## Test plan

- [x] `py -m pytest tests/tracker_parser/` → 60/60 pass
- [x] `py scripts/update_tracker_from_closure.py results/l_arc_8/ARC_CLOSURE.md --dry-run` → exit 0
- [x] `py scripts/update_tracker_from_closure.py results/l_arc_10/ARC_CLOSURE.md --dry-run` → exit 0 (v1.2 PASS-verdict gate runs + passes)
- [x] `py scripts/update_tracker_from_closure.py results/l_arc_11/ARC_CLOSURE.md --dry-run` → exit 0
- [ ] Chat review of three retrofitted §4 deployment_specs (Arc 10 primary; Arc 8/11 abbreviated)
- [ ] Chat review of three reconstructed config YAMLs

## Flags for chat (see `docs/dispatches/closure_template_v12_log.md` §"Anything I want to flag")

1. **Tracker diff in dry-run is expected, not a regression** — rolling state for Arcs 8 + 10 wasn't seeded in the prior parser-bootstrap PR per README "Bootstrap state (2026-05-22)". The diff content matches that pre-existing condition; addressing it is the separate cleanup work item documented at `results/re_evaluation_2026_05/SUMMARY.md`.
2. **`VALID_VERDICTS` extended** with `PASS-VIABLE-PROVISIONAL`, `PASS-DEPLOYABLE-PENDING-STEP6`, `PASS-VIABLE-PENDING-STEP6` to match the v1.2 §4 trigger spec. Forward extension; not a breaking change.
3. **Arc 10 §10 finalisation reconciliation post-rebase** — mid-dispatch fast-forward picked up main #178 (Step 6 audit clean → PASS-DEPLOYABLE confirmed). Updated three Arc 10 §4 references (header, §4.10 caveats × 2, §4.11 Step-6 row) to align. §10 itself untouched per dispatch rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)