### PR TITLE
[INFRA] CC_11 follow-up: parser backfill arcs 8/10 + parsed.log Arc 11 sha refresh

### DIFF
--- a/ARC_TRACKER.md
+++ b/ARC_TRACKER.md
@@ -4,7 +4,7 @@
 > Schema locked at v3.0. Replaces STATUS.md, CHANGELOG.md, ARC_QUEUE.md, and ACTIVE_ARCS.md.
 > First populated on first arc open under L_PROTOCOL v3.0.
 
-Last auto-update: manual: 2026-05-22 (Arc 10 Step 6 causal audit clean — `re_evaluated_verdict` upgraded from `PASS-DEPLOYABLE-PROVISIONAL` to `PASS-DEPLOYABLE` per Amendment 3 §"Evaluation order" item 3; see `results/l_arc_10/step_6/audit_report.md`. Prior update: 2026-05-22 Amendment 3 re-evaluation: arcs 8, 10, 11 — added `re_evaluated_verdict` column to Closed arcs summary; backfilled missing rows for arcs 8 and 10.)
+Last auto-update: parser: 2026-05-22 00:00:00
 
 ---
 
@@ -32,16 +32,21 @@ Last auto-update: manual: 2026-05-22 (Arc 10 Step 6 causal audit clean — `re_e
 
 | Feature | Arcs used | Avg WFO ratio with | Avg WFO ratio without | Verdict |
 |---|---|---|---|---|
-| w1_close_slope_sign | 1 | -0.769 | — | INSUFFICIENT |
-| d1_atr_percentile_100 | 1 | -0.769 | — | INSUFFICIENT |
-| prior_session_low_distance | 1 | -0.769 | — | INSUFFICIENT |
-| day_of_week | 1 | -0.769 | — | INSUFFICIENT |
-| session_london | 1 | -0.769 | — | INSUFFICIENT |
-| d1_close_slope_magnitude | 1 | -0.769 | — | INSUFFICIENT |
-| distance_to_round_number | 1 | -0.769 | — | INSUFFICIENT |
-| atr_percentile_100 | 1 | -0.769 | — | INSUFFICIENT |
-| usd_strength_index | 1 | -0.769 | — | INSUFFICIENT |
-| spread_vs_trailing_100 | 1 | -0.769 | — | INSUFFICIENT |
+| w1_close_slope_sign | 1 | -0.769 | 3.584 | INSUFFICIENT |
+| d1_atr_percentile_100 | 1 | -0.769 | 3.584 | INSUFFICIENT |
+| prior_session_low_distance | 2 | 0.490 | 5.418 | INSUFFICIENT |
+| day_of_week | 1 | -0.769 | 3.584 | INSUFFICIENT |
+| session_london | 1 | -0.769 | 3.584 | INSUFFICIENT |
+| d1_close_slope_magnitude | 1 | -0.769 | 3.584 | INSUFFICIENT |
+| distance_to_round_number | 2 | 0.490 | 5.418 | INSUFFICIENT |
+| atr_percentile_100 | 2 | 0.490 | 5.418 | INSUFFICIENT |
+| usd_strength_index | 2 | 0.490 | 5.418 | INSUFFICIENT |
+| spread_vs_trailing_100 | 2 | 0.490 | 5.418 | INSUFFICIENT |
+| swing_low_distance_14 | 1 | 1.749 | 5.418 | INSUFFICIENT |
+| atr_vs_trailing_100 | 1 | 1.749 | 5.418 | INSUFFICIENT |
+| kijun_26_distance | 1 | 1.749 | 5.418 | INSUFFICIENT |
+| dollar_bloc_state | 1 | 1.749 | 5.418 | INSUFFICIENT |
+| spread_percentile_100 | 1 | 1.749 | 5.418 | INSUFFICIENT |
 
 Schema:
 - `Avg WFO ratio with` — mean worst-fold ratio across arcs where this feature appeared in the winning config
@@ -54,12 +59,12 @@ Schema:
 
 | Architecture | Arcs tested | Won (best in arc) | Avg ratio when won |
 |---|---|---|---|
-| A1 system_level_filter | 1 | 0 | — |
+| A1 system_level_filter | 3 | 1 | 5.418 |
 | A2 classifier_filter | 1 | 0 | — |
-| A3 pipeline_de | 0 | 0 | — |
+| A3 pipeline_de | 1 | 0 | — |
 | A4 pipeline_d_exits | 0 | 0 | — |
 | A5 portfolio_composition | 0 | 0 | — |
-| A6 meta_labeling | 1 | 0 | — |
+| A6 meta_labeling | 3 | 1 | 1.749 |
 
 Note: Arc 11 has no architecture row marked "Won" because no config met §3 PASS thresholds. A2 is "best of FAIL" (highest worst_fold_ratio among configs that admitted trades); A6 admitted zero trades.
 
@@ -69,12 +74,12 @@ Note: Arc 11 has no architecture row marked "Won" because no config met §3 PASS
 
 | Archetype | Arcs where appeared | Avg in-cluster R | Avg in-cluster reach_1R |
 |---|---|---|---|
-| V-shape recovery | 0 | — | — |
+| V-shape recovery | 2 | 6.40 | 0.986 |
 | Stepwise climber | 0 | — | — |
 | Bimodal | 1 | 7.77 | 1.000 |
 | Monotonic up | 0 | — | — |
-| Monotonic down | 1 | 0.09 | 0.001 |
-| Choppy | 0 | — | — |
+| Monotonic down | 3 | 1.31 | 0.303 |
+| Choppy | 1 | 1.25 | 0.598 |
 | Unclassified | 1 | 1.31 | 0.504 |
 | Other / unclassified | 0 | — | — |
 
@@ -89,7 +94,7 @@ Note: "in-cluster R" tracked as `mfe_p50_r` per template §4.E. Unclassified row
 | pool_too_small | 0 | — | — |
 | no_clusters_separable | 0 | — | — |
 | no_capturable_cluster | 0 | — | — |
-| entry_feature_auc_ceiling | 0 | — | — |
+| entry_feature_auc_ceiling | 1 | l_arc_8 | 2026-05-22 |
 | step5_not_scalable | 0 | — | — |
 | step5_chained_dd_above_gate | 0 | — | — |
 | step5_daily_dd_breach | 0 | — | — |
@@ -119,6 +124,12 @@ Note: "in-cluster R" tracked as `mfe_p50_r` per template §4.E. Unclassified row
 | l_arc_11.c1 | Unclassified | 6287 | 2.1087 | 0.0350 | 0.9648 | 0.9678 | 0.6316 | — | 1.5 | dies_step4 |
 | l_arc_11.c2 | Unclassified | 5032 | 0.5111 | 0.9680 | 0.0425 | 0.1899 | — | — | 1.5 | dies_step3 |
 | l_arc_11.c3 | Monotonic_down | 4022 | 0.0901 | 0.9993 | 0.0007 | 0.0221 | — | — | 1.5 | dies_step3 |
+| l_arc_8.c0 | Monotonic_down | 1657 | 0.0690 | 0.0284 | 0.0000 | 0.3930 | — | — | 4.0 | dies_step3 |
+| l_arc_8.c1 | Choppy | 3560 | 1.2460 | 0.4003 | 0.5978 | 0.5620 | — | — | 1.5 | dies_step3 |
+| l_arc_8.c2 | V-shape | 1540 | 7.5270 | 0.0000 | 1.0000 | 1.0000 | 0.5300 | — | 1.5 | dies_step5 |
+| l_arc_10.c0 | monotonic_down | 1771 | 1.9950 | 0.5280 | 0.7100 | 0.6347 | — | — | 1.5 | dies_step3 |
+| l_arc_10.c1 | v_shape_recovery | 1528 | 5.2670 | 0.5060 | 0.9730 | 0.8628 | 0.5199 | — | 4.0 | wins_step5 |
+| l_arc_10.c2 | monotonic_down | 2 | 3.0710 | 0.5000 | 0.5000 | 0.6750 | — | — | 1.5 | dies_step3 |
 
 Schema:
 - `Cluster ID` — `<arc_name>.<cluster_id>` (e.g., `arc_07.c1`)
@@ -147,6 +158,17 @@ Schema:
 | shb_swing_detection_causal_clean_arc9_lesson_passed | 1 | l_arc_11 |
 | canonical_orchestrator_step5_run_context_gap | 1 | l_arc_11 |
 | step1_pool_uncapped_canonical_vs_capped_handrolled_2_5x_delta | 1 | l_arc_11 |
+| v_shape_auc_ceiling | 1 | l_arc_8 |
+| step4_classifier_at_chance | 1 | l_arc_8 |
+| oracle_real_gap_massive | 1 | l_arc_8 |
+| multi_tf_features_absent_at_step1 | 1 | l_arc_8 |
+| search_wfo_fail_holdout_pass_pattern | 1 | l_arc_8 |
+| v_shape_archetype_cross_arc_persistence | 1 | l_arc_10 |
+| exit_policy_dominates_classifier | 1 | l_arc_10 |
+| no_classifier_needed_for_v_shape_pass_viable | 1 | l_arc_10 |
+| v3_engine_first_pass_viable | 1 | l_arc_10 |
+| step4_auc_chance_full_pool_still_passes_via_exit_policy | 1 | l_arc_10 |
+| oracle_locked_to_sl_only_unfair_upper_bound | 1 | l_arc_10 |
 
 ---
 

--- a/scripts/tracker_parser/parsed.log
+++ b/scripts/tracker_parser/parsed.log
@@ -1,3 +1,5 @@
 # tracker_parser parsed-closures registry
 # one line per parse: <sha256>  <arc_name>
-16bc090125644bb42bb065bc3153e71b53e33d14153f9840d712dd0ef9e97661  l_arc_11
+0cc50c06e6107d5e05d6fde7fed64da33abacd49ccf4fe3d1fca68284b2095c1  l_arc_11
+0f9d4dfd2e40026249bec7797107476edf4787bbab44e55cf28cabcd1d2a6713  l_arc_10
+c9fb88a8b22c2ff51fdcb1525e57c25c1611190ffe321b7c4ecaab472bf92558  l_arc_8

--- a/scripts/tracker_parser/rolling_state.json
+++ b/scripts/tracker_parser/rolling_state.json
@@ -6,102 +6,185 @@
       "sum_mfe": 7.7664,
       "sum_reach": 1.0
     },
-    "Monotonic down": {
+    "Choppy": {
       "n_arcs": 1,
       "n_clusters": 1,
-      "sum_mfe": 0.0901,
-      "sum_reach": 0.0007
+      "sum_mfe": 1.246,
+      "sum_reach": 0.5978
+    },
+    "Monotonic down": {
+      "n_arcs": 3,
+      "n_clusters": 4,
+      "sum_mfe": 5.2251,
+      "sum_reach": 1.2107
     },
     "Unclassified": {
       "n_arcs": 1,
       "n_clusters": 2,
       "sum_mfe": 2.6197999999999997,
       "sum_reach": 1.0073
+    },
+    "V-shape recovery": {
+      "n_arcs": 2,
+      "n_clusters": 2,
+      "sum_mfe": 12.794,
+      "sum_reach": 1.9729999999999999
     }
   },
   "architectures": {
     "A1": {
-      "n_tested": 1,
-      "n_won": 0,
-      "sum_won_ratio": 0.0
+      "n_tested": 3,
+      "n_won": 1,
+      "sum_won_ratio": 5.4185
     },
     "A2": {
       "n_tested": 1,
       "n_won": 0,
       "sum_won_ratio": 0.0
     },
-    "A6": {
+    "A3": {
       "n_tested": 1,
       "n_won": 0,
       "sum_won_ratio": 0.0
+    },
+    "A6": {
+      "n_tested": 3,
+      "n_won": 1,
+      "sum_won_ratio": 1.749
     }
   },
   "features": {
     "atr_percentile_100": {
+      "n_with": 2,
+      "n_without": 1,
+      "sum_with": 0.9803000000000001,
+      "sum_without": 5.4185
+    },
+    "atr_vs_trailing_100": {
       "n_with": 1,
-      "n_without": 0,
-      "sum_with": -0.7687,
-      "sum_without": 0.0
+      "n_without": 1,
+      "sum_with": 1.749,
+      "sum_without": 5.4185
     },
     "d1_atr_percentile_100": {
       "n_with": 1,
-      "n_without": 0,
+      "n_without": 2,
       "sum_with": -0.7687,
-      "sum_without": 0.0
+      "sum_without": 7.1675
     },
     "d1_close_slope_magnitude": {
       "n_with": 1,
-      "n_without": 0,
+      "n_without": 2,
       "sum_with": -0.7687,
-      "sum_without": 0.0
+      "sum_without": 7.1675
     },
     "day_of_week": {
       "n_with": 1,
-      "n_without": 0,
+      "n_without": 2,
       "sum_with": -0.7687,
-      "sum_without": 0.0
+      "sum_without": 7.1675
     },
     "distance_to_round_number": {
+      "n_with": 2,
+      "n_without": 1,
+      "sum_with": 0.9803000000000001,
+      "sum_without": 5.4185
+    },
+    "dollar_bloc_state": {
       "n_with": 1,
-      "n_without": 0,
-      "sum_with": -0.7687,
-      "sum_without": 0.0
+      "n_without": 1,
+      "sum_with": 1.749,
+      "sum_without": 5.4185
+    },
+    "kijun_26_distance": {
+      "n_with": 1,
+      "n_without": 1,
+      "sum_with": 1.749,
+      "sum_without": 5.4185
     },
     "prior_session_low_distance": {
-      "n_with": 1,
-      "n_without": 0,
-      "sum_with": -0.7687,
-      "sum_without": 0.0
+      "n_with": 2,
+      "n_without": 1,
+      "sum_with": 0.9803000000000001,
+      "sum_without": 5.4185
     },
     "session_london": {
       "n_with": 1,
-      "n_without": 0,
+      "n_without": 2,
       "sum_with": -0.7687,
-      "sum_without": 0.0
+      "sum_without": 7.1675
+    },
+    "spread_percentile_100": {
+      "n_with": 1,
+      "n_without": 1,
+      "sum_with": 1.749,
+      "sum_without": 5.4185
     },
     "spread_vs_trailing_100": {
+      "n_with": 2,
+      "n_without": 1,
+      "sum_with": 0.9803000000000001,
+      "sum_without": 5.4185
+    },
+    "swing_low_distance_14": {
       "n_with": 1,
-      "n_without": 0,
-      "sum_with": -0.7687,
-      "sum_without": 0.0
+      "n_without": 1,
+      "sum_with": 1.749,
+      "sum_without": 5.4185
     },
     "usd_strength_index": {
-      "n_with": 1,
-      "n_without": 0,
-      "sum_with": -0.7687,
-      "sum_without": 0.0
+      "n_with": 2,
+      "n_without": 1,
+      "sum_with": 0.9803000000000001,
+      "sum_without": 5.4185
     },
     "w1_close_slope_sign": {
       "n_with": 1,
-      "n_without": 0,
+      "n_without": 2,
       "sum_with": -0.7687,
-      "sum_without": 0.0
+      "sum_without": 7.1675
     }
   },
   "tags": {
     "canonical_orchestrator_step5_run_context_gap": {
       "arcs": [
         "l_arc_11"
+      ],
+      "count": 1
+    },
+    "exit_policy_dominates_classifier": {
+      "arcs": [
+        "l_arc_10"
+      ],
+      "count": 1
+    },
+    "multi_tf_features_absent_at_step1": {
+      "arcs": [
+        "l_arc_8"
+      ],
+      "count": 1
+    },
+    "no_classifier_needed_for_v_shape_pass_viable": {
+      "arcs": [
+        "l_arc_10"
+      ],
+      "count": 1
+    },
+    "oracle_locked_to_sl_only_unfair_upper_bound": {
+      "arcs": [
+        "l_arc_10"
+      ],
+      "count": 1
+    },
+    "oracle_real_gap_massive": {
+      "arcs": [
+        "l_arc_8"
+      ],
+      "count": 1
+    },
+    "search_wfo_fail_holdout_pass_pattern": {
+      "arcs": [
+        "l_arc_8"
       ],
       "count": 1
     },
@@ -120,6 +203,36 @@
     "step4_auc_above_065_v3_first": {
       "arcs": [
         "l_arc_11"
+      ],
+      "count": 1
+    },
+    "step4_auc_chance_full_pool_still_passes_via_exit_policy": {
+      "arcs": [
+        "l_arc_10"
+      ],
+      "count": 1
+    },
+    "step4_classifier_at_chance": {
+      "arcs": [
+        "l_arc_8"
+      ],
+      "count": 1
+    },
+    "v3_engine_first_pass_viable": {
+      "arcs": [
+        "l_arc_10"
+      ],
+      "count": 1
+    },
+    "v_shape_archetype_cross_arc_persistence": {
+      "arcs": [
+        "l_arc_10"
+      ],
+      "count": 1
+    },
+    "v_shape_auc_ceiling": {
+      "arcs": [
+        "l_arc_8"
       ],
       "count": 1
     }


### PR DESCRIPTION
## Summary

Two items missed from CC_11 ([#181](https://github.com/kpanapabusiness-droid/Forex-Backtester/pull/181)).

- **Item 2 (first, to prevent double-apply):** Refreshed Arc 11 sha in `scripts/tracker_parser/parsed.log` from `16bc0901…` → `0cc50c06…`. CC_11's §4 deployment_spec retrofit changed Arc 11's closure-file sha and any subsequent parser run would have treated Arc 11 as unparsed and double-applied its contributions.
- **Item 1:** Backfilled Arc 8 + Arc 10 tracker sections C–I via live parser invocation. They previously only had Closed-arcs-summary rows (manual backfill from `[#177](https://github.com/kpanapabusiness-droid/Forex-Backtester/pull/177)`); rolling_state was missing their contributions. Arc 11 NOT re-run — full coverage already.

## Tracker deltas (Arcs 8 + 10 contributions added; Arc 11 unchanged)

- **Per-feature contribution:** rolling avgs include Arc 8 + Arc 10. 5 new feature rows from Arc 8 winning config.
- **Per-architecture win rate:** A1 tested=3 won=1@5.418 (Arc 10); A6 tested=3 won=1@1.749 (Arc 8); A3 tested=1 (Arc 10).
- **Per-archetype recurrence:** V-shape recovery cluster-count 0→2; Monotonic down 1→3; Choppy 0→1; rolling avgs updated.
- **Per-failure-mode count:** `entry_feature_auc_ceiling` now 1 (Arc 8).
- **Cluster registry:** 6 new cluster rows (Arc 8 c0/c1/c2 + Arc 10 c0/c1/c2).
- **Cross-arc tag registry:** 11 new tag rows (5 Arc 8 + 6 Arc 10).

## Closed-arcs-summary handling

Parser appended duplicate Closed-arcs-summary rows for Arcs 8 and 10 (with empty `Re-evaluated verdict` column — parser convention per `mapping.py` Q-4). Those parser-added rows were deleted in favour of the pre-existing manual rows that already carry Amendment 3 `re_evaluated_verdict` content (`FAIL` for Arc 8, `PASS-DEPLOYABLE` for Arc 10 post-Step-6). Net: 3 rows total in section B, one per arc, all content preserved.

## Last auto-update line

Moved from manual narrative ("Arc 10 Step 6 causal audit clean — …") to parser-deterministic timestamp (`parser: 2026-05-22 00:00:00`, Arc 10's `closed_timestamp`). Manual context preserved in commit history; going forward the parser owns this line per template Section 4-J.

## Idempotency verification

Re-running parser on all three closures post-backfill:
```
Arc 8:  INFO: already parsed (sha256=c9fb88a8…), no-op. Exit 0
Arc 10: INFO: already parsed (sha256=0f9d4dfd…), no-op. Exit 0
Arc 11: INFO: already parsed (sha256=0cc50c06…), no-op. Exit 0
```

All three idempotent. State is consistent.

## Test plan

- [x] `py -m pytest tests/tracker_parser/` → 60/60 pass
- [x] `py -m ruff check .` → all checks passed
- [x] Re-run parser on Arc 8 / Arc 10 / Arc 11 → all no-op (exit 0)
- [x] Tracker diff verified: Arc 11 rows untouched; Arcs 8/10 gained sections C–I as expected
- [ ] Chat review of tracker diff (full diff in PR Files Changed tab)

## Files changed (3)

- `ARC_TRACKER.md` — sections C, D, E, F, G, I updated with Arc 8 + Arc 10 contributions; section B duplicates removed; Last auto-update line.
- `scripts/tracker_parser/parsed.log` — Arc 11 sha refresh + Arc 8/10 entries added.
- `scripts/tracker_parser/rolling_state.json` — Arc 8 + Arc 10 contributions added to features/architectures/archetypes/tags maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)