### PR TITLE
[ENGINE] Step 6 causal audit framework + Amendment 4 + parser v1.3

### DIFF
--- a/ARC_TRACKER.md
+++ b/ARC_TRACKER.md
@@ -172,9 +172,20 @@ Schema:
 
 ---
 
+## Step 6 audit registry
+
+> Auto-dispatched Step 6 runs (per Amendment 4) append one row per arc. Manual CLI
+> invocations DO NOT append (read-only diagnostic per chat Q6).
+> Schema: Arc | Verdict | Step 6 ran | Step 6 passed | Critical fails | Warnings | Manifest
+
+| Arc | Verdict | Step 6 ran | Step 6 passed | Critical fails | Warnings | Manifest |
+|---|---|---|---|---|---|---|
+
+---
+
 ## Update mechanism
 
-Parser at `scripts/update_tracker_from_closure.py` applies the Section 4 A-K mapping from each closure doc's `§1 tracker_payload` YAML block. Invoke per `scripts/tracker_parser/README.md` — invocation is part of the standard arc-close workflow (run on the arc branch before opening the closure PR; tracker delta lands in the same atomic commit as the closure doc).
+Parser at `scripts/update_tracker_from_closure.py` applies the Section 4 A-M mapping from each closure doc's `§1 tracker_payload` YAML block. Invoke per `scripts/tracker_parser/README.md` — invocation is part of the standard arc-close workflow (run on the arc branch before opening the closure PR; tracker delta lands in the same atomic commit as the closure doc).
 
 - Parser writes the "Last auto-update" line as `parser: YYYY-MM-DD HH:MM:SS` (UTC, derived from the closure's `closed_timestamp`).
 - Manual updates (rare; for one-off cleanups or retroactive backfills) write `manual: YYYY-MM-DD` and an optional parenthetical describing the change.

--- a/L_PROTOCOL.md
+++ b/L_PROTOCOL.md
@@ -8,6 +8,7 @@
 > **Amendment 1 (2026-05-22):** Step 5 search policy clarified — informed by Steps 3-4, not exhaustive. Multi-cluster handling + holdout decision rule specified. See §2 Step 5.
 > **Amendment 2 (2026-05-22):** ML architecture mechanics specified for A2, A3, A4, A6. See §2 Step 5 ML mechanics subsection.
 > **Amendment 3 (2026-05-22):** Risk-normalised gates. §3 constraints preserved 1:1; evaluation now occurs at scaled risk `r_safe` / `r_hard` rather than at the WFO base risk. Scalability bounds, per-day DD recount, and explicit evaluation order added. Full text archived at `archive/L_PROTOCOL_v3_0_AMENDMENT_3.md`. See §3.
+> **Amendment 4 (2026-05-24):** Step 6 causal-audit framework. Six audit categories (lookahead, selection bias, execution realism, statistical integrity, determinism, deployment readiness) as runnable engine code. Auto-dispatches post-gate on Top-1 PASS-tier candidate; manual CLI invokable on any closure. Critical failure downgrades verdict via `step6_causal_audit_fail`. Closure template bumped to v1.3 with `§1 tracker_payload.step_6` block; parser v1.3 + Phase 2 tightening (PR-186-merge cutoff). Full text archived at `archive/L_PROTOCOL_v3_0_AMENDMENT_4.md`. See §2 Step 6.
 >
 > This protocol is the umbrella. It accepts any signal, any feature space, any architecture. Sub-protocols may layer on top to add signal-class-specific specificity. The overseer's gates and verdicts apply universally.
 
@@ -330,28 +331,33 @@ A2 and A6 use the single Step-4-fit classifier across every WFO fold. A3 and A4 
 
 **Verdict assignment:** per §3.
 
-### Step 6 — Causal audit (lazy, deployment-only)
+### Step 6 — Causal audit framework (Amendment 4)
 
-**Trigger:** runs only when Step 5 produces ≥ 1 candidate clearing PASS-DEPLOYABLE or PASS-VIABLE.
+> Amendment 4 (2026-05-24) replaces the sparse pre-Amendment Step 6 spec with a six-category runnable framework. Full text at [archive/L_PROTOCOL_v3_0_AMENDMENT_4.md](archive/L_PROTOCOL_v3_0_AMENDMENT_4.md). Summary below; refer to the amendment for severity rules, manifest schema, and Phase 2 parser-tightening details.
 
-**Mechanics:**
+**Trigger:** post-gate. Step 6 dispatches AFTER §3 constraints #1-9 clear on at least one top-K candidate (per §3 "Evaluation order"). Auto-dispatch runs on the **Top-1 verdict-carrying candidate only**; feature-set divergence vs Top-2/Top-3 surfaces as a `top_k_feature_set_divergence` warning. Manual CLI (`scripts/run_step_6.py`) invokable on any closure regardless of verdict (read-only).
 
-1. For each feature in the winning candidate's filter / classifier:
-   - Producer-level trace: where does this feature's value come from? What columns of the underlying OHLC drive it? What time index? Any aggregations?
-   - Verify producer code uses no lookahead, no post-signal data, no leakage from related instruments.
-   - Verify the feature value at trade time T is reproducible from data available at time T only.
+**Six categories** (each independent, no cross-category dependencies):
 
-2. End-to-end check: regenerate a small random sample of feature values from raw OHLC, byte-compare to pool values.
+1. **§6.1 Lookahead** — per-feature producer trace + D1 lag rule + cluster-feature audit + byte-compare from raw OHLC + threshold-selection lineage.
+2. **§6.2 Selection bias** — verifies Step 5's recorded configs_evaluated + Bonferroni-equivalent noise floor + holdout-reuse detector + cluster-selection record.
+3. **§6.3 Execution realism** — HistData M1 bid+ask source present + spread regime delta + fill realism + lot rounding at `r_safe` + mid-price refactor active + UTC bar boundary.
+4. **§6.4 Statistical integrity** — Lo-corrected Sharpe sample-size + 28-pair survivorship + vol-regime coverage (≥3 years) + cross-pair daily-bucket correlation.
+5. **§6.5 Determinism** — `step_4/classifiers/manifest.json` sha256 verify + required artefacts present + seed pinning + LF line endings. (Sha256-verify only; does NOT re-run sims — CI provides the two-run guarantee.)
+6. **§6.6 Deployment readiness** — `## §4 deployment_spec` heading + `config_artefact_path` resolvable + all §4.X subsections present + features live-computable + checklist marked.
 
-3. If any feature fails — flag, and either:
-   - Downgrade candidate (if the failing feature is in a non-critical filter)
-   - Kill candidate (if the failing feature is load-bearing)
+**Severity rules:**
+- `critical` failure → category FAIL → Step 6 FAIL → verdict downgrade
+- `warning` failure → category PASS but flagged; counted in `n_warnings`
+- `info` failure → recorded; no effect on category outcome
 
-**Output:**
-- `step_6/causal_audit_report.md`
-- `step_6/manifest.json`
+`CategoryAuditResult.passed = AND over critical-severity checks only`.
 
-**Heavy compute, rare invocation.** Not setup until needed.
+**Output:** `results/<arc>/step_6/` per auto-dispatch — `manifest.json`, `summary.md`, six `<category>_report.md`, `sha256_manifest.json`. Manual CLI writes to `results/<arc>/step_6_manual_<timestamp>/` (never clobbers auto).
+
+**Verdict effect:** when auto-dispatched Step 6 produces a critical failure, the Top-1's amended gate is re-classified with `causal_audit_clean=False` → `primary_failure_mode = step6_causal_audit_fail` (priority 11 per §3). Manual invocations never modify the verdict.
+
+**Backwards compatibility:** v1.0/v1.1/v1.2/v1.2.1 closures grandfathered. Arc 10's existing hand-written Step 6 stays canonical. Wave 2 arcs close at v1.3; Step 6 auto-dispatches.
 
 ---
 
@@ -447,14 +453,14 @@ Scales linearly with `k`. Threshold preserved from the prior §3 chained-DD spec
 
 ### Evaluation order
 
-Step 6 is lazy per §2. Amendment 3 specifies order explicitly:
+Amendment 3 specifies order explicitly; Amendment 4 makes the Step 6 dispatch concrete:
 
-1. Constraints #1-#9 (all non-Step-6 constraints, both tiers) evaluated in priority order.
-2. If ALL clear → Step 6 causal audit dispatched.
-3. Step 6 clean → PASS-DEPLOYABLE / PASS-VIABLE finalised.
-4. Step 6 fails → FAIL with `primary_failure_mode = step6_causal_audit_fail`.
+1. Constraints #1-#9 (all non-Step-6 constraints, both tiers) evaluated in priority order with `causal_audit_clean=True` (default).
+2. If ALL clear for at least one top-K candidate → Step 6 framework auto-dispatches on the **Top-1 verdict-carrying candidate** (per Amendment 4 chat Q2).
+3. Step 6 critical-clean → PASS-DEPLOYABLE / PASS-VIABLE finalised.
+4. Step 6 critical-fails → Top-1's amended gate re-classified with `causal_audit_clean=False` → FAIL with `primary_failure_mode = step6_causal_audit_fail`.
 
-Step 6 is the LAST gate, not concurrent with the others.
+Step 6 is the LAST gate, not concurrent with the others. Manual CLI invocations never modify the verdict regardless of Step 6 outcome.
 
 ### Failure-mode priority (tie-break)
 

--- a/archive/L_PROTOCOL_v3_0_AMENDMENT_4.md
+++ b/archive/L_PROTOCOL_v3_0_AMENDMENT_4.md
@@ -1,0 +1,189 @@
+# L_PROTOCOL Amendment 4 — Step 6 Causal Audit Framework (v1, locked)
+
+> **Date:** 2026-05-24
+> **Status:** locked and landed into `L_PROTOCOL.md` §2 Step 6 + §3 on 2026-05-24.
+> **Triggered by:** L_PROTOCOL v3.0 §2 Step 6 was sparse (producer trace + byte-compare). Engine capability audit 2026-05 surfaced five MISSING items: producer trace as runnable check, byte-compare from raw OHLC, D1 lag verification, auto-dispatch on PASS, manifest format. Arc 10's PROVISIONAL PASS-DEPLOYABLE made the gap concrete — the backtester said PASS, the EA tank ran post-closure.
+> **Scope:** Step 6 framework as runnable engine code. Auto-dispatches on any candidate that clears §3 constraints #1-9 (post-gate per evaluation order). Manual CLI invokable on any closure regardless of verdict (read-only diagnostic). Six audit categories, severity rules, manifest schema, closure template v1.3 bump, parser v1.3 schema + Phase 2 tightening.
+> **Supersedes:** L_PROTOCOL v3.0 §2 Step 6 (sparse 22-line spec). §3 verdict definitions clarified to make PASS-* conditional on Step 6 clean. Failure-mode taxonomy `step6_causal_audit_fail` retained from Amendment 3 §"Failure-mode priority" at priority 11.
+
+---
+
+## Core principle
+
+Step 6 is the **causal audit** — it verifies that the system Step 5 produced is causally clean and ready for live deployment. It does NOT re-run the search or duplicate Step 5 work. It VERIFIES that recorded paths produced clean output, that no lookahead crept in, that the deployment spec is complete, and that the artefact set is reproducible.
+
+Per chat resolution Q3: **audit = verification, not re-computation.** Several categories overlap existing engine paths (selection-bias accounting at Step 5, determinism in CI, deployment-readiness in §4 deployment_spec). Step 6's job is to verify those paths produced the right record, not redo the work.
+
+---
+
+## Trigger (post-gate per chat Q1)
+
+Step 6 dispatches AFTER `classify_amended_fold_stats` (Amendment 3) clears §3 constraints #1-9 with `causal_audit_clean=True` (default) for at least one top-K candidate. Constraints #1-9 are evaluated FIRST per Amendment 3 §"Evaluation order"; Step 6 is constraint #10.
+
+Auto-dispatch runs on the **Top-1 verdict-carrying candidate only** (chat Q2). When Top-2 / Top-3 use a feature set materially different from Top-1, Step 6 surfaces this as a `top_k_feature_set_divergence` warning on the lookahead category — chat may then opt to audit them manually.
+
+Step 6 critical-failure downgrades the Top-1's verdict by re-classifying its amended gate with `causal_audit_clean=False`, which routes to `primary_failure_mode = step6_causal_audit_fail`. Other top-K candidates are NOT re-classified.
+
+`skip_step_6: bool = False` on `ArcConfig` is the escape hatch for diagnostic / dev runs that don't need the audit.
+
+---
+
+## Six audit categories
+
+Each category is a self-contained module under `core/step_6/` that exports `audit(inputs, audit_config) -> CategoryAuditResult`. Categories CANNOT depend on each other (each runs independently).
+
+### §6.1 Lookahead
+
+Producer-level feature trace + D1 lag rule enforcement + cluster-feature audit + byte-compare from raw OHLC + threshold-selection lineage.
+
+Six checks (4 critical, 1 warning, 1 info):
+- `per_feature_lineage_clean` (critical)
+- `no_path_features_in_entry` (critical)
+- `d1_lag_rule_enforced` (critical, static source check)
+- `byte_compare_no_drift` (critical, N samples × M features)
+- `threshold_selection_lineage` (warning)
+- `feature_lineage_table_exists` (info)
+
+### §6.2 Selection bias
+
+Verifies Step 5's recorded selection-bias accounting: configs evaluated, Bonferroni-equivalent noise floor, holdout reuse detector, cluster-selection record.
+
+Five checks (3 critical, 1 warning, 1 info).
+
+### §6.3 Execution realism
+
+Real-spread source (HistData M1 bid+ask), per-pair spread regime delta, fill realism, lot rounding at `r_safe`, mid-price refactor active, UTC bar boundary.
+
+Six checks (4 critical, 1 warning, 1 info).
+
+### §6.4 Statistical integrity
+
+Per-fold + total trade count sufficiency, 28-pair survivorship, vol-regime coverage (≥ 3 calendar years), cross-pair daily-bucket correlation, Lo-corrected Sharpe with lag-1 autocorrelation correction.
+
+Five checks (2 critical, 2 warning, 1 info).
+
+### §6.5 Determinism
+
+`step_4/classifiers/manifest.json` sha256 match against on-disk file hashes, required arc artefacts present, seed pinning across producer modules, LF line terminators in text artefacts. Per chat Q5: sha256-manifest verify ONLY — does NOT re-run sims.
+
+Four checks (2 critical, 1 warning, 1 info).
+
+### §6.6 Deployment readiness
+
+`## §4 deployment_spec` heading present, `config_artefact_path` resolvable, every `§4.X` subsection (1-11) present, features live-computable per FeatureSpec registry, deployment-readiness checklist marked.
+
+Five checks (3 critical, 1 warning, 1 info).
+
+---
+
+## Severity rules (chat Q4)
+
+- `critical` failure → category FAIL → Step 6 FAIL → verdict downgrade (auto-dispatch only).
+- `warning` failure → category PASS but flagged; recorded in `n_warnings` total.
+- `info` failure → recorded; informational only.
+
+`CategoryAuditResult.passed = AND over critical-severity checks only`. Warnings and info do not affect the category's pass/fail decision.
+
+`--no-block` CLI flag demotes critical failures to warnings in the rendered report only; manual invocations never modify the verdict regardless.
+
+---
+
+## Manifest + artefact format
+
+`results/<arc>/step_6/` per auto-dispatch:
+- `manifest.json` — per dispatch Task 4 schema (arc_name, ran_at, trigger, overall_passed, verdict_impact, categories summary, report_paths, critical_failures, n_warnings)
+- `summary.md` — one-page roll-up
+- `<category>_report.md` × 6 — per-category check table + evidence
+- `sha256_manifest.json` — per-file sha256 for two-run determinism comparison
+
+`results/<arc>/step_6_manual_<timestamp>/` per manual CLI invocation — identical layout; never clobbers the auto-dispatched run (chat Q6).
+
+---
+
+## Closure template v1.3 — `§1 tracker_payload.step_6` block
+
+```yaml
+step_6:
+  ran: <bool>
+  trigger: auto_pass | manual | not_applicable
+  overall_passed: <bool or null>
+  manifest_path: results/<arc>/step_6/manifest.json
+  categories:
+    lookahead: <bool or null>
+    selection_bias: <bool or null>
+    execution_realism: <bool or null>
+    statistical: <bool or null>
+    determinism: <bool or null>
+    deployment_readiness: <bool or null>
+  critical_failures: [<list of "category.check_name" entries>]
+  warnings_count: <int>
+  verdict_impact: none | downgraded_to_fail
+```
+
+REQUIRED for any v1.3 PASS verdict. For FAIL / HALT closures the block records `ran: false` with all other fields null.
+
+---
+
+## Parser v1.3 — Phase 2 tightening (chat Q7)
+
+Cutoff: `2026-05-23T06:20:59Z` (PR-186 merge).
+
+For any PASS verdict with `closed_timestamp > 2026-05-23T06:20:59Z`:
+- REQUIRE Amendment 3 fields in `best_architecture` (`chained_max_dd_base_pct`, `k_safe`, `k_hard`, `r_safe_pct`, `r_hard_pct`, `scalable_to_safe`, `scalable_to_hard`).
+
+For `template_version: v1.3` PASS verdicts:
+- ADDITIONALLY require the `step_6` block with `overall_passed: true`.
+
+Pre-cutoff closures (v1.0/v1.1/v1.2/v1.2.1) grandfathered. Failed validation → parser HALT, blocking PR merge.
+
+---
+
+## §3 verdict definitions (clarification)
+
+§3 PASS-DEPLOYABLE and PASS-VIABLE both require "Step 6 causal audit clean" (constraint #10 in both tiers — pre-existing in v3.0). Amendment 4 makes the framework concrete:
+
+- Pre-Amendment-4: "Step 6 causal audit clean" was a manual gate, dispatched at chat's discretion.
+- Post-Amendment-4: "Step 6 causal audit clean" = `Step6Result.overall_passed == True`, evaluated on the Top-1 candidate after §3 constraints #1-9 clear. Engine-enforced.
+
+The `step6_causal_audit_fail` failure mode at priority 11 in §3 "Failure-mode priority" remains unchanged.
+
+---
+
+## Backwards compatibility (chat Q6)
+
+- v1.0 / v1.1 / v1.2 / v1.2.1 closures (Arcs 8, 10, 11, all retroactives) grandfathered. Parser handles them under the existing detection precedence. No retroactive Step 6 required.
+- Arc 10's PROVISIONAL PASS-DEPLOYABLE: existing hand-written Step 6 at `results/l_arc_10/step_6/` stays canonical. Re-running the framework via manual CLI lands in `results/l_arc_10/step_6_manual_<ts>/` and does NOT clobber. Arc 10's `template_version` stays v1.2; no v1.3 retrofit required.
+- Future arcs (Wave 2 onward) close at v1.3; Step 6 auto-dispatches on PASS-tier candidates.
+
+---
+
+## Discipline rules
+
+- Step 6 FAIL on an auto-dispatched candidate → MUST downgrade to FAIL. No override mechanism.
+- Manual invocations are read-only — never modify the verdict.
+- Severity rules locked: critical = blocking, warning = flagging, info = recording.
+- Step 6 modules are engine-side; audit categories CANNOT depend on each other.
+- All Step 6 outputs deterministic — same arc result → same Step 6 output bytes (modulo `ran_at` timestamp).
+
+---
+
+## Definition of done (PR scope)
+
+- [x] Six audit category modules implemented with check functions
+- [x] Auto-dispatch wired into orchestrator (post-gate per Q1, Top-1 per Q2)
+- [x] Manual CLI (`scripts/run_step_6.py`) working
+- [x] Closure template v1.3 with `step_6` block
+- [x] Tracker schema extended (new "Step 6 audit registry" section)
+- [x] Parser v1.3 detection + Step 6 block model + enum validation
+- [x] Parser Phase 2 tightening (PR-186-merge-date cutoff + v1.3 PASS Step 6 requirement)
+- [x] Amendment 4 landed in `archive/L_PROTOCOL_v3_0_AMENDMENT_4.md`
+- [x] L_PROTOCOL.md §2 Step 6 expanded with Amendment 4 reference
+- [x] L_PROTOCOL.md §3 verdict-Step 6 conditional clarified
+- [x] Full test suite passing (existing + new tests/step_6/)
+- [x] Documentation updated (PROTOCOL_RUNTIME.md, tracker_parser/README.md, engine_capability_audit footer)
+
+---
+
+## End
+
+Amendment locked. Future Step 6 framework changes require explicit redesign event documented in chat.

--- a/core/arc/_closure_template.py
+++ b/core/arc/_closure_template.py
@@ -3,11 +3,16 @@
 These are string templates — no Jinja or external templating engine, to
 keep the runtime dependency-light. The orchestrator fills the slots
 after Steps 1..5 complete.
+
+Per Amendment 4 (v1.3 template) ``render_step_6_block`` produces the
+``§1 tracker_payload.step_6`` YAML snippet from a
+:class:`core.step_6.manifest.Step6Manifest`. Callers paste the returned
+string into the §1 YAML body.
 """
 
 from __future__ import annotations
 
-from typing import Mapping
+from typing import Any, Mapping
 
 ARC_OPEN_TEMPLATE = """# ARC_OPEN — {arc_name}
 
@@ -113,9 +118,66 @@ def render_arc_closure(fields: Mapping[str, str]) -> str:
     return ARC_CLOSURE_TEMPLATE.format(**defaults)
 
 
+def render_step_6_block(manifest: Any | None) -> str:
+    """Render the v1.3 ``§1 tracker_payload.step_6`` YAML snippet.
+
+    ``manifest`` is a :class:`core.step_6.manifest.Step6Manifest` or
+    ``None``. When ``None`` the snippet records ``ran: false`` with all
+    other fields nulled — appropriate for FAIL closures where Step 6
+    did not dispatch.
+
+    Output indented for paste-in under the ``step_6:`` key of the
+    template's YAML body (4-space base indent).
+    """
+    if manifest is None:
+        lines = [
+            "  step_6:",
+            "    ran: false",
+            "    trigger: not_applicable",
+            "    overall_passed: null",
+            "    manifest_path: null",
+            "    categories:",
+            "      lookahead: null",
+            "      selection_bias: null",
+            "      execution_realism: null",
+            "      statistical: null",
+            "      determinism: null",
+            "      deployment_readiness: null",
+            "    critical_failures: []",
+            "    warnings_count: 0",
+            "    verdict_impact: none",
+        ]
+        return "\n".join(lines)
+    cats = {c.category: bool(c.passed) for c in manifest.categories}
+    crit_failures = list(manifest.critical_failures or ())
+    lines = [
+        "  step_6:",
+        "    ran: true",
+        f"    trigger: {manifest.trigger.value}",
+        f"    overall_passed: {str(bool(manifest.overall_passed)).lower()}",
+        f"    manifest_path: {manifest.report_paths.get('manifest', 'step_6/manifest.json')}",
+        "    categories:",
+    ]
+    for cat in ("lookahead", "selection_bias", "execution_realism",
+                "statistical", "determinism", "deployment_readiness"):
+        val = cats.get(cat)
+        rendered = "null" if val is None else str(val).lower()
+        lines.append(f"      {cat}: {rendered}")
+    # critical_failures rendered as a YAML inline list
+    if crit_failures:
+        bullets = ", ".join(f'"{n}"' for n in crit_failures)
+        lines.append(f"    critical_failures: [{bullets}]")
+    else:
+        lines.append("    critical_failures: []")
+    lines.append(f"    warnings_count: {int(manifest.n_warnings)}")
+    lines.append(f"    verdict_impact: {manifest.verdict_impact.value}")
+    return "\n".join(lines)
+
+
 __all__ = (
     "ARC_OPEN_TEMPLATE",
     "ARC_CLOSURE_TEMPLATE",
     "render_arc_open",
     "render_arc_closure",
+    "render_step_6_block",
 )

--- a/core/arc/arc_orchestrator.py
+++ b/core/arc/arc_orchestrator.py
@@ -43,6 +43,12 @@ from core.architectures.a1_system_level_filter import A1RunContext
 from core.runners._fold_stats_helpers import compute_per_day_max_dd
 from core.runners.arc_fold_runner import ArcFoldRunner
 from core.sim.panel import Panel
+from core.step_6.dispatch import (
+    DispatchOutcome,
+    maybe_dispatch_step_6,
+    replace_top_1_with_step6_fail,
+)
+from core.step_6.manifest import AuditConfig as Step6AuditConfig
 from core.steps.classifier_persistence import (
     build_a2_config_from_step4,
     build_a3_config_from_step4,
@@ -173,7 +179,12 @@ class ArcConfig:
     # dispatch time. See :class:`AutoArchSpec`. Empty by default.
     auto_arch_specs: tuple[AutoArchSpec, ...] = ()
     wfo_structure: WfoStructure | None = None  # None -> build_v3_folds()
-    invoke_step_6: bool = False  # set True after PASS-tier candidate detected
+    # Step 6 auto-dispatch (Amendment 4). Default behavior is to run Step 6
+    # automatically on any PASS-tier candidate after the amended gate clears
+    # §3 constraints #1-9. ``skip_step_6=True`` is an escape hatch — chat
+    # may set it for diagnostic / dev runs that don't need the audit.
+    skip_step_6: bool = False
+    step_6_audit_config: Step6AuditConfig | None = None
     # Amendment 3 §"Sizing convention" — when any candidate uses
     # ``sizing_convention="equity_pct"``, the scalability gate FAILs
     # by default. Set this to True only after chat approval of a
@@ -246,6 +257,9 @@ class ArcOrchestratorResult:
     raw_strategy_results: tuple[StrategyResult, ...] = field(default_factory=tuple)
     # Amendment 3 extension — None when no top-K candidates exist
     amended_wfo: AmendedWfoSearchResult | None = None
+    # Amendment 4 extension — None when Step 6 did not dispatch (no PASS-tier
+    # candidate cleared §3 constraints #1-9, or skip_step_6=True).
+    step_6_dispatch: DispatchOutcome | None = None
 
 
 class ArcOrchestrator:
@@ -787,6 +801,46 @@ class ArcOrchestrator:
                 wfo_struct=wfo_struct_amend,
             )
 
+        # Amendment 4: Step 6 causal-audit auto-dispatch.
+        # Post-gate per chat Q1 — runs only after the amended gate clears
+        # §3 constraints #1-9 for at least one candidate.
+        step_6_dispatch: DispatchOutcome | None = None
+        if (
+            amended_wfo is not None
+            and amended_wfo.amended_results
+            and not self.cfg.skip_step_6
+        ):
+            arc_root = self._resolve_output_dir()
+            arc_root.mkdir(parents=True, exist_ok=True)
+            wfo_struct_amend = self.cfg.wfo_structure or build_v3_folds()
+            holdout_start = None
+            if wfo_struct_amend.holdout is not None:
+                holdout_start = pd.Timestamp(wfo_struct_amend.holdout.oos_start)
+                if holdout_start.tzinfo is None:
+                    holdout_start = holdout_start.tz_localize("UTC")
+            step_6_dispatch = maybe_dispatch_step_6(
+                arc_orchestrator_result=_LightOrchestratorView(
+                    arc_name=self.cfg.arc_name,
+                    pool=pool, step_4=s4, wfo_search=s5,
+                    amended_wfo=amended_wfo,
+                ),
+                amended_wfo=amended_wfo,
+                arc_root=arc_root,
+                audit_config=self.cfg.step_6_audit_config,
+                holdout_start=holdout_start,
+                panels=self.panels,
+                feature_matrix=self.cfg.feature_matrix,
+                feature_lineage=self.cfg.feature_lineage,
+                signal_module_name=type(self.signal_module).__module__,
+                primary_tf=signal_eval.primary_tf,
+                pair_set=tuple(self.cfg.pair_set),
+            )
+            # Per Amendment 4 + chat Q1: if Step 6 critical-failed, downgrade
+            # the Top-1 candidate by re-classifying its gate with
+            # causal_audit_clean=False.
+            if step_6_dispatch.downgrade_top_1:
+                amended_wfo = replace_top_1_with_step6_fail(amended_wfo)
+
         # Verdict — source from Amendment 3 result if present, else legacy.
         verdict = "INCOMPLETE"
         if amended_wfo is not None and amended_wfo.amended_results:
@@ -815,7 +869,7 @@ class ArcOrchestrator:
             "step_3_summary": s3.summary_md,
             "step_4_summary": s4.summary_md if s4 else "(no candidate clusters; Step 4 skipped)",
             "step_5_summary": _step_5_summary(s5),
-            "step_6_summary": "(lazy — deferred to chat at PASS verdict)",
+            "step_6_summary": _step_6_summary(step_6_dispatch),
             "pass_or_failed_phrase": "passed" if "PASS" in verdict else "failed",
             "why_explanation": "(populated by chat in closure prose)",
             "improvements_list": "(populated by chat)",
@@ -834,6 +888,7 @@ class ArcOrchestrator:
             arc_closure_md=arc_closure_md,
             verdict=verdict,
             amended_wfo=amended_wfo,
+            step_6_dispatch=step_6_dispatch,
         )
 
     def write(self, result: ArcOrchestratorResult, out_dir: Path | None = None) -> Path:
@@ -938,6 +993,54 @@ def _best_architecture_summary(s5: WfoSearchResult | None) -> str:
         f"worst ROI {best.gate.worst_fold_roi:+.4%}, "
         f"worst DD {best.gate.worst_fold_dd:.4%}."
     )
+
+
+@dataclass(frozen=True)
+class _LightOrchestratorView:
+    """Minimal duck-type passed to ``core.step_6.io.from_arc_orchestrator_result``.
+
+    The orchestrator hasn't constructed its full ArcOrchestratorResult by the
+    time Step 6 dispatches (verdict + closure rendering happen after). This
+    shim exposes just the fields the Step 6 io builder reads.
+    """
+
+    arc_name: str
+    pool: Any
+    step_4: Any
+    wfo_search: Any
+    amended_wfo: Any
+
+
+def _step_6_summary(dispatch: DispatchOutcome | None) -> str:
+    if dispatch is None:
+        return "(not dispatched — no PASS-tier candidate cleared §3 #1-9 OR skip_step_6=True)"
+    if not dispatch.dispatched:
+        return "(not dispatched — no PASS-tier candidate cleared §3 #1-9)"
+    res = dispatch.step_6_result
+    if res is None:
+        return "(dispatched; no result captured)"
+    lines = [
+        f"Step 6 result: **overall_passed={bool(res.overall_passed)}**",
+        f"Trigger: `{res.trigger.value}` · Verdict impact: `{res.verdict_impact.value}`",
+        "",
+        "| Category | Passed | Critical fails | Warnings |",
+        "|---|---|---:|---:|",
+    ]
+    for c in res.categories:
+        lines.append(
+            f"| {c.category} | {bool(c.passed)} | "
+            f"{c.n_critical_fails}/{c.n_critical} | {c.n_warnings} |"
+        )
+    if dispatch.divergence_warning:
+        lines.append("")
+        lines.append("> ⚠ Top-1 feature set differs from other PASS-tier candidates — chat may want to audit them too (per Amendment 4 §Q2).")
+    crit = res.critical_failures()
+    if crit:
+        lines.append("")
+        lines.append("**Critical failures:**")
+        for name in crit:
+            lines.append(f"- `{name}`")
+    return "\n".join(lines)
 
 
 def _step_5_summary(s5: WfoSearchResult | None) -> str:

--- a/core/step_6/__init__.py
+++ b/core/step_6/__init__.py
@@ -1,0 +1,50 @@
+"""L_PROTOCOL §2 Step 6 — causal audit framework (Amendment 4).
+
+Six audit categories run on any candidate that clears §3 constraints
+#1-#9. Step 6 is the last gate per §3 "Evaluation order" — its failure
+downgrades a candidate to FAIL with
+``primary_failure_mode = step6_causal_audit_fail``.
+
+Public API:
+
+    run_step_6              # dispatch the six categories on one candidate
+    Step6Result             # bundle: per-category results + overall verdict
+    Step6Manifest           # serialisable artefact for the tracker payload
+    CategoryAuditResult     # one category's check bundle
+    CheckResult             # one check's outcome (passed + severity + evidence)
+    Severity                # critical | warning | info
+    AuditConfig             # per-run configuration knobs
+
+    AUDIT_CATEGORY_NAMES    # ordered tuple of the six category names
+
+Per chat resolution Q1 + Q2: the orchestrator calls ``run_step_6`` on
+the Top-1 verdict-carrying candidate AFTER the amended gate clears
+constraints #1-#9, then re-calls the amended gate with the real
+``causal_audit_clean`` value to finalise the verdict.
+"""
+
+from core.step_6.manifest import (
+    AUDIT_CATEGORY_NAMES,
+    AuditConfig,
+    CategoryAuditResult,
+    CheckResult,
+    Severity,
+    Step6Manifest,
+    Step6Result,
+    VerdictImpact,
+    write_step_6_manifest,
+)
+from core.step_6.orchestrator import run_step_6
+
+__all__ = (
+    "AUDIT_CATEGORY_NAMES",
+    "AuditConfig",
+    "CategoryAuditResult",
+    "CheckResult",
+    "Severity",
+    "Step6Manifest",
+    "Step6Result",
+    "VerdictImpact",
+    "run_step_6",
+    "write_step_6_manifest",
+)

--- a/core/step_6/artefacts.py
+++ b/core/step_6/artefacts.py
@@ -1,0 +1,224 @@
+"""Per-category markdown reports + summary + sha256_manifest.
+
+Layout written under ``results/<arc>/step_6/``:
+
+  manifest.json               # Step6Manifest
+  summary.md                  # one-page roll-up
+  lookahead_report.md         # §6.1 detail
+  selection_bias_report.md    # §6.2
+  execution_realism_report.md # §6.3
+  statistical_report.md       # §6.4
+  determinism_report.md       # §6.5
+  deployment_readiness_report.md  # §6.6
+  sha256_manifest.json        # per-file sha256 for two-run determinism
+
+Manual CLI variant writes under ``results/<arc>/step_6_manual_<timestamp>/``
+per chat Q6 — does not clobber the auto-dispatched run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from core.determinism import LINE_TERMINATOR, TEXT_ENCODING
+from core.step_6.manifest import (
+    CategoryAuditResult,
+    Severity,
+    Step6Manifest,
+    Step6Result,
+    write_step_6_manifest,
+)
+
+_REPORT_FILENAME = {
+    "lookahead": "lookahead_report.md",
+    "selection_bias": "selection_bias_report.md",
+    "execution_realism": "execution_realism_report.md",
+    "statistical": "statistical_report.md",
+    "determinism": "determinism_report.md",
+    "deployment_readiness": "deployment_readiness_report.md",
+}
+
+
+def _severity_marker(severity: Severity, passed: bool) -> str:
+    if passed:
+        return "PASS"
+    if severity == Severity.CRITICAL:
+        return "FAIL-CRITICAL"
+    if severity == Severity.WARNING:
+        return "WARNING"
+    return "INFO"
+
+
+def render_category_report(
+    category: CategoryAuditResult, *, no_block: bool = False
+) -> str:
+    """Render one category's detailed markdown report.
+
+    ``no_block`` per chat Q4 + manual CLI ``--no-block``: every critical
+    failure is rendered as ``DEMOTED-WARNING`` instead of ``FAIL-CRITICAL``
+    so the report reads as diagnostic, not blocking.
+    """
+    lines: list[str] = []
+    lines.append(f"# Step 6 — §6 {category.category} report")
+    lines.append("")
+    lines.append(f"- **Category:** `{category.category}`")
+    lines.append(f"- **Passed:** {bool(category.passed)}  "
+                 f"(critical: {category.n_critical_fails}/{category.n_critical} fails, "
+                 f"warnings: {category.n_warnings}, info: {category.n_info})")
+    if no_block:
+        lines.append("- **--no-block:** critical failures rendered as DEMOTED-WARNING")
+    lines.append("")
+    if category.diagnostic:
+        lines.append("## Diagnostic")
+        lines.append("")
+        lines.append("```json")
+        lines.append(json.dumps(dict(category.diagnostic), indent=2, sort_keys=True))
+        lines.append("```")
+        lines.append("")
+    lines.append("## Checks")
+    lines.append("")
+    lines.append("| # | Name | Status | Message |")
+    lines.append("|---:|---|---|---|")
+    for i, c in enumerate(category.checks, start=1):
+        marker = _severity_marker(c.severity, c.passed)
+        if no_block and marker == "FAIL-CRITICAL":
+            marker = "DEMOTED-WARNING"
+        msg = c.message.replace("|", "\\|").replace("\n", " ")
+        lines.append(f"| {i} | `{c.name}` | {marker} | {msg} |")
+    lines.append("")
+    # Evidence — append per-check JSON for traceability.
+    lines.append("## Evidence")
+    lines.append("")
+    for c in category.checks:
+        lines.append(f"### `{c.name}` ({_severity_marker(c.severity, c.passed)})")
+        lines.append("")
+        if c.evidence:
+            lines.append("```json")
+            lines.append(json.dumps(dict(c.evidence), indent=2, sort_keys=True, default=str))
+            lines.append("```")
+        else:
+            lines.append("_(no structured evidence)_")
+        lines.append("")
+    return LINE_TERMINATOR.join(lines) + LINE_TERMINATOR
+
+
+def render_summary(result: Step6Result) -> str:
+    lines: list[str] = []
+    lines.append(f"# Step 6 — `{result.arc_name}` summary")
+    lines.append("")
+    lines.append(f"- **Trigger:** `{result.trigger.value}`")
+    lines.append(f"- **Overall passed:** {bool(result.overall_passed)}")
+    lines.append(f"- **Verdict impact:** `{result.verdict_impact.value}`")
+    lines.append(f"- **Warnings total:** {result.n_warnings_total}")
+    if result.audit_config.no_block:
+        lines.append("- **--no-block:** critical failures suppressed for verdict purposes")
+    crit = result.critical_failures()
+    if crit:
+        lines.append("")
+        lines.append("**Critical failures:**")
+        for name in crit:
+            lines.append(f"- `{name}`")
+    lines.append("")
+    lines.append("## Categories")
+    lines.append("")
+    lines.append("| Category | Passed | Critical | Warnings | Info | Report |")
+    lines.append("|---|---|---:|---:|---:|---|")
+    for c in result.categories:
+        report = _REPORT_FILENAME.get(c.category, f"{c.category}_report.md")
+        lines.append(
+            f"| {c.category} | {bool(c.passed)} | "
+            f"{c.n_critical_fails}/{c.n_critical} | {c.n_warnings} | {c.n_info} | "
+            f"[{report}]({report}) |"
+        )
+    lines.append("")
+    return LINE_TERMINATOR.join(lines) + LINE_TERMINATOR
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def write_sha256_manifest(out_dir: Path, files: list[Path]) -> Path:
+    """Write ``sha256_manifest.json`` for two-run determinism comparison.
+
+    Lists every Step 6 artefact (manifest.json + per-category .md + summary.md)
+    with its sha256. Used by §6.5 determinism category and by CI tests.
+    """
+    entries = {}
+    for p in sorted(files):
+        if not p.exists():
+            continue
+        rel = p.relative_to(out_dir)
+        entries[str(rel).replace("\\", "/")] = _sha256_file(p)
+    payload = {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "files": entries,
+    }
+    out = out_dir / "sha256_manifest.json"
+    out.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + LINE_TERMINATOR,
+        encoding=TEXT_ENCODING, newline=LINE_TERMINATOR,
+    )
+    return out
+
+
+def write_step_6_artefacts(
+    result: Step6Result,
+    out_dir: Path,
+    *,
+    ran_at: str | None = None,
+) -> Step6Manifest:
+    """Write every Step 6 artefact to ``out_dir`` and return the manifest.
+
+    Idempotent — running twice on the same Step6Result writes byte-identical
+    files modulo ``ran_at`` (which is recorded in manifest.json and the
+    sha256_manifest.json header).
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    no_block = result.audit_config.no_block
+    report_paths: dict[str, str] = {}
+    written: list[Path] = []
+
+    for category in result.categories:
+        fname = _REPORT_FILENAME.get(category.category, f"{category.category}_report.md")
+        path = out_dir / fname
+        path.write_text(
+            render_category_report(category, no_block=no_block),
+            encoding=TEXT_ENCODING, newline=LINE_TERMINATOR,
+        )
+        report_paths[category.category] = fname
+        written.append(path)
+
+    summary_path = out_dir / "summary.md"
+    summary_path.write_text(
+        render_summary(result), encoding=TEXT_ENCODING, newline=LINE_TERMINATOR,
+    )
+    written.append(summary_path)
+
+    manifest = Step6Manifest.from_result(
+        result, report_paths=report_paths, summary_path="summary.md", ran_at=ran_at,
+    )
+    manifest_path = out_dir / "manifest.json"
+    write_step_6_manifest(manifest, manifest_path)
+    written.append(manifest_path)
+
+    # sha256 manifest written LAST and explicitly excludes itself.
+    write_sha256_manifest(out_dir, written)
+
+    return manifest
+
+
+__all__ = (
+    "render_category_report",
+    "render_summary",
+    "write_sha256_manifest",
+    "write_step_6_artefacts",
+)

--- a/core/step_6/byte_compare.py
+++ b/core/step_6/byte_compare.py
@@ -1,0 +1,275 @@
+"""Generic byte-compare harness.
+
+Factored from Arc 10's ``scripts/l_arc_10_v3/step_6_byte_compare.py`` into
+a feature-producer-agnostic check that the §6.1 lookahead audit can call
+on any registered :class:`core.features.lineage.FeatureSpec`.
+
+Procedure
+---------
+
+1. Sample ``n`` trades at random (seeded for determinism) from
+   ``inputs.pool_trades``.
+2. For each sampled trade, recompute every requested feature by calling
+   the registered ``FeatureSpec.producer`` on the pair's panel data
+   restricted to ``signal_time`` and prior.
+3. Compare the recomputed value against the value carried in
+   ``inputs.feature_matrix`` for that trade. Differences above the
+   absolute / relative tolerance are flagged.
+
+Constraints
+-----------
+
+- Panels MUST be supplied via ``inputs.panels`` (auto-dispatch path) or
+  the harness records an ``info`` check explaining that the harness
+  could not run; this is NOT a FAIL — manual CLI invocation on a closed
+  arc may not have panels in memory.
+- Producers that ``needs_panel=True`` but have no panel emit NaN; the
+  harness treats matching NaN-on-both-sides as equal.
+
+Returns
+-------
+
+A ``ByteCompareReport`` per :class:`Step6Inputs`-shaped invocation —
+one row per (trade, feature) sample with ``pool_value``, ``recomputed``,
+``abs_diff``, ``match``. The §6.1 lookahead audit converts this into
+:class:`CheckResult` entries.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import numpy as np
+import pandas as pd
+
+from core.features.pipeline import compute_feature_matrix
+from core.step_6.inputs import Step6Inputs
+
+# Tolerances per Arc 10 precedent: 1e-9 absolute + 1e-9 relative.
+DEFAULT_RTOL = 1e-9
+DEFAULT_ATOL = 1e-9
+
+
+@dataclass(frozen=True)
+class ByteCompareRow:
+    trade_id: int
+    pair: str
+    signal_time: pd.Timestamp
+    feature: str
+    pool_value: float
+    recomputed: float
+    abs_diff: float
+    match: bool
+
+
+@dataclass(frozen=True)
+class ByteCompareReport:
+    n_samples_requested: int
+    n_samples_used: int
+    seed: int
+    rtol: float
+    atol: float
+    rows: tuple[ByteCompareRow, ...]
+    skipped_reason: str | None = None  # None on a successful run; populated when n_used==0
+
+    @property
+    def all_match(self) -> bool:
+        if not self.rows:
+            return False
+        return all(r.match for r in self.rows)
+
+    @property
+    def mismatched_features(self) -> tuple[str, ...]:
+        names: set[str] = set()
+        for r in self.rows:
+            if not r.match:
+                names.add(r.feature)
+        return tuple(sorted(names))
+
+    def to_evidence(self) -> dict[str, Any]:
+        return {
+            "n_samples_requested": self.n_samples_requested,
+            "n_samples_used": self.n_samples_used,
+            "seed": self.seed,
+            "rtol": self.rtol,
+            "atol": self.atol,
+            "all_match": self.all_match,
+            "mismatched_features": list(self.mismatched_features),
+            "skipped_reason": self.skipped_reason,
+            "rows_preview": [
+                {
+                    "trade_id": int(r.trade_id),
+                    "pair": r.pair,
+                    "signal_time": str(r.signal_time),
+                    "feature": r.feature,
+                    "pool": r.pool_value,
+                    "recomputed": r.recomputed,
+                    "abs_diff": r.abs_diff,
+                    "match": r.match,
+                }
+                # Cap at 25 rows so manifests stay tractable; mismatches
+                # surface first so they aren't truncated.
+                for r in sorted(self.rows, key=lambda x: (x.match, x.feature))[:25]
+            ],
+        }
+
+
+def _compare_value(pool_val: Any, recomputed: Any, *, rtol: float, atol: float) -> tuple[float, bool]:
+    """Return (abs_diff, match). Both-NaN counts as match."""
+    try:
+        pv = float(pool_val)
+    except (TypeError, ValueError):
+        pv = float("nan")
+    try:
+        rv = float(recomputed)
+    except (TypeError, ValueError):
+        rv = float("nan")
+    pv_nan = math.isnan(pv)
+    rv_nan = math.isnan(rv)
+    if pv_nan and rv_nan:
+        return 0.0, True
+    if pv_nan or rv_nan:
+        return float("nan"), False
+    diff = abs(pv - rv)
+    return diff, bool(diff <= atol + rtol * max(abs(pv), abs(rv)))
+
+
+def run_byte_compare(
+    inputs: Step6Inputs,
+    *,
+    feature_names: tuple[str, ...] | None = None,
+    n_samples: int = 5,
+    seed: int = 42,
+    rtol: float = DEFAULT_RTOL,
+    atol: float = DEFAULT_ATOL,
+) -> ByteCompareReport:
+    """Sample n trades, recompute features from raw OHLC, byte-compare.
+
+    Skips with ``skipped_reason`` set (and ``n_samples_used = 0``) when:
+    - ``inputs.pool_trades`` is missing
+    - ``inputs.feature_matrix`` is missing
+    - ``inputs.panels`` is missing (we cannot recompute without panels)
+    """
+    if inputs.pool_trades is None:
+        return ByteCompareReport(
+            n_samples_requested=n_samples, n_samples_used=0, seed=seed,
+            rtol=rtol, atol=atol, rows=(),
+            skipped_reason="inputs.pool_trades missing — cannot sample trades",
+        )
+    if inputs.feature_matrix is None:
+        return ByteCompareReport(
+            n_samples_requested=n_samples, n_samples_used=0, seed=seed,
+            rtol=rtol, atol=atol, rows=(),
+            skipped_reason="inputs.feature_matrix missing — cannot read pool values",
+        )
+    if inputs.panels is None:
+        return ByteCompareReport(
+            n_samples_requested=n_samples, n_samples_used=0, seed=seed,
+            rtol=rtol, atol=atol, rows=(),
+            skipped_reason="inputs.panels missing — cannot recompute features",
+        )
+
+    trades = inputs.pool_trades.copy()
+    if len(trades) == 0:
+        return ByteCompareReport(
+            n_samples_requested=n_samples, n_samples_used=0, seed=seed,
+            rtol=rtol, atol=atol, rows=(), skipped_reason="empty pool",
+        )
+
+    fm = inputs.feature_matrix
+    if "trade_id" in fm.columns:
+        fm = fm.set_index("trade_id")
+
+    available_features = tuple(fm.columns)
+    feature_names = feature_names or available_features
+    feature_names = tuple(f for f in feature_names if f in available_features)
+    if not feature_names:
+        return ByteCompareReport(
+            n_samples_requested=n_samples, n_samples_used=0, seed=seed,
+            rtol=rtol, atol=atol, rows=(),
+            skipped_reason="no overlap between requested features and feature_matrix columns",
+        )
+
+    rng = np.random.default_rng(seed)
+    n_avail = len(trades)
+    if n_avail < n_samples:
+        sample_idx = np.arange(n_avail)
+    else:
+        sample_idx = rng.choice(n_avail, size=n_samples, replace=False)
+    sample = trades.iloc[sample_idx].copy()
+
+    primary_tf = inputs.primary_tf or _guess_primary_tf(inputs.panels)
+    if primary_tf is None or primary_tf not in inputs.panels:
+        return ByteCompareReport(
+            n_samples_requested=n_samples, n_samples_used=0, seed=seed,
+            rtol=rtol, atol=atol, rows=(),
+            skipped_reason=f"primary_tf={primary_tf!r} not in panels",
+        )
+    primary_panel = inputs.panels[primary_tf]
+
+    rows: list[ByteCompareRow] = []
+    for _, trade in sample.iterrows():
+        pair = str(trade["pair"])
+        signal_time = pd.Timestamp(trade["signal_time"]) if "signal_time" in trade.index \
+            else pd.Timestamp(trade.get("entry_time"))
+        if pair not in primary_panel.pairs:
+            continue
+        pair_df = primary_panel.frame(pair)
+        # Trim to bars STRICTLY at or before signal_time (no future leakage).
+        pair_df_trimmed = pair_df.loc[pair_df.index <= signal_time]
+        if pair_df_trimmed.empty:
+            continue
+        try:
+            recomputed = compute_feature_matrix(
+                pair, pair_df_trimmed, panel=primary_panel,
+                names=list(feature_names),
+            )
+        except Exception:
+            # Recompute failed entirely for this trade — record one
+            # row per requested feature flagged as mismatch.
+            for f in feature_names:
+                rows.append(ByteCompareRow(
+                    trade_id=int(trade["trade_id"]), pair=pair, signal_time=signal_time,
+                    feature=f, pool_value=float("nan"), recomputed=float("nan"),
+                    abs_diff=float("nan"), match=False,
+                ))
+            continue
+        recomputed_row = recomputed.matrix.iloc[-1]  # value at signal bar
+        if int(trade["trade_id"]) not in fm.index:
+            continue
+        pool_row = fm.loc[int(trade["trade_id"])]
+        for f in feature_names:
+            pv = pool_row.get(f, float("nan"))
+            rv = recomputed_row.get(f, float("nan"))
+            abs_diff, match = _compare_value(pv, rv, rtol=rtol, atol=atol)
+            rows.append(ByteCompareRow(
+                trade_id=int(trade["trade_id"]), pair=pair, signal_time=signal_time,
+                feature=f, pool_value=float(pv) if pd.notna(pv) else float("nan"),
+                recomputed=float(rv) if pd.notna(rv) else float("nan"),
+                abs_diff=abs_diff, match=match,
+            ))
+
+    return ByteCompareReport(
+        n_samples_requested=n_samples, n_samples_used=len(sample_idx),
+        seed=seed, rtol=rtol, atol=atol, rows=tuple(rows),
+    )
+
+
+def _guess_primary_tf(panels: Mapping[str, Any]) -> str | None:
+    # Prefer "H4" > "1H" > "H1" > first key.
+    for candidate in ("H4", "1H", "H1", "D1", "M30", "M15"):
+        if candidate in panels:
+            return candidate
+    keys = list(panels.keys())
+    return keys[0] if keys else None
+
+
+__all__ = (
+    "ByteCompareReport",
+    "ByteCompareRow",
+    "DEFAULT_ATOL",
+    "DEFAULT_RTOL",
+    "run_byte_compare",
+)

--- a/core/step_6/deployment_readiness.py
+++ b/core/step_6/deployment_readiness.py
@@ -1,0 +1,224 @@
+"""§6.6 Deployment readiness audit.
+
+Per chat Q3: reads the closure's §4 deployment_spec section, verifies
+fields are populated, and confirms ``config_artefact_path`` exists +
+is self-contained. Does not duplicate the parser's Section 4-L PASS
+validation (which the parser already enforces pre-merge) — the audit's
+job here is to surface DEPLOYABLE-READY issues to the closure reader.
+
+Five checks:
+
+  1. ``deployment_spec_section_present`` (critical) — closure doc has
+     a ``## §4 deployment_spec`` heading. Mirrors parser Section 4-L
+     check but runs at engine-time so PASS arcs surface the issue
+     before the parser HALT at PR time.
+  2. ``config_artefact_path_resolvable`` (critical) — ``config_artefact_path``
+     is non-null AND the referenced file exists.
+  3. ``deployment_spec_subsections_present`` (critical) — every §4.X
+     subsection heading (§4.1 through §4.11) is present in the closure
+     doc.
+  4. ``features_live_computable`` (warning) — every feature in
+     ``best_candidate_features`` has a non-empty Step 6.3
+     equivalent: its FeatureSpec exists in the registry AND
+     `needs_panel == False` OR a panel is realistically available live.
+  5. ``deployment_checklist_marked`` (info) — count of checked items
+     in the §4.11 checklist.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from core.step_6.inputs import Step6Inputs
+from core.step_6.manifest import (
+    AuditConfig,
+    CategoryAuditResult,
+    CheckResult,
+    Severity,
+)
+
+DEPLOYMENT_SPEC_HEADING_RE = re.compile(r"^## §4 deployment_spec\b", re.MULTILINE)
+SUBSECTION_RE = re.compile(r"^### 4\.(\d+)\b", re.MULTILINE)
+CHECKED_ITEM_RE = re.compile(r"^- \[(x|X)\]", re.MULTILINE)
+UNCHECKED_ITEM_RE = re.compile(r"^- \[ \]", re.MULTILINE)
+
+
+def _load_closure_text(arc_root: Path) -> str | None:
+    closure = arc_root / "ARC_CLOSURE.md"
+    if not closure.exists():
+        return None
+    return closure.read_text(encoding="utf-8")
+
+
+def _check_deployment_spec_heading(inputs: Step6Inputs) -> CheckResult:
+    text = _load_closure_text(inputs.arc_root)
+    if text is None:
+        return CheckResult(
+            name="deployment_spec_section_present",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message="ARC_CLOSURE.md not found under arc_root",
+            evidence={"arc_root": str(inputs.arc_root)},
+        )
+    present = bool(DEPLOYMENT_SPEC_HEADING_RE.search(text))
+    return CheckResult(
+        name="deployment_spec_section_present",
+        passed=present,
+        severity=Severity.CRITICAL,
+        message=(
+            "§4 deployment_spec heading present" if present
+            else "§4 deployment_spec heading missing — required for PASS verdicts"
+        ),
+        evidence={"closure_path": str(inputs.arc_root / "ARC_CLOSURE.md")},
+    )
+
+
+def _check_config_artefact_path(inputs: Step6Inputs) -> CheckResult:
+    payload = inputs.closure_payload or {}
+    ba = payload.get("best_architecture") or {}
+    path_str = ba.get("config_artefact_path")
+    if not path_str:
+        # Auto-dispatch path may have populated via orchestrator differently;
+        # try to recover from extras.
+        path_str = inputs.extras.get("config_artefact_path") if inputs.extras else None
+    if not path_str:
+        return CheckResult(
+            name="config_artefact_path_resolvable",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message="best_architecture.config_artefact_path missing or null",
+            evidence={"path_str": path_str},
+        )
+    repo_root = inputs.arc_root.resolve().parents[1] if len(inputs.arc_root.resolve().parents) >= 2 else inputs.arc_root.resolve()
+    full = repo_root / path_str
+    if not full.exists():
+        return CheckResult(
+            name="config_artefact_path_resolvable",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=f"config_artefact_path does not resolve to a file: {full}",
+            evidence={"path_str": path_str, "resolved": str(full)},
+        )
+    return CheckResult(
+        name="config_artefact_path_resolvable",
+        passed=True,
+        severity=Severity.CRITICAL,
+        message=f"config_artefact_path resolves to {path_str} ({full.stat().st_size} bytes)",
+        evidence={"path_str": path_str, "size_bytes": int(full.stat().st_size)},
+    )
+
+
+def _check_subsections_present(inputs: Step6Inputs) -> CheckResult:
+    text = _load_closure_text(inputs.arc_root)
+    if text is None:
+        return CheckResult(
+            name="deployment_spec_subsections_present",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message="ARC_CLOSURE.md not found",
+            evidence={},
+        )
+    found = sorted({int(m.group(1)) for m in SUBSECTION_RE.finditer(text)})
+    required = list(range(1, 12))  # §4.1 .. §4.11
+    missing = sorted(set(required) - set(found))
+    passed = not missing
+    return CheckResult(
+        name="deployment_spec_subsections_present",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"§4 subsections present: {found}; missing: {missing if missing else 'none'}"
+        ),
+        evidence={"found": found, "missing": missing, "required": required},
+    )
+
+
+def _check_features_live_computable(inputs: Step6Inputs) -> CheckResult:
+    features = inputs.best_candidate_features
+    if not features:
+        return CheckResult(
+            name="features_live_computable",
+            passed=True,
+            severity=Severity.INFO,
+            message="no winning-candidate features (rule-based arc)",
+            evidence={},
+        )
+    try:
+        from core.features.registry import get as _get_spec  # type: ignore
+    except ImportError as exc:
+        return CheckResult(
+            name="features_live_computable",
+            passed=False,
+            severity=Severity.WARNING,
+            message=f"could not import feature registry: {exc}",
+            evidence={"error": str(exc)},
+        )
+    needs_panel: list[str] = []
+    unknown: list[str] = []
+    for f in features:
+        try:
+            spec = _get_spec(f)
+        except KeyError:
+            unknown.append(f)
+            continue
+        if getattr(spec, "needs_panel", False):
+            needs_panel.append(f)
+    passed = not unknown
+    return CheckResult(
+        name="features_live_computable",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"{len(features)} features inspected: {len(needs_panel)} require panel data, "
+            f"{len(unknown)} unknown to registry"
+        ),
+        evidence={
+            "n_features": len(features),
+            "needs_panel": needs_panel,
+            "unknown_to_registry": unknown,
+        },
+    )
+
+
+def _check_deployment_checklist(inputs: Step6Inputs) -> CheckResult:
+    text = _load_closure_text(inputs.arc_root)
+    if text is None:
+        return CheckResult(
+            name="deployment_checklist_marked",
+            passed=True,
+            severity=Severity.INFO,
+            message="closure doc not found",
+            evidence={},
+        )
+    checked = len(CHECKED_ITEM_RE.findall(text))
+    unchecked = len(UNCHECKED_ITEM_RE.findall(text))
+    total = checked + unchecked
+    return CheckResult(
+        name="deployment_checklist_marked",
+        passed=True,
+        severity=Severity.INFO,
+        message=f"deployment-readiness checklist: {checked}/{total} items checked",
+        evidence={"checked": checked, "unchecked": unchecked, "total": total},
+    )
+
+
+def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult:
+    checks = (
+        _check_deployment_spec_heading(inputs),
+        _check_config_artefact_path(inputs),
+        _check_subsections_present(inputs),
+        _check_features_live_computable(inputs),
+        _check_deployment_checklist(inputs),
+    )
+    diagnostic: dict[str, Any] = {
+        "best_candidate_architecture": inputs.best_candidate_architecture,
+        "best_candidate_config_id": inputs.best_candidate_config_id,
+    }
+    return CategoryAuditResult(
+        category="deployment_readiness", checks=checks, diagnostic=diagnostic,
+    )
+
+
+__all__ = ("audit",)

--- a/core/step_6/determinism.py
+++ b/core/step_6/determinism.py
@@ -1,0 +1,215 @@
+"""§6.5 Determinism audit.
+
+Per chat Q5: sha256-manifest verify ONLY — does NOT re-run sims. The
+two-run sha256 guarantee is provided by ``tests/test_determinism.py``
+in CI. Step 6's job is to confirm the on-disk artefacts match the
+recorded manifest, catching post-emission tampering / corruption.
+
+Four checks:
+
+  1. ``step_4_manifest_sha256_match`` (critical) — every entry in
+     ``step_4/classifiers/manifest.json`` matches the recomputed sha256
+     of its file on disk.
+  2. ``arc_artefacts_present`` (critical) — required artefacts
+     (ARC_CLOSURE.md, step_1/pool.parquet, step_5/wfo_results.csv if
+     present, etc.) are on disk under arc_root.
+  3. ``seed_pinning_verified`` (warning) — grep producer source files
+     for ``random_state=`` references; flag any classifier builder that
+     doesn't pin the seed.
+  4. ``line_terminator_lf`` (info) — sample text artefacts use LF line
+     endings.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from core.step_6.inputs import Step6Inputs
+from core.step_6.manifest import (
+    AuditConfig,
+    CategoryAuditResult,
+    CheckResult,
+    Severity,
+)
+
+_RANDOM_STATE_RE = re.compile(r"random_state\s*=\s*(\d+|RANDOM_STATE)")
+_REQUIRED_ARTEFACTS = (
+    Path("ARC_CLOSURE.md"),
+    Path("step_1/pool.parquet"),
+    Path("step_3/capturability.csv"),
+)
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _check_step_4_manifest(inputs: Step6Inputs) -> CheckResult:
+    manifest_path = inputs.arc_root / "step_4" / "classifiers" / "manifest.json"
+    if not manifest_path.exists():
+        return CheckResult(
+            name="step_4_manifest_sha256_match",
+            passed=True,
+            severity=Severity.INFO,
+            message="no Step 4 classifier manifest — arc is rule-based",
+            evidence={"manifest_path": str(manifest_path)},
+        )
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    classifiers = data.get("classifiers") or {}
+    mismatches: list[dict[str, Any]] = []
+    verified: list[dict[str, Any]] = []
+    for cid, entry in classifiers.items():
+        rel_path = entry.get("path")
+        expected = entry.get("sha256")
+        if rel_path is None or expected is None:
+            mismatches.append({"cluster_id": cid, "issue": "missing path or sha256"})
+            continue
+        full = manifest_path.parent / rel_path
+        if not full.exists():
+            mismatches.append({"cluster_id": cid, "issue": "file missing", "path": str(full)})
+            continue
+        actual = _sha256_file(full)
+        if actual != expected:
+            mismatches.append({
+                "cluster_id": cid,
+                "issue": "sha256 mismatch",
+                "expected": expected,
+                "actual": actual,
+            })
+        else:
+            verified.append({"cluster_id": cid, "sha256": actual[:16] + "..."})
+    passed = len(mismatches) == 0
+    return CheckResult(
+        name="step_4_manifest_sha256_match",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"{len(verified)} classifier(s) verified, {len(mismatches)} mismatch(es)"
+        ),
+        evidence={
+            "n_verified": len(verified),
+            "n_mismatched": len(mismatches),
+            "mismatches": mismatches,
+            "verified": verified,
+        },
+    )
+
+
+def _check_arc_artefacts_present(inputs: Step6Inputs) -> CheckResult:
+    missing: list[str] = []
+    present: list[str] = []
+    for rel in _REQUIRED_ARTEFACTS:
+        full = inputs.arc_root / rel
+        if full.exists():
+            present.append(str(rel))
+        else:
+            missing.append(str(rel))
+    passed = len(missing) == 0
+    return CheckResult(
+        name="arc_artefacts_present",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"{len(present)}/{len(_REQUIRED_ARTEFACTS)} required artefact(s) on disk; "
+            f"missing: {missing if missing else 'none'}"
+        ),
+        evidence={"present": present, "missing": missing, "arc_root": str(inputs.arc_root)},
+    )
+
+
+def _check_seed_pinning() -> CheckResult:
+    try:
+        from core.steps import _classifier_defaults  # type: ignore
+    except ImportError as exc:
+        return CheckResult(
+            name="seed_pinning_verified",
+            passed=False,
+            severity=Severity.WARNING,
+            message=f"could not import _classifier_defaults: {exc}",
+            evidence={"error": str(exc)},
+        )
+    try:
+        source = inspect.getsource(_classifier_defaults)
+    except OSError as exc:
+        return CheckResult(
+            name="seed_pinning_verified",
+            passed=False,
+            severity=Severity.WARNING,
+            message=f"could not read source: {exc}",
+            evidence={"error": str(exc)},
+        )
+    matches = _RANDOM_STATE_RE.findall(source)
+    builders = source.count("def build_")
+    passed = len(matches) >= builders and builders > 0
+    return CheckResult(
+        name="seed_pinning_verified",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"{len(matches)} random_state= reference(s) across {builders} builder(s)"
+        ),
+        evidence={
+            "n_random_state_references": len(matches),
+            "n_builders": builders,
+            "seeds_seen": matches,
+        },
+    )
+
+
+def _check_line_terminator(inputs: Step6Inputs) -> CheckResult:
+    # Sample ARC_CLOSURE.md + capturability summary if present.
+    samples = (
+        inputs.arc_root / "ARC_CLOSURE.md",
+        inputs.arc_root / "step_3" / "capturability_summary.md",
+    )
+    findings: list[dict[str, Any]] = []
+    for p in samples:
+        if not p.exists():
+            continue
+        data = p.read_bytes()
+        has_crlf = b"\r\n" in data
+        findings.append({"path": str(p.relative_to(inputs.arc_root)), "has_crlf": has_crlf})
+    if not findings:
+        return CheckResult(
+            name="line_terminator_lf",
+            passed=True,
+            severity=Severity.INFO,
+            message="no sample text artefacts available",
+            evidence={},
+        )
+    any_crlf = any(f["has_crlf"] for f in findings)
+    return CheckResult(
+        name="line_terminator_lf",
+        passed=not any_crlf,
+        severity=Severity.INFO,
+        message=(
+            "all sampled text artefacts use LF" if not any_crlf
+            else f"{sum(1 for f in findings if f['has_crlf'])} artefact(s) carry CRLF"
+        ),
+        evidence={"samples": findings},
+    )
+
+
+def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult:
+    checks = (
+        _check_step_4_manifest(inputs),
+        _check_arc_artefacts_present(inputs),
+        _check_seed_pinning(),
+        _check_line_terminator(inputs),
+    )
+    diagnostic: dict[str, Any] = {"arc_root": str(inputs.arc_root)}
+    return CategoryAuditResult(
+        category="determinism", checks=checks, diagnostic=diagnostic,
+    )
+
+
+__all__ = ("audit",)

--- a/core/step_6/dispatch.py
+++ b/core/step_6/dispatch.py
@@ -1,0 +1,280 @@
+"""Auto-dispatch helpers used by :class:`core.arc.arc_orchestrator.ArcOrchestrator`.
+
+Per chat Q1: post-gate. Amended gate runs first with the default
+``causal_audit_clean=True``. If the Top-1 candidate clears PASS-tier,
+Step 6 dispatches; if it FAILs, the orchestrator re-classifies the
+Top-1 with ``causal_audit_clean=False`` to downgrade.
+
+Per chat Q2: Top-1 only. Top-2/Top-3 feature-set divergence surfaces
+as a ``feature_set_divergence`` warning on the Step 6 manifest.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+
+from core.step_6.artefacts import write_step_6_artefacts
+from core.step_6.io import from_arc_orchestrator_result
+from core.step_6.manifest import (
+    AuditConfig,
+    CategoryAuditResult,
+    CheckResult,
+    Severity,
+    Step6Manifest,
+    Step6Result,
+    TriggerSource,
+)
+from core.step_6.orchestrator import run_step_6
+
+
+@dataclass(frozen=True)
+class DispatchOutcome:
+    """Result of an auto-dispatch invocation.
+
+    ``step_6_result`` / ``step_6_manifest`` are None when no PASS-tier
+    candidate cleared §3 constraints #1-9 (no dispatch warranted).
+
+    ``downgrade_top_1`` is True iff Step 6 surfaced at least one
+    critical failure on a PASS-tier candidate; the orchestrator must
+    re-call :func:`classify_amended_fold_stats` with
+    ``causal_audit_clean=False`` for the Top-1 candidate.
+
+    ``divergence_warning`` is True iff Top-2/Top-3 use a materially
+    different feature set from Top-1 (per chat Q2).
+    """
+
+    dispatched: bool
+    step_6_result: Step6Result | None
+    step_6_manifest: Step6Manifest | None
+    downgrade_top_1: bool
+    divergence_warning: bool
+    out_dir: Path | None
+
+
+def _select_top1_amended(amended_wfo: Any) -> Any | None:
+    """Return the Top-1 :class:`CandidateAmendedResult` by verdict rank.
+
+    Mirrors arc_orchestrator._amended_verdict_rank: PASS_DEPLOYABLE > PASS_VIABLE > FAIL.
+    """
+    if amended_wfo is None or not amended_wfo.amended_results:
+        return None
+    ranked = sorted(
+        amended_wfo.amended_results,
+        key=lambda r: _verdict_rank(r.amended_gate.verdict),
+        reverse=True,
+    )
+    return ranked[0]
+
+
+def _verdict_rank(verdict: Any) -> int:
+    name = verdict.name if hasattr(verdict, "name") else str(verdict)
+    if name == "PASS_DEPLOYABLE":
+        return 2
+    if name == "PASS_VIABLE":
+        return 1
+    return 0
+
+
+def _is_pass_tier(verdict: Any) -> bool:
+    return _verdict_rank(verdict) >= 1
+
+
+def _feature_sets_diverge(
+    top1: Any, others: tuple[Any, ...], strategy_results: Mapping[str, Any] | None,
+) -> bool:
+    """Heuristic: if Top-2/Top-3 carry a different architecture name from
+    Top-1, OR their config_id prefix differs, flag divergence.
+
+    Strategy: arc-orchestrator config_ids look like ``"A2::cfg_xxx"`` — split
+    on ``"::"`` and compare prefixes. When the prefixes differ we likely
+    have different feature sets (A1 vs A2 vs A6).
+    """
+    if not others:
+        return False
+    top1_prefix = top1.config_id.split("::", 1)[0]
+    for other in others:
+        other_prefix = other.config_id.split("::", 1)[0]
+        if other_prefix != top1_prefix:
+            return True
+    return False
+
+
+def maybe_dispatch_step_6(
+    *,
+    arc_orchestrator_result: Any,
+    amended_wfo: Any,
+    arc_root: Path,
+    audit_config: AuditConfig | None = None,
+    holdout_start: pd.Timestamp | None = None,
+    panels: Mapping[str, Any] | None = None,
+    feature_matrix: pd.DataFrame | None = None,
+    feature_lineage: pd.DataFrame | None = None,
+    signal_module_name: str | None = None,
+    primary_tf: str | None = None,
+    pair_set: tuple[str, ...] = (),
+) -> DispatchOutcome:
+    """If the Top-1 amended candidate is PASS-tier, run Step 6 and return
+    the outcome bundle. Otherwise return a no-op outcome.
+    """
+    top1 = _select_top1_amended(amended_wfo)
+    if top1 is None or not _is_pass_tier(top1.amended_gate.verdict):
+        return DispatchOutcome(
+            dispatched=False, step_6_result=None, step_6_manifest=None,
+            downgrade_top_1=False, divergence_warning=False, out_dir=None,
+        )
+
+    cfg = audit_config or AuditConfig()
+
+    # Build Step6Inputs from the live result. Pass through any extras the
+    # auto-dispatch path can supply.
+    inputs = from_arc_orchestrator_result(
+        arc_orchestrator_result, arc_root=arc_root,
+        feature_matrix=feature_matrix,
+        feature_lineage=feature_lineage,
+        panels=panels,
+        signal_module_name=signal_module_name,
+        primary_tf=primary_tf,
+        pair_set=pair_set,
+        holdout_start=holdout_start,
+    )
+
+    result = run_step_6(inputs, trigger=TriggerSource.AUTO_PASS, audit_config=cfg)
+
+    # Top-K feature-set divergence per chat Q2. Surface as a synthetic check
+    # appended to the first category so it shows in the report.
+    others = tuple(
+        r for r in amended_wfo.amended_results
+        if r is not top1 and _is_pass_tier(r.amended_gate.verdict)
+    )
+    divergence = _feature_sets_diverge(top1, others, None)
+    if divergence and result.categories:
+        # Append divergence warning to the lookahead category (first in list).
+        first_cat = result.categories[0]
+        divergence_check = CheckResult(
+            name="top_k_feature_set_divergence",
+            passed=False,
+            severity=Severity.WARNING,
+            message=(
+                f"Top-1 ({top1.config_id}) has feature set distinct from "
+                f"Top-{len(others)+1} candidate(s); chat may want to audit them too"
+            ),
+            evidence={
+                "top1_config_id": top1.config_id,
+                "other_config_ids": [r.config_id for r in others],
+            },
+        )
+        first_cat_with_warn = CategoryAuditResult(
+            category=first_cat.category,
+            checks=first_cat.checks + (divergence_check,),
+            diagnostic=first_cat.diagnostic,
+        )
+        result = Step6Result(
+            arc_name=result.arc_name,
+            trigger=result.trigger,
+            categories=(first_cat_with_warn,) + result.categories[1:],
+            audit_config=result.audit_config,
+        )
+
+    out_dir = arc_root / "step_6"
+    manifest = write_step_6_artefacts(result, out_dir)
+
+    return DispatchOutcome(
+        dispatched=True,
+        step_6_result=result,
+        step_6_manifest=manifest,
+        downgrade_top_1=not result.overall_passed,
+        divergence_warning=divergence,
+        out_dir=out_dir,
+    )
+
+
+def replace_top_1_with_step6_fail(amended_wfo: Any) -> Any:
+    """Re-classify the Top-1 amended candidate's gate with
+    ``causal_audit_clean=False`` per Amendment 4 §"Verdict downgrade".
+
+    Returns a new :class:`AmendedWfoSearchResult` with the Top-1's
+    ``amended_gate`` replaced; other candidates untouched.
+
+    The re-classify path inside ``classify_amended_fold_stats`` needs the
+    full input set (folds, chained DD, per-day DD, holdout safe/hard).
+    We replay those from the CandidateAmendedResult bundle so no holdout
+    sim is repeated. Per-day max-DD DataFrame is re-loaded from the
+    parquet path the original eval recorded.
+    """
+    from core.wfo.amended_gates import (  # local import keeps boot cheap
+        classify_amended_fold_stats,
+    )
+
+    if amended_wfo is None or not amended_wfo.amended_results:
+        return amended_wfo
+
+    top1 = _select_top1_amended(amended_wfo)
+    if top1 is None:
+        return amended_wfo
+
+    # Reload per-day DF from parquet path the first pass recorded
+    per_day_df = None
+    if top1.per_day_max_dd_artefact_path is not None and Path(top1.per_day_max_dd_artefact_path).exists():
+        try:
+            per_day_df = pd.read_parquet(top1.per_day_max_dd_artefact_path)
+        except Exception:
+            per_day_df = None
+
+    # We don't have direct access to the original holdout FoldStats objects
+    # (they live in the orchestrator's holdout_results tuple). Reconstruct
+    # minimal FoldStats from the AmendedGateResult fields when present.
+    from core.wfo.gates import FoldStats
+    safe = None
+    if top1.amended_gate.holdout_roi_at_r_safe_pct is not None:
+        safe = FoldStats(
+            fold_id=-1, n_trades=0,
+            roi_pct=top1.amended_gate.holdout_roi_at_r_safe_pct,
+            max_dd_pct=top1.amended_gate.holdout_dd_at_r_safe_pct or 0.0,
+            days_breaching_daily_5pct=0,
+            roi_dd_ratio=0.0,
+        )
+    hard = None
+    if top1.amended_gate.holdout_roi_at_r_hard_pct is not None:
+        hard = FoldStats(
+            fold_id=-1, n_trades=0,
+            roi_pct=top1.amended_gate.holdout_roi_at_r_hard_pct,
+            max_dd_pct=top1.amended_gate.holdout_dd_at_r_hard_pct or 0.0,
+            days_breaching_daily_5pct=0,
+            roi_dd_ratio=0.0,
+        )
+
+    # We need the original fold stats — those live on the underlying
+    # CandidateSearchResult, accessible via amended_wfo.base.top_k.
+    fold_stats = ()
+    for cand in amended_wfo.base.top_k:
+        if cand.config_id == top1.config_id:
+            fold_stats = cand.fold_stats
+            break
+
+    new_gate = classify_amended_fold_stats(
+        folds=fold_stats,
+        chained_max_dd_base_pct=top1.chained_max_dd_base_pct,
+        per_day_max_dd_df=per_day_df,
+        holdout_stats_at_r_safe=safe,
+        holdout_stats_at_r_hard=hard,
+        sizing_convention=top1.amended_gate.sizing_convention,
+        causal_audit_clean=False,
+    )
+
+    new_top1 = replace(top1, amended_gate=new_gate)
+    new_results = tuple(
+        new_top1 if r is top1 else r for r in amended_wfo.amended_results
+    )
+    # Same shape as AmendedWfoSearchResult constructor — preserve base.
+    return type(amended_wfo)(base=amended_wfo.base, amended_results=new_results)
+
+
+__all__ = (
+    "DispatchOutcome",
+    "maybe_dispatch_step_6",
+    "replace_top_1_with_step6_fail",
+)

--- a/core/step_6/execution_realism.py
+++ b/core/step_6/execution_realism.py
@@ -1,0 +1,318 @@
+"""§6.3 Execution realism audit.
+
+Verifies that the backtest's execution assumptions are realistic against
+the live broker (5ers). Per chat Q3: audit = verification, not
+re-computation — these checks read recorded artefacts (HistData M1
+bid+ask under `data/histdata/`, pool spread regime samples) and the
+deployment_spec; they do not re-run the simulator.
+
+Six checks:
+
+  1. ``real_spread_source_present`` (critical) — HistData M1 bid+ask
+     directory exists per L_PROTOCOL §1 "Real bid/ask spreads. HistData
+     M1 bid+ask is the canonical spread source." (Pre-PR-162 arcs used
+     `configs/spread_floors_5ers.yaml`; that file was purged in PR-162
+     when real-spread mechanics landed.)
+  2. ``spread_regime_within_tolerance`` (critical) — per-pair spread
+     activation rate on the pool stays under the warn threshold (cfg
+     ``spread_delta_warn_pct``) vs the locked floor.
+  3. ``next_bar_open_fill_realistic`` (critical) — primary-TF bars in
+     the pool are spaced ≤ the TF's nominal duration. M1 tick data
+     existence (under ``data/1H/`` or pair-level) recorded as evidence.
+  4. ``lot_rounding_at_r_safe`` (critical) — at the candidate's
+     ``r_safe``, computed lot size at the median trade is above the
+     broker minimum (0.01 lots for 5ers).
+  5. ``mid_price_refactor_active`` (warning) — backtester uses mid-OHLC
+     path features rather than bid-only for path measurements. Read from
+     the deployment_spec entry mechanics + reverse-grep of
+     `core/sim/multipair_backtester.py`.
+  6. ``utc_bar_boundary`` (info) — pool's signal_time / entry_time
+     values carry a UTC tz; daily-DD measurement uses UTC broker-day per
+     Amendment 3.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from core.step_6.inputs import Step6Inputs
+from core.step_6.manifest import (
+    AuditConfig,
+    CategoryAuditResult,
+    CheckResult,
+    Severity,
+)
+
+REAL_SPREAD_SOURCE = Path("data/histdata")  # post-PR-162; M1 bid+ask per L_PROTOCOL §1
+BROKER_MIN_LOTS = 0.01  # 5ers minimum
+DEFAULT_PRIMARY_TF_BAR_MINUTES = {"M1": 1, "M5": 5, "M15": 15, "M30": 30,
+                                  "H1": 60, "1H": 60, "H4": 240, "4H": 240, "D1": 1440}
+
+
+def _check_real_spread_source(inputs: Step6Inputs) -> CheckResult:
+    # Resolve relative to repo root via arc_root: results/<arc>/ → ../..
+    repo_root = inputs.arc_root.resolve().parents[1] if len(inputs.arc_root.resolve().parents) >= 2 else inputs.arc_root.resolve()
+    path = repo_root / REAL_SPREAD_SOURCE
+    if not path.exists() or not path.is_dir():
+        return CheckResult(
+            name="real_spread_source_present",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=f"HistData spread source directory missing: {path}",
+            evidence={"expected_path": str(path)},
+        )
+    n_pairs = len([p for p in path.iterdir() if p.is_dir()])
+    return CheckResult(
+        name="real_spread_source_present",
+        passed=True,
+        severity=Severity.CRITICAL,
+        message=f"HistData spread source present at {REAL_SPREAD_SOURCE} ({n_pairs} pair dir(s))",
+        evidence={"path": str(path), "n_pair_dirs": n_pairs},
+    )
+
+
+def _check_spread_regime(inputs: Step6Inputs, cfg: AuditConfig) -> CheckResult:
+    trades = inputs.pool_trades
+    if trades is None or len(trades) == 0:
+        return CheckResult(
+            name="spread_regime_within_tolerance",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool_trades absent — cannot evaluate spread regime",
+            evidence={},
+        )
+    # The pool's spread column convention varies; try a few common names.
+    spread_col = None
+    for cand in ("spread_pips", "spread_pip", "spread", "entry_spread", "spread_at_entry"):
+        if cand in trades.columns:
+            spread_col = cand
+            break
+    if spread_col is None:
+        return CheckResult(
+            name="spread_regime_within_tolerance",
+            passed=True,
+            severity=Severity.INFO,
+            message="no recognised spread column in pool — skipping",
+            evidence={"columns_seen": [c for c in trades.columns if "spread" in c.lower()]},
+        )
+    by_pair = trades.groupby("pair")[spread_col].agg(["count", "mean", "median", "max"])
+    # Flag any pair whose median spread is more than the critical threshold above
+    # the pair's expected typical spread. We don't have a hard reference here —
+    # so we use median across pairs as the reference, and flag outliers.
+    overall_median = float(trades[spread_col].median())
+    if overall_median <= 0:
+        return CheckResult(
+            name="spread_regime_within_tolerance",
+            passed=True,
+            severity=Severity.INFO,
+            message=f"pool median spread is {overall_median} — likely synthetic / zero-spread",
+            evidence={"overall_median": overall_median},
+        )
+    by_pair["delta_pct"] = (by_pair["median"] - overall_median) / overall_median
+    n_warn = int((by_pair["delta_pct"].abs() > cfg.spread_delta_warn_pct).sum())
+    n_crit = int((by_pair["delta_pct"].abs() > cfg.spread_delta_critical_pct).sum())
+    passed = n_crit == 0
+    return CheckResult(
+        name="spread_regime_within_tolerance",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"{n_crit} pair(s) > critical threshold "
+            f"({cfg.spread_delta_critical_pct:.0%}), "
+            f"{n_warn} > warn ({cfg.spread_delta_warn_pct:.0%})"
+        ),
+        evidence={
+            "n_pairs": int(len(by_pair)),
+            "n_warn": n_warn,
+            "n_critical": n_crit,
+            "overall_median_spread": overall_median,
+            "spread_column": spread_col,
+        },
+    )
+
+
+def _check_next_bar_open_fill(inputs: Step6Inputs) -> CheckResult:
+    trades = inputs.pool_trades
+    if trades is None or "signal_time" not in trades.columns or "entry_time" not in trades.columns:
+        return CheckResult(
+            name="next_bar_open_fill_realistic",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool lacks signal_time/entry_time — cannot verify fill spacing",
+            evidence={},
+        )
+    sig = pd.to_datetime(trades["signal_time"], utc=True)
+    ent = pd.to_datetime(trades["entry_time"], utc=True)
+    delta_minutes = (ent - sig).dt.total_seconds() / 60.0
+    nominal = DEFAULT_PRIMARY_TF_BAR_MINUTES.get(inputs.primary_tf or "H4", 240)
+    # Allow up to 2 × nominal (weekend / market-closed gap tolerance).
+    threshold = nominal * 2.0
+    n_violations = int((delta_minutes > threshold).sum())
+    n_negative = int((delta_minutes <= 0).sum())
+    passed = n_negative == 0 and (n_violations / max(1, len(trades))) < 0.05
+    return CheckResult(
+        name="next_bar_open_fill_realistic",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"{n_negative} non-positive fill deltas; "
+            f"{n_violations}/{len(trades)} > {threshold:.0f} min "
+            f"(nominal bar {nominal} min)"
+        ),
+        evidence={
+            "n_trades": int(len(trades)),
+            "n_non_positive_delta": n_negative,
+            "n_long_gap": n_violations,
+            "threshold_minutes": threshold,
+            "nominal_bar_minutes": nominal,
+            "primary_tf": inputs.primary_tf,
+        },
+    )
+
+
+def _check_lot_rounding_at_r_safe(inputs: Step6Inputs) -> CheckResult:
+    r_safe = inputs.r_safe_pct
+    if r_safe is None or inputs.pool_trades is None:
+        return CheckResult(
+            name="lot_rounding_at_r_safe",
+            passed=True,
+            severity=Severity.INFO,
+            message="r_safe / pool_trades missing — cannot evaluate lot rounding",
+            evidence={"r_safe_pct": r_safe},
+        )
+    trades = inputs.pool_trades
+    # Approximate lot calc: required risk in account currency = balance × r_safe;
+    # per-trade SL pips × pip_value_per_lot ≈ risk per lot. We don't have
+    # pip values without broker data; instead, surface the implied lots
+    # under a $100k account at the median sl_distance.
+    if "sl_distance_atr" not in trades.columns and "sl_atr_distance" not in trades.columns:
+        return CheckResult(
+            name="lot_rounding_at_r_safe",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool lacks sl_distance column — cannot infer lot sizing",
+            evidence={"columns_seen": [c for c in trades.columns if "sl" in c.lower()]},
+        )
+    starting_balance = 100_000.0
+    risk_dollars = starting_balance * float(r_safe)
+    # Rough conversion: assume 1 lot ≈ $10 per pip on majors. Implied lots
+    # at the median sl_distance — too coarse for hard FAIL, surface as warn.
+    median_sl = float(trades.get("sl_distance_atr", trades.get("sl_atr_distance")).median())
+    median_atr_pips = 30.0  # rough across majors; refined in deployment_spec
+    implied_lots = risk_dollars / max(1e-9, median_sl * median_atr_pips * 10.0)
+    passed = implied_lots >= BROKER_MIN_LOTS
+    return CheckResult(
+        name="lot_rounding_at_r_safe",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"r_safe={r_safe:.4%} on $100k → implied lots≈{implied_lots:.3f} "
+            f"(broker min {BROKER_MIN_LOTS}); approximate — refine in deployment_spec"
+        ),
+        evidence={
+            "r_safe_pct": float(r_safe),
+            "implied_lots_approx": implied_lots,
+            "median_sl_distance_atr": median_sl,
+            "broker_min_lots": BROKER_MIN_LOTS,
+        },
+    )
+
+
+def _check_mid_price_refactor() -> CheckResult:
+    try:
+        from core.sim import multipair_backtester  # type: ignore
+    except ImportError as exc:
+        return CheckResult(
+            name="mid_price_refactor_active",
+            passed=False,
+            severity=Severity.WARNING,
+            message=f"could not import multipair_backtester: {exc}",
+            evidence={"error": str(exc)},
+        )
+    try:
+        source = inspect.getsource(multipair_backtester)
+    except OSError as exc:
+        return CheckResult(
+            name="mid_price_refactor_active",
+            passed=False,
+            severity=Severity.WARNING,
+            message=f"could not read source: {exc}",
+            evidence={"error": str(exc)},
+        )
+    mentions_mid = source.count("mid_") + source.count("_mid")
+    mentions_bid_only = source.count("bid_view") + source.count("bid_only")
+    passed = mentions_mid > 0
+    return CheckResult(
+        name="mid_price_refactor_active",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"multipair_backtester has {mentions_mid} mid-price references, "
+            f"{mentions_bid_only} bid-only references"
+        ),
+        evidence={
+            "mid_references": mentions_mid,
+            "bid_references": mentions_bid_only,
+        },
+    )
+
+
+def _check_utc_bar_boundary(inputs: Step6Inputs) -> CheckResult:
+    trades = inputs.pool_trades
+    if trades is None or len(trades) == 0:
+        return CheckResult(
+            name="utc_bar_boundary",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool_trades absent — skipping",
+            evidence={},
+        )
+    col = "signal_time" if "signal_time" in trades.columns else (
+        "entry_time" if "entry_time" in trades.columns else None
+    )
+    if col is None:
+        return CheckResult(
+            name="utc_bar_boundary",
+            passed=True,
+            severity=Severity.INFO,
+            message="no timestamp column to verify",
+            evidence={},
+        )
+    sample = pd.to_datetime(trades[col].head(5), utc=True, errors="coerce")
+    tz_present = bool(sample.dt.tz is not None)
+    return CheckResult(
+        name="utc_bar_boundary",
+        passed=tz_present,
+        severity=Severity.INFO,
+        message=(
+            f"{col} parses with UTC tz on sample" if tz_present
+            else f"{col} sample did not parse as tz-aware UTC"
+        ),
+        evidence={"sample_count": int(sample.size), "tz_present": tz_present},
+    )
+
+
+def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult:
+    checks = (
+        _check_real_spread_source(inputs),
+        _check_spread_regime(inputs, audit_config),
+        _check_next_bar_open_fill(inputs),
+        _check_lot_rounding_at_r_safe(inputs),
+        _check_mid_price_refactor(),
+        _check_utc_bar_boundary(inputs),
+    )
+    diagnostic: dict[str, Any] = {
+        "r_safe_pct": inputs.r_safe_pct,
+        "sizing_convention": inputs.sizing_convention,
+        "primary_tf": inputs.primary_tf,
+    }
+    return CategoryAuditResult(
+        category="execution_realism", checks=checks, diagnostic=diagnostic,
+    )
+
+
+__all__ = ("audit",)

--- a/core/step_6/inputs.py
+++ b/core/step_6/inputs.py
@@ -1,0 +1,86 @@
+"""Step 6 input bundle.
+
+Wraps the data + paths that the six audit categories need. Built two ways:
+
+  - :func:`from_arc_orchestrator_result` — auto-dispatch path, live in-memory
+    objects from :class:`core.arc.arc_orchestrator.ArcOrchestratorResult`
+  - :func:`from_closure_dir` — manual CLI path, reads everything off disk
+    from a closure directory (``results/<arc>/``)
+
+Categories check for the presence of optional fields and record an
+``info`` severity ``CheckResult`` when a field is missing rather than
+raising — manual CLI on an old arc may have a thinner bundle than an
+auto-dispatched run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Step6Inputs:
+    """Everything Step 6 categories may consult.
+
+    Required:
+      - ``arc_name`` — for manifest + log lines
+      - ``arc_root`` — the on-disk results/<arc> dir (manifests, parquet etc.)
+
+    Optional (None when not available for the invocation mode):
+      - ``best_candidate_config_id`` — Top-1 verdict-carrier (e.g. ``"A1::cfg_42"``)
+      - ``best_candidate_architecture`` — short name ("A1"/"A2"/...)
+      - ``best_candidate_features`` — feature names in the winning filter/classifier
+      - ``arc_orchestrator_result`` — auto-dispatch path; live object
+      - ``closure_payload`` — parsed §1 tracker_payload dict (manual CLI path)
+      - ``pool_trades`` — Step 1 trades DataFrame, when loadable
+      - ``pool_paths`` — Step 1 forward-path DataFrame, when loadable
+      - ``feature_matrix`` — entry-time feature matrix
+      - ``feature_lineage`` — feature lineage DataFrame (name + lineage tag)
+      - ``signal_module_name`` — fully qualified module path of the signal producer
+      - ``primary_tf`` — primary timeframe (e.g. "1H", "4H")
+      - ``pair_set`` — pairs in scope
+      - ``window_start`` / ``window_end`` — arc window bounds
+      - ``r_safe_pct`` / ``r_hard_pct`` — Amendment 3 scaled risk values
+      - ``sizing_convention`` — "reset_floor" | "equity_pct"
+      - ``configs_evaluated_step5`` — total config count (for §6.2 Bonferroni)
+      - ``holdout_start`` — UTC date marking start of holdout window
+    """
+
+    arc_name: str
+    arc_root: Path
+
+    best_candidate_config_id: str | None = None
+    best_candidate_architecture: str | None = None
+    best_candidate_features: tuple[str, ...] = ()
+
+    arc_orchestrator_result: Any | None = None
+    closure_payload: Mapping[str, Any] | None = None
+
+    pool_trades: pd.DataFrame | None = None
+    pool_paths: pd.DataFrame | None = None
+    feature_matrix: pd.DataFrame | None = None
+    feature_lineage: pd.DataFrame | None = None
+    panels: Mapping[str, Any] | None = None
+
+    signal_module_name: str | None = None
+    primary_tf: str | None = None
+    pair_set: tuple[str, ...] = ()
+    window_start: pd.Timestamp | None = None
+    window_end: pd.Timestamp | None = None
+
+    r_safe_pct: float | None = None
+    r_hard_pct: float | None = None
+    sizing_convention: str | None = None
+
+    configs_evaluated_step5: int | None = None
+    holdout_start: pd.Timestamp | None = None
+
+    # Per-arc extras (e.g. classifier path, broker spread floor file). Free-form.
+    extras: Mapping[str, Any] = field(default_factory=dict)
+
+
+__all__ = ("Step6Inputs",)

--- a/core/step_6/io.py
+++ b/core/step_6/io.py
@@ -1,0 +1,258 @@
+"""Build :class:`Step6Inputs` from two sources: live orchestrator
+result (auto-dispatch) and on-disk closure directory (manual CLI).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+import yaml
+
+from core.step_6.inputs import Step6Inputs
+
+
+def from_arc_orchestrator_result(
+    result: Any,
+    arc_root: Path,
+    *,
+    pool_trades: pd.DataFrame | None = None,
+    pool_paths: pd.DataFrame | None = None,
+    feature_matrix: pd.DataFrame | None = None,
+    feature_lineage: pd.DataFrame | None = None,
+    panels: Mapping[str, Any] | None = None,
+    signal_module_name: str | None = None,
+    primary_tf: str | None = None,
+    pair_set: tuple[str, ...] = (),
+    holdout_start: pd.Timestamp | None = None,
+) -> Step6Inputs:
+    """Auto-dispatch path — builds from a live :class:`ArcOrchestratorResult`.
+
+    The orchestrator passes the live ``ArcPool`` + its config + Step 4
+    output directly so categories don't have to re-read from disk.
+    """
+    best_arch_name = None
+    best_config_id = None
+    best_features: tuple[str, ...] = ()
+    r_safe_pct = None
+    r_hard_pct = None
+    sizing_convention = None
+    configs_evaluated = None
+
+    amended_wfo = getattr(result, "amended_wfo", None)
+    if amended_wfo is not None and amended_wfo.amended_results:
+        # Best amended candidate is the one with the highest verdict rank
+        # — per arc_orchestrator's existing ranking logic.
+        best_amended = amended_wfo.amended_results[0]
+        best_config_id = best_amended.config_id
+        gate = best_amended.amended_gate
+        r_safe_pct = gate.r_safe_pct if gate.scalable_to_safe else None
+        r_hard_pct = gate.r_hard_pct if gate.scalable_to_hard else None
+        sizing_convention = gate.sizing_convention
+
+    wfo_search = getattr(result, "wfo_search", None)
+    if wfo_search is not None:
+        configs_evaluated = wfo_search.n_candidates_evaluated
+        if wfo_search.top_k:
+            top1 = wfo_search.top_k[0]
+            best_arch_name = (
+                top1.config.architecture_name
+                if hasattr(top1.config, "architecture_name")
+                else top1.config_id.split("::")[0] if "::" in top1.config_id else None
+            )
+
+    # Feature names: prefer Step 4 fitted classifier feature_order if present;
+    # otherwise use the full feature_matrix columns minus trade_id.
+    step_4 = getattr(result, "step_4", None)
+    if step_4 is not None and step_4.per_cluster:
+        first_cluster = step_4.per_cluster[0]
+        if first_cluster.fitted_classifier_feature_order is not None:
+            best_features = first_cluster.fitted_classifier_feature_order
+        else:
+            best_features = first_cluster.used_features
+
+    if not best_features and feature_matrix is not None:
+        best_features = tuple(
+            c for c in feature_matrix.columns if c != "trade_id"
+        )
+
+    pool = getattr(result, "pool", None)
+    if pool_trades is None and pool is not None:
+        pool_trades = getattr(pool, "trades", None)
+    if pool_paths is None and pool is not None:
+        pool_paths = getattr(pool, "paths", None)
+
+    return Step6Inputs(
+        arc_name=result.arc_name,
+        arc_root=arc_root,
+        best_candidate_config_id=best_config_id,
+        best_candidate_architecture=best_arch_name,
+        best_candidate_features=best_features,
+        arc_orchestrator_result=result,
+        pool_trades=pool_trades,
+        pool_paths=pool_paths,
+        feature_matrix=feature_matrix,
+        feature_lineage=feature_lineage,
+        panels=panels,
+        signal_module_name=signal_module_name,
+        primary_tf=primary_tf,
+        pair_set=pair_set,
+        r_safe_pct=r_safe_pct,
+        r_hard_pct=r_hard_pct,
+        sizing_convention=sizing_convention,
+        configs_evaluated_step5=configs_evaluated,
+        holdout_start=holdout_start,
+    )
+
+
+def from_closure_dir(closure_dir: Path, *, arc_name: str | None = None) -> Step6Inputs:
+    """Manual CLI path — read closure doc + on-disk artefacts.
+
+    Reads ARC_CLOSURE.md's §1 tracker_payload to recover best_architecture
+    fields. Loads parquet pool + feature matrix if present. Anything
+    missing stays None — category modules check and record info-level
+    skips.
+    """
+    closure_dir = Path(closure_dir)
+    if closure_dir.is_file():
+        # Caller passed the closure doc path itself; the directory is its parent.
+        closure_dir = closure_dir.parent
+    if not closure_dir.is_dir():
+        raise FileNotFoundError(f"closure dir not found: {closure_dir}")
+
+    payload: Mapping[str, Any] | None = None
+    closure_md = closure_dir / "ARC_CLOSURE.md"
+    if closure_md.exists():
+        payload = _extract_tracker_payload(closure_md.read_text(encoding="utf-8"))
+
+    arc_name = arc_name or (payload or {}).get("arc_name") or closure_dir.name
+
+    best_arch_name = None
+    best_config_id = None
+    best_features: tuple[str, ...] = ()
+    r_safe_pct = None
+    r_hard_pct = None
+    sizing_convention = None
+    configs_evaluated = None
+    primary_tf = None
+    pair_set: tuple[str, ...] = ()
+    window_start = None
+    window_end = None
+    holdout_start = None
+
+    if payload:
+        primary_tf = payload.get("tf")
+        pool_meta = payload.get("pool_metadata") or {}
+        configs_evaluated = pool_meta.get("configs_evaluated_step5")
+        ws = pool_meta.get("window_start")
+        we = pool_meta.get("window_end")
+        if ws:
+            window_start = pd.Timestamp(ws)
+        if we:
+            window_end = pd.Timestamp(we)
+        ba = payload.get("best_architecture") or {}
+        if ba:
+            best_arch_name = ba.get("name")
+            best_config_id = ba.get("config")
+            best_features = tuple(ba.get("features_in_winning_config") or ())
+            r_safe_pct = ba.get("r_safe_pct")
+            r_hard_pct = ba.get("r_hard_pct")
+            sizing_convention = ba.get("sizing_convention")
+
+    # On-disk data
+    pool_trades = _maybe_read_parquet(closure_dir / "step_1" / "pool.parquet")
+    pool_paths = _maybe_read_parquet(closure_dir / "step_1" / "paths.parquet")
+    feature_matrix = _maybe_read_parquet(closure_dir / "step_1" / "feature_matrix.parquet")
+    feature_lineage = _maybe_read_csv(closure_dir / "step_1" / "feature_lineage.csv")
+
+    # If best_features wasn't in the closure payload (older arcs), fall back
+    # to the persisted classifier feature_order.
+    if not best_features:
+        clf_manifest = closure_dir / "step_4" / "classifiers" / "manifest.json"
+        if clf_manifest.exists():
+            import json as _json
+            data = _json.loads(clf_manifest.read_text(encoding="utf-8"))
+            for entry in (data.get("classifiers") or {}).values():
+                order = entry.get("feature_order")
+                if order:
+                    best_features = tuple(order)
+                    break
+
+    return Step6Inputs(
+        arc_name=arc_name,
+        arc_root=closure_dir,
+        best_candidate_config_id=best_config_id,
+        best_candidate_architecture=best_arch_name,
+        best_candidate_features=best_features,
+        closure_payload=payload,
+        pool_trades=pool_trades,
+        pool_paths=pool_paths,
+        feature_matrix=feature_matrix,
+        feature_lineage=feature_lineage,
+        primary_tf=primary_tf,
+        pair_set=pair_set,
+        window_start=window_start,
+        window_end=window_end,
+        r_safe_pct=r_safe_pct,
+        r_hard_pct=r_hard_pct,
+        sizing_convention=sizing_convention,
+        configs_evaluated_step5=configs_evaluated,
+        holdout_start=holdout_start,
+    )
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+
+def _extract_tracker_payload(text: str) -> Mapping[str, Any] | None:
+    """Extract the §1 tracker_payload YAML block from ARC_CLOSURE.md.
+
+    Mirrors :func:`scripts.tracker_parser.extract.extract_payload_from_text`
+    but tolerant: returns ``None`` rather than raising on a missing block,
+    so manual CLI invocation on older docs degrades gracefully.
+    """
+    import re
+
+    heading = re.search(r"^## §1 tracker_payload\s*$", text, re.MULTILINE)
+    if heading is None:
+        return None
+    body = text[heading.end():]
+    fence = re.search(r"^```yaml\s*$", body, re.MULTILINE)
+    if fence is None:
+        return None
+    yaml_start = fence.end()
+    close_idx = body.find("\n```", yaml_start)
+    if close_idx == -1:
+        return None
+    try:
+        parsed = yaml.safe_load(body[yaml_start:close_idx])
+    except yaml.YAMLError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    inner = parsed.get("tracker_payload")
+    if not isinstance(inner, dict):
+        return None
+    return inner
+
+
+def _maybe_read_parquet(path: Path) -> pd.DataFrame | None:
+    if not path.exists():
+        return None
+    try:
+        return pd.read_parquet(path)
+    except Exception:
+        return None
+
+
+def _maybe_read_csv(path: Path) -> pd.DataFrame | None:
+    if not path.exists():
+        return None
+    try:
+        return pd.read_csv(path)
+    except Exception:
+        return None
+
+
+__all__ = ("from_arc_orchestrator_result", "from_closure_dir")

--- a/core/step_6/lookahead.py
+++ b/core/step_6/lookahead.py
@@ -1,0 +1,329 @@
+"""§6.1 Lookahead audit.
+
+Six checks (4 critical, 2 warning):
+
+  1. ``per_feature_lineage_clean`` (critical) — every feature in the
+     winning candidate has ``causal_lineage == "clean"`` per Step 1's
+     feature_lineage DataFrame.
+  2. ``no_path_features_in_entry`` (critical) — features named like
+     forward-path metrics (`mfe_*`, `mae_*`, `ww_*`, `final_r_*`,
+     `bars_held*`, `path_*`) never appear in the winning
+     candidate's entry-decision feature set.
+  3. ``d1_lag_rule_enforced`` (critical) — multi-TF D1 producer code
+     routes through ``core.features.multi_tf._build_d1_lag1_series``.
+     The check inspects the source module to confirm the helper is in
+     use (catches a hand-written replacement that forgot the lag).
+  4. ``byte_compare_no_drift`` (critical) — Arc 10 precedent: sample N
+     trades, recompute features from raw OHLC, byte-compare against the
+     pool's stored values. Any abs_diff above tolerance fails.
+  5. ``threshold_selection_lineage`` (warning) — Step 4's
+     ``best_threshold`` is the mean of per-fold AUC-best thresholds,
+     never picked on the full-data ROC curve. Verified by reading the
+     persisted classifier manifest.
+  6. ``feature_lineage_table_exists`` (info) — record presence /
+     absence of a feature_lineage table on disk.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from typing import Any
+
+from core.step_6.byte_compare import run_byte_compare
+from core.step_6.inputs import Step6Inputs
+from core.step_6.manifest import (
+    AuditConfig,
+    CategoryAuditResult,
+    CheckResult,
+    Severity,
+)
+
+# Patterns flagging forward-path metrics that must NOT appear at entry time.
+# Path-shape clustering uses these; entry features must never reference them.
+_PATH_FEATURE_PATTERNS = (
+    re.compile(r"^mfe_", re.IGNORECASE),
+    re.compile(r"^mae_", re.IGNORECASE),
+    re.compile(r"^ww_", re.IGNORECASE),
+    re.compile(r"^wrong_way_", re.IGNORECASE),
+    re.compile(r"^final_r", re.IGNORECASE),
+    re.compile(r"^reach_\d+r", re.IGNORECASE),
+    re.compile(r"^ttp_", re.IGNORECASE),
+    re.compile(r"^bars_held", re.IGNORECASE),
+    re.compile(r"^path_", re.IGNORECASE),
+)
+
+
+def _check_per_feature_lineage(inputs: Step6Inputs) -> CheckResult:
+    features = inputs.best_candidate_features
+    lineage = inputs.feature_lineage
+
+    if not features:
+        return CheckResult(
+            name="per_feature_lineage_clean",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message="best_candidate_features is empty — cannot enforce lineage",
+            evidence={"features_in_winning_config": []},
+        )
+    if lineage is None:
+        return CheckResult(
+            name="per_feature_lineage_clean",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message="feature_lineage table missing — lineage enforcement skipped",
+            evidence={"features_in_winning_config": list(features)},
+        )
+
+    if "causal_lineage" not in lineage.columns or "name" not in lineage.columns:
+        return CheckResult(
+            name="per_feature_lineage_clean",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=(
+                "feature_lineage missing required columns (name, causal_lineage); "
+                f"got {list(lineage.columns)}"
+            ),
+            evidence={"columns": list(lineage.columns)},
+        )
+
+    tag_by_name = dict(zip(lineage["name"].astype(str), lineage["causal_lineage"].astype(str)))
+    suspect_or_missing: list[tuple[str, str]] = []
+    for f in features:
+        tag = tag_by_name.get(f, "UNKNOWN")
+        if tag != "clean":
+            suspect_or_missing.append((f, tag))
+
+    if suspect_or_missing:
+        return CheckResult(
+            name="per_feature_lineage_clean",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=(
+                f"{len(suspect_or_missing)}/{len(features)} winning-candidate features "
+                f"are not lineage-clean"
+            ),
+            evidence={"non_clean_features": [
+                {"feature": n, "lineage": t} for n, t in suspect_or_missing
+            ]},
+        )
+    return CheckResult(
+        name="per_feature_lineage_clean",
+        passed=True,
+        severity=Severity.CRITICAL,
+        message=f"all {len(features)} winning-candidate features are lineage-clean",
+        evidence={"n_features": len(features)},
+    )
+
+
+def _check_no_path_features_in_entry(inputs: Step6Inputs) -> CheckResult:
+    features = inputs.best_candidate_features
+    if not features:
+        return CheckResult(
+            name="no_path_features_in_entry",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message="best_candidate_features is empty — cannot enforce no-path-in-entry",
+            evidence={"features_in_winning_config": []},
+        )
+    leaks: list[str] = []
+    for f in features:
+        for pattern in _PATH_FEATURE_PATTERNS:
+            if pattern.search(f):
+                leaks.append(f)
+                break
+    if leaks:
+        return CheckResult(
+            name="no_path_features_in_entry",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=(
+                f"{len(leaks)} entry-time feature(s) match forward-path patterns: "
+                f"{', '.join(leaks)}"
+            ),
+            evidence={"leaking_features": leaks},
+        )
+    return CheckResult(
+        name="no_path_features_in_entry",
+        passed=True,
+        severity=Severity.CRITICAL,
+        message="no entry-time feature name matches a forward-path pattern",
+        evidence={"n_features_checked": len(features)},
+    )
+
+
+def _check_d1_lag_rule() -> CheckResult:
+    """Static check: every D1 multi-TF producer routes through ``_build_d1_lag1_series``.
+
+    Inspects ``core.features.multi_tf`` source and confirms the helper is
+    called from each public D1-derived feature.
+    """
+    try:
+        from core.features import multi_tf  # type: ignore
+    except ImportError as exc:
+        return CheckResult(
+            name="d1_lag_rule_enforced",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=f"could not import core.features.multi_tf: {exc}",
+            evidence={"error": str(exc)},
+        )
+    try:
+        source = inspect.getsource(multi_tf)
+    except OSError as exc:
+        return CheckResult(
+            name="d1_lag_rule_enforced",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=f"could not read multi_tf source: {exc}",
+            evidence={"error": str(exc)},
+        )
+    if "_build_d1_lag1_series" not in source:
+        return CheckResult(
+            name="d1_lag_rule_enforced",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message="multi_tf module does not reference _build_d1_lag1_series",
+            evidence={"helper_present": False},
+        )
+    # Count D1 producer references vs lag1-helper calls. Heuristic — any
+    # D1-producer that DOESN'T call the helper is flagged.
+    helper_calls = source.count("_build_d1_lag1_series(")
+    d1_producers = source.count("def _d1_")  # convention in multi_tf.py
+    if d1_producers > 0 and helper_calls < d1_producers:
+        return CheckResult(
+            name="d1_lag_rule_enforced",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=(
+                f"D1 producers ({d1_producers}) > lag-helper calls ({helper_calls}) "
+                "— one or more D1 producers may skip the lag rule"
+            ),
+            evidence={"d1_producers": d1_producers, "helper_calls": helper_calls},
+        )
+    return CheckResult(
+        name="d1_lag_rule_enforced",
+        passed=True,
+        severity=Severity.CRITICAL,
+        message=(
+            f"multi_tf D1 producers all route through _build_d1_lag1_series "
+            f"({helper_calls} calls)"
+        ),
+        evidence={"helper_calls": helper_calls, "d1_producers": d1_producers},
+    )
+
+
+def _check_byte_compare(inputs: Step6Inputs, cfg: AuditConfig) -> CheckResult:
+    report = run_byte_compare(
+        inputs,
+        feature_names=inputs.best_candidate_features or None,
+        n_samples=cfg.byte_compare_n_samples,
+        seed=cfg.byte_compare_seed,
+    )
+    if report.skipped_reason:
+        return CheckResult(
+            name="byte_compare_no_drift",
+            passed=True,  # info-only when we can't run it; demoted via severity
+            severity=Severity.INFO,
+            message=f"byte-compare skipped: {report.skipped_reason}",
+            evidence=report.to_evidence(),
+        )
+    passed = report.all_match
+    return CheckResult(
+        name="byte_compare_no_drift",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"byte-compare on {report.n_samples_used} trade(s) × "
+            f"{len(set(r.feature for r in report.rows))} feature(s) — "
+            f"all_match={passed}"
+        ),
+        evidence=report.to_evidence(),
+    )
+
+
+def _check_threshold_selection_lineage(inputs: Step6Inputs) -> CheckResult:
+    """Verify Step 4's best_threshold came from per-fold averaging, not full-data ROC."""
+    manifest_path = inputs.arc_root / "step_4" / "classifiers" / "manifest.json"
+    if not manifest_path.exists():
+        return CheckResult(
+            name="threshold_selection_lineage",
+            passed=True,  # nothing to check on a rule-based arc
+            severity=Severity.INFO,
+            message="no Step 4 classifier manifest — arc is rule-based or pre-CC_12",
+            evidence={"manifest_path": str(manifest_path)},
+        )
+    import json
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    classifiers = data.get("classifiers") or {}
+    anomalies: list[dict[str, Any]] = []
+    for cid, entry in classifiers.items():
+        thr = entry.get("best_threshold")
+        # Heuristic: per-fold averaged thresholds typically fall in (0.0, 1.0)
+        # and never sit exactly at the F1-best on a full-data ROC (which
+        # tends to land at integer-fraction boundaries — 0.5 is the most
+        # common smell). We flag exactly 0.5 only if every classifier has it.
+        if thr is None:
+            anomalies.append({"cluster_id": cid, "issue": "best_threshold missing"})
+            continue
+        if not (0.0 < float(thr) < 1.0):
+            anomalies.append({"cluster_id": cid, "best_threshold": thr, "issue": "out of (0,1)"})
+    if anomalies:
+        return CheckResult(
+            name="threshold_selection_lineage",
+            passed=False,
+            severity=Severity.WARNING,
+            message=f"{len(anomalies)} classifier threshold(s) flagged for review",
+            evidence={"anomalies": anomalies, "n_classifiers": len(classifiers)},
+        )
+    return CheckResult(
+        name="threshold_selection_lineage",
+        passed=True,
+        severity=Severity.WARNING,
+        message=(
+            f"{len(classifiers)} classifier threshold(s) in (0,1); "
+            "per-fold averaging assumed"
+        ),
+        evidence={"n_classifiers": len(classifiers)},
+    )
+
+
+def _check_lineage_table_exists(inputs: Step6Inputs) -> CheckResult:
+    if inputs.feature_lineage is None:
+        return CheckResult(
+            name="feature_lineage_table_exists",
+            passed=False,
+            severity=Severity.INFO,
+            message="feature_lineage table absent — falling back to source-code inspection",
+            evidence={"present": False},
+        )
+    n_rows = int(len(inputs.feature_lineage))
+    return CheckResult(
+        name="feature_lineage_table_exists",
+        passed=True,
+        severity=Severity.INFO,
+        message=f"feature_lineage table present ({n_rows} features)",
+        evidence={"present": True, "n_features": n_rows},
+    )
+
+
+def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult:
+    checks = (
+        _check_per_feature_lineage(inputs),
+        _check_no_path_features_in_entry(inputs),
+        _check_d1_lag_rule(),
+        _check_byte_compare(inputs, audit_config),
+        _check_threshold_selection_lineage(inputs),
+        _check_lineage_table_exists(inputs),
+    )
+    diagnostic: dict[str, Any] = {
+        "features_in_winning_config": list(inputs.best_candidate_features),
+        "best_candidate_architecture": inputs.best_candidate_architecture,
+        "best_candidate_config_id": inputs.best_candidate_config_id,
+    }
+    return CategoryAuditResult(
+        category="lookahead", checks=checks, diagnostic=diagnostic,
+    )
+
+
+__all__ = ("audit",)

--- a/core/step_6/manifest.py
+++ b/core/step_6/manifest.py
@@ -1,0 +1,290 @@
+"""Step 6 dataclasses + manifest serde.
+
+`CheckResult` is one check (one row in a category report). `CategoryAuditResult`
+bundles all checks for one category. `Step6Result` bundles all six categories.
+`Step6Manifest` is the on-disk JSON artefact written to
+``results/<arc>/step_6/manifest.json``.
+
+Severity rules per chat resolution Q4:
+- ``critical`` failure → category FAIL → Step 6 FAIL → verdict downgrade
+- ``warning`` failure → category PASS but flagged
+- ``info`` failure → recorded only; no effect on category outcome
+
+``CategoryAuditResult.passed`` is the AND over critical-severity checks only.
+Warnings tracked separately as ``n_warnings``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from core.determinism import LINE_TERMINATOR, TEXT_ENCODING
+
+
+class Severity(str, Enum):
+    CRITICAL = "critical"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class VerdictImpact(str, Enum):
+    NONE = "none"
+    DOWNGRADED_TO_FAIL = "downgraded_to_fail"
+
+
+class TriggerSource(str, Enum):
+    AUTO_PASS = "auto_pass"
+    MANUAL = "manual"
+    NOT_APPLICABLE = "not_applicable"
+
+
+AUDIT_CATEGORY_NAMES: tuple[str, ...] = (
+    "lookahead",
+    "selection_bias",
+    "execution_realism",
+    "statistical",
+    "determinism",
+    "deployment_readiness",
+)
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """One audit check outcome."""
+
+    name: str
+    passed: bool
+    severity: Severity
+    message: str
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "passed": bool(self.passed),
+            "severity": self.severity.value,
+            "message": self.message,
+            "evidence": dict(self.evidence),
+        }
+
+
+@dataclass(frozen=True)
+class CategoryAuditResult:
+    """All checks for one audit category.
+
+    ``passed`` per chat Q4 = AND over critical-severity check results.
+    Warnings flag but do not block; info records only.
+    """
+
+    category: str
+    checks: tuple[CheckResult, ...]
+    diagnostic: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        return all(c.passed for c in self.checks if c.severity == Severity.CRITICAL)
+
+    @property
+    def n_critical(self) -> int:
+        return sum(1 for c in self.checks if c.severity == Severity.CRITICAL)
+
+    @property
+    def n_critical_fails(self) -> int:
+        return sum(
+            1 for c in self.checks
+            if c.severity == Severity.CRITICAL and not c.passed
+        )
+
+    @property
+    def n_warnings(self) -> int:
+        return sum(
+            1 for c in self.checks
+            if c.severity == Severity.WARNING and not c.passed
+        )
+
+    @property
+    def n_info(self) -> int:
+        return sum(
+            1 for c in self.checks
+            if c.severity == Severity.INFO and not c.passed
+        )
+
+    def critical_failures(self) -> tuple[str, ...]:
+        return tuple(
+            c.name for c in self.checks
+            if c.severity == Severity.CRITICAL and not c.passed
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "category": self.category,
+            "passed": bool(self.passed),
+            "n_checks": len(self.checks),
+            "n_critical": self.n_critical,
+            "n_critical_fails": self.n_critical_fails,
+            "n_warnings": self.n_warnings,
+            "n_info": self.n_info,
+            "critical_failures": list(self.critical_failures()),
+            "checks": [c.to_dict() for c in self.checks],
+            "diagnostic": dict(self.diagnostic),
+        }
+
+
+@dataclass(frozen=True)
+class AuditConfig:
+    """Per-run configuration knobs.
+
+    ``no_block`` (manual CLI ``--no-block`` flag) demotes every critical
+    failure to a warning in the rendered report and prevents the
+    orchestrator from downgrading the verdict — diagnostic only.
+
+    ``categories_to_run`` restricts the dispatch to a subset; ``None``
+    runs all six.
+
+    ``byte_compare_n_samples`` controls how many random trades are
+    re-computed from raw OHLC for the lookahead category.
+
+    ``spread_delta_warn_pct`` / ``spread_delta_critical_pct`` configure
+    execution-realism §6.3 thresholds.
+    """
+
+    no_block: bool = False
+    categories_to_run: tuple[str, ...] | None = None
+    byte_compare_n_samples: int = 5
+    byte_compare_seed: int = 42
+    spread_delta_warn_pct: float = 0.20
+    spread_delta_critical_pct: float = 0.50
+    lo_corrected_min_trades: int = 100
+    correlation_warn_threshold: float = 0.70
+
+
+@dataclass(frozen=True)
+class Step6Result:
+    """Bundle of all six category results + overall verdict + trigger."""
+
+    arc_name: str
+    trigger: TriggerSource
+    categories: tuple[CategoryAuditResult, ...]
+    audit_config: AuditConfig
+
+    @property
+    def overall_passed(self) -> bool:
+        return all(c.passed for c in self.categories)
+
+    @property
+    def verdict_impact(self) -> VerdictImpact:
+        # Manual invocations NEVER downgrade per Q6 + dispatch
+        # "Discipline rules" line "Manual invocations don't change verdicts".
+        # --no-block also short-circuits per AuditConfig docstring.
+        if self.trigger == TriggerSource.MANUAL or self.audit_config.no_block:
+            return VerdictImpact.NONE
+        if self.overall_passed:
+            return VerdictImpact.NONE
+        return VerdictImpact.DOWNGRADED_TO_FAIL
+
+    @property
+    def n_warnings_total(self) -> int:
+        return sum(c.n_warnings for c in self.categories)
+
+    def critical_failures(self) -> tuple[str, ...]:
+        out: list[str] = []
+        for c in self.categories:
+            for name in c.critical_failures():
+                out.append(f"{c.category}.{name}")
+        return tuple(out)
+
+
+@dataclass(frozen=True)
+class Step6Manifest:
+    """On-disk manifest schema for ``results/<arc>/step_6/manifest.json``.
+
+    Field set tracks the dispatch's Task 4 manifest shape verbatim so
+    closure-template v1.3 `§1 tracker_payload.step_6` consumers can mirror
+    these field names 1:1.
+    """
+
+    arc_name: str
+    ran_at: str  # ISO-8601 UTC, second precision
+    trigger: TriggerSource
+    overall_passed: bool
+    verdict_impact: VerdictImpact
+    categories: tuple[CategoryAuditResult, ...]
+    report_paths: Mapping[str, str]  # category -> "step_6/<category>_report.md"
+    summary_path: str
+    critical_failures: tuple[str, ...]
+    n_warnings: int
+
+    @classmethod
+    def from_result(
+        cls,
+        result: Step6Result,
+        *,
+        report_paths: Mapping[str, str],
+        summary_path: str,
+        ran_at: str | None = None,
+    ) -> "Step6Manifest":
+        return cls(
+            arc_name=result.arc_name,
+            ran_at=ran_at or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            trigger=result.trigger,
+            overall_passed=result.overall_passed,
+            verdict_impact=result.verdict_impact,
+            categories=result.categories,
+            report_paths=dict(report_paths),
+            summary_path=summary_path,
+            critical_failures=result.critical_failures(),
+            n_warnings=result.n_warnings_total,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        # Per-category summary (compact) — full check detail lives in the
+        # markdown reports under report_paths[category].
+        categories_summary: dict[str, dict[str, Any]] = {}
+        for c in self.categories:
+            categories_summary[c.category] = {
+                "passed": bool(c.passed),
+                "n_checks": len(c.checks),
+                "n_critical": c.n_critical,
+                "n_critical_fails": c.n_critical_fails,
+                "n_warnings": c.n_warnings,
+                "n_info": c.n_info,
+            }
+        return {
+            "arc_name": self.arc_name,
+            "ran_at": self.ran_at,
+            "trigger": self.trigger.value,
+            "overall_passed": bool(self.overall_passed),
+            "verdict_impact": self.verdict_impact.value,
+            "categories": categories_summary,
+            "report_paths": dict(self.report_paths),
+            "summary_path": self.summary_path,
+            "critical_failures": list(self.critical_failures),
+            "n_warnings": int(self.n_warnings),
+        }
+
+
+def write_step_6_manifest(manifest: Step6Manifest, out_path: Path) -> Path:
+    """Serialise manifest to ``out_path`` (UTF-8, LF, sort_keys=True)."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    body = json.dumps(manifest.to_dict(), indent=2, sort_keys=True) + LINE_TERMINATOR
+    out_path.write_text(body, encoding=TEXT_ENCODING, newline=LINE_TERMINATOR)
+    return out_path
+
+
+__all__ = (
+    "AUDIT_CATEGORY_NAMES",
+    "AuditConfig",
+    "CategoryAuditResult",
+    "CheckResult",
+    "Severity",
+    "Step6Manifest",
+    "Step6Result",
+    "TriggerSource",
+    "VerdictImpact",
+    "write_step_6_manifest",
+)

--- a/core/step_6/orchestrator.py
+++ b/core/step_6/orchestrator.py
@@ -1,0 +1,100 @@
+"""Step 6 dispatch — runs the six audit categories independently.
+
+Per chat Q1: invoked from :class:`core.arc.arc_orchestrator.ArcOrchestrator`
+AFTER the amended gate clears constraints #1-9 on the Top-1 candidate.
+
+Per dispatch "Discipline rules": each category runs independently —
+no cross-category data dependencies. A category may FAIL while others
+PASS; their results are bundled into :class:`Step6Result`.
+
+Manual CLI invocation per chat Q6: ``run_step_6`` accepts
+``trigger=TriggerSource.MANUAL``; verdict downgrade is suppressed.
+"""
+
+from __future__ import annotations
+
+from core.step_6.inputs import Step6Inputs
+from core.step_6.manifest import (
+    AUDIT_CATEGORY_NAMES,
+    AuditConfig,
+    CategoryAuditResult,
+    Step6Result,
+    TriggerSource,
+)
+
+# Per-category audit callables (deferred imports to avoid pulling
+# heavyweight dependencies — sklearn, scipy — when only the orchestrator
+# scaffolding is imported, e.g. by the closure-writer).
+_CATEGORY_DISPATCH = {
+    "lookahead": "core.step_6.lookahead:audit",
+    "selection_bias": "core.step_6.selection_bias:audit",
+    "execution_realism": "core.step_6.execution_realism:audit",
+    "statistical": "core.step_6.statistical:audit",
+    "determinism": "core.step_6.determinism:audit",
+    "deployment_readiness": "core.step_6.deployment_readiness:audit",
+}
+
+
+def _resolve(target: str):
+    """Resolve ``"module.path:attr"`` to a callable."""
+    module_path, attr = target.split(":")
+    mod = __import__(module_path, fromlist=[attr])
+    return getattr(mod, attr)
+
+
+def run_step_6(
+    inputs: Step6Inputs,
+    *,
+    trigger: TriggerSource = TriggerSource.AUTO_PASS,
+    audit_config: AuditConfig | None = None,
+) -> Step6Result:
+    """Run the six audit categories on the given inputs.
+
+    Parameters
+    ----------
+    inputs
+        :class:`Step6Inputs` bundle. Built by
+        :func:`core.step_6.io.from_arc_orchestrator_result` for the
+        auto-dispatch path or :func:`core.step_6.io.from_closure_dir`
+        for the manual CLI path.
+    trigger
+        ``TriggerSource.AUTO_PASS`` for orchestrator-driven invocation
+        on a candidate that cleared §3 constraints #1-9.
+        ``TriggerSource.MANUAL`` for CLI invocation; verdict downgrade
+        is suppressed per chat Q6.
+    audit_config
+        Per-run knobs. Defaults to :class:`AuditConfig` defaults.
+    """
+    cfg = audit_config or AuditConfig()
+    categories_to_run = cfg.categories_to_run or AUDIT_CATEGORY_NAMES
+
+    # Validate the requested category names against the locked set.
+    unknown = tuple(c for c in categories_to_run if c not in AUDIT_CATEGORY_NAMES)
+    if unknown:
+        raise ValueError(
+            f"Unknown audit categories requested: {unknown}; "
+            f"valid: {AUDIT_CATEGORY_NAMES}"
+        )
+
+    results: list[CategoryAuditResult] = []
+    for name in AUDIT_CATEGORY_NAMES:
+        if name not in categories_to_run:
+            continue
+        audit_callable = _resolve(_CATEGORY_DISPATCH[name])
+        cat_result = audit_callable(inputs, cfg)
+        if not isinstance(cat_result, CategoryAuditResult):
+            raise TypeError(
+                f"category {name!r} returned {type(cat_result).__name__}; "
+                "expected CategoryAuditResult"
+            )
+        results.append(cat_result)
+
+    return Step6Result(
+        arc_name=inputs.arc_name,
+        trigger=trigger,
+        categories=tuple(results),
+        audit_config=cfg,
+    )
+
+
+__all__ = ("run_step_6",)

--- a/core/step_6/selection_bias.py
+++ b/core/step_6/selection_bias.py
@@ -1,0 +1,288 @@
+"""§6.2 Selection bias audit.
+
+Per chat Q3: this category VERIFIES that selection-bias accounting at
+Step 5 produced the right record — it does not re-run the search.
+
+Five checks:
+
+  1. ``configs_evaluated_recorded`` (critical) — pool_metadata exposes
+     ``configs_evaluated_step5`` and the search-scope flag is in
+     {"thin", "normal", "broad"} per template.
+  2. ``ratio_clears_bonferroni_noise_floor`` (critical) — for the Top-1
+     candidate, worst-fold ratio is large enough vs the noise floor
+     implied by N configs evaluated. Noise floor: 2.0 + 0.01 × log2(N)
+     (a soft lower bound; chat tightens via amendment when calibration
+     evidence accumulates).
+  3. ``holdout_never_touched_during_is`` (critical) — search artefacts
+     reference only IS dates (< holdout_start). Reads
+     ``step_5/wfo_results.csv`` if present and checks every fold's
+     OOS date upper bound.
+  4. ``cluster_selection_recorded`` (warning) — every cluster Step 3
+     considered is on disk via ``step_3/capturability.csv`` AND the
+     winning cluster is tagged ``is_candidate=True``.
+  5. ``search_scope_flag_matches_n`` (info) — flag derivation matches
+     the closed template definitions (thin <50, normal 50-99, broad 100+).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pandas as pd
+
+from core.step_6.inputs import Step6Inputs
+from core.step_6.manifest import (
+    AuditConfig,
+    CategoryAuditResult,
+    CheckResult,
+    Severity,
+)
+
+
+def _scope_from_n(n: int) -> str:
+    if n < 50:
+        return "thin"
+    if n < 100:
+        return "normal"
+    return "broad"
+
+
+def _bonferroni_noise_floor(n_configs: int) -> float:
+    """Soft noise floor: 2.0 + 0.01 × log2(max(1, N)).
+
+    Rationale: §3 baseline DEPLOYABLE ratio is 2.0; each doubling of the
+    config count adds 0.01 pp pressure. At N=128 the floor is 2.07; at
+    N=1024 it's 2.10. Chat may tighten via amendment.
+    """
+    return 2.0 + 0.01 * math.log2(max(1, n_configs))
+
+
+def _check_configs_evaluated_recorded(inputs: Step6Inputs) -> CheckResult:
+    n = inputs.configs_evaluated_step5
+    if n is None:
+        return CheckResult(
+            name="configs_evaluated_recorded",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message="configs_evaluated_step5 missing from pool_metadata",
+            evidence={"configs_evaluated_step5": None},
+        )
+    derived_scope = _scope_from_n(int(n))
+    closure_payload = inputs.closure_payload or {}
+    recorded_scope = (
+        (closure_payload.get("pool_metadata") or {}).get("search_scope_flag")
+    )
+    return CheckResult(
+        name="configs_evaluated_recorded",
+        passed=True,
+        severity=Severity.CRITICAL,
+        message=(
+            f"configs_evaluated_step5 = {n}; scope flag = "
+            f"{recorded_scope!r} (derived from N: {derived_scope})"
+        ),
+        evidence={
+            "configs_evaluated_step5": int(n),
+            "recorded_scope": recorded_scope,
+            "derived_scope": derived_scope,
+        },
+    )
+
+
+def _check_ratio_clears_bonferroni(inputs: Step6Inputs) -> CheckResult:
+    n = inputs.configs_evaluated_step5
+    closure_payload = inputs.closure_payload or {}
+    ba = closure_payload.get("best_architecture") or {}
+    worst_fold_ratio = ba.get("worst_fold_ratio")
+
+    # Auto-dispatch path — read from live result.
+    if worst_fold_ratio is None and inputs.arc_orchestrator_result is not None:
+        wfo_search = getattr(inputs.arc_orchestrator_result, "wfo_search", None)
+        if wfo_search is not None and wfo_search.top_k:
+            worst_fold_ratio = wfo_search.top_k[0].gate.worst_fold_ratio
+
+    if worst_fold_ratio is None or n is None:
+        return CheckResult(
+            name="ratio_clears_bonferroni_noise_floor",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=(
+                "missing inputs — "
+                f"worst_fold_ratio={worst_fold_ratio!r}, configs_evaluated_step5={n!r}"
+            ),
+            evidence={
+                "worst_fold_ratio": worst_fold_ratio,
+                "configs_evaluated_step5": n,
+            },
+        )
+
+    noise_floor = _bonferroni_noise_floor(int(n))
+    passed = float(worst_fold_ratio) >= noise_floor
+    return CheckResult(
+        name="ratio_clears_bonferroni_noise_floor",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"worst-fold ratio {float(worst_fold_ratio):.3f} "
+            f"vs Bonferroni-equivalent floor {noise_floor:.3f} "
+            f"(N={n})"
+        ),
+        evidence={
+            "worst_fold_ratio": float(worst_fold_ratio),
+            "noise_floor": noise_floor,
+            "configs_evaluated_step5": int(n),
+        },
+    )
+
+
+def _check_holdout_never_touched(inputs: Step6Inputs) -> CheckResult:
+    holdout_start = inputs.holdout_start
+    if holdout_start is None:
+        # Default to L_PROTOCOL Step 5 spec: holdout = 2021-01-01
+        holdout_start = pd.Timestamp("2021-01-01", tz="UTC")
+    wfo_csv = inputs.arc_root / "step_5" / "wfo_results.csv"
+    if not wfo_csv.exists():
+        return CheckResult(
+            name="holdout_never_touched_during_is",
+            passed=True,
+            severity=Severity.INFO,
+            message=f"{wfo_csv.name} absent — cannot verify",
+            evidence={"path": str(wfo_csv)},
+        )
+    try:
+        wfo = pd.read_csv(wfo_csv)
+    except Exception as exc:
+        return CheckResult(
+            name="holdout_never_touched_during_is",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=f"could not read {wfo_csv.name}: {exc}",
+            evidence={"error": str(exc)},
+        )
+    # Heuristic — any column whose name ends with "_end" / "_oos_end" or
+    # contains "fold_end" + date values represents a fold's OOS upper bound.
+    suspect_rows: list[dict[str, Any]] = []
+    date_columns = [c for c in wfo.columns if "end" in c.lower() and "fold" in c.lower()]
+    if not date_columns:
+        date_columns = [c for c in wfo.columns if c.lower().endswith("_end")]
+    for col in date_columns:
+        try:
+            col_ts = pd.to_datetime(wfo[col], utc=True, errors="coerce")
+        except Exception:
+            continue
+        leaked = wfo.loc[col_ts >= holdout_start]
+        if len(leaked) > 0:
+            suspect_rows.append({"column": col, "n_leaked_rows": int(len(leaked))})
+    if suspect_rows:
+        return CheckResult(
+            name="holdout_never_touched_during_is",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=(
+                f"WFO search artefacts reference dates ≥ holdout_start "
+                f"({holdout_start.isoformat()})"
+            ),
+            evidence={"suspects": suspect_rows, "holdout_start": str(holdout_start)},
+        )
+    return CheckResult(
+        name="holdout_never_touched_during_is",
+        passed=True,
+        severity=Severity.CRITICAL,
+        message=(
+            f"WFO search artefacts all bounded before holdout_start "
+            f"({holdout_start.isoformat()})"
+        ),
+        evidence={"date_columns_checked": date_columns, "holdout_start": str(holdout_start)},
+    )
+
+
+def _check_cluster_selection_recorded(inputs: Step6Inputs) -> CheckResult:
+    cap = inputs.arc_root / "step_3" / "capturability.csv"
+    if not cap.exists():
+        return CheckResult(
+            name="cluster_selection_recorded",
+            passed=False,
+            severity=Severity.WARNING,
+            message=f"{cap.name} absent — cluster selection record missing",
+            evidence={"path": str(cap)},
+        )
+    try:
+        df = pd.read_csv(cap)
+    except Exception as exc:
+        return CheckResult(
+            name="cluster_selection_recorded",
+            passed=False,
+            severity=Severity.WARNING,
+            message=f"could not read {cap.name}: {exc}",
+            evidence={"error": str(exc)},
+        )
+    n_clusters = len(df)
+    if "is_candidate" not in df.columns:
+        return CheckResult(
+            name="cluster_selection_recorded",
+            passed=False,
+            severity=Severity.WARNING,
+            message="capturability.csv missing 'is_candidate' column",
+            evidence={"columns": list(df.columns)},
+        )
+    n_candidates = int(df["is_candidate"].sum())
+    return CheckResult(
+        name="cluster_selection_recorded",
+        passed=True,
+        severity=Severity.WARNING,
+        message=(
+            f"{n_clusters} cluster(s) considered, {n_candidates} flagged candidate"
+        ),
+        evidence={
+            "n_clusters_considered": n_clusters,
+            "n_candidate_clusters": n_candidates,
+        },
+    )
+
+
+def _check_scope_flag_matches_n(inputs: Step6Inputs) -> CheckResult:
+    n = inputs.configs_evaluated_step5
+    closure_payload = inputs.closure_payload or {}
+    recorded = (
+        (closure_payload.get("pool_metadata") or {}).get("search_scope_flag")
+    )
+    if n is None or recorded is None:
+        return CheckResult(
+            name="search_scope_flag_matches_n",
+            passed=True,
+            severity=Severity.INFO,
+            message="cannot verify scope flag — missing inputs",
+            evidence={"n": n, "recorded_scope": recorded},
+        )
+    derived = _scope_from_n(int(n))
+    passed = derived == recorded
+    return CheckResult(
+        name="search_scope_flag_matches_n",
+        passed=passed,
+        severity=Severity.INFO,
+        message=(
+            f"recorded={recorded!r}, derived={derived!r} (N={n}); "
+            f"{'match' if passed else 'MISMATCH'}"
+        ),
+        evidence={"n": int(n), "derived": derived, "recorded": recorded},
+    )
+
+
+def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult:
+    checks = (
+        _check_configs_evaluated_recorded(inputs),
+        _check_ratio_clears_bonferroni(inputs),
+        _check_holdout_never_touched(inputs),
+        _check_cluster_selection_recorded(inputs),
+        _check_scope_flag_matches_n(inputs),
+    )
+    diagnostic = {
+        "configs_evaluated_step5": inputs.configs_evaluated_step5,
+        "holdout_start": str(inputs.holdout_start) if inputs.holdout_start else None,
+    }
+    return CategoryAuditResult(
+        category="selection_bias", checks=checks, diagnostic=diagnostic,
+    )
+
+
+__all__ = ("audit",)

--- a/core/step_6/statistical.py
+++ b/core/step_6/statistical.py
@@ -1,0 +1,297 @@
+"""§6.4 Statistical integrity audit.
+
+Per chat Q3: verification, not re-computation. Reads recorded artefacts
+and applies Lo-corrected Sharpe / survivorship / regime-coverage /
+correlation sanity checks.
+
+Five checks:
+
+  1. ``sample_size_adequate`` (critical) — per-fold trade count is at
+     least ``MIN_TRADES_PER_FOLD`` (=25 per L_PROTOCOL §3) AND total
+     trades clear the Lo-corrected threshold (configurable via
+     ``audit_config.lo_corrected_min_trades`` — default 100).
+  2. ``pair_set_survivorship`` (critical) — every pair in ``inputs.pair_set``
+     has at least one trade in the pool. Missing pairs may indicate
+     delisting / data gap / wrong pair set.
+  3. ``regime_coverage_diverse`` (warning) — pool trades span at least
+     three calendar years (rough vol-regime coverage proxy).
+  4. ``cross_pair_correlation_acceptable`` (warning) — pair-level
+     trade-time correlation matrix max off-diagonal is below
+     ``audit_config.correlation_warn_threshold`` (default 0.70).
+  5. ``lo_corrected_sharpe_recorded`` (info) — Lo's autocorrelation
+     correction Sharpe = `mean_R / std_R × sqrt(N) × sqrt(1 / (1 + 2 × ρ))`
+     is computed for the closure record. Cannot fail (informational).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from core.step_6.inputs import Step6Inputs
+from core.step_6.manifest import (
+    AuditConfig,
+    CategoryAuditResult,
+    CheckResult,
+    Severity,
+)
+
+MIN_TRADES_PER_FOLD = 25  # mirrored from core.wfo.gates
+EXPECTED_REGIME_YEARS_MIN = 3
+
+
+def _check_sample_size(inputs: Step6Inputs, cfg: AuditConfig) -> CheckResult:
+    trades = inputs.pool_trades
+    if trades is None:
+        return CheckResult(
+            name="sample_size_adequate",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message="pool_trades absent",
+            evidence={},
+        )
+    n_total = int(len(trades))
+    closure_payload = inputs.closure_payload or {}
+    sign_pos = (closure_payload.get("best_architecture") or {}).get("sign_pos_folds")
+    # We don't have per-fold trade counts in the bundle by default; surface n_total
+    # and rely on §3 gate plumbing to fail per-fold counts upstream.
+    passed = n_total >= cfg.lo_corrected_min_trades
+    return CheckResult(
+        name="sample_size_adequate",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"pool has {n_total} trades; "
+            f"≥ {cfg.lo_corrected_min_trades} required for Lo-corrected Sharpe meaning. "
+            f"Per-fold ≥ {MIN_TRADES_PER_FOLD} verified by §3 gate "
+            f"(sign_pos_folds={sign_pos!r})"
+        ),
+        evidence={
+            "n_total_trades": n_total,
+            "lo_corrected_min_trades": cfg.lo_corrected_min_trades,
+            "sign_pos_folds": sign_pos,
+        },
+    )
+
+
+def _check_pair_survivorship(inputs: Step6Inputs) -> CheckResult:
+    trades = inputs.pool_trades
+    if trades is None or "pair" not in trades.columns:
+        return CheckResult(
+            name="pair_set_survivorship",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message="pool_trades absent or missing pair column",
+            evidence={},
+        )
+    pairs_in_pool = set(trades["pair"].astype(str).unique())
+    pairs_expected = set(inputs.pair_set) if inputs.pair_set else pairs_in_pool
+    missing = sorted(pairs_expected - pairs_in_pool)
+    passed = len(missing) == 0
+    return CheckResult(
+        name="pair_set_survivorship",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"{len(pairs_in_pool)} pair(s) present in pool, "
+            f"{len(missing)} missing from expected pair_set"
+        ),
+        evidence={
+            "n_pairs_in_pool": len(pairs_in_pool),
+            "n_pairs_expected": len(pairs_expected),
+            "missing": missing,
+        },
+    )
+
+
+def _check_regime_coverage(inputs: Step6Inputs) -> CheckResult:
+    trades = inputs.pool_trades
+    if trades is None or len(trades) == 0:
+        return CheckResult(
+            name="regime_coverage_diverse",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool_trades absent",
+            evidence={},
+        )
+    col = "signal_time" if "signal_time" in trades.columns else (
+        "entry_time" if "entry_time" in trades.columns else None
+    )
+    if col is None:
+        return CheckResult(
+            name="regime_coverage_diverse",
+            passed=True,
+            severity=Severity.INFO,
+            message="no timestamp column",
+            evidence={},
+        )
+    ts = pd.to_datetime(trades[col], utc=True, errors="coerce")
+    years = sorted({int(t.year) for t in ts.dropna()})
+    passed = len(years) >= EXPECTED_REGIME_YEARS_MIN
+    return CheckResult(
+        name="regime_coverage_diverse",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"pool spans {len(years)} calendar year(s) ({years[0]}-{years[-1] if years else 'NA'}); "
+            f"≥ {EXPECTED_REGIME_YEARS_MIN} expected for vol-regime diversity"
+        ),
+        evidence={"n_years": len(years), "years": years},
+    )
+
+
+def _check_cross_pair_correlation(inputs: Step6Inputs, cfg: AuditConfig) -> CheckResult:
+    trades = inputs.pool_trades
+    if trades is None or "pair" not in trades.columns:
+        return CheckResult(
+            name="cross_pair_correlation_acceptable",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool_trades / pair column absent",
+            evidence={},
+        )
+    r_col = next(
+        (c for c in ("final_r", "trade_r", "realised_r", "r") if c in trades.columns), None,
+    )
+    if r_col is None:
+        return CheckResult(
+            name="cross_pair_correlation_acceptable",
+            passed=True,
+            severity=Severity.INFO,
+            message="no realised-R column in pool",
+            evidence={},
+        )
+    ts_col = "signal_time" if "signal_time" in trades.columns else "entry_time"
+    if ts_col not in trades.columns:
+        return CheckResult(
+            name="cross_pair_correlation_acceptable",
+            passed=True,
+            severity=Severity.INFO,
+            message="no timestamp column",
+            evidence={},
+        )
+    df = trades[[ts_col, "pair", r_col]].copy()
+    df[ts_col] = pd.to_datetime(df[ts_col], utc=True, errors="coerce")
+    df = df.dropna(subset=[ts_col, r_col])
+    if df.empty:
+        return CheckResult(
+            name="cross_pair_correlation_acceptable",
+            passed=True,
+            severity=Severity.INFO,
+            message="dataframe empty after dropna",
+            evidence={},
+        )
+    df["bucket"] = df[ts_col].dt.tz_convert("UTC").dt.floor("D")
+    pivot = df.pivot_table(index="bucket", columns="pair", values=r_col, aggfunc="sum")
+    pivot = pivot.fillna(0.0)
+    if pivot.shape[1] < 2:
+        return CheckResult(
+            name="cross_pair_correlation_acceptable",
+            passed=True,
+            severity=Severity.INFO,
+            message=f"only {pivot.shape[1]} pair(s) — correlation not meaningful",
+            evidence={"n_pairs": int(pivot.shape[1])},
+        )
+    corr = pivot.corr().fillna(0.0)
+    arr = np.array(corr.values, dtype=float, copy=True)
+    np.fill_diagonal(arr, 0.0)
+    max_corr = float(np.abs(arr).max())
+    passed = max_corr <= cfg.correlation_warn_threshold
+    return CheckResult(
+        name="cross_pair_correlation_acceptable",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"max abs cross-pair daily-bucket correlation = {max_corr:.3f}; "
+            f"warn at {cfg.correlation_warn_threshold:.2f}"
+        ),
+        evidence={
+            "max_abs_correlation": max_corr,
+            "threshold": cfg.correlation_warn_threshold,
+            "n_pairs": int(pivot.shape[1]),
+        },
+    )
+
+
+def _check_lo_corrected_sharpe(inputs: Step6Inputs) -> CheckResult:
+    trades = inputs.pool_trades
+    if trades is None or len(trades) < 30:
+        return CheckResult(
+            name="lo_corrected_sharpe_recorded",
+            passed=True,
+            severity=Severity.INFO,
+            message="insufficient trades for meaningful Sharpe",
+            evidence={},
+        )
+    r_col = next(
+        (c for c in ("final_r", "trade_r", "realised_r", "r") if c in trades.columns), None,
+    )
+    if r_col is None:
+        return CheckResult(
+            name="lo_corrected_sharpe_recorded",
+            passed=True,
+            severity=Severity.INFO,
+            message="no realised-R column in pool",
+            evidence={},
+        )
+    rs = trades[r_col].dropna().astype(float).values
+    if len(rs) < 30 or rs.std(ddof=1) == 0:
+        return CheckResult(
+            name="lo_corrected_sharpe_recorded",
+            passed=True,
+            severity=Severity.INFO,
+            message="rs too small / zero variance",
+            evidence={},
+        )
+    mean = float(rs.mean())
+    std = float(rs.std(ddof=1))
+    n = int(len(rs))
+    raw_sharpe = mean / std * math.sqrt(n)
+    # Lo correction factor — uses lag-1 autocorrelation as the leading term.
+    if n >= 3:
+        rho = float(np.corrcoef(rs[:-1], rs[1:])[0, 1])
+        if math.isnan(rho):
+            rho = 0.0
+    else:
+        rho = 0.0
+    denom = math.sqrt(max(1e-9, 1.0 + 2.0 * rho))
+    lo_sharpe = raw_sharpe / denom
+    return CheckResult(
+        name="lo_corrected_sharpe_recorded",
+        passed=True,
+        severity=Severity.INFO,
+        message=(
+            f"raw Sharpe ≈ {raw_sharpe:.3f}, Lo-corrected ≈ {lo_sharpe:.3f} "
+            f"(N={n}, lag-1 ρ = {rho:.3f})"
+        ),
+        evidence={
+            "n_trades": n,
+            "mean_r": mean,
+            "std_r": std,
+            "raw_sharpe": raw_sharpe,
+            "lo_corrected_sharpe": lo_sharpe,
+            "lag1_autocorr": rho,
+        },
+    )
+
+
+def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult:
+    checks = (
+        _check_sample_size(inputs, audit_config),
+        _check_pair_survivorship(inputs),
+        _check_regime_coverage(inputs),
+        _check_cross_pair_correlation(inputs, audit_config),
+        _check_lo_corrected_sharpe(inputs),
+    )
+    diagnostic: dict[str, Any] = {
+        "n_pool_trades": int(len(inputs.pool_trades)) if inputs.pool_trades is not None else None,
+    }
+    return CategoryAuditResult(
+        category="statistical", checks=checks, diagnostic=diagnostic,
+    )
+
+
+__all__ = ("audit",)

--- a/docs/PROTOCOL_RUNTIME.md
+++ b/docs/PROTOCOL_RUNTIME.md
@@ -553,9 +553,111 @@ The orchestrator:
    `core.wfo.orchestrator.run_search` + `run_holdout`
 4. Writes ARC_OPEN.md + ARC_CLOSURE.md skeleton + step artefacts
 
-Step 6 (causal audit) is **lazy**: not invoked by the orchestrator
-unless a candidate clears PASS-DEPLOYABLE / PASS-VIABLE — at v3.0
-launch it's a stub that says "deferred to chat."
+Step 6 (causal audit) is **post-gate auto-dispatched** per
+Amendment 4 — see §10b below.
+
+---
+
+## §10b Step 6 — causal audit framework (Amendment 4)
+
+`core/step_6/` implements the six-category causal-audit framework that
+L_PROTOCOL Amendment 4 (2026-05-24) ratifies. Step 6 dispatches AFTER
+the amended gate (Amendment 3) clears §3 constraints #1-9 on at least
+one top-K candidate — per §3 "Evaluation order" item 2.
+
+**Module map:**
+
+```
+core/step_6/
+├── __init__.py
+├── inputs.py                 # Step6Inputs bundle
+├── manifest.py               # CheckResult, CategoryAuditResult, Step6Result,
+│                             # Step6Manifest, Severity, VerdictImpact
+├── orchestrator.py           # run_step_6() dispatcher
+├── byte_compare.py           # Generic feature-producer byte-compare harness
+├── artefacts.py              # markdown/manifest writers
+├── io.py                     # from_arc_orchestrator_result + from_closure_dir
+├── dispatch.py               # maybe_dispatch_step_6 + replace_top_1_with_step6_fail
+├── lookahead.py              # §6.1
+├── selection_bias.py         # §6.2
+├── execution_realism.py      # §6.3
+├── statistical.py            # §6.4
+├── determinism.py            # §6.5
+└── deployment_readiness.py   # §6.6
+```
+
+**Trigger semantics** (chat resolution Q1):
+
+1. `_run_amendment_3_evaluation` produces per-top-K
+   :class:`AmendedGateResult` with `causal_audit_clean=True` (default).
+2. If at least one top-K candidate has verdict PASS-DEPLOYABLE / PASS-VIABLE,
+   `maybe_dispatch_step_6` runs Step 6 on the **Top-1** candidate (chat
+   resolution Q2).
+3. If Step 6 produces ≥ 1 critical failure, `replace_top_1_with_step6_fail`
+   re-classifies the Top-1's gate with `causal_audit_clean=False` →
+   `primary_failure_mode = step6_causal_audit_fail`.
+4. Top-2 / Top-3 candidates are NOT downgraded; feature-set divergence
+   surfaces as a `top_k_feature_set_divergence` warning on the lookahead
+   category.
+
+**Severity rules** (chat resolution Q4):
+
+- `critical` failure → category FAIL → Step 6 FAIL → verdict downgrade
+- `warning` failure → category PASS but flagged; counted in `n_warnings`
+- `info` failure → recorded; no effect on category outcome
+
+`CategoryAuditResult.passed = AND over critical-severity checks only`.
+
+**Manual CLI** — `scripts/run_step_6.py`:
+
+```bash
+# Run all six categories on a closure
+python scripts/run_step_6.py results/l_arc_10/ARC_CLOSURE.md
+
+# Restrict to one category
+python scripts/run_step_6.py results/l_arc_10/ARC_CLOSURE.md --category lookahead
+
+# Demote critical failures to warnings in the report (still no verdict modification)
+python scripts/run_step_6.py results/l_arc_10/ARC_CLOSURE.md --no-block
+
+# Validate inputs without running audits
+python scripts/run_step_6.py results/l_arc_10/ARC_CLOSURE.md --dry-run
+```
+
+Manual invocations write to `results/<arc>/step_6_manual_<timestamp>/`
+and **never modify the verdict** (chat resolution Q6).
+
+**Artefact layout** (per auto-dispatched run):
+
+```
+results/<arc>/step_6/
+├── manifest.json               # Step6Manifest (per dispatch Task 4 schema)
+├── summary.md                  # one-page roll-up
+├── lookahead_report.md
+├── selection_bias_report.md
+├── execution_realism_report.md
+├── statistical_report.md
+├── determinism_report.md
+├── deployment_readiness_report.md
+└── sha256_manifest.json        # per-file sha256 (excludes itself)
+```
+
+**Closure integration** — closure template v1.3 carries a new
+`§1 tracker_payload.step_6` block keyed off `Step6Manifest`. Parser
+v1.3 detection precedence: explicit `template_version: v1.3` → top-level
+`step_6` field → fall-through to v1.2. Phase 2 tightening: for any PASS
+verdict with `closed_timestamp > 2026-05-23T06:20:59Z` (PR-186 merge),
+Amendment 3 fields required; v1.3 PASS verdicts additionally require
+`step_6.overall_passed: true`.
+
+**Backwards compatibility:**
+
+- v1.0 / v1.1 / v1.2 / v1.2.1 closures grandfathered. Parser handles
+  them via existing detection.
+- Arc 10's hand-written Step 6 at `results/l_arc_10/step_6/` stays
+  canonical; manual CLI re-runs land in `step_6_manual_<ts>/` and do
+  NOT clobber.
+- Wave 2 onward closes at v1.3; Step 6 auto-dispatches.
 
 ---
 

--- a/docs/audits/engine_capability_audit_2026_05.md
+++ b/docs/audits/engine_capability_audit_2026_05.md
@@ -477,3 +477,19 @@
 | **Total** | **30** | **24** | **13** | **1** | **68** |
 
 End of audit.
+
+---
+
+## Post-audit update — 2026-05-24 (L_PROTOCOL Amendment 4 / CC_17)
+
+§"Step 6 — Causal audit" capability statuses transition MISSING → WIRED:
+
+1. **Producer-level feature trace as a runnable check** — WIRED at `core/step_6/lookahead.py`. Per-feature `causal_lineage` enforcement via the §6.1 `per_feature_lineage_clean` critical check.
+2. **Byte-compare from raw OHLC for feature reproduction** — WIRED at `core/step_6/byte_compare.py` (generic harness factored from Arc 10's `step_6_byte_compare.py`). Invoked by §6.1 `byte_compare_no_drift`.
+3. **D1 lag rule verification check** — WIRED at `core/step_6/lookahead.py:_check_d1_lag_rule` (static source-inspection check).
+4. **Automated trigger on PASS verdict** — WIRED at `core/step_6/dispatch.py:maybe_dispatch_step_6` + `core/arc/arc_orchestrator.py` `run()`. Post-gate per chat Q1.
+5. **Manifest / report artefact format** — WIRED at `core/step_6/manifest.py` + `core/step_6/artefacts.py`. Closure template v1.3 + parser v1.3 + tracker "Step 6 audit registry" section per dispatch Tasks 4-6.
+
+Capability count delta: Step 6 row updates from `0 WIRED / 0 PARTIAL / 5 MISSING` to `5 WIRED / 0 PARTIAL / 0 MISSING`. Overall: WIRED 30 → 35, MISSING 13 → 8.
+
+Remaining Tier 1 / 2 items (Amendment 3 engine emission, heavy_ml_probe sub-protocol, etc.) unchanged by this PR.

--- a/docs/dispatches/cc_17_step_6_framework_intent.md
+++ b/docs/dispatches/cc_17_step_6_framework_intent.md
@@ -1,0 +1,187 @@
+# CC_17 — Step 6 Framework Intent
+
+> **Branch:** `engine/step-6-causal-audit-framework`
+> **Authored:** 2026-05-24 by CC_17 from `CC_17_STEP_6_FRAMEWORK.md` Read-first phase.
+> **Status:** intent only. No engine code written. Chat review required before implementation begins.
+
+---
+
+## Read-first artefacts consumed
+
+| Source | Take-away that shapes this intent |
+|---|---|
+| [L_PROTOCOL.md](L_PROTOCOL.md) §2 Step 6 | Sparse: trigger = ≥ 1 PASS-tier candidate; mechanics = producer-trace + byte-compare; downgrade or kill candidate. No category framework. |
+| [L_PROTOCOL.md](L_PROTOCOL.md) §3 Evaluation order | Step 6 is constraint #10 — runs ONLY after #1-9 clear. `step6_causal_audit_fail` already in the failure-mode taxonomy at priority 11. |
+| [docs/audits/engine_capability_audit_2026_05.md](docs/audits/engine_capability_audit_2026_05.md) §"Step 6 — Causal audit" | All 5 audited items MISSING: producer-trace, byte-compare, D1-lag check, auto-trigger, manifest format. Tier 4 of the Recommendations. |
+| [core/wfo/amended_gates.py:248](core/wfo/amended_gates.py:248) | `classify_amended_fold_stats(..., causal_audit_clean: bool = True)` is the plumbed hook — Step 6 already has a callsite shape; today the orchestrator never passes the parameter. |
+| [core/arc/arc_orchestrator.py:818](core/arc/arc_orchestrator.py:818) | Today's Step 6 = `"(lazy — deferred to chat at PASS verdict)"`. `ArcConfig.invoke_step_6: bool = False` at [:176](core/arc/arc_orchestrator.py:176) is never flipped. |
+| [core/arc/arc_orchestrator.py:779-836](core/arc/arc_orchestrator.py:779) | Amendment 3 evaluation runs per top-K candidate, picks best by verdict rank. Step 6 dispatch lands AFTER `_run_amendment_3_evaluation`. |
+| [docs/templates/ARC_CLOSURE_TEMPLATE.md](docs/templates/ARC_CLOSURE_TEMPLATE.md) v1.2.1 | §1 tracker_payload has no `step_6` block today. Version bump path v1.2 → v1.2.1 (additive `chained_dd_method` field). Dispatch wants v1.3. |
+| [scripts/tracker_parser/schema.py:41](scripts/tracker_parser/schema.py:41) | Schema detection precedence template_version → v1.2-exclusive fields → v1.1-exclusive fields → v1.0. Detection function is the v1.3 extension point. |
+| [scripts/l_arc_10_v3/step_6_byte_compare.py](scripts/l_arc_10_v3/step_6_byte_compare.py) (250 LOC) + [results/l_arc_10/step_6/](results/l_arc_10/step_6/) | Arc 10's hand-written precedent. Manifest schema is informal; report is prose. Useful template, NOT directly reusable as a feature-producer-agnostic harness. |
+| [ARC_TRACKER.md](ARC_TRACKER.md) | No "Step 6 audit registry" section today. The new section (Task 6) is a fresh append at line ~175 (after "Cross-arc tag registry"). |
+
+---
+
+## Component map + LOC estimates
+
+> All LOC numbers are budget targets. Final counts will vary ±20%.
+
+### New engine modules (`core/step_6/`)
+
+| File | LOC | Role |
+|---|---:|---|
+| `__init__.py` | 30 | Public exports (orchestrator, CategoryAuditResult, CheckResult). |
+| `manifest.py` | 180 | `CategoryAuditResult`, `CheckResult`, `Step6Manifest` dataclasses; severity enum; manifest.json serde + sha256. |
+| `orchestrator.py` | 250 | `run_step_6(arc_result, audit_config) -> Step6Result` — dispatches the 6 categories, applies severity rules, decides verdict_impact. |
+| `lookahead.py` | 280 | §6.1 — per-feature producer-trace + D1 lag-rule + cluster-feature audit + threshold-selection lineage. |
+| `selection_bias.py` | 220 | §6.2 — Bonferroni denominator from `pool_metadata.configs_evaluated_step5`; holdout-touch detector; cluster-selection justification. |
+| `execution_realism.py` | 300 | §6.3 — spread regime delta vs broker; fill realism (M1 next-bar-open feasibility); lot-rounding; margin/leverage at `r_safe`; mid-price refactor + UTC bar boundary checks. |
+| `statistical.py` | 240 | §6.4 — Lo-corrected Sharpe sample-size check; pair-set survivorship; vol-regime coverage; cross-pair correlation. |
+| `determinism.py` | 180 | §6.5 — verify on-disk `sha256_manifest.json` matches recomputed sha256 of Step 4 + Step 5 artefacts; verify seed pinning in producer code (NOT a sim re-run — see §"Open questions" Q5). |
+| `deployment_readiness.py` | 200 | §6.6 — §4 deployment_spec field-by-field validator; feature live-computability; latency-tolerance metadata; restart-safety metadata; `config_artefact_path` self-containment. |
+| `byte_compare.py` | 300 | Generic feature-producer-agnostic harness (factored from Arc 10's `step_6_byte_compare.py`). Iterates over registered `FeatureSpec` set, samples N trades, recomputes from raw OHLC, byte-compares to pool. |
+| `artefacts.py` | 240 | Per-category markdown writers + `summary.md` + `sha256_manifest.json`. |
+| **Engine subtotal** | **2,420** | |
+
+### CLI (`scripts/`)
+
+| File | LOC | Role |
+|---|---:|---|
+| `scripts/run_step_6.py` | 180 | Manual invocation per Task 7 — flags: `--category`, `--no-block`, `--dry-run`; outputs to `results/<arc>/step_6_manual_<timestamp>/`. |
+
+### Tests (`tests/step_6/`)
+
+| File | LOC | Role |
+|---|---:|---|
+| `__init__.py` + `conftest.py` + `_fixtures.py` | 200 | Synthetic arc-result fixtures; minimal pool + step-1/4/5 artefacts for fast unit tests. |
+| `test_lookahead.py` | 200 | Per-feature clean / leaky / D1-same-day / threshold-from-full-data cases. |
+| `test_selection_bias.py` | 150 | Bonferroni denominator math; holdout-touch detection. |
+| `test_execution_realism.py` | 200 | Spread delta thresholds; lot-rounding at broker minimums; mid-price/UTC checks. |
+| `test_statistical.py` | 150 | Lo-corrected Sharpe arithmetic on toy returns; pair-set survivorship. |
+| `test_determinism.py` | 120 | sha256_manifest match + mismatch cases. |
+| `test_deployment_readiness.py` | 200 | §4 deployment_spec field validation + missing-field FAIL paths. |
+| `test_byte_compare.py` | 150 | Harness on a 2-feature synthetic producer; happy path + drift detection. |
+| `test_orchestrator.py` | 250 | End-to-end synthetic arcs covering Task 10 cases 1-6 (PASS clean, PASS leaky → downgrade, FAIL with manual invocation, --no-block, two-run determinism, schema-validation HALT). |
+| `test_manual_cli.py` | 200 | CLI invocation matrix; exit codes; output directory layout. |
+| **Test subtotal** | **1,820** | |
+
+### Modified files
+
+| File | LOC delta | Change |
+|---|---:|---|
+| `core/arc/arc_orchestrator.py` | +120 | Step 6 dispatch after `_run_amendment_3_evaluation`; verdict re-classification when Step 6 FAILs; persist `Step6Manifest` to `results/<arc>/step_6/`; populate the existing `invoke_step_6` flag (currently dead code at [:176](core/arc/arc_orchestrator.py:176)). |
+| `core/wfo/amended_gates.py` | +20 | No structural change. Document the `causal_audit_clean` callsite invariant. Adjust `_fail` reason text for `STEP6_CAUSAL_AUDIT_FAIL` to surface which category failed. |
+| `core/arc/_closure_template.py` | +60 | Emit §1 tracker_payload `step_6` block keyed off `Step6Manifest`. |
+| `L_PROTOCOL.md` | +150 | §2 Step 6 expanded from sparse spec (lines 333-354 today) to six-category framework per Amendment 4. §3 PASS-* conditional on Step 6. |
+| `docs/templates/ARC_CLOSURE_TEMPLATE.md` | +80 | v1.2.1 → v1.3 (see §"Open questions" Q8). New §1 `step_6` block schema. v1.3 row in the Schema versioning table. |
+| `archive/L_PROTOCOL_v3_0_AMENDMENT_4.md` | +250 (new file) | Full Amendment 4 text. Authored by mastermind chat per Task 8, applied here. |
+| `ARC_TRACKER.md` | +30 | New "Step 6 audit registry" section after "Cross-arc tag registry" (line ~175). Append-only per arc, auto-PASS dispatch only. |
+| `scripts/tracker_parser/schema.py` | +80 | `BestArchitectureV13`, `TrackerPayloadV13`, `step_6` block model. `detect_schema_version` v1.3 path. Phase 2 tightening per Task 9. |
+| `scripts/tracker_parser/mapping.py` | +50 | New Section 4-M: Step 6 audit registry mutation. |
+| `scripts/tracker_parser/extract.py` | +20 | Step 6 block presence check helper (for v1.3 PASS validation). |
+| `scripts/tracker_parser/README.md` | +60 | v1.3 schema notes; Phase 2 enforcement rules. |
+| `docs/PROTOCOL_RUNTIME.md` | +80 | New §"Step 6 framework" section. |
+| `docs/audits/engine_capability_audit_2026_05.md` | +20 | Footer note: Step 6 MISSING items → WIRED post-PR. |
+| **Modified subtotal** | **+1,020** | |
+
+### Grand total
+
+| Bucket | LOC |
+|---:|---:|
+| New engine | 2,420 |
+| New CLI | 180 |
+| New tests | 1,820 |
+| Modified | +1,020 |
+| **Total** | **~5,440** |
+
+Sits at the upper end of "multi-day (3-5 days CC)". 35% is tests, 19% is docs+schema — matches the dispatch's stated bias toward audit-grade rigour over feature volume.
+
+---
+
+## Open questions for chat review
+
+These need resolution BEFORE the implementation phase begins. Each has a recommended default; chat may override.
+
+### Q1 — Gate-pass / Step-6 ordering (CRITICAL)
+
+[`classify_amended_fold_stats`](core/wfo/amended_gates.py:248) already takes `causal_audit_clean: bool = True`. Two readings of Task 1 ("After Step 5 verdict assignment, check if verdict starts with PASS-… automatically dispatch"):
+
+- **(A) Pre-gate path:** Step 6 runs FIRST for every top-K candidate, then `classify_amended_fold_stats` is called with the real `causal_audit_clean` value. Cost: Step 6 runs even on candidates that fail #1-9 (waste).
+- **(B) Post-gate path:** Amended gate runs first with `causal_audit_clean=True` default; if any candidate clears all of #1-9, Step 6 runs; if Step 6 FAILs, re-call the gate with `causal_audit_clean=False` to downgrade. Matches §3 "Evaluation order" item 2 exactly.
+
+**Recommend (B)** — matches §3 ordering verbatim and avoids wasted Step 6 invocations on candidates that fail #1-9.
+
+### Q2 — Step 6 per-candidate scope (CRITICAL)
+
+Amendment 3 emits per top-K results. Top-1 is the verdict-carrier; Top-2/Top-3 are reported for selection-bias accounting. Dispatch says "automatically dispatch `run_step_6(arc_result)`" — singular arc_result, ambiguous on top-K.
+
+- **Per-Top-1:** Only the verdict-carrying candidate gets audited. Top-2/Top-3 marked `step_6.ran = false`. Cheapest, matches "winning candidate's filter/classifier" language in §2 Step 6.
+- **Per-top-K:** Every PASS-tier candidate audited. Expensive (byte-compare is heavy); produces redundant reports when Top-1/Top-2 share feature sets.
+
+**Recommend Per-Top-1**, with a note in the manifest if Top-2 / Top-3 use a feature set disjoint from Top-1 (rare). Chat can override per-arc via CLI flag if a Top-2 candidate becomes interesting.
+
+### Q3 — Scope creep beyond protocol §2 Step 6 (CRITICAL — Amendment 4 ratification)
+
+L_PROTOCOL §2 Step 6 today specifies only producer-feature trace + byte-compare. Dispatch §6.2-§6.6 add five categories, several of which overlap existing engine paths:
+
+| Dispatch category | Overlap |
+|---|---|
+| §6.2 Selection bias | Step 5 already emits `configs_evaluated_step5` + `search_scope_flag` (thin/normal/broad). Bonferroni accounting today in closure prose, not engine. |
+| §6.3 Execution realism — spread delta | Step 1 integrity check `spread-floor activation rate per pair` is on the engine-capability-audit "MISSING" list — different check. Spread delta vs broker is genuinely new. |
+| §6.3 Execution realism — lot rounding, margin | Belongs in closure template v1.2 §4 deployment_spec §4.8 by current template wording. |
+| §6.5 Determinism | `tests/test_determinism.py` (CI) + per-step `sha256_manifest.json` already enforce this at engine-side. Step 6 re-runs would be expensive duplication. |
+| §6.6 Deployment readiness | Closure template v1.2 §4 deployment_spec already has a "Deployment readiness checklist" with 6 items, parser-enforced via Section 4-L. |
+
+Risk: Step 6 becomes a kitchen sink and no real-world PASS verdict ever clears it cleanly.
+
+**Recommend** chat confirm Amendment 4 ratifies all six categories as Step 6 scope and clarifies the overlap rules (e.g., §6.6 deployment readiness READS the existing §4 deployment_spec rather than duplicating the checks). If full §6.2-§6.6 scope is too aggressive, propose narrower v1 = §6.1 lookahead + §6.6 deployment readiness only; defer §6.2-§6.5 to a follow-up amendment when Wave 2 produces the first auto-dispatched PASS.
+
+### Q4 — Severity rules + warnings-only category (MINOR)
+
+Dispatch §"Severity rules": `critical` fails block; `warning` fails flag-only; `info` records. Dispatch §"CategoryAuditResult.passed = AND of all check.passed" contradicts this — a check with severity=warning that fails would set `check.passed = false` and tank the category.
+
+**Recommend** redefine: `CategoryAuditResult.passed = AND over only the critical-severity checks` (warnings tracked separately in `n_warnings`). Document explicitly in `manifest.py` docstrings.
+
+### Q5 — Determinism category cost (MINOR)
+
+Dispatch §6.5 says "Two-run sha256 reproduction on Step 4 + Step 5 artefacts". Full-arc Step 4 + Step 5 re-run is expensive (10+ min on a real arc). `tests/test_determinism.py` already covers this at mini-pipeline level in CI.
+
+**Recommend** Step 6 determinism check = verify the existing `step_4/manifest.json` + `step_5/sha256_manifest.json` sha256 entries match a recomputed sha256 of the artefacts on disk (cheap; catches post-emission tampering). DO NOT re-run sims. The two-run sha256 guarantee is provided by CI, not by Step 6.
+
+### Q6 — Arc 10 retroactive (MINOR)
+
+Dispatch §"Backwards compatibility" says Arc 10 must run Step 6 manually if its PROVISIONAL verdict becomes definitive PASS. Arc 10 already has hand-written Step 6 outputs in [results/l_arc_10/step_6/](results/l_arc_10/step_6/) including a PASS verdict.
+
+**Recommend** clarify in Amendment 4 §"Backwards compatibility": Arc 10's existing hand-written Step 6 stays canonical. If re-run under the framework via manual CLI, results write to `results/l_arc_10/step_6_manual_<timestamp>/` and do NOT clobber the existing audit. Arc 10's `template_version` stays at v1.2; no v1.3 retrofit required.
+
+### Q7 — Parser v1.3 grandfathering date (COSMETIC)
+
+Task 9 references "PR-186 merge date" as the timestamp for the v1.2 PASS Amendment-3-field-required cutoff. Need the literal ISO timestamp from `git log --format="%aI" -1 7c238e8^` (the merge commit predecessor; PR-186 is commit `1b15774`). Will resolve at implementation time, but flag now so chat is aware the cutoff date is a load-bearing parser constant.
+
+### Q8 — Template version v1.3 vs v1.2.2 (COSMETIC)
+
+Closure template is at v1.2.1 today (PR-186). Dispatch says v1.3. Amendment 4 is genuinely a bigger schema change than v1.2.1 (additive `chained_dd_method` field only). v1.3 is the right call — locks the schema for "Wave 2 from-scratch PASS arcs run Step 6 from first close."
+
+**Recommend** confirm v1.3 (not v1.2.2). v1.3 row added to the Schema versioning table; v1.2.1 closures grandfathered.
+
+---
+
+## Risks beyond design questions
+
+- **Risk #1 — Wave 2 dispatch coupling.** Engine audit Tier 4 lists Step 6 framework as separate from Tier 1 (Amendment 3 gate rewrite). Both PR-185 and PR-186 already landed; Wave 2 is not strictly blocked on Step 6. But once Step 6 lands, every PASS verdict gates on it — if Step 6 framework has bugs at landing, every Wave 2 PASS arc tanks. Recommend a buffer week between PR landing and Wave 2 dispatch to shake out false-positive critical fails.
+- **Risk #2 — Hand-written Arc 10 Step 6 as test fixture.** Tempting to use Arc 10's existing outputs as a golden-test fixture. But Arc 10's manifest was hand-written and its format predates the spec the framework will lock. Will produce a synthetic golden fixture instead and treat Arc 10 as a separate manual-CLI-validation case.
+- **Risk #3 — `core/step_6/byte_compare.py` generic harness vs producer signature variability.** Arc 10's byte-compare uses producer-specific imports (`signals.lchar_dlr_long`). A truly generic harness needs to introspect `FeatureSpec` producers and reconstruct their inputs from raw OHLC. Manageable for the v3.0 registered feature classes; future bespoke signal-side features will need to register a `step_6_recompute(panel, signal_row) -> dict` hook. Will add this to the protocol-level `SignalModule` interface as part of the engine PR (~30 LOC extra in `core/arc/signal_protocol.py`).
+
+---
+
+## What this intent does NOT cover
+
+- A4 portfolio composition spec (separate amendment per dispatch §"After this lands")
+- Heavy ML probe sub-protocol engine path (Phase 2 prerequisite per engine audit Tier 2)
+- Full-window-sim chained DD method (`chained_dd_method: full_window_sim`, deferred per Amendment 3 chat directive Q6)
+- Cross-platform CI determinism check (engine audit Tier 6 housekeeping)
+
+---
+
+End of intent. Awaiting chat review of the 8 open questions before implementation begins.

--- a/docs/templates/ARC_CLOSURE_TEMPLATE.md
+++ b/docs/templates/ARC_CLOSURE_TEMPLATE.md
@@ -1,4 +1,4 @@
-# ARC_CLOSURE.md Template (Locked v1.2)
+# ARC_CLOSURE.md Template (Locked v1.3)
 
 > **Location:** `docs/templates/ARC_CLOSURE_TEMPLATE.md`
 > **Status:** locked. Every arc closure MUST follow this template.
@@ -11,6 +11,7 @@
 >
 > **v1.1 (2026-05-22, L_PROTOCOL Amendment 3):** risk-normalised gate fields added to `best_architecture` block. Two fields renamed (see §"Schema versioning" at end of template). `primary_failure_mode` enum extended.
 > **v1.2 (2026-05-23, deployment-spec addition):** `config_artefact_path`, `deployment_spec_section_present`, `template_version` fields added to `best_architecture` block. New §4 deployment_spec section: REQUIRED for any PASS verdict, OPTIONAL for FAIL / HALT / DISCOVERY_COMPLETE. Parser enforces config path + §4 presence for PASS verdicts.
+> **v1.3 (2026-05-24, L_PROTOCOL Amendment 4):** Step 6 causal-audit framework. New `§1 tracker_payload.step_6` block. Step 6 auto-dispatches on any candidate that clears §3 constraints #1-9; manual CLI available for any closure. Step 6 critical-failure downgrades verdict to FAIL with `primary_failure_mode = step6_causal_audit_fail`. Parser v1.3 detection + Phase 2 tightening: for any PASS verdict with `closed_timestamp > 2026-05-23T06:20:59Z`, Amendment 3 fields required; for `template_version: v1.3` PASS, `step_6` block required.
 
 ---
 
@@ -30,7 +31,7 @@
 ```yaml
 tracker_payload:
 
-  template_version: v1.2   # Schema dispatch. Accepts v1.0, v1.1, v1.2 (parser detects via this field OR v1.1/v1.2-exclusive fields).
+  template_version: v1.3   # Schema dispatch. Accepts v1.0, v1.1, v1.2, v1.3 (parser detects via this field OR version-exclusive fields).
 
   # ────── Identity ──────
   arc_name: <arc_name>
@@ -156,6 +157,28 @@ tracker_payload:
   # ────── Cross-arc observation tags (terse, one-line each) ──────
   cross_arc_tags: [<tag_1>, <tag_2>]
   # Examples: "v_shape_auc_ceiling", "pipeline_d1_admit_vs_deployment", "co_fire_with_arc_7"
+
+  # ────── Step 6 causal-audit registry (v1.3 / Amendment 4) ──────
+  # REQUIRED for v1.3 PASS verdicts. OPTIONAL otherwise (e.g. FAIL/HALT
+  # closures that did not run Step 6, or manual CLI invocations on older
+  # closures). When ``ran: false`` for a non-PASS closure the rest of the
+  # block may be null. Manual CLI invocations record ``trigger: manual``
+  # and NEVER modify the verdict per Amendment 4 §"Discipline rules".
+  step_6:
+    ran: <bool>                  # true when Step 6 dispatched (auto OR manual)
+    trigger: auto_pass | manual | not_applicable
+    overall_passed: <bool or null>
+    manifest_path: results/<arc>/step_6/manifest.json     # null when ran=false
+    categories:
+      lookahead: <bool or null>
+      selection_bias: <bool or null>
+      execution_realism: <bool or null>
+      statistical: <bool or null>
+      determinism: <bool or null>
+      deployment_readiness: <bool or null>
+    critical_failures: [<list of "category.check_name" entries>]
+    warnings_count: <int>
+    verdict_impact: none | downgraded_to_fail
 ```
 
 ---
@@ -374,6 +397,7 @@ Parser specification (preserved here for reference):
 | v1.1 | 2026-05-22 | L_PROTOCOL Amendment 3. Risk-normalised fields added to `best_architecture`. Two fields renamed: `worst_fold_roi_pct` → `worst_fold_roi_base_pct`, `worst_fold_dd_pct` → `worst_fold_dd_base_pct`. `primary_failure_mode` enum extended. Pre-v1.1 closures retain v1.0 field names; parser handles both via version detection. |
 | v1.2 | 2026-05-23 | Deployment-spec addition. Three new fields in `best_architecture`: `config_artefact_path`, `deployment_spec_section_present`, `template_version` (the last was conventional in v1.1; locked at v1.2). New §4 deployment_spec section: REQUIRED for PASS-* verdicts (DEPLOYABLE, VIABLE, *-PROVISIONAL, *-PENDING-STEP6), OPTIONAL otherwise. Parser HALTs on PASS verdict if config path missing / file absent / §4 heading missing (Section 4-L). Pre-v1.2 closures unaffected. |
 | v1.2.1 | 2026-05-23 | `chained_dd_method` field added to `best_architecture` per PR-186 review item 1. Records the method used to reconstruct chained equity for `chained_max_dd_base_pct`: `"equity_stitching"` (v3.0.1 engine default) or `"full_window_sim"` (v3.0.2 follow-up). Phase 1: parser accepts as OPTIONAL. Phase 2 (post-Wave-2 first PASS arc): parser REQUIRES the field for any PASS verdict with `closed_timestamp > PR-186 merge date`. Older closures grandfathered by closed_timestamp check. v1.2 / v1.2.1 share the same `template_version: v1.2` declaration — the field's presence/absence is the v1.2.1 discriminator, not a separate version string. |
+| v1.3 | 2026-05-24 | L_PROTOCOL Amendment 4 — Step 6 causal-audit framework. New `§1 tracker_payload.step_6` block (`ran`, `trigger`, `overall_passed`, `manifest_path`, `categories`, `critical_failures`, `warnings_count`, `verdict_impact`). REQUIRED for any v1.3 PASS verdict. Parser v1.3 detection precedence: explicit `template_version: v1.3` → v1.3-exclusive `step_6` field → fall-through to v1.2 detection. Phase 2 tightening bundled (PR-186-merge-date cutoff): for any PASS verdict with `closed_timestamp > 2026-05-23T06:20:59Z` the parser REQUIRES Amendment 3 fields in `best_architecture`; for v1.3 PASS verdicts the parser ADDITIONALLY requires the `step_6` block + `step_6.overall_passed: true`. Closures landed before the cutoff (v1.0/v1.1/v1.2/v1.2.1) are grandfathered. |
 
 Closures MUST reference the template version they were written against (e.g., `template_version: v1.2` near the top of `§1 tracker_payload` is the convention going forward — pre-v1.1 closures without this field are assumed v1.0; pre-v1.2 closures without `config_artefact_path` are assumed v1.1). v1.2.1 stays under the `v1.2` declaration; the `chained_dd_method` field is the only discriminator and is OPTIONAL during Phase 1.
 

--- a/scripts/run_step_6.py
+++ b/scripts/run_step_6.py
@@ -1,0 +1,147 @@
+"""Manual CLI for the L_PROTOCOL §2 Step 6 causal-audit framework.
+
+Per Amendment 4 + chat Q6: manual invocations are READ-ONLY w.r.t. the
+arc verdict. Output lands in ``results/<arc>/step_6_manual_<timestamp>/``
+so it never clobbers an auto-dispatched run.
+
+Usage:
+    python scripts/run_step_6.py results/<arc>/ARC_CLOSURE.md [options]
+
+Options:
+    --category NAME       Run a single category. Repeatable. Default: all six.
+    --no-block            Demote critical failures to warnings in the report.
+                          (Manual invocations already do not modify the verdict;
+                          this flag only affects how the report renders.)
+    --dry-run             Validate Step6Inputs, do NOT execute any audit.
+    --out-dir DIR         Override output directory. Default: results/<arc>/step_6_manual_<TS>/.
+    --byte-compare-n N    Sample N trades for byte-compare (default 5).
+    --verbose             Print per-category check tables.
+
+Exit codes:
+    0  Step 6 ran AND no critical failures (or --no-block in effect)
+    1  Step 6 ran AND at least one critical failure surfaced
+    2  Inputs error (closure dir invalid, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from core.step_6 import AUDIT_CATEGORY_NAMES, AuditConfig, run_step_6  # noqa: E402
+from core.step_6.artefacts import write_step_6_artefacts  # noqa: E402
+from core.step_6.io import from_closure_dir  # noqa: E402
+from core.step_6.manifest import TriggerSource  # noqa: E402
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Manually run L_PROTOCOL §2 Step 6 on any closure."
+    )
+    p.add_argument("closure_path", type=Path, help="results/<arc>/ARC_CLOSURE.md OR results/<arc>/")
+    p.add_argument(
+        "--category", action="append", default=None,
+        help=f"Restrict to one category (repeatable). Valid: {', '.join(AUDIT_CATEGORY_NAMES)}",
+    )
+    p.add_argument(
+        "--no-block", action="store_true",
+        help="Demote critical failures to warnings in the rendered report.",
+    )
+    p.add_argument("--dry-run", action="store_true", help="Validate inputs only; no audit.")
+    p.add_argument("--out-dir", type=Path, default=None, help="Override output directory.")
+    p.add_argument(
+        "--byte-compare-n", type=int, default=5,
+        help="Sample size for §6.1 byte-compare (default 5).",
+    )
+    p.add_argument("--verbose", action="store_true", help="Print check tables to stdout.")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = _build_parser().parse_args(argv)
+
+    closure_path: Path = args.closure_path
+    if not closure_path.exists():
+        logging.error("closure_path does not exist: %s", closure_path)
+        return 2
+
+    try:
+        inputs = from_closure_dir(closure_path)
+    except FileNotFoundError as exc:
+        logging.error("could not build Step6Inputs: %s", exc)
+        return 2
+
+    if args.category:
+        unknown = [c for c in args.category if c not in AUDIT_CATEGORY_NAMES]
+        if unknown:
+            logging.error(
+                "unknown --category value(s): %s; valid: %s",
+                unknown, AUDIT_CATEGORY_NAMES,
+            )
+            return 2
+        categories_to_run = tuple(args.category)
+    else:
+        categories_to_run = None
+
+    cfg = AuditConfig(
+        no_block=args.no_block,
+        categories_to_run=categories_to_run,
+        byte_compare_n_samples=args.byte_compare_n,
+    )
+
+    if args.dry_run:
+        logging.info(
+            "DRY-RUN: arc=%s, root=%s, features=%d, categories=%s, no_block=%s",
+            inputs.arc_name, inputs.arc_root, len(inputs.best_candidate_features),
+            categories_to_run or AUDIT_CATEGORY_NAMES, args.no_block,
+        )
+        return 0
+
+    result = run_step_6(inputs, trigger=TriggerSource.MANUAL, audit_config=cfg)
+
+    out_dir = args.out_dir
+    if out_dir is None:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        out_dir = inputs.arc_root / f"step_6_manual_{ts}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    write_step_6_artefacts(result, out_dir)
+
+    print(f"Step 6 manual run: arc={inputs.arc_name}")
+    print(f"  Output: {out_dir}")
+    print(f"  Trigger: {result.trigger.value}")
+    print(f"  Overall passed: {bool(result.overall_passed)}")
+    print(f"  Verdict impact: {result.verdict_impact.value}  (manual = always 'none')")
+    print(f"  Warnings: {result.n_warnings_total}")
+    if args.verbose:
+        print("\n  Category summary:")
+        for c in result.categories:
+            print(
+                f"    {c.category:25s} passed={c.passed!s:5s} "
+                f"crit={c.n_critical_fails}/{c.n_critical} "
+                f"warn={c.n_warnings} info={c.n_info}"
+            )
+        crit = result.critical_failures()
+        if crit:
+            print("\n  Critical failures:")
+            for name in crit:
+                print(f"    - {name}")
+    print(f"  Manifest: {out_dir / 'manifest.json'}")
+
+    # Manual invocations don't modify verdicts (chat Q6). Exit code reflects
+    # whether any critical fired, so CI / scripts can react.
+    if result.critical_failures() and not args.no_block:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tracker_parser/README.md
+++ b/scripts/tracker_parser/README.md
@@ -49,22 +49,25 @@ The parser detects the closure doc's template version automatically:
 
 | Detection rule | Outcome |
 |---|---|
-| `template_version` field present in `§1 tracker_payload` | Use it (accepts `v1.0`, `v1.1`, `v1.2`, `1.0`, `1.1`, `1.2`). |
+| `template_version` field present in `§1 tracker_payload` | Use it (accepts `v1.0`, `v1.1`, `v1.2`, `v1.3`, `1.0`, `1.1`, `1.2`, `1.3`). |
+| Top-level `step_6` block present | Infer v1.3. |
 | Any v1.2-exclusive field present in `best_architecture` (`config_artefact_path`, `deployment_spec_section_present`) | Infer v1.2. |
 | Any v1.1-exclusive field present (`worst_fold_dd_base_pct`, `k_safe`, etc.) | Infer v1.1. |
 | Otherwise | v1.0. |
 
-Detection precedence: 1.2 → 1.1 → 1.0 → error.
+Detection precedence: 1.3 → 1.2 → 1.1 → 1.0 → error.
 
 v1.0 closures use legacy field names (`worst_fold_roi_pct`, `worst_fold_dd_pct`). The parser internally renames them to v1.1 names (`*_base_pct`) and fills v1.1-exclusive Amendment 3 fields with `null`. v1.1 closures are passed through.
 
 v1.2 closures add `config_artefact_path` + `deployment_spec_section_present` to the `best_architecture` block plus a new `§4 deployment_spec` section in the closure doc. Retrofitted v1.2 closures may retain v1.0-style field names (`worst_fold_roi_pct`); the parser renames them pre-validation via `_coerce_legacy_field_names` — purely additive on §1, no manual rewrite required.
 
-Either way, the mapping logic operates on a unified v1.1+-shaped dict — historical closures are never rewritten.
+v1.3 closures (L_PROTOCOL Amendment 4) add a top-level `step_6` block to `tracker_payload`. The block records Step 6 framework outcome (ran/trigger/overall_passed/categories/critical_failures/warnings_count/verdict_impact). REQUIRED for any v1.3 PASS verdict; OPTIONAL for FAIL/HALT closures (records `ran: false`).
+
+The mapping logic operates on a unified v1.1+-shaped dict — historical closures are never rewritten. v1.3 adds Section 4-M (Step 6 audit registry) which is silently no-op'd against trackers that lack the section.
 
 ## v1.2 PASS-verdict validation
 
-When `template_version == 1.2` AND `verdict` starts with `PASS-`, the parser enforces (after schema validation, BEFORE any tracker mutation):
+When `template_version` ∈ `{1.2, 1.3}` AND `verdict` starts with `PASS-`, the parser enforces (after schema validation, BEFORE any tracker mutation):
 
 1. `best_architecture.config_artefact_path` MUST be non-null.
 2. The file at that path (resolved relative to repo root) MUST exist.
@@ -73,9 +76,25 @@ When `template_version == 1.2` AND `verdict` starts with `PASS-`, the parser enf
 
 Any failure → HALT exit code 1, no tracker write, no rolling-state update. Fix the closure (re-create the missing config YAML, add the §4 section, set the flag) and re-run.
 
-For non-PASS verdicts in v1.2 (FAIL / HALT / DISCOVERY_COMPLETE), the validation block is skipped — §4 is optional and `config_artefact_path` may be `null`.
+For non-PASS verdicts (FAIL / HALT / DISCOVERY_COMPLETE), the validation block is skipped — §4 is optional and `config_artefact_path` may be `null`.
 
-For v1.0 and v1.1 closures, the validation block is not evaluated.
+For v1.0 and v1.1 closures, the v1.2 validation block is not evaluated.
+
+## Phase 2 tightening (v1.3 / Amendment 4)
+
+Cutoff: `2026-05-23T06:20:59Z` (PR-186 merge per chat resolution Q7).
+
+For any PASS verdict whose `closed_timestamp > 2026-05-23T06:20:59Z`, the parser REQUIRES Amendment 3 fields in `best_architecture` (`chained_max_dd_base_pct`, `k_safe`, `k_hard`, `r_safe_pct`, `r_hard_pct`, `scalable_to_safe`, `scalable_to_hard`). Missing any field → HALT.
+
+For `template_version: v1.3` PASS verdicts, the parser ADDITIONALLY requires:
+
+1. `step_6` block present.
+2. `step_6.ran == true`.
+3. `step_6.overall_passed == true`.
+
+PASS verdicts cannot ship without a clean Step 6 dispatch. Manual invocations cannot satisfy this requirement (they always carry `trigger: manual` and `verdict_impact: none`); only auto-dispatched runs produce `overall_passed: true` with engine confidence.
+
+Pre-cutoff closures (v1.0 / v1.1 / v1.2 / v1.2.1 closed before the cutoff) are grandfathered — none of the Phase 2 checks fire.
 
 ## Idempotency
 

--- a/scripts/tracker_parser/mapping.py
+++ b/scripts/tracker_parser/mapping.py
@@ -417,6 +417,46 @@ def apply_cross_arc_tags(
             )
 
 
+def apply_step_6_audit_registry(state: TrackerState, payload: dict[str, Any]) -> None:
+    """Section 4-M (v1.3 / Amendment 4) — append one row per auto-dispatched Step 6 run.
+
+    Append-only. Manual CLI invocations DO NOT add rows (per chat Q6).
+    Skips silently when ``payload`` carries no ``step_6`` block (pre-v1.3 closures).
+    Skips when ``step_6.ran == false`` (Step 6 didn't dispatch — typical for FAIL closures).
+    Skips when ``step_6.trigger == "manual"``.
+    """
+    if "step_6_audit_registry" not in state.tables:
+        # Older trackers without the section — silently no-op.
+        return
+    step6 = payload.get("step_6")
+    if not isinstance(step6, dict):
+        return
+    if not step6.get("ran"):
+        return
+    if step6.get("trigger") == "manual":
+        return
+
+    arc_name = payload["arc_name"]
+    verdict = payload["verdict"]
+    overall = step6.get("overall_passed")
+    cats = step6.get("categories") or {}
+    n_crit = sum(
+        1 for v in cats.values() if v is False  # explicit False; null/None means not run
+    )
+    n_warn = int(step6.get("warnings_count") or 0)
+    manifest_path = step6.get("manifest_path") or EMDASH
+    cells = [
+        arc_name,
+        verdict,
+        "true" if step6.get("ran") else "false",
+        "true" if overall else ("false" if overall is False else EMDASH),
+        str(n_crit),
+        str(n_warn),
+        str(manifest_path),
+    ]
+    state.append_row("step_6_audit_registry", cells)
+
+
 def apply_last_auto_update(state: TrackerState, payload: dict[str, Any]) -> None:
     """Section 4J — format `closed_timestamp` as YYYY-MM-DD HH:MM:SS in the Last auto-update line.
 
@@ -469,4 +509,5 @@ def apply_payload(
     apply_cluster_registry(state, payload)
     apply_cost_decomp(state, payload)
     apply_cross_arc_tags(state, payload, rolling)
+    apply_step_6_audit_registry(state, payload)
     apply_last_auto_update(state, payload)

--- a/scripts/tracker_parser/schema.py
+++ b/scripts/tracker_parser/schema.py
@@ -1,4 +1,4 @@
-"""Pydantic models for ARC_CLOSURE.md §1 tracker_payload — v1.0, v1.1, and v1.2 schemas + normalisation.
+"""Pydantic models for ARC_CLOSURE.md §1 tracker_payload — v1.0, v1.1, v1.2, and v1.3 schemas + normalisation.
 
 Schema versions:
 - v1.0 — pre-Amendment 3 (legacy field names `worst_fold_roi_pct`, `worst_fold_dd_pct`)
@@ -6,16 +6,22 @@ Schema versions:
 - v1.2 — deployment-spec addition (adds `config_artefact_path`, `deployment_spec_section_present` to
   `best_architecture`). PASS-verdict closures must point to a canonical config YAML; the parser CLI
   enforces the file's existence + §4 heading presence before applying tracker mappings.
+- v1.3 — L_PROTOCOL Amendment 4 (Step 6 causal-audit framework). Adds top-level `step_6` block
+  to `tracker_payload`. REQUIRED for any v1.3 PASS verdict. Phase 2 tightening: any PASS verdict
+  with ``closed_timestamp > 2026-05-23T06:20:59Z`` (PR-186 merge) MUST carry Amendment 3 fields
+  in `best_architecture`; v1.3 PASS verdicts MUST additionally have a `step_6` block with
+  `overall_passed: true`. Pre-cutoff closures grandfathered.
 
 Detection precedence (see `detect_schema_version`):
 1. `template_version` field present → use that
-2. Any v1.2-exclusive field present → v1.2
-3. Any v1.1-exclusive field present → v1.1
-4. Else → v1.0
+2. Any v1.3-exclusive field present (top-level `step_6`) → v1.3
+3. Any v1.2-exclusive field present → v1.2
+4. Any v1.1-exclusive field present → v1.1
+5. Else → v1.0
 
-`normalize_to_v12()` returns a v1.2-shaped dict that mapping logic consumes uniformly. The mapping
-layer only reads v1.0/v1.1-era fields, so v1.2-exclusive fields are not consumed downstream — they
-are validated at the CLI layer before tracker mutations begin.
+`normalize_to_v13()` returns a v1.3-shaped dict that mapping logic consumes uniformly. The mapping
+layer reads v1.0/v1.1-era fields + the new `step_6` block; v1.2-exclusive fields are validated at
+the CLI layer before tracker mutations begin.
 """
 
 from __future__ import annotations
@@ -24,7 +30,11 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-SchemaVersion = Literal["1.0", "1.1", "1.2"]
+SchemaVersion = Literal["1.0", "1.1", "1.2", "1.3"]
+
+# PR-186 merge cutoff for Phase 2 tightening (per chat Q7).
+# After this timestamp, PASS verdicts must carry Amendment 3 fields.
+PHASE_2_CUTOFF_ISO: str = "2026-05-23T06:20:59Z"
 
 V11_EXCLUSIVE_FIELDS = {
     "worst_fold_dd_base_pct",
@@ -41,6 +51,11 @@ V11_EXCLUSIVE_FIELDS = {
 V12_EXCLUSIVE_FIELDS = {
     "config_artefact_path",
     "deployment_spec_section_present",
+}
+
+# v1.3-exclusive payload-level fields (NOT inside best_architecture).
+V13_EXCLUSIVE_TOP_LEVEL_FIELDS = {
+    "step_6",
 }
 
 VALID_FAILURE_MODES = {
@@ -82,13 +97,15 @@ VALID_ARCHITECTURES = {"A1", "A2", "A3", "A4", "A5", "A6"}
 
 
 def detect_schema_version(payload: dict[str, Any]) -> SchemaVersion:
-    """Return '1.0', '1.1', or '1.2' based on the rules in the module docstring.
+    """Return '1.0', '1.1', '1.2', or '1.3' based on the rules in the module docstring.
 
-    Accepts `template_version` values: 'v1.0', 'v1.1', 'v1.2', '1.0', '1.1', '1.2'.
+    Accepts `template_version` values: 'v1.0', 'v1.1', 'v1.2', 'v1.3', '1.0', '1.1', '1.2', '1.3'.
     """
     raw = payload.get("template_version")
     if raw is not None:
         s = str(raw).lstrip("v").lstrip("V").strip()
+        if s == "1.3":
+            return "1.3"
         if s == "1.2":
             return "1.2"
         if s == "1.1":
@@ -96,8 +113,13 @@ def detect_schema_version(payload: dict[str, Any]) -> SchemaVersion:
         if s == "1.0":
             return "1.0"
         raise ValueError(
-            f"Unknown template_version {raw!r} — expected one of v1.0, v1.1, v1.2, 1.0, 1.1, 1.2"
+            f"Unknown template_version {raw!r} — expected one of "
+            f"v1.0, v1.1, v1.2, v1.3, 1.0, 1.1, 1.2, 1.3"
         )
+
+    # v1.3 detected via top-level step_6 block presence.
+    if any(k in payload for k in V13_EXCLUSIVE_TOP_LEVEL_FIELDS):
+        return "1.3"
 
     best_arch = payload.get("best_architecture") or {}
     if not isinstance(best_arch, dict):
@@ -343,6 +365,67 @@ class TrackerPayloadV12(_TrackerPayloadBase):
         return d
 
 
+# ── v1.3 — Step 6 causal-audit framework (Amendment 4) ──
+
+
+class Step6Categories(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    lookahead: bool | None = None
+    selection_bias: bool | None = None
+    execution_realism: bool | None = None
+    statistical: bool | None = None
+    determinism: bool | None = None
+    deployment_readiness: bool | None = None
+
+
+class Step6Block(BaseModel):
+    """v1.3 ``§1 tracker_payload.step_6`` block per ARC_CLOSURE_TEMPLATE v1.3.
+
+    Field semantics:
+    - ``ran``: true when Step 6 dispatched (auto OR manual). False = "not run for this closure".
+    - ``trigger``: ``auto_pass`` (orchestrator dispatched), ``manual`` (CLI invoked),
+      ``not_applicable`` (didn't run).
+    - ``overall_passed``: null when ``ran=false``.
+    - ``manifest_path``: relative path to `step_6/manifest.json`. Null when ``ran=false``.
+    - ``verdict_impact``: ``none`` for PASS audits + manual invocations + ``--no-block``;
+      ``downgraded_to_fail`` when auto-dispatch detected a critical failure.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    ran: bool
+    trigger: str  # auto_pass | manual | not_applicable
+    overall_passed: bool | None = None
+    manifest_path: str | None = None
+    categories: Step6Categories = Field(default_factory=Step6Categories)
+    critical_failures: list[str] = Field(default_factory=list)
+    warnings_count: int = 0
+    verdict_impact: str = "none"
+
+
+VALID_STEP6_TRIGGERS = {"auto_pass", "manual", "not_applicable"}
+VALID_STEP6_VERDICT_IMPACTS = {"none", "downgraded_to_fail"}
+
+
+class BestArchitectureV13(BestArchitectureV12):
+    """v1.3 best_architecture block — identical to v1.2 (Amendment 4 added no
+    best_architecture-level fields; the new ``step_6`` block is top-level).
+    """
+
+
+class TrackerPayloadV13(_TrackerPayloadBase):
+    """v1.3 payload — Amendment 4 Step 6 framework."""
+
+    best_architecture: BestArchitectureV13 | None = None
+    step_6: Step6Block | None = None
+
+    def normalize_to_v13(self) -> dict[str, Any]:
+        d = self.model_dump()
+        d["template_version"] = "1.3"
+        return d
+
+
 def _coerce_legacy_field_names(payload: dict[str, Any]) -> dict[str, Any]:
     """Rename v1.0 best_architecture fields to v1.1 names if present.
 
@@ -370,15 +453,20 @@ def parse_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
     Returns a v1.1-shaped dict for v1.0/v1.1 closures (legacy compatibility — mapping logic
     consumes a unified v1.1 shape). For v1.2 closures, returns a v1.2-shaped dict (a superset
-    of v1.1; mapping logic ignores the two extra fields).
+    of v1.1; mapping logic ignores the two extra fields). For v1.3 closures, returns a
+    v1.3-shaped dict (superset of v1.2 + ``step_6`` block).
 
-    For v1.2 closures that retain v1.0-style field names in `best_architecture` (the retrofit
-    pattern — see `_coerce_legacy_field_names`), legacy names are renamed pre-validation.
+    For v1.2/v1.3 closures that retain v1.0-style field names in `best_architecture` (the
+    retrofit pattern — see `_coerce_legacy_field_names`), legacy names are renamed pre-validation.
 
     Raises pydantic.ValidationError on schema violations and ValueError on unknown enum values.
     """
     version = detect_schema_version(payload)
-    if version == "1.2":
+    if version == "1.3":
+        payload = _coerce_legacy_field_names(payload)
+        validated = TrackerPayloadV13.model_validate(payload)
+        norm = validated.normalize_to_v13()
+    elif version == "1.2":
         payload = _coerce_legacy_field_names(payload)
         validated = TrackerPayloadV12.model_validate(payload)
         norm = validated.normalize_to_v12()
@@ -405,6 +493,20 @@ def parse_payload(payload: dict[str, Any]) -> dict[str, Any]:
         if arch not in VALID_ARCHITECTURES:
             raise ValueError(
                 f"architecture {arch!r} not in {{A1…A6}}"
+            )
+
+    # v1.3 step_6 block enum validation
+    step6 = norm.get("step_6")
+    if isinstance(step6, dict):
+        trigger = step6.get("trigger")
+        if trigger is not None and trigger not in VALID_STEP6_TRIGGERS:
+            raise ValueError(
+                f"step_6.trigger {trigger!r} not in {sorted(VALID_STEP6_TRIGGERS)}"
+            )
+        impact = step6.get("verdict_impact")
+        if impact is not None and impact not in VALID_STEP6_VERDICT_IMPACTS:
+            raise ValueError(
+                f"step_6.verdict_impact {impact!r} not in {sorted(VALID_STEP6_VERDICT_IMPACTS)}"
             )
 
     return norm

--- a/scripts/tracker_parser/tracker_io.py
+++ b/scripts/tracker_parser/tracker_io.py
@@ -27,6 +27,7 @@ SECTION_HEADINGS: dict[str, str] = {
     "## Cross-arc cluster registry": "cross_arc_cluster_registry",
     "## Cost-decomposition registry": "cost_decomposition_registry",
     "## Cross-arc tag registry": "cross_arc_tag_registry",
+    "## Step 6 audit registry": "step_6_audit_registry",
 }
 
 

--- a/scripts/update_tracker_from_closure.py
+++ b/scripts/update_tracker_from_closure.py
@@ -70,6 +70,97 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _is_post_phase_2_cutoff(closed_ts: str | None) -> bool:
+    """Return True iff ``closed_ts`` is strictly after the PR-186 merge cutoff
+    (2026-05-23T06:20:59Z per chat Q7) and therefore subject to Phase 2 tightening.
+
+    Closures missing or with malformed timestamps are treated as PRE-cutoff
+    (grandfathered) — Phase 2 tightening kicks in only when we can confidently
+    determine the closure post-dates the merge.
+    """
+    if not closed_ts:
+        return False
+    from datetime import datetime, timezone
+    s = str(closed_ts).strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return False
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    dt_utc = dt.astimezone(timezone.utc)
+    cutoff_s = schema.PHASE_2_CUTOFF_ISO[:-1] + "+00:00"
+    cutoff_dt = datetime.fromisoformat(cutoff_s).astimezone(timezone.utc)
+    return dt_utc > cutoff_dt
+
+
+def _validate_phase_2_amendment_3_fields(payload: dict, closure_path: Path) -> int:
+    """Phase 2 tightening: for PASS verdicts with closed_timestamp > PR-186 merge,
+    REQUIRE the Amendment 3 risk-normalised fields on `best_architecture`
+    (chat Q7 / template v1.3 Schema versioning row).
+
+    Pre-cutoff closures grandfathered (return 0).
+    """
+    ba = payload.get("best_architecture") or {}
+    required = (
+        "chained_max_dd_base_pct",
+        "k_safe",
+        "k_hard",
+        "r_safe_pct",
+        "r_hard_pct",
+        "scalable_to_safe",
+        "scalable_to_hard",
+    )
+    missing = [k for k in required if ba.get(k) is None]
+    if missing:
+        logging.error(
+            "Phase 2 tightening: PASS verdict at closed_timestamp=%r is post-PR-186-merge "
+            "(%s) but best_architecture is missing Amendment 3 fields: %s. Closure %s.",
+            payload.get("closed_timestamp"),
+            schema.PHASE_2_CUTOFF_ISO,
+            missing,
+            closure_path,
+        )
+        return 1
+    return 0
+
+
+def _validate_v13_pass_step6(payload: dict, closure_path: Path) -> int:
+    """Phase 2 tightening: v1.3 PASS verdicts MUST carry a step_6 block with
+    overall_passed=true (chat Q7 / template v1.3 Schema versioning row).
+
+    Manual invocations cannot satisfy this — only auto-dispatch can produce
+    overall_passed=true with verdict_impact=none.
+    """
+    step6 = payload.get("step_6")
+    if not isinstance(step6, dict):
+        logging.error(
+            "v1.3 PASS-verdict validation: §1 tracker_payload.step_6 block missing. "
+            "Closure %s has verdict %r — step_6 block REQUIRED for v1.3 PASS verdicts.",
+            closure_path,
+            payload.get("verdict"),
+        )
+        return 1
+    if not step6.get("ran"):
+        logging.error(
+            "v1.3 PASS-verdict validation: step_6.ran is false but verdict is %r. "
+            "PASS verdicts cannot ship without Step 6 dispatch.",
+            payload.get("verdict"),
+        )
+        return 1
+    if step6.get("overall_passed") is not True:
+        logging.error(
+            "v1.3 PASS-verdict validation: step_6.overall_passed is %r — must be true "
+            "for PASS verdicts. (verdict_impact=%r)",
+            step6.get("overall_passed"),
+            step6.get("verdict_impact"),
+        )
+        return 1
+    return 0
+
+
 def _validate_v12_pass_verdict(payload: dict, closure_path: Path) -> int:
     """v1.2 PASS-verdict validation per template Section 4-L.
 
@@ -170,12 +261,26 @@ def main(argv: list[str] | None = None) -> int:
         logging.error("schema validation failed: %s", exc)
         return 1
 
-    # v1.2 PASS-verdict validation (template Section 4-L). Runs BEFORE tracker mutation so a
-    # missing config artefact or missing §4 section blocks the write atomically.
-    if payload.get("template_version") == "1.2" and str(payload.get("verdict", "")).startswith(
-        "PASS-"
-    ):
+    template_version = payload.get("template_version")
+    verdict_str = str(payload.get("verdict", ""))
+    is_pass = verdict_str.startswith("PASS-")
+
+    # v1.2+ PASS-verdict validation (template Section 4-L) — config_artefact_path + §4 heading.
+    if template_version in ("1.2", "1.3") and is_pass:
         rc = _validate_v12_pass_verdict(payload, closure_path)
+        if rc != 0:
+            return rc
+
+    # Phase 2 tightening (template v1.3 Schema versioning row, chat Q7):
+    # PASS verdict closed after PR-186 merge MUST have Amendment 3 fields.
+    if is_pass and _is_post_phase_2_cutoff(payload.get("closed_timestamp")):
+        rc = _validate_phase_2_amendment_3_fields(payload, closure_path)
+        if rc != 0:
+            return rc
+
+    # v1.3 PASS verdicts MUST have a step_6 block with overall_passed=true.
+    if template_version == "1.3" and is_pass:
+        rc = _validate_v13_pass_step6(payload, closure_path)
         if rc != 0:
             return rc
 

--- a/tests/step_6/__init__.py
+++ b/tests/step_6/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Step 6 causal-audit framework (Amendment 4)."""

--- a/tests/step_6/_fixtures.py
+++ b/tests/step_6/_fixtures.py
@@ -1,0 +1,99 @@
+"""Synthetic fixtures for Step 6 tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from core.step_6.inputs import Step6Inputs
+
+
+def build_clean_inputs(
+    arc_root: Path,
+    *,
+    arc_name: str = "synth_arc",
+    n_trades: int = 100,
+    features: tuple[str, ...] = ("atr_pct", "d1_slope_sign", "kijun_dist"),
+    configs_evaluated: int = 80,
+    pair_set: tuple[str, ...] = ("EURUSD", "GBPUSD", "USDJPY"),
+) -> Step6Inputs:
+    """Build a Step6Inputs bundle with a clean synthetic pool + lineage."""
+    arc_root.mkdir(parents=True, exist_ok=True)
+
+    # Synthetic trades: timestamped, multi-pair, with R outcomes
+    import numpy as np
+    rng = np.random.default_rng(42)
+    dates = pd.date_range("2018-01-01", periods=n_trades, freq="D", tz="UTC")
+    trades = pd.DataFrame({
+        "trade_id": range(1, n_trades + 1),
+        "pair": [pair_set[i % len(pair_set)] for i in range(n_trades)],
+        "signal_time": dates,
+        "entry_time": dates + pd.Timedelta(hours=4),
+        "final_r": rng.normal(0.5, 1.5, n_trades),
+        "spread_pips": rng.uniform(1.0, 2.5, n_trades),
+        "sl_distance_atr": rng.uniform(1.5, 2.5, n_trades),
+    })
+
+    # Synthetic feature matrix
+    fm = pd.DataFrame({
+        "trade_id": trades["trade_id"],
+        **{f: rng.normal(0, 1, n_trades) for f in features},
+    })
+
+    # Synthetic lineage — all clean
+    lineage = pd.DataFrame({
+        "name": list(features),
+        "feature_class": ["test"] * len(features),
+        "causal_lineage": ["clean"] * len(features),
+        "needs_panel": [False] * len(features),
+        "description": [""] * len(features),
+    })
+
+    return Step6Inputs(
+        arc_name=arc_name,
+        arc_root=arc_root,
+        best_candidate_config_id="A1::cfg_synth",
+        best_candidate_architecture="A1",
+        best_candidate_features=features,
+        pool_trades=trades,
+        feature_matrix=fm,
+        feature_lineage=lineage,
+        primary_tf="H4",
+        pair_set=pair_set,
+        r_safe_pct=0.005,
+        sizing_convention="reset_floor",
+        configs_evaluated_step5=configs_evaluated,
+    )
+
+
+def build_leaky_inputs(arc_root: Path) -> Step6Inputs:
+    """Inputs with a forward-path feature in entry decisions → §6.1 critical fail."""
+    inp = build_clean_inputs(arc_root)
+    # Replace one feature with a path-shape leak
+    leaky_features = tuple(
+        f if f != "atr_pct" else "mfe_p50_r" for f in inp.best_candidate_features
+    )
+    # Update lineage table to include the new name
+    new_lineage = inp.feature_lineage.copy()
+    new_lineage.loc[new_lineage["name"] == "atr_pct", "name"] = "mfe_p50_r"
+    new_fm = inp.feature_matrix.rename(columns={"atr_pct": "mfe_p50_r"})
+
+    return Step6Inputs(
+        arc_name=inp.arc_name,
+        arc_root=inp.arc_root,
+        best_candidate_config_id=inp.best_candidate_config_id,
+        best_candidate_architecture=inp.best_candidate_architecture,
+        best_candidate_features=leaky_features,
+        pool_trades=inp.pool_trades,
+        feature_matrix=new_fm,
+        feature_lineage=new_lineage,
+        primary_tf=inp.primary_tf,
+        pair_set=inp.pair_set,
+        r_safe_pct=inp.r_safe_pct,
+        sizing_convention=inp.sizing_convention,
+        configs_evaluated_step5=inp.configs_evaluated_step5,
+    )
+
+
+__all__ = ("build_clean_inputs", "build_leaky_inputs")

--- a/tests/step_6/conftest.py
+++ b/tests/step_6/conftest.py
@@ -1,0 +1,35 @@
+"""Collection-time skip mirroring tests/protocol_runtime/conftest.py.
+
+The Step 6 framework imports sklearn (via the feature pipeline) and
+relies on pyarrow for parquet reads. CI's clean env skips both. Local
+dev / workstation runs gate separately.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _missing(modname: str) -> bool:
+    try:
+        __import__(modname)
+        return False
+    except ImportError:
+        return True
+
+
+_required_modules = ("sklearn", "pyarrow")
+_missing_modules = [m for m in _required_modules if _missing(m)]
+
+if _missing_modules:
+    collect_ignore_glob = ["test_*.py"]
+
+    pytestmark = pytest.mark.skip(
+        reason=(
+            "step_6 suite needs "
+            + ", ".join(_required_modules)
+            + " (missing: "
+            + ", ".join(_missing_modules)
+            + "); CI clean env intentionally excludes these."
+        )
+    )

--- a/tests/step_6/test_cli.py
+++ b/tests/step_6/test_cli.py
@@ -1,0 +1,51 @@
+"""Manual CLI scripts/run_step_6.py invocation tests."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "scripts/run_step_6.py", *args],
+        cwd=str(cwd), capture_output=True, text=True,
+    )
+
+
+def test_cli_help_runs(tmp_path: Path):
+    repo_root = Path(__file__).resolve().parents[2]
+    result = _run(["--help"], cwd=repo_root)
+    assert result.returncode == 0
+    assert "Step 6" in result.stdout
+
+
+def test_cli_dry_run_on_closure_dir(tmp_path: Path):
+    repo_root = Path(__file__).resolve().parents[2]
+    # Create a synthetic closure dir
+    arc_dir = tmp_path / "synth_arc"
+    arc_dir.mkdir()
+    (arc_dir / "ARC_CLOSURE.md").write_text(
+        "# stub\n\n## §1 tracker_payload\n\n```yaml\ntracker_payload:\n  arc_name: synth_arc\n  tf: H4\n```\n",
+        encoding="utf-8",
+    )
+    result = _run(["--dry-run", str(arc_dir / "ARC_CLOSURE.md")], cwd=repo_root)
+    assert result.returncode == 0
+    assert "DRY-RUN" in result.stderr or "DRY-RUN" in result.stdout
+
+
+def test_cli_rejects_unknown_category(tmp_path: Path):
+    repo_root = Path(__file__).resolve().parents[2]
+    arc_dir = tmp_path / "synth_arc"
+    arc_dir.mkdir()
+    (arc_dir / "ARC_CLOSURE.md").write_text(
+        "# stub\n\n## §1 tracker_payload\n\n```yaml\ntracker_payload:\n  arc_name: synth_arc\n```\n",
+        encoding="utf-8",
+    )
+    result = _run(
+        ["--category", "not_a_real_category", str(arc_dir / "ARC_CLOSURE.md")],
+        cwd=repo_root,
+    )
+    assert result.returncode == 2
+    assert "unknown" in (result.stderr + result.stdout).lower()

--- a/tests/step_6/test_lookahead.py
+++ b/tests/step_6/test_lookahead.py
@@ -1,0 +1,56 @@
+"""§6.1 lookahead audit tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.step_6.lookahead import audit
+from core.step_6.manifest import AuditConfig, Severity
+from tests.step_6._fixtures import build_clean_inputs, build_leaky_inputs
+
+
+def test_clean_inputs_pass_lineage_check(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit(inputs, AuditConfig())
+    lineage_check = next(c for c in result.checks if c.name == "per_feature_lineage_clean")
+    assert lineage_check.passed is True
+    assert lineage_check.severity == Severity.CRITICAL
+
+
+def test_leaky_feature_fails_no_path_features_check(tmp_path: Path):
+    inputs = build_leaky_inputs(tmp_path)
+    result = audit(inputs, AuditConfig())
+    leak_check = next(c for c in result.checks if c.name == "no_path_features_in_entry")
+    assert leak_check.passed is False
+    assert "mfe_p50_r" in leak_check.evidence["leaking_features"]
+
+
+def test_d1_lag_rule_helper_present_in_multi_tf():
+    # The check is static — inspects core.features.multi_tf source. Should always pass.
+    inputs = build_clean_inputs(Path("/tmp/_unused"))  # arc_root not used by this check
+    result = audit(inputs, AuditConfig())
+    d1_check = next(c for c in result.checks if c.name == "d1_lag_rule_enforced")
+    assert d1_check.passed is True
+
+
+def test_byte_compare_skipped_without_panels(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    # No panels provided → byte-compare records info-level skip
+    result = audit(inputs, AuditConfig())
+    bc_check = next(c for c in result.checks if c.name == "byte_compare_no_drift")
+    assert bc_check.severity == Severity.INFO  # demoted when can't run
+    assert "panels" in bc_check.message.lower() or "skip" in bc_check.message.lower()
+
+
+def test_lineage_table_info_check(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit(inputs, AuditConfig())
+    lt = next(c for c in result.checks if c.name == "feature_lineage_table_exists")
+    assert lt.passed is True
+    assert lt.severity == Severity.INFO
+
+
+def test_category_is_lookahead(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit(inputs, AuditConfig())
+    assert result.category == "lookahead"

--- a/tests/step_6/test_manifest.py
+++ b/tests/step_6/test_manifest.py
@@ -1,0 +1,121 @@
+"""Step 6 manifest/dataclass smoke tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.step_6.manifest import (
+    AUDIT_CATEGORY_NAMES,
+    AuditConfig,
+    CategoryAuditResult,
+    CheckResult,
+    Severity,
+    Step6Manifest,
+    Step6Result,
+    TriggerSource,
+    VerdictImpact,
+    write_step_6_manifest,
+)
+
+
+def _make_check(name: str, passed: bool, severity: Severity = Severity.CRITICAL) -> CheckResult:
+    return CheckResult(name=name, passed=passed, severity=severity, message=name)
+
+
+def test_category_passes_only_with_all_critical_clean():
+    checks = (
+        _make_check("c1", True),
+        _make_check("c2", True),
+        _make_check("c3", False, Severity.WARNING),  # warning does NOT block
+        _make_check("c4", False, Severity.INFO),     # info does NOT block
+    )
+    cat = CategoryAuditResult(category="lookahead", checks=checks)
+    assert cat.passed is True
+    assert cat.n_critical == 2
+    assert cat.n_critical_fails == 0
+    assert cat.n_warnings == 1
+    assert cat.n_info == 1
+
+
+def test_category_fails_when_critical_fails():
+    checks = (
+        _make_check("c1", True),
+        _make_check("c2", False, Severity.CRITICAL),
+    )
+    cat = CategoryAuditResult(category="lookahead", checks=checks)
+    assert cat.passed is False
+    assert cat.critical_failures() == ("c2",)
+
+
+def test_step_6_result_overall_passed_aggregates_categories():
+    cat_a = CategoryAuditResult(category="lookahead", checks=(_make_check("c1", True),))
+    cat_b = CategoryAuditResult(category="determinism", checks=(_make_check("c2", False),))
+    result = Step6Result(
+        arc_name="t", trigger=TriggerSource.AUTO_PASS,
+        categories=(cat_a, cat_b), audit_config=AuditConfig(),
+    )
+    assert result.overall_passed is False
+    assert result.critical_failures() == ("determinism.c2",)
+
+
+def test_manual_invocation_never_downgrades():
+    cat = CategoryAuditResult(
+        category="lookahead", checks=(_make_check("c1", False),),
+    )
+    result = Step6Result(
+        arc_name="t", trigger=TriggerSource.MANUAL,
+        categories=(cat,), audit_config=AuditConfig(),
+    )
+    assert result.overall_passed is False
+    assert result.verdict_impact == VerdictImpact.NONE  # manual NEVER downgrades
+
+
+def test_no_block_suppresses_verdict_downgrade():
+    cat = CategoryAuditResult(
+        category="lookahead", checks=(_make_check("c1", False),),
+    )
+    result = Step6Result(
+        arc_name="t", trigger=TriggerSource.AUTO_PASS,
+        categories=(cat,), audit_config=AuditConfig(no_block=True),
+    )
+    assert result.verdict_impact == VerdictImpact.NONE
+
+
+def test_auto_dispatch_downgrades_on_critical_fail():
+    cat = CategoryAuditResult(
+        category="lookahead", checks=(_make_check("c1", False),),
+    )
+    result = Step6Result(
+        arc_name="t", trigger=TriggerSource.AUTO_PASS,
+        categories=(cat,), audit_config=AuditConfig(),
+    )
+    assert result.verdict_impact == VerdictImpact.DOWNGRADED_TO_FAIL
+
+
+def test_manifest_serde_roundtrip(tmp_path: Path):
+    cat = CategoryAuditResult(
+        category="lookahead", checks=(_make_check("c1", True),),
+    )
+    result = Step6Result(
+        arc_name="t", trigger=TriggerSource.AUTO_PASS,
+        categories=(cat,), audit_config=AuditConfig(),
+    )
+    manifest = Step6Manifest.from_result(
+        result, report_paths={"lookahead": "lookahead_report.md"},
+        summary_path="summary.md", ran_at="2026-05-24T12:00:00Z",
+    )
+    out = tmp_path / "manifest.json"
+    write_step_6_manifest(manifest, out)
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["arc_name"] == "t"
+    assert data["trigger"] == "auto_pass"
+    assert data["overall_passed"] is True
+    assert "lookahead" in data["categories"]
+
+
+def test_audit_category_names_locked():
+    assert AUDIT_CATEGORY_NAMES == (
+        "lookahead", "selection_bias", "execution_realism",
+        "statistical", "determinism", "deployment_readiness",
+    )

--- a/tests/step_6/test_orchestrator.py
+++ b/tests/step_6/test_orchestrator.py
@@ -1,0 +1,115 @@
+"""End-to-end Step 6 orchestrator tests covering dispatch's Task 10 cases."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.step_6 import AUDIT_CATEGORY_NAMES, AuditConfig, run_step_6
+from core.step_6.artefacts import write_step_6_artefacts
+from core.step_6.manifest import (
+    TriggerSource,
+    VerdictImpact,
+)
+from tests.step_6._fixtures import build_clean_inputs, build_leaky_inputs
+
+
+def test_case_1_clean_inputs_auto_dispatch_high_pass_rate(tmp_path: Path):
+    """Synthetic clean arc, auto-dispatch — lookahead passes on clean lineage."""
+    inputs = build_clean_inputs(tmp_path)
+    result = run_step_6(inputs, trigger=TriggerSource.AUTO_PASS)
+    by_name = {c.category: c for c in result.categories}
+    # Lookahead is the load-bearing category for cleanliness — should pass on clean lineage.
+    assert by_name["lookahead"].passed
+    # All six categories ran.
+    assert len(result.categories) == 6
+
+
+def test_case_2_leaky_feature_downgrades_verdict(tmp_path: Path):
+    """Leaky path-feature in entry decision → Step 6 FAIL → verdict_impact downgrade."""
+    inputs = build_leaky_inputs(tmp_path)
+    result = run_step_6(inputs, trigger=TriggerSource.AUTO_PASS)
+    assert result.overall_passed is False
+    assert result.verdict_impact == VerdictImpact.DOWNGRADED_TO_FAIL
+    crit = result.critical_failures()
+    assert any("no_path_features_in_entry" in n for n in crit)
+
+
+def test_case_3_manual_invocation_never_downgrades(tmp_path: Path):
+    """Manual CLI on a leaky arc — verdict_impact stays NONE (chat Q6)."""
+    inputs = build_leaky_inputs(tmp_path)
+    result = run_step_6(inputs, trigger=TriggerSource.MANUAL)
+    assert result.overall_passed is False  # leak still surfaces
+    assert result.verdict_impact == VerdictImpact.NONE  # but no verdict impact
+
+
+def test_case_4_no_block_flag_suppresses_downgrade(tmp_path: Path):
+    inputs = build_leaky_inputs(tmp_path)
+    result = run_step_6(
+        inputs, trigger=TriggerSource.AUTO_PASS,
+        audit_config=AuditConfig(no_block=True),
+    )
+    assert result.verdict_impact == VerdictImpact.NONE
+
+
+def test_case_5_two_run_determinism(tmp_path: Path):
+    """Same inputs run twice → identical category pass/fail + critical_failures."""
+    inputs1 = build_clean_inputs(tmp_path / "run1")
+    inputs2 = build_clean_inputs(tmp_path / "run2")
+    r1 = run_step_6(inputs1, trigger=TriggerSource.MANUAL)
+    r2 = run_step_6(inputs2, trigger=TriggerSource.MANUAL)
+    # Compare per-category pass states + critical_failures
+    cats1 = {c.category: (c.passed, c.critical_failures()) for c in r1.categories}
+    cats2 = {c.category: (c.passed, c.critical_failures()) for c in r2.categories}
+    assert cats1 == cats2
+
+
+def test_case_6_unknown_category_raises(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    with pytest.raises(ValueError, match="Unknown audit categories"):
+        run_step_6(
+            inputs, audit_config=AuditConfig(categories_to_run=("not_a_category",)),
+        )
+
+
+def test_categories_to_run_restricts_dispatch(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = run_step_6(
+        inputs, audit_config=AuditConfig(categories_to_run=("lookahead",)),
+    )
+    assert len(result.categories) == 1
+    assert result.categories[0].category == "lookahead"
+
+
+def test_all_six_categories_dispatch_by_default(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = run_step_6(inputs)
+    assert tuple(c.category for c in result.categories) == AUDIT_CATEGORY_NAMES
+
+
+def test_artefacts_written_to_disk(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = run_step_6(inputs)
+    out_dir = tmp_path / "step_6"
+    manifest = write_step_6_artefacts(result, out_dir)
+    # Manifest + six category reports + summary + sha256
+    assert (out_dir / "manifest.json").exists()
+    assert (out_dir / "summary.md").exists()
+    assert (out_dir / "sha256_manifest.json").exists()
+    for cat in AUDIT_CATEGORY_NAMES:
+        assert (out_dir / f"{cat}_report.md").exists()
+    data = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert data["arc_name"] == manifest.arc_name
+
+
+def test_sha256_manifest_excludes_itself(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = run_step_6(inputs)
+    out_dir = tmp_path / "step_6"
+    write_step_6_artefacts(result, out_dir)
+    sha_manifest = json.loads((out_dir / "sha256_manifest.json").read_text(encoding="utf-8"))
+    # sha256_manifest.json must not list itself
+    assert "sha256_manifest.json" not in sha_manifest["files"]
+    assert "manifest.json" in sha_manifest["files"]

--- a/tests/step_6/test_parser_v13.py
+++ b/tests/step_6/test_parser_v13.py
@@ -1,0 +1,119 @@
+"""Parser v1.3 schema detection + Step 6 block validation + Phase 2 tightening."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.tracker_parser.schema import (
+    PHASE_2_CUTOFF_ISO,
+    Step6Block,
+    detect_schema_version,
+    parse_payload,
+)
+
+
+def test_phase_2_cutoff_locked():
+    assert PHASE_2_CUTOFF_ISO == "2026-05-23T06:20:59Z"
+
+
+def test_detect_v13_via_template_version():
+    assert detect_schema_version({"template_version": "v1.3"}) == "1.3"
+    assert detect_schema_version({"template_version": "1.3"}) == "1.3"
+
+
+def test_detect_v13_via_top_level_step_6():
+    assert detect_schema_version({"step_6": {"ran": True, "trigger": "auto_pass"}}) == "1.3"
+
+
+def test_detect_v12_unaffected_by_v13_detection():
+    assert detect_schema_version({"template_version": "v1.2"}) == "1.2"
+    assert (
+        detect_schema_version({"best_architecture": {"config_artefact_path": "x"}})
+        == "1.2"
+    )
+
+
+def test_step_6_block_required_fields():
+    b = Step6Block(ran=True, trigger="auto_pass", overall_passed=True)
+    assert b.ran is True
+    assert b.trigger == "auto_pass"
+    assert b.overall_passed is True
+    assert b.warnings_count == 0
+
+
+def test_invalid_trigger_raises():
+    payload = {
+        "template_version": "v1.3",
+        "arc_name": "x", "signal": "s", "tf": "H4", "sub_protocol": "vanilla",
+        "closed_timestamp": "2026-05-24T00:00:00Z",
+        "closure_doc_link": "p",
+        "verdict": "FAIL", "one_line": "x", "failed_at_step": "5",
+        "primary_failure_mode": "step6_causal_audit_fail",
+        "pool_metadata": {
+            "total_n": 0, "window_start": "2010", "window_end": "2020",
+            "configs_evaluated_step5": 0, "search_scope_flag": "thin",
+        },
+        "clusters": {}, "architectures_tested": [],
+        "architecture_results": {}, "archetypes_observed": [],
+        "step_6": {
+            "ran": True, "trigger": "INVALID_TRIGGER", "overall_passed": True,
+        },
+    }
+    with pytest.raises(ValueError, match="step_6.trigger"):
+        parse_payload(payload)
+
+
+def test_invalid_verdict_impact_raises():
+    payload = {
+        "template_version": "v1.3",
+        "arc_name": "x", "signal": "s", "tf": "H4", "sub_protocol": "vanilla",
+        "closed_timestamp": "2026-05-24T00:00:00Z",
+        "closure_doc_link": "p",
+        "verdict": "FAIL", "one_line": "x", "failed_at_step": "5",
+        "primary_failure_mode": "step6_causal_audit_fail",
+        "pool_metadata": {
+            "total_n": 0, "window_start": "2010", "window_end": "2020",
+            "configs_evaluated_step5": 0, "search_scope_flag": "thin",
+        },
+        "clusters": {}, "architectures_tested": [],
+        "architecture_results": {}, "archetypes_observed": [],
+        "step_6": {
+            "ran": True, "trigger": "auto_pass",
+            "verdict_impact": "INVALID_IMPACT",
+        },
+    }
+    with pytest.raises(ValueError, match="verdict_impact"):
+        parse_payload(payload)
+
+
+def test_v13_payload_round_trip_with_step_6():
+    payload = {
+        "template_version": "v1.3",
+        "arc_name": "test_arc", "signal": "x", "tf": "H4", "sub_protocol": "vanilla",
+        "closed_timestamp": "2026-05-24T12:00:00Z",
+        "closure_doc_link": "results/test_arc/ARC_CLOSURE.md",
+        "verdict": "PASS-DEPLOYABLE", "one_line": "x", "failed_at_step": "N/A",
+        "primary_failure_mode": "N/A",
+        "pool_metadata": {
+            "total_n": 500, "window_start": "2010", "window_end": "2020",
+            "configs_evaluated_step5": 80, "search_scope_flag": "normal",
+        },
+        "clusters": {}, "architectures_tested": ["A1"],
+        "architecture_results": {"A1": {"tested": True, "won": True, "worst_fold_ratio": 2.5}},
+        "archetypes_observed": [],
+        "step_6": {
+            "ran": True, "trigger": "auto_pass", "overall_passed": True,
+            "manifest_path": "results/test_arc/step_6/manifest.json",
+            "categories": {
+                "lookahead": True, "selection_bias": True,
+                "execution_realism": True, "statistical": True,
+                "determinism": True, "deployment_readiness": True,
+            },
+            "critical_failures": [], "warnings_count": 0,
+            "verdict_impact": "none",
+        },
+    }
+    norm = parse_payload(payload)
+    assert norm["template_version"] == "1.3"
+    assert norm["step_6"]["ran"] is True
+    assert norm["step_6"]["overall_passed"] is True

--- a/tests/step_6/test_per_category.py
+++ b/tests/step_6/test_per_category.py
@@ -1,0 +1,99 @@
+"""Per-category smoke tests for the five categories beyond lookahead."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.step_6 import AuditConfig
+from core.step_6.deployment_readiness import audit as audit_deployment
+from core.step_6.determinism import audit as audit_determinism
+from core.step_6.execution_realism import audit as audit_exec
+from core.step_6.selection_bias import audit as audit_selbias
+from core.step_6.statistical import audit as audit_stat
+from tests.step_6._fixtures import build_clean_inputs
+
+
+def test_selection_bias_records_configs_evaluated(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path, configs_evaluated=80)
+    result = audit_selbias(inputs, AuditConfig())
+    rec = next(c for c in result.checks if c.name == "configs_evaluated_recorded")
+    assert rec.passed is True
+    assert rec.evidence["configs_evaluated_step5"] == 80
+
+
+def test_execution_realism_finds_histdata_dir(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_exec(inputs, AuditConfig())
+    spread = next(c for c in result.checks if c.name == "real_spread_source_present")
+    # Spread source check looks for data/histdata under repo root —
+    # exists in dev worktree, may not in CI clean env. Either outcome
+    # is valid here; just verify the check ran and produced a verdict.
+    assert spread.passed in (True, False)
+
+
+def test_statistical_sample_size_check(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path, n_trades=150)
+    result = audit_stat(inputs, AuditConfig(lo_corrected_min_trades=100))
+    ss = next(c for c in result.checks if c.name == "sample_size_adequate")
+    assert ss.passed is True
+    assert ss.evidence["n_total_trades"] == 150
+
+
+def test_statistical_sample_size_fail_when_below(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path, n_trades=30)
+    result = audit_stat(inputs, AuditConfig(lo_corrected_min_trades=100))
+    ss = next(c for c in result.checks if c.name == "sample_size_adequate")
+    assert ss.passed is False
+
+
+def test_statistical_pair_survivorship(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path, pair_set=("EURUSD", "GBPUSD", "USDJPY"))
+    result = audit_stat(inputs, AuditConfig())
+    surv = next(c for c in result.checks if c.name == "pair_set_survivorship")
+    assert surv.passed is True
+
+
+def test_determinism_skips_when_no_step4_manifest(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_determinism(inputs, AuditConfig())
+    s4 = next(c for c in result.checks if c.name == "step_4_manifest_sha256_match")
+    # No Step 4 manifest in synth dir → info skip, passes
+    assert s4.passed is True
+
+
+def test_determinism_seed_pinning_check():
+    inputs = build_clean_inputs(Path("/tmp/_unused"))
+    result = audit_determinism(inputs, AuditConfig())
+    seed = next(c for c in result.checks if c.name == "seed_pinning_verified")
+    # Pin check is static — passes when builders contain random_state=
+    assert seed.evidence["n_random_state_references"] >= 0
+
+
+def test_deployment_readiness_flags_missing_closure(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_deployment(inputs, AuditConfig())
+    heading_check = next(c for c in result.checks if c.name == "deployment_spec_section_present")
+    # No ARC_CLOSURE.md in synth dir → critical fail
+    assert heading_check.passed is False
+
+
+def test_deployment_readiness_finds_closure_heading(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    # Write a minimal closure with the §4 heading
+    closure = tmp_path / "ARC_CLOSURE.md"
+    closure.write_text(
+        "# ARC_CLOSURE — synth\n\n## §1 tracker_payload\n\n```yaml\nfoo: bar\n```\n\n"
+        "## §4 deployment_spec\n\n### 4.1 Pair set\n\n### 4.2 Signal\n\n### 4.3 Features\n\n"
+        "### 4.4 Filters\n\n### 4.5 Entry\n\n### 4.6 Exit\n\n### 4.7 Exposure\n\n"
+        "### 4.8 Risk\n\n### 4.9 Session\n\n### 4.10 Discrepancies\n\n### 4.11 Checklist\n\n"
+        "- [x] item 1\n- [ ] item 2\n",
+        encoding="utf-8",
+    )
+    result = audit_deployment(inputs, AuditConfig())
+    heading_check = next(c for c in result.checks if c.name == "deployment_spec_section_present")
+    assert heading_check.passed is True
+    subs = next(c for c in result.checks if c.name == "deployment_spec_subsections_present")
+    assert subs.passed is True
+    checklist = next(c for c in result.checks if c.name == "deployment_checklist_marked")
+    assert checklist.evidence["checked"] == 1
+    assert checklist.evidence["unchecked"] == 1


### PR DESCRIPTION
## Summary

- **Six-category Step 6 framework** lands as runnable engine code under `core/step_6/` per L_PROTOCOL Amendment 4. Auto-dispatches post-gate on the Top-1 verdict-carrying candidate after `classify_amended_fold_stats` clears §3 constraints #1-9; critical failure downgrades the verdict via `causal_audit_clean=False` re-classification → `primary_failure_mode=step6_causal_audit_fail`.
- **Manual CLI** at `scripts/run_step_6.py` runs the audit on any closure (read-only diagnostic per chat Q6). Output lands in `results/<arc>/step_6_manual_<timestamp>/` and never clobbers the auto-dispatched run.
- **Closure template v1.3** adds a top-level `§1 tracker_payload.step_6` block. Parser v1.3 detects via `template_version` or top-level `step_6` field; **Phase 2 tightening** enforces Amendment 3 fields on any PASS verdict with `closed_timestamp > 2026-05-23T06:20:59Z` (PR-186 merge) and additionally requires `step_6.overall_passed=true` on v1.3 PASS verdicts.
- **Tracker** grows a `## Step 6 audit registry` section appended by auto-dispatched runs only; manual invocations don't add rows.
- **Amendment 4** authored at `archive/L_PROTOCOL_v3_0_AMENDMENT_4.md`. L_PROTOCOL.md §2 Step 6 expanded; §3 Evaluation order clarified.

## Open questions resolved (chat directives)

| Q | Resolution | Implementation |
|---|---|---|
| Q1 | Post-gate dispatch | `ArcOrchestrator.run()` calls `maybe_dispatch_step_6` AFTER `_run_amendment_3_evaluation` clears |
| Q2 | Top-1 only with divergence warning | `dispatch.py:_feature_sets_diverge` appends `top_k_feature_set_divergence` warning |
| Q3 | Full scope ratified (audit = verification, not re-computation) | All 6 categories implemented |
| Q4 | `category.passed = AND over critical-severity only` | `CategoryAuditResult.passed` in `manifest.py` |
| Q5 | sha256-manifest verify only | `determinism.py:_check_step_4_manifest` |
| Q6 | Manual = read-only; lands in `step_6_manual_<ts>/` | `Step6Result.verdict_impact` short-circuits MANUAL |
| Q7 | Cutoff `2026-05-23T06:20:59Z` | `schema.py:PHASE_2_CUTOFF_ISO` |
| Q8 | v1.3 (not v1.2.2) | Template + parser bumped to v1.3 |

## Test plan

- [x] `pytest tests/step_6/` — 44/44 pass (manifest, lookahead, per-category, orchestrator, parser v1.3, CLI)
- [x] `pytest tests/tracker_parser/` — 60/60 pass (v1.3 schema is additive; existing golden retrofits unchanged)
- [x] `pytest tests/protocol_runtime/` — 105/105 pass (auto-dispatch wiring + skip_step_6 escape hatch verified)
- [x] `ruff check` clean across all touched modules
- [x] Manual CLI smoke against `results/l_arc_10/ARC_CLOSURE.md` runs end-to-end and writes a complete artefact set
- [ ] Wave 2 first PASS arc — first opportunity to exercise auto-dispatch end-to-end on a real arc (post-merge work)

## What this does NOT cover

- A5 portfolio composition spec (separate amendment per dispatch §"After this lands")
- heavy_ml_probe sub-protocol engine path (Phase 2 prerequisite per engine audit Tier 2)
- Full-window-sim chained DD method (`chained_dd_method: full_window_sim`, deferred)
- Cross-platform CI determinism check

🤖 Generated with [Claude Code](https://claude.com/claude-code)