### PR TITLE
[ENGINE] Signal parity: mid-feature leaks + trail mid + 5ers EET bar boundaries

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 > The operational todo list. Append, check off, delete as work completes.
 > Distinct from `ARC_TRACKER.md` (which is auto-updated arc state) and `ARC_HISTORY.md` (frozen pre-v3.0 record).
-> Last updated: 2026-05-22 (CC_08 closure template + tracker schema extension)
+> Last updated: 2026-05-24 (PR #187 signal parity engine — Sub-changes A.distance + A.trail + C.EET)
 
 ---
 
@@ -18,6 +18,15 @@
 ## Current state — quick view
 
 **Phase 0 — Framework validation:** 🟢 READY (v3.0 backtester closed PR-E.1.7 / 2026-05-22; KH-24 anchor partial-by-attribution per Path B)
+
+### Queued follow-up dispatches (post PR #187 — signal parity)
+
+- 🔴 **Legacy engine retirement.** Migrate `live/run_daily.py` + 32 other importers off `core/backtester.py` + `core/signal_logic.py` onto V3 paths (core/sim/multipair_backtester, core/features, core/architectures). Then delete both legacy files. **Gate:** KH-24 anchor preservation (±0.5pp ROI / ±1pp DD on worst-fold). Out of scope for PR #187 per chat resolution (KH-24 live deployment continuity). Separate dispatch needed.
+- 🔴 **5ers timezone verification.** PR #187 assumes 5ers = EET/EEST (EU DST rules). User to verify against 5ers documentation. If NY-close session rollover, a small follow-up PR adjusts the boundary convention parameter — engine code is convention-parameterised already.
+- 🔴 **Arc 10 signal-parity re-run.** Workstation execution of `py -m scripts.l_arc_10_v3.step_5` on the tightened engine to quantify the delta. Procedure documented in [docs/calibration/arc_10_signal_parity_rerun_2026_05.md](docs/calibration/arc_10_signal_parity_rerun_2026_05.md). Expected delta near-zero. Not blocking; documented as required follow-up per dispatch Task 4.
+- 🔴 **HistData ↔ 5ers MT5 4H comparison (5 majors).** User pulls 5ers MT5 H4 closes from VPS for EURUSD/GBPUSD/USDJPY/AUDUSD/USDCAD over a 30-day post-2020 window; comparison documented per [docs/calibration/histdata_mt5_aggregation_parity_2026_05.md §5](docs/calibration/histdata_mt5_aggregation_parity_2026_05.md). Acceptance: per-pair mean abs diff <5 pips on majors.
+- 🔴 **5ers_eet cache build for 28 pairs × 7 TFs.** One-time workstation operation to populate the new `data/cache/<TF>_5ers_eet/` cache directory. Procedure in PROTOCOL_RUNTIME.md §15.3.
+- 🔴 **EA mid-trail update.** Live MT5 EA currently uses `CopyClose(PERIOD_H4)` (bid-side) for trail logic per PR-E.1.6. To maintain backtest↔EA parity with PR #187's mid-trail, the EA must be updated to compute mid from bid+ask CopyClose calls. Separate deployment PR.
 **Phase 1 — Arc 1-11 re-runs:** 🔴 NOT STARTED (blocked on Phase 0 launch)
 **Phase 2 — New signals + sub-protocol probes:** 🔴 NOT STARTED (blocked on Phase 1 closure)
 

--- a/core/data/aggregator.py
+++ b/core/data/aggregator.py
@@ -14,14 +14,44 @@ independently with standard OHLC rules:
 aggregated ``close_ask`` / ``close_bid`` (the per-minute quality flag does not
 propagate — a 5-minute bar is its own thing).
 
-TF boundaries (UTC, fixed):
-    M5     every  5 minutes anchored to epoch (which is :00 / :05 / :10 ...)
-    M15    every 15 minutes anchored to epoch
-    M30    every 30 minutes anchored to epoch
-    H1     every hour at :00
-    H4     every 4 hours at 00:00 / 04:00 / 08:00 / 12:00 / 16:00 / 20:00 UTC
-    D1     daily at 00:00 UTC
-    W1     weekly starting Monday 00:00 UTC
+Two boundary conventions are supported:
+
+    ``boundary_convention="utc"`` (default) — TF boundaries anchored to UTC:
+        M5     every  5 minutes anchored to epoch (:00 / :05 / :10 ...)
+        M15    every 15 minutes anchored to epoch
+        M30    every 30 minutes anchored to epoch
+        H1     every hour at :00 UTC
+        H4     every 4 hours at 00:00 / 04:00 / 08:00 / 12:00 / 16:00 / 20:00 UTC
+        D1     daily at 00:00 UTC
+        W1     weekly starting Monday 00:00 UTC
+
+    ``boundary_convention="5ers_eet"`` — anchored to the 5ers broker EET/EEST
+    trading day (EU DST rules via the ``Europe/Athens`` zone). The M1 UTC
+    index is converted to EET before resampling, then bar labels are converted
+    back to UTC for storage. Anchors in UTC terms (DST-dependent):
+
+        H4 boundaries (EET-local 00/04/.../20):
+            EET winter (UTC+2): UTC 22, 02, 06, 10, 14, 18
+            EEST summer (UTC+3): UTC 21, 01, 05, 09, 13, 17
+        D1: EET 00:00 → UTC 22:00 winter / UTC 21:00 summer
+        W1: Monday 00:00 EET
+
+    DST transitions (handled automatically by ``tz_convert``):
+        - Spring forward (last Sun in March): EET 03:00 → EEST 04:00. The
+          4H bar starting at EET 00:00 that day spans only ~3 wall-clock
+          hours but the same 4 UTC hours. No bar is missing.
+        - Autumn fall-back (last Sun in October): EEST 04:00 → EET 03:00.
+          The EET 02:00-03:00 wall-clock interval occurs twice. UTC index
+          is unambiguous; the 4H bar starting at EET 00:00 spans ~5
+          wall-clock hours but the same 4 UTC hours. No duplicate bar
+          emitted because the UTC index is monotonic.
+
+Cache layout:
+    UTC:      <cache_root>/<TF>/<PAIR>.parquet
+    5ers EET: <cache_root>/<TF>_5ers_eet/<PAIR>.parquet
+
+The two convention caches coexist; the convention is encoded in both the
+directory name and the cache_key sidecar so cross-pollination is impossible.
 
 Determinism guarantees:
     1. Bid and ask streams are aggregated in a fixed order with deterministic
@@ -31,7 +61,7 @@ Determinism guarantees:
        dropped — these correspond to weekend gaps / market closures.
 
 Two-run byte-identical parquet output is the contract (tested in
-tests/test_aggregator.py).
+tests/test_aggregator.py and tests/test_aggregator_5ers_eet.py).
 """
 
 from __future__ import annotations
@@ -66,6 +96,16 @@ from core.data.histdata_loader import (
 #     midnight UTC which is what we want
 #   - W1: ``W-MON`` with label='left' / closed='left' gives Monday 00:00 → Sunday
 SUPPORTED_TFS: tuple[str, ...] = ("M5", "M15", "M30", "H1", "H4", "D1", "W1")
+
+# Supported boundary conventions. "utc" is the legacy default; "5ers_eet"
+# anchors bars to the 5ers broker EET/EEST trading day.
+SUPPORTED_BOUNDARY_CONVENTIONS: tuple[str, ...] = ("utc", "5ers_eet")
+
+# Representative IANA zone for EET/EEST with EU DST rules. 5ers is a Cyprus-
+# regulated firm; ``Asia/Nicosia`` follows the same EU rules as
+# ``Europe/Athens`` and the two are byte-identical for the 2010+ HistData
+# range we care about. Picked Athens for brevity and historical stability.
+_EET_TZ: str = "Europe/Athens"
 
 _TF_TO_FREQ: dict[str, str] = {
     "M5": "5min",
@@ -110,7 +150,44 @@ def _aggregate_side(df: pd.DataFrame, side: str, freq: str, origin: str) -> pd.D
     return resampled.rename(columns={k: f"{k}_{side}" for k in _OHLC_AGG})
 
 
-def aggregate_m1_to_tf(df_m1: pd.DataFrame, tf: str) -> pd.DataFrame:
+def _aggregate_side_per_day(df: pd.DataFrame, side: str, freq: str) -> pd.DataFrame:
+    """Per-local-date resample for the 5ers EET sub-day re-anchoring path.
+
+    For H4 under EET, the day starts at local midnight (which is a UTC anchor
+    that shifts at DST). Standard ``resample(origin='start_day')`` anchors
+    to the first day's midnight only and does NOT re-anchor at DST. To get
+    local 00/04/08/12/16/20 bars on every day, we group by local date and
+    resample each day independently from its own midnight.
+    """
+    cols = {f"{k}_{side}": f"{k}_{side}" for k in _OHLC_AGG}
+    side_df = df[list(cols)].rename(columns={f"{k}_{side}": k for k in _OHLC_AGG})
+    local_dates = pd.Index(side_df.index.date, name="__local_date")
+    parts = []
+    for _, group in side_df.groupby(local_dates, sort=True):
+        parts.append(
+            group.resample(freq, label="left", closed="left", origin="start_day").agg(_OHLC_AGG)
+        )
+    if not parts:
+        out = pd.DataFrame(columns=list(_OHLC_AGG.keys()), index=pd.DatetimeIndex([], tz=df.index.tz))
+    else:
+        out = pd.concat(parts).sort_index()
+    return out.rename(columns={k: f"{k}_{side}" for k in _OHLC_AGG})
+
+
+def _aggregate_volume_per_day(volume: pd.Series, freq: str) -> pd.Series:
+    """Per-local-date volume sum for the 5ers EET sub-day path."""
+    local_dates = pd.Index(volume.index.date, name="__local_date")
+    parts = []
+    for _, group in volume.groupby(local_dates, sort=True):
+        parts.append(group.resample(freq, label="left", closed="left", origin="start_day").sum())
+    if not parts:
+        return pd.Series([], dtype="int64", name=volume.name)
+    return pd.concat(parts).sort_index()
+
+
+def aggregate_m1_to_tf(
+    df_m1: pd.DataFrame, tf: str, boundary_convention: str = "utc"
+) -> pd.DataFrame:
     """Aggregate an M1 DataFrame (per ``histdata_loader.M1_COLUMNS``) to ``tf``.
 
     Parameters
@@ -120,21 +197,51 @@ def aggregate_m1_to_tf(df_m1: pd.DataFrame, tf: str) -> pd.DataFrame:
         per ``M1_COLUMNS``.
     tf : str
         Target TF, one of ``SUPPORTED_TFS``.
+    boundary_convention : str, default ``"utc"``
+        ``"utc"`` (legacy) or ``"5ers_eet"`` (EET/EEST broker day; EU DST
+        rules via ``Europe/Athens``).
 
     Returns
     -------
     pd.DataFrame
-        Same column ordering as ``M1_COLUMNS``; DatetimeIndex left-labelled
-        at the TF boundary; bars with no underlying M1 data are dropped.
+        Same column ordering as ``M1_COLUMNS``; DatetimeIndex (UTC)
+        left-labelled at the convention-appropriate TF boundary; bars with
+        no underlying M1 data are dropped.
     """
     if tf not in SUPPORTED_TFS:
         raise ValueError(f"Unsupported TF {tf!r}; expected one of {SUPPORTED_TFS}")
+    if boundary_convention not in SUPPORTED_BOUNDARY_CONVENTIONS:
+        raise ValueError(
+            f"Unsupported boundary_convention {boundary_convention!r}; "
+            f"expected one of {SUPPORTED_BOUNDARY_CONVENTIONS}"
+        )
     freq = _TF_TO_FREQ[tf]
-    origin = "start_day" if tf in ("H4",) else "epoch"
 
-    bid = _aggregate_side(df_m1, "bid", freq, origin)
-    ask = _aggregate_side(df_m1, "ask", freq, origin)
-    volume = df_m1["volume"].resample(freq, **_resample_kwargs(freq, origin)).sum()
+    if boundary_convention == "utc":
+        origin = "start_day" if tf in ("H4",) else "epoch"
+        bid = _aggregate_side(df_m1, "bid", freq, origin)
+        ask = _aggregate_side(df_m1, "ask", freq, origin)
+        volume = df_m1["volume"].resample(freq, **_resample_kwargs(freq, origin)).sum()
+    else:
+        # 5ers EET: convert to local tz so anchors are computed in local
+        # wall-clock terms.
+        df_work = df_m1.copy()
+        df_work.index = df_work.index.tz_convert(_EET_TZ)
+        # D1 / W1: pandas' built-in resample on tz-aware index does per-day
+        # / per-week re-anchoring correctly across DST.
+        # Sub-hourly (M5..H1): bin edges are sub-DST-shift so bins coincide
+        # with the UTC convention; we fall through to the simple path.
+        # H4: pandas does NOT re-anchor sub-day bins per DST day — we go
+        # through the per-local-date path to keep bars at local 00/04/.../20.
+        if tf == "H4":
+            bid = _aggregate_side_per_day(df_work, "bid", freq)
+            ask = _aggregate_side_per_day(df_work, "ask", freq)
+            volume = _aggregate_volume_per_day(df_work["volume"], freq)
+        else:
+            origin = "start_day"
+            bid = _aggregate_side(df_work, "bid", freq, origin)
+            ask = _aggregate_side(df_work, "ask", freq, origin)
+            volume = df_work["volume"].resample(freq, **_resample_kwargs(freq, origin)).sum()
 
     out = pd.concat([bid, ask, volume.rename("volume")], axis=1)
     # Drop bars where either side is entirely NaN (no underlying minutes).
@@ -150,11 +257,18 @@ def aggregate_m1_to_tf(df_m1: pd.DataFrame, tf: str) -> pd.DataFrame:
     dq.loc[bad_spread] = DQ_ZERO_OR_NEG_SPREAD
     out["bid_ask_data_quality"] = dq
 
+    if boundary_convention != "utc":
+        # Storage convention: UTC-naive bar labels regardless of resample tz.
+        out.index = out.index.tz_convert("UTC")
+
     return out[M1_COLUMNS]
 
 
-def _tf_cache_parquet(paths: HistDataPaths, tf: str, pair: str) -> Path:
-    return paths.cache_root / tf / f"{pair}.parquet"
+def _tf_cache_parquet(
+    paths: HistDataPaths, tf: str, pair: str, boundary_convention: str = "utc"
+) -> Path:
+    layer = tf if boundary_convention == "utc" else f"{tf}_{boundary_convention}"
+    return paths.cache_root / layer / f"{pair}.parquet"
 
 
 def _write_parquet(df: pd.DataFrame, path: Path) -> None:
@@ -168,35 +282,47 @@ def aggregate(
     histdata_root: Path | str = "data/histdata",
     cache_root: Path | str = "data/cache",
     use_cache: bool = True,
+    boundary_convention: str = "utc",
 ) -> pd.DataFrame:
     """Load (or compute + cache) aggregated TF bars for ``pair``.
 
     On a cache hit (parquet exists + sidecar cache_key matches the upstream M1
-    key for that pair), the parquet is read directly. Otherwise the M1 layer
-    is loaded (which itself may build its cache), aggregated, written to
-    ``<cache_root>/<tf>/<pair>.parquet``, and returned.
+    key for that pair under the given boundary convention), the parquet is
+    read directly. Otherwise the M1 layer is loaded (which itself may build
+    its cache), aggregated, written to the convention-appropriate path:
+
+        ``"utc"``      → ``<cache_root>/<tf>/<pair>.parquet``       (legacy)
+        ``"5ers_eet"`` → ``<cache_root>/<tf>_5ers_eet/<pair>.parquet``
+
+    and returned.
     """
     if tf not in SUPPORTED_TFS:
         raise ValueError(f"Unsupported TF {tf!r}; expected one of {SUPPORTED_TFS}")
+    if boundary_convention not in SUPPORTED_BOUNDARY_CONVENTIONS:
+        raise ValueError(
+            f"Unsupported boundary_convention {boundary_convention!r}; "
+            f"expected one of {SUPPORTED_BOUNDARY_CONVENTIONS}"
+        )
 
     paths = HistDataPaths(Path(histdata_root), Path(cache_root))
     manifest = load_m1_manifest(paths.m1_manifest_path)
     m1_key = m1_cache_key_for_pair(manifest, pair)
-    key = tf_cache_key(m1_key, tf)
-    parquet_path = _tf_cache_parquet(paths, tf, pair)
+    key = tf_cache_key(m1_key, tf, boundary_convention)
+    parquet_path = _tf_cache_parquet(paths, tf, pair, boundary_convention)
+    layer = tf if boundary_convention == "utc" else f"{tf}_{boundary_convention}"
 
     if use_cache and cache_valid(parquet_path, key):
         return pd.read_parquet(parquet_path)
 
     df_m1 = load_m1(pair, histdata_root=histdata_root, cache_root=cache_root, use_cache=use_cache)
-    df_tf = aggregate_m1_to_tf(df_m1, tf)
+    df_tf = aggregate_m1_to_tf(df_m1, tf, boundary_convention=boundary_convention)
 
     _write_parquet(df_tf, parquet_path)
     write_meta(
         parquet_path,
         CacheMeta(
             pair=pair,
-            layer=tf,
+            layer=layer,
             cache_key=key,
             source_m1_manifest_sha256=manifest_self_sha256(paths.m1_manifest_path),
             n_rows=int(len(df_tf)),

--- a/core/data/cache_keys.py
+++ b/core/data/cache_keys.py
@@ -72,9 +72,16 @@ def m1_cache_key_for_pair(manifest: dict[str, Any], pair: str) -> str:
     return sha256_bytes("\n".join(lines).encode("utf-8"))
 
 
-def tf_cache_key(m1_key: str, tf: str) -> str:
-    """Cache key for an aggregated TF derives from the M1 key + TF label."""
-    return sha256_bytes(f"{m1_key}|{tf}".encode("utf-8"))
+def tf_cache_key(m1_key: str, tf: str, boundary_convention: str = "utc") -> str:
+    """Cache key for an aggregated TF derives from the M1 key + TF label.
+
+    ``boundary_convention="utc"`` (default) preserves byte-identical legacy keys.
+    Non-default conventions (e.g. ``"5ers_eet"``) append the label so caches
+    under different bar-boundary regimes never collide.
+    """
+    if boundary_convention == "utc":
+        return sha256_bytes(f"{m1_key}|{tf}".encode("utf-8"))
+    return sha256_bytes(f"{m1_key}|{tf}|{boundary_convention}".encode("utf-8"))
 
 
 def manifest_self_sha256(manifest_path: Path) -> str:

--- a/core/features/distance.py
+++ b/core/features/distance.py
@@ -10,22 +10,22 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from core.features._helpers import mid_close, pip_size_for_pair
+from core.features._helpers import mid_close, mid_high, mid_low, pip_size_for_pair
 from core.features.lineage import CausalLineage, FeatureSpec
 from core.features.registry import register
 
 
 def _prior_session_high(pair_df: pd.DataFrame, panel=None) -> pd.Series:
-    """Distance from current mid-close to the prior-calendar-day's session high.
+    """Distance from current mid-close to the prior-calendar-day's mid session high.
 
     "Session" here is the calendar UTC day. Implementation: shift to prior
-    day, group by date, take max(high). This is by-construction strictly
-    prior (we only consult days earlier than the signal day).
+    day, group by date, take max(mid_high). Strictly prior by construction
+    (we only consult days earlier than the signal day).
     """
     df = pair_df.copy()
     df["_date"] = df.index.normalize()
-    daily_high = df.groupby("_date")["high_bid"].max().rename("prior_day_high_bid")
-    # Look up *previous* date's high for each row
+    df["_mid_high"] = mid_high(pair_df).values
+    daily_high = df.groupby("_date")["_mid_high"].max().rename("prior_day_high_mid")
     prev_date_high = pd.Series(
         df["_date"].map(lambda d: daily_high.get(d - pd.Timedelta(days=1), np.nan)).values,
         index=df.index,
@@ -42,9 +42,9 @@ register(
         feature_class="distance",
         description=(
             "Distance from the prior-bar mid-close to the prior-calendar-day's "
-            "bid-side session high. Positive ⇒ above prior day's high."
+            "mid-price session high. Positive ⇒ above prior day's high."
         ),
-        inputs={"reference": "prior_calendar_day_high_bid"},
+        inputs={"reference": "prior_calendar_day_high_mid"},
     )
 )
 
@@ -52,7 +52,8 @@ register(
 def _prior_session_low(pair_df: pd.DataFrame, panel=None) -> pd.Series:
     df = pair_df.copy()
     df["_date"] = df.index.normalize()
-    daily_low = df.groupby("_date")["low_ask"].min().rename("prior_day_low_ask")
+    df["_mid_low"] = mid_low(pair_df).values
+    daily_low = df.groupby("_date")["_mid_low"].min().rename("prior_day_low_mid")
     prev_date_low = pd.Series(
         df["_date"].map(lambda d: daily_low.get(d - pd.Timedelta(days=1), np.nan)).values,
         index=df.index,
@@ -69,9 +70,9 @@ register(
         feature_class="distance",
         description=(
             "Distance from the prior-bar mid-close to the prior-calendar-day's "
-            "ask-side session low. Positive ⇒ above prior day's low."
+            "mid-price session low. Positive ⇒ above prior day's low."
         ),
-        inputs={"reference": "prior_calendar_day_low_ask"},
+        inputs={"reference": "prior_calendar_day_low_mid"},
     )
 )
 

--- a/core/sim/trailing_stop.py
+++ b/core/sim/trailing_stop.py
@@ -129,13 +129,14 @@ class TrailManager:
     def update_all_at_close(
         self, snapshot: dict[str, pd.Series | None], account: Account
     ) -> dict[int, float]:
-        """Update every registered trail using the bar's BID close.
+        """Update every registered trail using the bar's MID close.
 
-        Per PR-E.1.6 diff doc Section B: EA reads ``CopyClose(PERIOD_H4)``
-        which is bid-side single OHLC. Earlier (pre-PR-E.1.6) v3 used
-        ``(close_bid + close_ask) / 2`` (mid), which made the trail
-        activate earlier and ratchet higher than the EA — cutting big
-        winners short.
+        Signal-parity convention (PR #187, supersedes PR-E.1.6 bid-side
+        trail): activation + ratchet operate on mid-close so that trail
+        behaviour is venue-independent. Hit detection (see
+        ``trail_exit_triggers_at_close``) still uses bid-side close per
+        worst-case-fill realism. The EA must be updated to read mid in
+        a parallel deployment PR.
 
         Returns ``{position_id: new_sl_price}`` for positions whose
         trail moved this bar.
@@ -145,27 +146,24 @@ class TrailManager:
             state = self._states[pos_id]
             pos = account._open.get(pos_id)  # noqa: SLF001
             if pos is None:
-                # Position closed — clean up
                 self.deregister(pos_id)
                 continue
             bar = snapshot.get(pos.pair)
-            if bar is None or pd.isna(bar.get("close_bid")):
+            if bar is None or pd.isna(bar.get("close_bid")) or pd.isna(bar.get("close_ask")):
                 continue
-            close_bid = float(bar["close_bid"])
-            if state.update_at_close(close_bid):
+            close_mid = (float(bar["close_bid"]) + float(bar["close_ask"])) / 2.0
+            if state.update_at_close(close_mid):
                 updates[pos_id] = state.current_sl_price
         return updates
 
     def trail_exit_triggers_at_close(
         self, snapshot: dict[str, pd.Series | None], account: Account
     ) -> dict[int, float]:
-        """Identify positions whose trail's activated AND bar close ≤ trail.
+        """Identify positions whose trail's activated AND bid close ≤ trail.
 
-        Per PR-E.1.6 diff doc Section B: the EA's trail exit fires when
-        the H4 bar's CLOSE (bid) falls to or below the trail level —
-        NOT on an intra-bar wick of the following bar. This method
-        flags such positions so the driver can queue them for next-bar
-        open fill (EA's pending_close pattern).
+        Signal-parity convention (PR #187): activation/ratchet uses mid
+        (see ``update_all_at_close``); hit uses bid for worst-case-fill
+        realism — long exits when its bid falls to the trail level.
 
         Returns ``{position_id: trail_level_when_triggered}``. Caller
         decides what fill price to use.

--- a/docs/BACKTESTER_ARCHITECTURE.md
+++ b/docs/BACKTESTER_ARCHITECTURE.md
@@ -52,7 +52,22 @@ below.
 
 ---
 
-## Data layer (PR-A)
+## Data layer (PR-A; PR #187 EET extension)
+
+Under PR #187, the M1→TF aggregator supports two bar-boundary
+conventions via `boundary_convention=` parameter:
+
+- `"utc"` (default, legacy) — UTC-anchored bins; existing caches
+  byte-identical to pre-PR #187.
+- `"5ers_eet"` — 5ers broker EET/EEST-anchored; per-day re-anchored
+  for H4 to handle DST transitions. Cache namespace
+  `data/cache/<TF>_5ers_eet/<PAIR>.parquet`.
+
+See [PROTOCOL_RUNTIME.md §15.3](PROTOCOL_RUNTIME.md) and
+[docs/calibration/histdata_mt5_aggregation_parity_2026_05.md](calibration/histdata_mt5_aggregation_parity_2026_05.md)
+for full convention specs and DST handling.
+
+### Pre-PR-#187 layer (unchanged for UTC)
 
 - **Loader:** `core.data.histdata_loader.load_m1(pair, ...)` reads
   per-pair-month M1 bid + ask CSVs and joins them into a single
@@ -82,13 +97,20 @@ below.
   any external floor file (L_PROTOCOL §1 non-negotiable, enforced
   since PR-B).
 
-## Spread + sim (PR-B)
+## Spread + sim (PR-B; PR #187 updates)
 
 - **`core.spread.real_spread`** — per-bar spread + tradability mask +
   data-quality summary.
 - **`core.sim.fill`** — 8 bar-level fill primitives. Long entry =
   `open_ask`, long exit = `close_bid`, intra-bar SL/TP triggered
-  against `low_bid`/`high_bid`. Short symmetric.
+  against `low_bid`/`high_bid`. Short symmetric. Worst-case fills
+  satisfy PR #187 Sub-change B — spread is implicit in the bid/ask
+  wings, no separate deduction step.
+- **`core.sim.trailing_stop.TrailManager`** — trail activation +
+  ratchet operate on **mid close** under PR #187 (signal-parity
+  convention; reverses PR-E.1.6's bid-only trail). Trail hit detection
+  remains bid-side for worst-case-fill realism. See
+  [PROTOCOL_RUNTIME.md §15.2](PROTOCOL_RUNTIME.md).
 - **`core.sim.panel.Panel`** — multi-pair wrapper over
   `dict[pair, DataFrame]` with union-of-timestamps iteration and
   `snapshot_at(t)` for cross-pair access.

--- a/docs/PROTOCOL_RUNTIME.md
+++ b/docs/PROTOCOL_RUNTIME.md
@@ -649,7 +649,121 @@ structural equivalence check on the synthetic mini-fixture
 
 ---
 
-## §14 What lives elsewhere
+## §15 Signal parity (mid-price + 5ers EET + worst-case fills) — PR #187
+
+The v3 engine produces venue-independent signals. Three invariants:
+
+### §15.1 Mid-price feature computation
+
+All Step-1 price-derived features (price_geometry, vol_regime, multi_tf,
+cross_pair, distance, plus the load-bearing Arc 10 feature
+`L1_minus_L0_atr` in [core/features/multi_tf.py](../core/features/multi_tf.py))
+compute on **mid price** = `(close_bid + close_ask) / 2` per OHLC field.
+Spread is treated as pure cost, not as feature input.
+
+Exempt by design: `spread_regime.*` features read `spread_close` as a
+structural regime indicator (preserved per dispatch B.5). These do not
+leak bid/ask asymmetry into per-bar price-derived computations — they
+report the regime, they don't shape it.
+
+D1 lag rule (L_PROTOCOL §1 non-negotiable) is unchanged: features that
+use D1 lag-1 close now use D1 lag-1 **mid** close. The lag itself —
+`iClose(D1, 1)` semantics, enforced by
+[`_build_d1_lag1_series`](../core/features/multi_tf.py) via
+`merge_asof(direction="backward")` — is unaffected.
+
+Verification: [tests/test_feature_parity_mid.py](../tests/test_feature_parity_mid.py)
+locks the contract — same mid OHLC + different bid/ask spread → identical
+mid-price features.
+
+### §15.2 Worst-case fill execution
+
+[core/sim/fill.py](../core/sim/fill.py) and
+[core/sim/multipair_backtester.py](../core/sim/multipair_backtester.py)
+already implemented worst-case fills in V3:
+- Long entry: fills at `bar.open_ask`
+- Short entry: fills at `bar.open_bid`
+- Long SL hit: `bar.low_bid ≤ sl_price` → fills at `sl_price`
+- Short SL hit: `bar.high_ask ≥ sl_price` → fills at `sl_price`
+- Long TP hit: `bar.high_bid ≥ tp_price` → fills at `tp_price`
+- Short TP hit: `bar.low_ask ≤ tp_price` → fills at `tp_price`
+
+Spread cost is implicit in `(open_ask − open_bid)` and the bid/ask wing
+of SL/TP — no separate "spread deduction" step is applied.
+
+[core/sim/trailing_stop.py](../core/sim/trailing_stop.py): **trail
+activation + ratchet read MID close** (PR #187 reverses PR-E.1.6's bid-only
+trail); **trail hit detection still reads BID close** (worst-case-fill
+realism — long exits when its bid falls to the trail level). This
+asymmetric model (mid-anchored decision, bid-anchored fill) is the
+dispatch's strict reading of B.3. The live EA must be updated to match
+mid activation in a parallel deployment PR — until then, EA divergence
+from backtest is expected on the trail-activation side.
+
+### §15.3 5ers EET bar boundary
+
+[core/data/aggregator.py](../core/data/aggregator.py) supports two
+boundary conventions via the `boundary_convention` parameter:
+
+- `"utc"` (default, legacy) — bars anchored to UTC midnights / hours.
+- `"5ers_eet"` — bars anchored to the 5ers broker EET/EEST trading day
+  using the IANA `Europe/Athens` zone (functionally identical to
+  `Asia/Nicosia` for the 2010+ HistData range). DST handled automatically.
+
+Steady-state anchors:
+
+| TF | Winter (EET = UTC+2) | Summer (EEST = UTC+3) |
+|---|---|---|
+| H4 | UTC 22, 02, 06, 10, 14, 18 | UTC 21, 01, 05, 09, 13, 17 |
+| D1 | UTC 22:00 (= EET 00:00 next day) | UTC 21:00 (= EEST 00:00 next day) |
+| W1 | UTC Sun 22:00 (= EET Mon 00:00) | UTC Sun 21:00 (= EEST Mon 00:00) |
+
+Sub-hourly TFs (M5/M15/M30/H1) have bin widths smaller than the DST
+shift; the UTC bin SET is identical to local-anchored bins (only the
+display label differs). The 5ers_eet path stores them under the same
+schema as UTC for storage parity.
+
+**DST transition handling:**
+- Spring forward (last Sunday March): EET 03:00 → EEST 04:00. The local
+  day has 23 wall-clock hours. The H4 bar starting at local 00:00 on
+  the DST day spans 3 wall-clock hours (4 UTC hours). Subsequent bars
+  re-anchor to EEST.
+- Autumn fall-back (last Sunday October): EEST 04:00 → EET 03:00. The
+  local day has 25 wall-clock hours. The H4 bar starting at local
+  00:00 on the DST day spans 5 wall-clock hours (4 UTC hours). The
+  duplicate EET 02:00-03:00 wall-clock hour is unambiguous in the
+  underlying UTC index. An extra short bar (1 UTC hour) appears at
+  local "00:00 EET of next day" within the DST day's groupby — this
+  is an internally consistent artefact of per-local-day re-anchoring
+  and is documented in
+  [docs/calibration/histdata_mt5_aggregation_parity_2026_05.md](calibration/histdata_mt5_aggregation_parity_2026_05.md).
+
+Implementation: H4 uses per-local-date groupby + per-day
+`origin="start_day"` resample because pandas' `origin="start_day"` on
+a tz-aware multi-day index does NOT re-anchor at DST. D1 and W1 use
+pandas' built-in `resample("1D")` / `resample("W-MON")` on the
+tz-converted index, which is DST-aware out of the box.
+
+**Cache layout:**
+
+```
+data/cache/<TF>/<PAIR>.parquet            # UTC (legacy)
+data/cache/<TF>_5ers_eet/<PAIR>.parquet   # 5ers EET (new)
+```
+
+The two convention caches coexist; the convention is encoded in both
+the directory name and the cache_key sidecar so cross-pollination is
+impossible. UTC caches built pre-PR-#187 remain valid.
+
+Verification:
+- [tests/test_aggregator_5ers_eet.py](../tests/test_aggregator_5ers_eet.py)
+  — anchor + DST + cache namespace tests
+- [tests/test_aggregator.py](../tests/test_aggregator.py) — legacy UTC
+  byte-identity preserved
+
+---
+
+## §16 What lives elsewhere
 
 - Backtester (M1 loader, TF aggregator, fill, sim, account, panel,
   WFO folds + gates + orchestrator) — [BACKTESTER_ARCHITECTURE.md](BACKTESTER_ARCHITECTURE.md)

--- a/docs/calibration/arc_10_signal_parity_rerun_2026_05.md
+++ b/docs/calibration/arc_10_signal_parity_rerun_2026_05.md
@@ -1,0 +1,165 @@
+# Arc 10 Signal-Parity Re-run Procedure & Expected Delta (2026-05)
+
+> **Source PR:** [PR #187 Signal Parity Engine](../../signal_parity_intent.md)
+> **Author:** CC (jovial-mcnulty-1b0855)
+> **Date:** 2026-05-24
+> **Status:** procedure documented; actual re-run is a follow-up workstation operation
+> **No closure modification** — Arc 10 `docs/archive/arc_results/ARC_10_RESULT.md` is unchanged.
+
+---
+
+## §1 Context
+
+PR #187 (signal parity engine) made three engine changes:
+1. Two mid-leak fixes in [core/features/distance.py](../../core/features/distance.py)
+   (prior_session_high uses mid_high; prior_session_low uses mid_low)
+2. Trail manager activation + ratchet switched to mid close (hit detection
+   stays bid; see [core/sim/trailing_stop.py](../../core/sim/trailing_stop.py))
+3. 5ers EET bar-boundary convention added to
+   [core/data/aggregator.py](../../core/data/aggregator.py) (UTC default
+   unchanged, so existing caches are byte-identical)
+
+Arc 10 (DLR — D1 swing-low rejection long) used the A1 architecture
+with `sl_partial_close_1r_runner_trail` exit policy. Per
+[ARC_10_RESULT.md](../archive/arc_results/ARC_10_RESULT.md), the
+load-bearing feature is `L1_minus_L0_atr` (D1 high-low slope magnitude,
+EXP-02 contributed 116% of HTF LOO drop).
+
+**Pre-run delta hypothesis:** near-zero. Justification:
+
+- `L1_minus_L0_atr` lives in [core/features/multi_tf.py](../../core/features/multi_tf.py)
+  `_d1_close_slope_magnitude` and **already computed on mid** pre-PR-187
+  (the multi_tf module was correctly mid-anchored from PR #185 onwards).
+- Arc 10's other features come from price_geometry, vol_regime,
+  cross_pair, all of which were already mid-priced in the V3 path.
+- The only features that change in Arc 10's feature envelope are the
+  two distance leaks: `prior_session_high_distance` and
+  `prior_session_low_distance` (now use mid_high/mid_low instead of
+  high_bid/low_ask). These are 2 of ~17 features in the load-bearing
+  subset.
+- A1 architecture (system_level_filter) uses the trail manager. Arc 10's
+  exit policy `sl_partial_close_1r_runner_trail` uses a runner trail
+  whose activation/update was switched from bid-close to mid-close in
+  PR #187. This may shift trail-exit fills by half a spread on average
+  (~0.1 pip on majors → ~0.005R per trade on 2.5×ATR SL).
+- 5ers EET aggregation is opt-in (UTC default); Arc 10 ran on UTC and
+  remains on UTC unless explicitly re-aggregated.
+
+**Acceptable range:** worst-fold ROI delta within ±2pp (vs the original
+26.49% worst-fold), worst-fold DD delta within ±2pp (vs the original
+9.22%). Anything outside → investigate the trail-manager delta first
+(half-spread × trail exits is the leading expected driver).
+
+---
+
+## §2 Original Arc 10 closure numbers (search WFO, 11 folds)
+
+From [results/l_arc_10/step_5/wfo_results.csv](../../results/l_arc_10/step_5/wfo_results.csv)
+row 1 (winning A1 config):
+
+| Metric | Value |
+|---|---|
+| Architecture | A1 |
+| SL multiplier | 3.5 × ATR |
+| Exit policy | sl_partial_close_1r_runner_trail |
+| Exposure cap | unlimited |
+| Search worst-fold ROI | 0.2649 (26.49%) |
+| Search worst-fold DD | 0.0922 (9.22%) |
+| Search worst-fold ratio | 5.4185 |
+| Search mean ROI | 0.4987 (49.87%) |
+| Search mean DD | 0.0385 (3.85%) |
+| Search mean ratio | 16.18 |
+| Sign consistency | 11 / 11 folds positive |
+| Negative folds | 0 |
+| Total trades | 2162 |
+| Verdict (closure §1) | PASS-VIABLE |
+| Verdict (closure §10 amendment 3) | PASS-DEPLOYABLE-PROVISIONAL |
+
+---
+
+## §3 Re-run procedure
+
+Workstation invocation (paths assume parent project, not worktree):
+
+```powershell
+# 1. Sync worktree's PR #187 code into project root (if running from project root)
+git checkout claude/jovial-mcnulty-1b0855  # or whatever the merged main branch is
+
+# 2. (Optional) Rebuild 5ers_eet cache if the re-run will use EET bars.
+#    For parity with original Arc 10 (which used UTC), KEEP UTC convention.
+#    No cache rebuild needed.
+
+# 3. Re-run Arc 10 Step 5 WFO
+py -m scripts.l_arc_10_v3.step_5 \
+    --config configs/l_arc_10_v3/arc_open.yaml \
+    --out results/l_arc_10_pr187_rerun/step_5/
+```
+
+Expected runtime: 6-12 hours (full 11-fold WFO across 28 pairs ×
+2010-2020 search window).
+
+---
+
+## §4 Comparison
+
+After the re-run completes:
+
+```powershell
+py -m scripts.l_arc_10_v3.compare_runs \
+    --original results/l_arc_10/step_5/wfo_results.csv \
+    --rerun    results/l_arc_10_pr187_rerun/step_5/wfo_results.csv \
+    --out      docs/calibration/arc_10_signal_parity_delta.md
+```
+
+(The `compare_runs` script is a candidate follow-up; if not present, do
+the diff manually.)
+
+Per-fold comparison checklist:
+- ROI delta per fold (should be near-zero with possible -0.005R/trade
+  trail-spread bias)
+- DD delta per fold (should be near-zero)
+- Signal count (should be unchanged — signal logic is V3 path unchanged)
+- Trade count (should be unchanged — entries fire at same bars; only
+  trail exits may shift by ≤1 bar)
+
+---
+
+## §5 Outcomes
+
+### §5.1 Expected outcome (near-zero delta)
+
+If the re-run confirms ±2pp ROI/DD per fold:
+- Arc 10's edge is genuinely signal-derived, not bid-price/spread
+  artefact
+- Arc 10 verdict UNCHANGED: PASS-VIABLE → PASS-DEPLOYABLE-PROVISIONAL
+- Document the run with a delta summary in this doc's §5.1 section
+- No closure modification
+
+### §5.2 Surprise outcome (delta > ±2pp)
+
+If the re-run shifts worst-fold by more than ±2pp:
+- Investigate trail-manager change first (most likely driver)
+- Run with trail manager pinned to bid-only via a debug switch (if added)
+  to isolate
+- If isolated to trail: document as "trail-mid causes Xpp ROI shift on
+  Arc 10" in this doc's §5.2 section
+- If NOT isolated to trail: investigate distance.py mid changes
+  (less likely to be material since they're 2/17 features and Arc 10's
+  load-bearing feature is unaffected)
+- Closure §1 still NOT modified per dispatch rule; instead add a §12
+  "Signal-parity re-run" appendix to the closure noting the delta
+
+### §5.3 Documentation update
+
+After the run completes, fill in §6 below with the actual per-fold delta
+table and an outcome verdict (5.1 vs 5.2).
+
+---
+
+## §6 Re-run results
+
+*To be filled after workstation re-run.*
+
+---
+
+End of doc.

--- a/docs/calibration/histdata_mt5_aggregation_parity_2026_05.md
+++ b/docs/calibration/histdata_mt5_aggregation_parity_2026_05.md
@@ -1,0 +1,191 @@
+# HistData → 5ers MT5 Aggregation Parity (2026-05)
+
+> **Source PR:** [PR #187 Signal Parity Engine](../../signal_parity_intent.md)
+> **Author:** CC (jovial-mcnulty-1b0855)
+> **Date:** 2026-05-24
+> **Status:** investigation framework + DST findings; cross-broker 5-major comparison deferred to user pull from VPS
+
+---
+
+## §1 Why
+
+PR #187 changed the engine's bar boundary convention from UTC-anchored
+to 5ers-broker EET/EEST-anchored so that aggregated artefacts match
+what 5ers MT5 produces on the same M1 stream. This doc records:
+
+1. The EET/EEST convention chosen
+2. DST transition behaviour
+3. Volume/data-integrity verification on the synthetic DST fixture
+4. (Deferred) cross-broker comparison on 5 majors with real 5ers MT5
+   H4 closes pulled from the VPS
+
+---
+
+## §2 EET/EEST convention
+
+Reference zone: IANA `Europe/Athens` (functionally identical to
+`Asia/Nicosia` for the 2010+ HistData range). 5ers is Cyprus-regulated
+and follows EU DST rules: last Sunday of March (spring forward, EET→EEST)
+and last Sunday of October (autumn fall-back, EEST→EET).
+
+UTC anchors (steady state):
+
+| TF | Winter (UTC+2 EET) | Summer (UTC+3 EEST) |
+|---|---|---|
+| H4 | 22, 02, 06, 10, 14, 18 | 21, 01, 05, 09, 13, 17 |
+| D1 | 22:00 prior day | 21:00 prior day |
+| W1 | Sun 22:00 → Mon 00:00 EET | Sun 21:00 → Mon 00:00 EEST |
+| H1, M30, M15, M5 | UTC :00 / :30 / :15 / :05 | UTC :00 / :30 / :15 / :05 |
+
+Sub-hourly TFs (M5..H1) have bin widths smaller than the DST shift,
+so the UTC bin SET is identical to local-anchored bins.
+
+---
+
+## §3 DST transition behaviour
+
+### §3.1 Spring forward (last Sunday March)
+
+Sequence at 01:00 UTC:
+- Pre: UTC 00:59 = EET 02:59 (clocks tick normally to 02:59 EET)
+- Transition: UTC 01:00 = EET 03:00, which immediately jumps to EEST 04:00
+- Post: UTC 01:01 = EEST 04:01
+
+Local day has **23 wall-clock hours / 23 real hours** (the EET 03:00-03:59
+hour skipped).
+
+H4 bar boundaries on the DST day, per-day groupby with
+`origin="start_day"` resample:
+- Bar 0: start UTC 22:00 d-1 (= EET 00:00 d), spans 4 real UTC hours
+  → wall-clock spans 00:00 EET to 04:00 EEST (3 wall-clock hours due
+  to the skip; 4 real hours)
+- Bars 1-5: start at UTC +4h intervals from origin → labels in EEST
+  wall-clock
+
+Verification:
+[tests/test_aggregator_5ers_eet.py::test_dst_total_volume_conserved](../../tests/test_aggregator_5ers_eet.py)
+confirms every M1 minute of the spring-forward day ends up in some
+H4 bar (no minutes dropped).
+
+### §3.2 Autumn fall-back (last Sunday October)
+
+Sequence at 01:00 UTC:
+- Pre: UTC 00:59 = EEST 03:59
+- Transition: UTC 01:00 = EEST 04:00 = EET 03:00 (clocks fall back)
+- Post: UTC 01:01 = EET 03:01
+
+Local day has **25 wall-clock hours / 25 real hours**. The EET
+02:00-02:59 wall-clock hour occurs twice (once as EEST, once as EET);
+the underlying UTC index disambiguates.
+
+H4 bar boundaries on the DST day, per-day groupby:
+- Bar 0: start UTC 21:00 d-1 (= EEST 00:00 d), spans 4 real hours
+  → wall-clock 00:00 EEST to 04:00 EEST (4 wall-clock hours)
+- Bar 1: start UTC 01:00 d (= EEST 04:00 = EET 03:00 wall-clock at
+  the moment of fall-back), spans 4 real hours (wall-clock 03:00 EET
+  to 07:00 EET; includes the duplicate EET 02:00-03:00 ... wait,
+  04:00 EEST IS the same UTC instant as 03:00 EET; the duplicate
+  03:00-04:00 wall-clock is the post-fallback hour 03:00-04:00 EET,
+  which UTC-maps to 01:00-02:00 UTC — these fall in bar 1)
+- Bars 2-5: standard 4h intervals
+- Bar 6 (artefact): UTC 21:00 d, which is "+24h from start_day origin"
+  (= EET 00:00 d+1) — contains only 1 hour of M1 data (UTC 20:00-20:59
+  of fall-back day). This is the "extra short bar" of the autumn DST
+  day.
+
+The extra bar is an internally-consistent side-effect of per-local-day
+re-anchoring (each local day's groupby has its own start_day origin).
+It is NOT a duplicate timestamp — every bar label is unique in UTC.
+It IS a short bar (1h instead of 4h) that downstream consumers should
+be aware of if they assume every H4 bar has exactly 4 real hours of
+underlying data.
+
+**Mitigation options** (not implemented in PR #187, candidates for
+follow-up):
+- Drop the +24h artefact bar entirely (loses 1 hour of M1 data)
+- Merge into the next day's bar 0 (breaks per-day independence)
+- Keep as-is and flag in `bid_ask_data_quality` (current behavior;
+  data quality stays "ok" if both bid/ask present)
+
+Verification:
+[tests/test_aggregator_5ers_eet.py::test_dst_total_volume_conserved](../../tests/test_aggregator_5ers_eet.py)
++ `test_dst_autumn_no_duplicate_bars` confirm conservation + uniqueness.
+
+---
+
+## §4 Cache layout
+
+```
+data/cache/<TF>/<PAIR>.parquet            # UTC (legacy, byte-identical pre-PR-187)
+data/cache/<TF>_5ers_eet/<PAIR>.parquet   # 5ers EET (new)
+```
+
+The two convention caches coexist. Cache keys include the convention
+(`sha256(m1_key|tf|convention)` for non-UTC) so cross-pollination is
+impossible. UTC default (`sha256(m1_key|tf)`) preserves legacy cache
+validity.
+
+To populate the 5ers_eet cache for one pair / TF:
+
+```python
+from core.data.aggregator import aggregate
+aggregate("EURUSD", "H4", boundary_convention="5ers_eet")
+```
+
+Full 28-pair × 7 TF rebuild takes ~10-20 minutes on a workstation
+(rough estimate; dominated by parquet IO of pre-existing M1 cache).
+
+---
+
+## §5 Cross-broker parity comparison (DEFERRED — needs user data pull)
+
+The dispatch's Sub-change C.4 requires comparing HistData M1 →
+5ers_eet H4 closes against 5ers MT5 H4 closes on 5 majors over a
+30-day sample:
+
+- EURUSD, GBPUSD, USDJPY, AUDUSD, USDCAD
+- Window: any 30 consecutive days post-2020 (user's discretion)
+- Per-pair metrics: mean abs diff, max abs diff, percentile distribution
+
+This requires the user to:
+1. Pull 5ers MT5 H4 closes from the VPS for the 5 pairs / 30-day window
+2. Save as CSVs under `data/calibration/5ers_mt5_h4/<pair>.csv` with
+   schema `timestamp_utc,open_bid,high_bid,low_bid,close_bid,
+   open_ask,high_ask,low_ask`
+3. Run the comparison script (to be added in a follow-up dispatch):
+   ```
+   py -m scripts.calibration.histdata_mt5_h4_compare \
+       --pairs EURUSD,GBPUSD,USDJPY,AUDUSD,USDCAD \
+       --window 2024-09-01..2024-09-30 \
+       --out docs/calibration/histdata_mt5_h4_comparison.md
+   ```
+4. Acceptance: per-pair `mean_abs_diff < 5 pips` on majors → ACCEPTED;
+   `10+ pips` → identify cause (tick filter, holiday, broker data quirk)
+   and either patch the aggregator to match or document as irreducible
+   source
+
+Expected drivers of residual divergence (after EET alignment):
+- HistData M1 tick filter: drops bars with all-NaN bid OR ask;
+  conservative
+- 5ers MT5 tick filter: unknown — needs verification on a sample
+- Weekend gap conventions: both should drop weekends but EOW Friday
+  / SOW Sunday cutoffs may differ
+- Holiday treatment: HistData drops; MT5 typically also drops but
+  may include partial-day data for some holidays
+
+---
+
+## §6 Findings summary
+
+| Item | Status |
+|---|---|
+| EET/EEST boundary convention implemented | ✓ ([core/data/aggregator.py](../../core/data/aggregator.py)) |
+| DST spring-forward handled (23h day) | ✓ verified by test |
+| DST fall-back handled (25h day, extra short bar artefact documented) | ✓ verified by test |
+| Cache namespace separation (UTC vs 5ers_eet) | ✓ ([data/cache/<TF>_5ers_eet/](../../data/cache/)) |
+| Cross-broker 5-major comparison | DEFERRED — needs user MT5 data pull |
+| Real-data EET cache built for all 28 pairs | DEFERRED — user runs `aggregate(..., boundary_convention="5ers_eet")` |
+
+---
+
+End of doc.

--- a/docs/templates/ARC_CLOSURE_TEMPLATE.md
+++ b/docs/templates/ARC_CLOSURE_TEMPLATE.md
@@ -249,6 +249,7 @@ Known differences between backtest and expected live deployment.
 - [ ] EA implementation matches §4.2-4.9 line-by-line
 - [ ] Backtest-vs-EA byte-identical pre-deployment shadow run on 30 days of data
 - [ ] Step 6 causal audit clean
+- [ ] **Signal parity verified against deployment venue (PR #187 hard requirement).** Re-aggregate HistData M1 → primary TF under `boundary_convention="5ers_eet"` and confirm aggregated closes match 5ers MT5 closes on the deployment pair set within tolerance (mean abs diff <5 pips on majors). Document the comparison artefact under `docs/calibration/` per the dispatch's C.4 procedure. Skipping this check is a hard FAIL of the deployment gate.
 
 ```
 

--- a/signal_parity_intent.md
+++ b/signal_parity_intent.md
@@ -1,0 +1,205 @@
+# Signal Parity Engine — Read-First Intent
+
+> **Dispatch:** `CC_15_SIGNAL_PARITY_ENGINE.md`
+> **Branch (planned):** `engine/signal-parity-mid-price-and-utc-bars`
+> **Status:** Read-first only. No code changes yet. Awaiting chat review.
+> **Author:** CC (jovial-mcnulty-1b0855)
+> **Date:** 2026-05-24
+
+---
+
+## TL;DR — the dispatch's premise is largely already true in V3
+
+A four-way audit of `core/features/`, `core/sim/`, `core/data/`, and `core/spread/` shows that **most of the work prescribed in Sub-changes A and C is already implemented in the V3 path**. Specifically:
+
+- **Sub-change A (mid-price features):** ~95% already done. All "production" features in `price_geometry`, `vol_regime`, `multi_tf`, `cross_pair`, and most of `distance` already compute mid-OHLC from `*_bid` / `*_ask` columns. Remaining leaks: 2 functions in `distance.py`, the unprefixed `close` reads in `signal_logic.py`, and the trail manager's `close_bid`-only update path.
+- **Sub-change B (worst-case fills):** ~100% already done in V3 `core/sim/fill.py` + `core/sim/multipair_backtester.py`. Long entries fill at `open_ask`, shorts at `open_bid`, SL/TP hit checks already use direction-correct bid/ask. **Legacy `core/backtester.py` (2011 LOC) still uses single-price OHLC** — needs a scoping decision (deprecate vs. retrofit).
+- **Sub-change C (5ers UTC bar boundaries):** ~100% already correct for the canonical UTC convention. H4 already uses `origin="start_day"` → UTC 00/04/08/12/16/20. D1 already midnight UTC. W1 already Monday 00:00 UTC. **The only open question is whether 5ers actually uses UTC** or NY-close session rollover — that is a chat decision, not a code change.
+
+**The dispatch was written on the premise that engine state is pre-V3** (bid-price features, single-price fills, HistData-default boundaries). V3 already shipped most of these properties as side effects of [PR #185](../../) (Step 4 fitted-classifier persistence) and [PR #186](../../) (Amendment 3 implementation). The actual remaining delta is much narrower than the dispatch's "3-5 days CC work" estimate.
+
+**Recommendation:** chat re-scope before any code work. See "Recommendation / open questions" at the end.
+
+---
+
+## §1 — Read-first findings per file
+
+### A. `core/features/` audit
+
+| Module | Price columns read | Bid/ask/mid state |
+|---|---|---|
+| `_helpers.py` | `high/low/close` (BID convention) AND `{high,low,close}_{bid,ask}` for mid helpers | Provides `mid_close()`, `mid_high()`, `mid_low()` — already exists |
+| `cache.py` | none (orchestration) | N/A |
+| `cross_pair.py` | `close_{bid,ask}`, `high_{bid,ask}`, `low_{bid,ask}` | **Already computes mid** from both sides for all 4 features (USD strength, EUR strength, dollar-bloc, signal density) |
+| `distance.py` | `high_bid` (L27), `low_ask` (L55), mid-close elsewhere | **LEAK: `_prior_session_high()` reads `high_bid` directly; `_prior_session_low()` reads `low_ask` directly.** Both are session-reference baselines for distance features. |
+| `lineage.py` | none (metadata) | N/A |
+| `multi_tf.py` | D1 `{close,high,low}_{bid,ask}` | **Already computes mid** for d1_close_slope_{sign,magnitude}, d1_atr_percentile_100, w1_close_slope_sign. D1 lag enforced via `_build_d1_lag1_series()` with `merge_asof(direction="backward")`. |
+| `pipeline.py` | none (orchestrator) | N/A |
+| `price_geometry.py` | mid-OHLC throughout | **Already mid**: atr_14, kijun_26_distance, swing_{high,low}_distance_14, range_close_ratio |
+| `registry.py` | none (metadata) | N/A |
+| `session.py` | none (timestamp only) | N/A |
+| `spread_regime.py` | `spread_close` only | **Clean** — structural regime only, no bid/ask asymmetry leaks into per-bar price computations. Preserve per dispatch B.5. |
+| `vol_regime.py` | mid-OHLC | **Already mid**: atr_vs_trailing_100, atr_percentile_100 |
+| `signal_logic.py` | unprefixed `close` (BID by convention) at L83, L96, L99, L103–107, L305, L391–393, L405–420, L521–524, L554–556, L565–567 | **LEAK: entry/exit signal logic reads single-price `close`** (no mid derivation). Highest-impact remaining bid leak. |
+| `features_path_so_far.py` | OHLC input arrays (not df columns directly) | Computes 8 entry features + 7 path features from arrays passed in. **Mid-ness depends on caller passing mid arrays.** Verify callers. |
+| `utils.py` | unprefixed `high/low/close` in `calculate_atr()` | Utility, possibly used by legacy paths. Verify call sites. |
+
+**D1 lag rule status (L_PROTOCOL §1):** ✅ Enforced in `multi_tf.py::_build_d1_lag1_series()` (lines 32–50) via `merge_asof(direction="backward")` on shifted-by-1-day key. Comment: "at calendar day T, only D1 bars from T-1 or earlier are visible." Per dispatch A.3, this rule is preserved and will continue to use mid close after refactor.
+
+---
+
+### B. `core/sim/` + `core/spread/` audit
+
+| File | Entry fill (long / short) | SL hit | TP hit | Trail | Spread treatment |
+|---|---|---|---|---|---|
+| `multipair_backtester.py` | `open_ask` / `open_bid` (L248, 250) — **already worst-case** | Delegates to fill.py | Delegates to fill.py | Delegates to TrailManager | Implicit in bid/ask columns (no separate deduction) |
+| `fill.py` | L37: `bar["open_ask"]` (long); L70: `bar["open_bid"]` (short) — **already worst-case** | L45: `bar["low_bid"] <= sl_price` → fills at `sl_price` (long); L78: `bar["high_ask"] >= sl_price` (short) — **already worst-case** | L56: `bar["high_bid"] >= tp_price` (long); L85: `bar["low_ask"] <= tp_price` (short) — **already worst-case** | N/A | None |
+| `trailing_stop.py` | N/A | N/A | N/A | **Activation: `close_price >= entry + activation_atr_mult × atr`** at L72; **trail update: `close_bid`** at L154; **hit check: `close_bid <= current_sl_price`** at L184 | None — `close_bid` only |
+| `exit_hooks.py` | N/A | N/A | N/A | Signal-driven; queued for next-bar open fill | None |
+| `account.py` | Caller supplies entry_price | Position stores immutable `sl_price` | Position stores immutable `tp_price` | N/A | None |
+| `panel.py` | N/A | N/A | N/A | N/A | Enforces schema invariant; bid+ask columns canonical |
+| `spread/real_spread.py` | N/A | N/A | N/A | N/A | `per_bar_spread()` = `spread_close` column (= `close_ask - close_bid`); `is_tradable_bar()` returns DQ_OK mask. **No cost deduction here — purely audit/quality.** |
+| `backtester.py` (legacy, 2011 LOC) | L1011: `r_next["open"]` — **single-price** (no bid/ask) | Intra-bar low/high vs. `sl_px` (single price) | Intra-bar high/low vs. `tp_px` (single price) | `trail_level_from_close(d_int, close_px, atr_entry)` — single close | `resolve_spread_pips()` → applied as slippage deduction at exit (L484) |
+| `exit_policies.py` | N/A | N/A | N/A | Trail armed post-MFE-lock; operates on trade dict | N/A |
+
+**Status vs dispatch Sub-change B:**
+
+- B.1 entry fills using ask (long) / bid (short): ✅ **already true in V3** (`fill.py:37`, `fill.py:70`)
+- B.2 SL anchored at entry price, hit logic uses bid (long) / ask (short): ✅ **already true in V3** (`fill.py:45`, `fill.py:78`)
+- B.3 TP/trail with worst-side fills: ✅ TP already true (`fill.py:56`, `fill.py:85`). ⚠️ **Trail partially: hit check uses `close_bid` (L184), but activation uses an unspecified `close_price` (L72) — need to verify it's bid-side and decide if mid is preferred per the dispatch's wording "(in mid-price terms)".** Dispatch B.3 actually specifies bid-side trail hit (long), which matches V3. So the trail layer is consistent — only activation phrasing is ambiguous.
+- B.4 spread cost = exit + entry slippage emerges from worst-side fills: ✅ **already true in V3** (no separate deduction path; cost is implicit in `open_ask` − `open_bid` ≠ 0)
+- B.5 remove spread-as-feature uses: ✅ **already true** — `spread_regime.py` is the only feature reading spread and it's structural (no asymmetry leak)
+
+---
+
+### C. `core/data/` audit
+
+| File | Source TZ | M5/M15/M30/H1 anchor | H4 anchor | D1 anchor | W1 anchor | Bid/ask in output |
+|---|---|---|---|---|---|---|
+| `histdata_loader.py` | UTC (`utc=True`, `format="ISO8601"`) — ISO-8601 `Z` suffix | M1 only, no resample | N/A | N/A | N/A | Inner-merged bid+ask, full OHLC both sides |
+| `aggregator.py` | UTC inherited from loader | `origin="epoch"` → UTC :00/:05/...:55 / :00 of every hour | **`origin="start_day"` → UTC 00/04/08/12/16/20** (L133) ✅ matches dispatch C.1 exactly | `"1D"` resample → UTC 00:00 midnight ✅ | `"W-MON"` → Monday 00:00 UTC ✅ | Both sides aggregated independently (`_aggregate_side(df_m1, "bid"/"ask")` L135–136); output schema: `open_{bid,ask}, high_{bid,ask}, low_{bid,ask}, close_{bid,ask}, volume, spread_close, bid_ask_data_quality` |
+| `cache_keys.py` | N/A | N/A | N/A | N/A | N/A | TF cache key = `sha256(m1_key | tf)` (no boundary convention parameter) |
+| `__init__.py` | N/A (public API) | | | | | |
+
+**Status vs dispatch Sub-change C:**
+
+- C.1 4H aligned to UTC 00/04/08/12/16/20: ✅ **already correct** (`aggregator.py:133`)
+- C.1 1H aligned to UTC :00: ✅ **already correct** (epoch origin)
+- C.1 D1 aligned to UTC 00:00: ✅ **already correct**
+- C.1 W1 aligned to Monday 00:00 UTC: ✅ **already correct**
+- C.2 re-aggregate to "5ers UTC convention": no-op IF 5ers uses UTC; **need chat to verify 5ers session convention** before deciding if any change is needed
+- C.3 HistData/MT5 aggregation parity investigation: **still needed** — this is a measurement / documentation task, not a code change. Bar filter: only drops bars where bid OR ask has all-NaN OHLC (L140–142); volume mismatch tolerance 0.1% (loader L198–206)
+- C.4 Comparison artefact for 5 majors: **still needed** — requires user to pull 5ers MT5 4H closes from VPS
+
+**Cache namespace:** TF cache path is `data/cache/<TF>/<PAIR>.parquet`. **No boundary-convention namespace in path.** If we end up changing the convention, the parallel `_5ers_utc/` namespace per dispatch C.2 is a real code change. If 5ers = UTC (likely), this work collapses to a no-op.
+
+---
+
+### D. `L_PROTOCOL.md` §1 non-negotiables (verbatim, lines 32–44)
+
+```
+## §1 Non-negotiables
+
+These cannot be violated, ever, regardless of arc, sub-protocol, or chat instruction:
+
+- No lookahead. Every feature is computable from data closed strictly before the entry bar's open.
+- Ex-ante population construction. Population is built before any outcome data is observed. No outcome-aware filtering anywhere in pool construction.
+- D1 one-bar lag rule. iClose(D1, 1) semantics — same-day D1 close is NOT available intraday.
+- Real bid/ask spreads. HistData M1 bid+ask is the canonical spread source. No fallback mechanism — zero-spread bars are a data quality flag, not silently backfilled.
+- Determinism. Every result file is reproducible from seed. sha256 manifests on every artefact. lineterminator='\n' for cross-platform reproducibility.
+- Config-driven. All parameters via YAML. No hardcoding.
+- Anchor preservation. Any cross-arc evaluation framework must reproduce KH-24's documented worst-fold numbers within tolerance (±0.5pp ROI, ±1pp DD). Framework failing reproduction = framework has a methodology bug.
+- Permanently eliminated items in CLAUDE.md never return under any framing.
+```
+
+**Protocol-touching vs engine-only assessment:**
+
+- ✅ "No lookahead", "Ex-ante population construction", "D1 one-bar lag", "Determinism", "Config-driven", "Anchor preservation", "Permanently eliminated" — all unaffected by this PR
+- ⚠️ "Real bid/ask spreads. HistData M1 bid+ask is the canonical spread source." — the dispatch's mid-price-features framing is **consistent** with this non-negotiable (mid is derived from real bid+ask; the spread is still treated as a real, per-bar quantity). No protocol amendment needed. Confirm in `PROTOCOL_RUNTIME.md` per dispatch A.4.
+- ⚠️ "Anchor preservation" — KH-24 was characterized under the pre-V3 / pre-A3 regime. If signal-parity changes affect KH-24's worst-fold by more than ±0.5pp ROI / ±1pp DD, this non-negotiable is violated. **This is a hard gate that the dispatch doesn't explicitly address.** Recommend adding a KH-24 anchor regression to Task 7 verification.
+
+### E. Arc 10 closure §4 deployment_spec — **doesn't exist**
+
+The dispatch reads "Read Arc 10's closure §4 deployment_spec — identify which features the Arc 10 strategy uses." The Arc 10 closure (`docs/archive/arc_results/ARC_10_RESULT.md`) closed `STEP_4_HALT` and has no §4 deployment_spec section (per `L_PROTOCOL` ARC_CLOSURE format, §4 deployment_spec only required for PASS-* verdicts).
+
+**Best available substitute:** Arc 10's post-closure experimentation surfaced `L1_minus_L0_atr` (D1 high-low slope magnitude) as the load-bearing feature in the EXP-02 holdout LOO analysis (116% of HTF LOO drop). This single feature is the priority parity target. It lives in `core/features/multi_tf.py::_d1_close_slope_magnitude()` (L84–91) and **already uses mid** (computed from `d1_df["close_{bid,ask}"]` averaged at L89).
+
+**Implication:** Arc 10's load-bearing feature is *already mid-price-correct* in the current engine. Re-running Arc 10 on this engine should produce identical (or near-identical) classifier AUC. The dispatch's "Risk 1: Arc 10 may not survive mid-price refactor" probably does not apply — Arc 10 was already running on mid features. **Chat should verify this against the original Arc 10 closure run.**
+
+### F. Test impact
+
+**Total: 222 test functions across 26 files** that import from `core.{features, sim, spread, data}`. The dispatch's "50-100 tests needing expected-value updates" is **likely a significant overestimate** under the corrected scope (since most features already mid, most fills already worst-case). Realistic impact:
+
+| Bucket | Files | Tests | Likely impact |
+|---|---|---|---|
+| Feature numerics | test_features_{pipeline,individual,cache}.py | 40 | Low — already mid. Only `distance.py` leak fix affects 2 features. |
+| Fill numerics | test_fill.py, test_multipair_backtester.py | 24 | Near-zero — already worst-case. Only changes if trail/signal_logic switch to mid. |
+| Trail | test_trailing_stop.py, test_trail_close_driven.py | 16 | Medium — if trail switches off `close_bid` to mid, all hit-level fixtures shift. |
+| Spread | test_real_spread.py | 9 | Near-zero — spread treatment unchanged. |
+| Data/aggregation | test_aggregator.py, test_histdata_loader.py, test_cache_keys.py, test_panel.py | 51 | Near-zero IF 5ers = UTC. Otherwise medium for re-anchored aggregator. |
+| E2E / KH-24 | test_kh24_*.py, test_determinism.py, test_live_balance_risk.py | 32 | **High-risk** — KH-24 anchor must be preserved per L_PROTOCOL §1. Any byte-shift here is a hard fail. |
+| Protocol runtime | tests/protocol_runtime/*.py | 31 | Medium — depends on signal_logic.py mid-switch. |
+| Account | test_account.py | 14 | Near-zero — Account is price-agnostic. |
+
+**Realistic estimate: 15–40 tests need expected-value updates** (not 50–100), gated on which specific deltas chat agrees to ship.
+
+---
+
+## §2 — File modification list & LOC estimate (corrected scope)
+
+| Path | Change | Est. LOC | Notes |
+|---|---|---|---|
+| `core/features/distance.py` | Switch `high_bid` (L27) and `low_ask` (L55) reads to `mid_high()`/`mid_low()` | ~10 | Trivial. Two functions. |
+| `core/signal_logic.py` | Switch all unprefixed `close` reads (~12 sites L83–L567) to a derived mid_close column injected upstream OR computed inline | **~40-100** | **Highest-risk single change.** Verify ATR (`out["atr"]`) and baseline (`out["baseline"]`) are also mid-derived. Affects entry/exit signal generation directly. |
+| `core/sim/trailing_stop.py` | Switch trail activation, level update, hit check off `close_bid` (L72, L154, L184) to either mid-close or leave bid-side per dispatch B.3's actual wording | ~15 | **Needs chat decision** — dispatch B.3 says "trail level updates based on highest CLOSE × ATR(mid) below" and "long hits trail when bid ≤ trail_level". Currently V3 uses `close_bid` for both activation and hit. Mid for activation, bid for hit, is the strict reading. |
+| `core/utils.py::calculate_atr()` | Either deprecate or switch to mid inputs | ~10 | Need to scan call sites first. May only be used by legacy `backtester.py`. |
+| `core/features_path_so_far.py` | Audit all call sites in `core/runners/`, `core/steps/`, `core/discovery/`, `core/strategies/` to confirm callers pass mid OHLC arrays | ~0 (audit) or ~20 (if any caller passes bid) | Verification pass; no code change unless leak found. |
+| `core/backtester.py` (legacy, 2011 LOC) | **Decision needed** — deprecate entirely, or retrofit with bid/ask | 0 or ~200 | **Major scoping question for chat.** Is this still used by any runner / step / arc execution path? If not, mark deprecated. If yes, full A+B treatment. |
+| `core/data/aggregator.py` | Add boundary-convention parameter + parallel cache namespace IF 5ers ≠ UTC | 0 or ~30 | **Needs chat decision on 5ers session.** No-op if 5ers = UTC. |
+| `docs/PROTOCOL_RUNTIME.md` | Add §"Mid-price feature computation", §"Worst-case fill execution", §"5ers UTC bar boundary" — document the *invariants we already hold* | ~150 | Mostly documenting existing state, not new behavior. |
+| `docs/BACKTESTER_ARCHITECTURE.md` | Update Step 1 features section, Step 5 execution section | ~80 | |
+| `docs/calibration/histdata_mt5_aggregation_parity_2026_05.md` | New | ~200 | Investigation + measurement output. Needs 5ers MT5 4H closes from user. |
+| `docs/calibration/arc_10_signal_parity_rerun_2026_05.md` | New | ~150 | Arc 10 re-run delta documentation. May be near-zero delta if findings above hold. |
+| `docs/audits/engine_capability_audit_2026_05.md` | Footer note | ~10 | |
+| `ARC_CLOSURE_TEMPLATE.md` | §4 deployment_spec add hard requirement | ~10 | Affects all future PASS closures. |
+| Test updates | Per bucket table above | ~80-200 | Depends on which changes ship. |
+| New tests (parity, alignment, regression) | New files in `tests/` and `tests/protocol_runtime/` | ~250 | Feature parity (same OHLC + different spreads → identical mid features), bar boundary alignment, Arc 10 regression delta. |
+
+**Total estimated LOC: ~1000-1500** (vs the implied ~3000-5000 in a 3-5 day refactor framing). The bulk is documentation + tests, not engine code.
+
+---
+
+## §3 — Recommendation / open questions for chat
+
+Before any code work begins, recommend chat resolve:
+
+1. **Is engine state pre-V3 or post-V3 in the dispatch's mental model?** The dispatch reads as if features are bid-priced and fills are single-priced. Reality: V3 already shipped both. If the dispatch is just locking in invariants we already hold + adding doc, the PR collapses to ~500 LOC of doc + ~200 LOC of leak fixes + tests. If chat believes there's a deeper bid-leak we missed, name the specific feature / file.
+
+2. **5ers session convention: UTC or NY-close?** Dispatch C.1 says "verify 5ers' actual session boundary via their documentation before locking." If UTC, the aggregator is already correct and Sub-change C is a measurement-only investigation. If NY-close (5pm ET rollover), then D1 and W1 anchors need to shift and the parallel cache namespace becomes real.
+
+3. **Legacy `core/backtester.py` (2011 LOC) — deprecate or retrofit?** It's the only place left using single-price OHLC. Needs a call-site scan and a decision. If still active in any L-arc step or KH-24 path, the dispatch's worst-case fill change is a large retrofit. If dead, delete and move on.
+
+4. **Trail manager: pure bid-side, pure mid, or asymmetric (mid for activation, bid for hit)?** Dispatch B.3 is internally inconsistent (says "highest CLOSE × ATR(mid)" implying mid update, then "long hits trail when bid ≤ trail_level" implying bid hit). V3 currently is pure bid. Chat needs to pick a model.
+
+5. **`signal_logic.py` mid-conversion: in-place or pipeline-injected?** This is the highest-risk single change. Recommend injecting a `close_mid` column upstream in the panel construction step so `signal_logic.py` reads `out["close_mid"]` everywhere — minimises diff size but adds one column to the canonical schema. Alternative: compute inline at each read site (larger diff, no schema change).
+
+6. **KH-24 anchor preservation (L_PROTOCOL §1).** Hard gate. Any change to signal_logic or trail or aggregator that shifts KH-24's worst-fold by more than ±0.5pp ROI / ±1pp DD violates the non-negotiable. **Recommend adding KH-24 byte-identity check as the first verification gate in Task 7**, before Arc 10 re-run.
+
+7. **Arc 10 re-run premise.** Arc 10's load-bearing feature (`L1_minus_L0_atr`) already uses mid. Expected delta: near-zero. If chat agrees, Task 4 collapses to a confirmation run rather than a verdict-changing experiment. Risk 1 in the dispatch ("Arc 10 may not survive mid-price refactor") is likely a non-risk.
+
+8. **Spread-floors YAML.** Arc work uses `configs/spread_floors_5ers.yaml`. This is orthogonal to the bid/ask column changes — the per-bar real spread from HistData is what's already in the cached parquets. Confirm chat does not want this to change as part of the PR.
+
+---
+
+## §4 — Read-first end-of-turn
+
+Per dispatch: **end turn for chat review**. No file paths modified. No tests run. No git changes.
+
+When chat resumes, expected re-scoped task order:
+
+1. Confirm answers to questions 1-8 above
+2. Pick the actual deltas to ship (likely a subset of the dispatch's sub-changes)
+3. CC executes the narrowed scope in a single PR per dispatch's structure
+4. Verification gates per Task 7, with KH-24 anchor regression as gate 0
+
+End of intent.

--- a/tests/fixtures/histdata_dst/build.py
+++ b/tests/fixtures/histdata_dst/build.py
@@ -1,0 +1,127 @@
+"""DST-aware mini fixture for 5ers EET boundary tests.
+
+Synthesises HistData M1 bid+ask CSVs spanning both EU DST transitions
+within a single year so the aggregator's 5ers_eet boundary code is
+exercised at:
+
+  - spring forward (last Sunday of March, EET 03:00 → EEST 04:00)
+  - autumn fall back (last Sunday of October, EEST 04:00 → EET 03:00)
+
+The fixture covers Mar-2024 and Oct-2024 minutes only — enough to label
+H4 / D1 bars at EET 00:00/04:00/.../20:00 and confirm DST is handled
+without producing duplicate or missing bars.
+"""
+
+from __future__ import annotations
+
+import calendar
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DstFixtureSpec:
+    pairs: tuple[str, ...] = ("EURUSD",)
+    # (yyyymm, day_start_inclusive, day_end_inclusive) windows. Picked so
+    # each window straddles a DST transition.
+    windows: tuple[tuple[str, int, int], ...] = (
+        ("202403", 29, 31),  # 2024-03-31 = spring forward; include 29 pre + 31 transition
+        ("202404", 1, 2),  # 2024-04-01..02 = post spring-forward steady state (EEST)
+        ("202410", 25, 27),  # 2024-10-27 = autumn fall-back; include 25 pre + 27 transition
+        ("202410", 28, 29),  # 2024-10-28..29 = post fall-back steady state (EET)
+    )
+    base_bid: float = 1.0850
+    spread_pips: float = 0.5
+
+
+def _gen_rows(pair: str, side: str, yyyymm: str, day_lo: int, day_hi: int, spec: DstFixtureSpec):
+    year = int(yyyymm[:4])
+    month = int(yyyymm[4:])
+    _, last_day = calendar.monthrange(year, month)
+    day_hi_capped = min(day_hi, last_day)
+    pair_offset = sum(ord(c) for c in pair) % 17 / 10_000
+    start_bid = spec.base_bid + pair_offset
+    spread_price = spec.spread_pips * 0.0001
+
+    rows: list[tuple[str, float, float, float, float, int]] = []
+    walk = 0
+    cur = datetime(year, month, day_lo, 0, 0, tzinfo=timezone.utc)
+    end = datetime(year, month, day_hi_capped, 23, 59, tzinfo=timezone.utc)
+    while cur <= end:
+        b = start_bid + walk * 0.00002
+        o = round(b, 5)
+        h = round(b + 0.00015, 5)
+        lo = round(b - 0.00005, 5)
+        c = round(b + 0.00010 + (walk % 3) * 0.00001, 5)
+        if side == "ask":
+            o, h, lo, c = (round(x + spread_price, 5) for x in (o, h, lo, c))
+        ts = cur.strftime("%Y-%m-%dT%H:%M:%SZ")
+        volume = 5 + (walk % 4)
+        rows.append((ts, o, h, lo, c, volume))
+        walk += 1
+        cur += timedelta(minutes=1)
+    return rows
+
+
+def _write_csv(path: Path, rows) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as f:
+        f.write("timestamp_utc,open,high,low,close,volume\n")
+        for ts, o, h, lo, c, v in rows:
+            f.write(f"{ts},{o},{h},{lo},{c},{v}\n")
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_dst_fixture(root: Path, spec: DstFixtureSpec | None = None) -> Path:
+    """Materialise the DST mini fixture under ``root``."""
+    spec = spec or DstFixtureSpec()
+    root.mkdir(parents=True, exist_ok=True)
+
+    manifest_pairs: dict[str, dict] = {}
+    for pair in spec.pairs:
+        files: dict[str, dict] = {}
+        # Aggregate per (yyyymm, side) into one CSV file containing all windows
+        # for that month, so the manifest has one file per pair-month per side.
+        by_month: dict[str, dict[str, list]] = {}
+        for yyyymm, day_lo, day_hi in spec.windows:
+            for side in ("bid", "ask"):
+                by_month.setdefault(yyyymm, {}).setdefault(side, []).extend(
+                    _gen_rows(pair, side, yyyymm, day_lo, day_hi, spec)
+                )
+        for yyyymm, sides in by_month.items():
+            year = yyyymm[:4]
+            for side, rows in sides.items():
+                rel = f"{pair}/m1/{side}/{year}/{pair}_M1_{side.upper()}_{yyyymm}.csv"
+                path = root / rel
+                rows.sort(key=lambda r: r[0])
+                _write_csv(path, rows)
+                files[rel] = {
+                    "n_ticks_source": 0,
+                    "rows": len(rows),
+                    "sha256": _sha256_file(path),
+                    "size_bytes": path.stat().st_size,
+                }
+        manifest_pairs[pair] = {"files": files}
+
+    manifest = {
+        "aggregated_at": datetime(2026, 1, 1, tzinfo=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S+00:00"
+        ),
+        "pairs": manifest_pairs,
+    }
+    (root / "m1_manifest.json").write_text(
+        json.dumps(manifest, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    return root

--- a/tests/test_aggregator_5ers_eet.py
+++ b/tests/test_aggregator_5ers_eet.py
@@ -1,0 +1,232 @@
+"""Tests for 5ers EET boundary aggregation (PR #187 Sub-change C).
+
+Covers:
+  - EET boundary anchors in winter (UTC+2) and summer (UTC+3) wall-clock
+  - DST autumn fall-back: no duplicate bars in the EET 02:00-03:00 wrap
+  - DST spring-forward: no missing bars across the EET 03:00→04:00 jump
+  - Cache namespace + key invalidation parity with the legacy UTC path
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.data.aggregator import (
+    SUPPORTED_BOUNDARY_CONVENTIONS,
+    SUPPORTED_TFS,
+    aggregate,
+    aggregate_m1_to_tf,
+)
+from core.data.cache_keys import read_meta
+from core.data.histdata_loader import M1_COLUMNS, load_m1
+from tests.fixtures.histdata_dst.build import build_dst_fixture
+from tests.fixtures.histdata_mini.build import FixtureSpec, build_fixture
+
+
+@pytest.fixture
+def dst_root(tmp_path: Path) -> Path:
+    return build_dst_fixture(tmp_path / "histdata")
+
+
+@pytest.fixture
+def m1_dst(dst_root: Path, tmp_path: Path) -> pd.DataFrame:
+    return load_m1("EURUSD", histdata_root=dst_root, cache_root=tmp_path / "cache")
+
+
+@pytest.fixture
+def mini_root(tmp_path: Path) -> Path:
+    return build_fixture(tmp_path / "histdata", FixtureSpec(minutes_per_month=1440))
+
+
+# ── Convention plumbing ────────────────────────────────────────────────
+
+
+def test_supported_conventions_include_utc_and_5ers_eet() -> None:
+    assert "utc" in SUPPORTED_BOUNDARY_CONVENTIONS
+    assert "5ers_eet" in SUPPORTED_BOUNDARY_CONVENTIONS
+
+
+def test_unsupported_convention_raises(m1_dst: pd.DataFrame) -> None:
+    with pytest.raises(ValueError, match="Unsupported boundary_convention"):
+        aggregate_m1_to_tf(m1_dst, "H4", boundary_convention="bogus")
+
+
+def test_utc_default_byte_identical_to_explicit_utc(mini_root: Path, tmp_path: Path) -> None:
+    """Default convention is 'utc' and matches explicit-utc output exactly."""
+    a = aggregate(
+        "EURUSD",
+        "H4",
+        histdata_root=mini_root,
+        cache_root=tmp_path / "cache_a",
+        use_cache=False,
+    )
+    b = aggregate(
+        "EURUSD",
+        "H4",
+        histdata_root=mini_root,
+        cache_root=tmp_path / "cache_b",
+        use_cache=False,
+        boundary_convention="utc",
+    )
+    pd.testing.assert_frame_equal(a, b)
+
+
+# ── EET wall-clock anchoring ───────────────────────────────────────────
+
+
+def test_h4_anchors_to_eet_in_steady_state_winter(m1_dst: pd.DataFrame) -> None:
+    """Steady-state winter (full day post-autumn-fallback): H4 bars at EET
+    00/04/08/12/16/20 wall-clock → UTC 22/02/06/10/14/18."""
+    out = aggregate_m1_to_tf(m1_dst, "H4", boundary_convention="5ers_eet")
+    # 2024-10-29 is fully in EET (post-fallback steady state)
+    winter_bars = out.loc["2024-10-29":"2024-10-29 23:59"]
+    if len(winter_bars) == 0:
+        pytest.skip("fixture window doesn't extend to 2024-10-29")
+    expected_utc_hours = {22, 2, 6, 10, 14, 18}
+    assert set(winter_bars.index.hour).issubset(expected_utc_hours), (
+        f"Winter steady-state H4 bars must anchor to EET 00/04/.../20 "
+        f"(UTC 22/02/.../18); got hours={sorted(set(winter_bars.index.hour))}"
+    )
+
+
+def test_h4_anchors_to_eet_in_steady_state_summer(m1_dst: pd.DataFrame) -> None:
+    """Steady-state summer (full day post-spring-forward): H4 bars at EEST
+    00/04/08/12/16/20 wall-clock → UTC 21/01/05/09/13/17."""
+    out = aggregate_m1_to_tf(m1_dst, "H4", boundary_convention="5ers_eet")
+    # 2024-04-02 is fully in EEST (post-spring-forward steady state)
+    summer_bars = out.loc["2024-04-02":"2024-04-02 23:59"]
+    if len(summer_bars) == 0:
+        pytest.skip("fixture window doesn't extend to 2024-04-02")
+    expected_utc_hours = {21, 1, 5, 9, 13, 17}
+    assert set(summer_bars.index.hour).issubset(expected_utc_hours), (
+        f"Summer steady-state H4 bars must anchor to EEST 00/04/.../20 "
+        f"(UTC 21/01/.../17); got hours={sorted(set(summer_bars.index.hour))}"
+    )
+
+
+def test_d1_anchors_to_eet_midnight(m1_dst: pd.DataFrame) -> None:
+    """D1 bars labelled at EET 00:00 → UTC 22:00 winter / UTC 21:00 summer."""
+    out = aggregate_m1_to_tf(m1_dst, "D1", boundary_convention="5ers_eet")
+    hours = set(out.index.hour)
+    # All D1 bars should fall at UTC 21 or 22 depending on season
+    assert hours.issubset({21, 22}), (
+        f"D1 EET bars must label at UTC 21 (summer) or UTC 22 (winter); got {sorted(hours)}"
+    )
+
+
+def test_w1_anchors_to_eet_monday(m1_dst: pd.DataFrame) -> None:
+    """W1 bars label at Monday 00:00 EET (= UTC 22:00 Sun winter / 21:00 Sun summer)."""
+    out = aggregate_m1_to_tf(m1_dst, "W1", boundary_convention="5ers_eet")
+    # Convert UTC label back to EET wall-clock to verify Monday 00:00 anchor.
+    eet_index = out.index.tz_convert("Europe/Athens")
+    assert all(d.weekday() == 0 for d in eet_index), (
+        f"W1 EET bars must label at Monday in EET wall-clock; got "
+        f"weekdays={[d.weekday() for d in eet_index]}"
+    )
+    assert all(d.hour == 0 for d in eet_index), (
+        f"W1 EET bars must label at 00:00 EET; got hours={[d.hour for d in eet_index]}"
+    )
+    # UTC label hour is 21 or 22 depending on DST regime
+    assert set(out.index.hour).issubset({21, 22}), (
+        f"W1 EET bars must label at UTC 21/22; got {sorted(set(out.index.hour))}"
+    )
+
+
+# ── DST transition handling ────────────────────────────────────────────
+
+
+def test_dst_autumn_no_duplicate_bars(m1_dst: pd.DataFrame) -> None:
+    """Autumn fall-back: EET 02:00-03:00 wall-clock occurs twice on 2024-10-27.
+
+    The aggregator's UTC-indexed output must remain monotonic with no
+    duplicate timestamps despite the wall-clock ambiguity.
+    """
+    out = aggregate_m1_to_tf(m1_dst, "H4", boundary_convention="5ers_eet")
+    fall_back_window = out.loc["2024-10-26":"2024-10-28"]
+    assert fall_back_window.index.is_unique, "Duplicate UTC bar labels around DST fall-back"
+    assert fall_back_window.index.is_monotonic_increasing, "Non-monotonic UTC index across DST"
+
+
+def test_dst_total_volume_conserved(m1_dst: pd.DataFrame) -> None:
+    """Across the entire DST-spanning fixture, total bar volume == total M1
+    volume — no minute is dropped through spring-forward or fall-back."""
+    out = aggregate_m1_to_tf(m1_dst, "H4", boundary_convention="5ers_eet")
+    assert out["volume"].sum() == m1_dst["volume"].sum(), (
+        "M1 volume not conserved across DST transitions (H4 5ers_eet)"
+    )
+
+
+def test_dst_d1_volume_conserved(m1_dst: pd.DataFrame) -> None:
+    """D1 5ers_eet must also conserve volume across DST."""
+    out = aggregate_m1_to_tf(m1_dst, "D1", boundary_convention="5ers_eet")
+    assert out["volume"].sum() == m1_dst["volume"].sum(), (
+        "M1 volume not conserved across DST transitions (D1 5ers_eet)"
+    )
+
+
+# ── Cache namespace separation ─────────────────────────────────────────
+
+
+def test_cache_namespace_separates_conventions(mini_root: Path, tmp_path: Path) -> None:
+    """UTC and 5ers_eet caches live under distinct directories."""
+    cache_root = tmp_path / "cache"
+    aggregate("EURUSD", "H4", histdata_root=mini_root, cache_root=cache_root)
+    aggregate(
+        "EURUSD",
+        "H4",
+        histdata_root=mini_root,
+        cache_root=cache_root,
+        boundary_convention="5ers_eet",
+    )
+    assert (cache_root / "H4" / "EURUSD.parquet").exists()
+    assert (cache_root / "H4_5ers_eet" / "EURUSD.parquet").exists()
+
+
+def test_cache_keys_differ_between_conventions(mini_root: Path, tmp_path: Path) -> None:
+    cache_root = tmp_path / "cache"
+    aggregate("EURUSD", "H4", histdata_root=mini_root, cache_root=cache_root)
+    aggregate(
+        "EURUSD",
+        "H4",
+        histdata_root=mini_root,
+        cache_root=cache_root,
+        boundary_convention="5ers_eet",
+    )
+    utc_meta = read_meta(cache_root / "H4" / "EURUSD.parquet")
+    eet_meta = read_meta(cache_root / "H4_5ers_eet" / "EURUSD.parquet")
+    assert utc_meta is not None and eet_meta is not None
+    assert utc_meta.cache_key != eet_meta.cache_key, (
+        "Cache keys must differ between UTC and 5ers_eet conventions"
+    )
+    assert utc_meta.layer == "H4"
+    assert eet_meta.layer == "H4_5ers_eet"
+
+
+def test_cache_byte_identical_two_runs(m1_dst: pd.DataFrame, tmp_path: Path) -> None:
+    """Two EET aggregations of the same M1 input produce byte-identical parquet."""
+    a = aggregate_m1_to_tf(m1_dst, "H4", boundary_convention="5ers_eet")
+    b = aggregate_m1_to_tf(m1_dst, "H4", boundary_convention="5ers_eet")
+    pd.testing.assert_frame_equal(a, b)
+
+    p_a = tmp_path / "a.parquet"
+    p_b = tmp_path / "b.parquet"
+    a.to_parquet(p_a, engine="pyarrow", compression="snappy", index=True)
+    b.to_parquet(p_b, engine="pyarrow", compression="snappy", index=True)
+    sha_a = hashlib.sha256(p_a.read_bytes()).hexdigest()
+    sha_b = hashlib.sha256(p_b.read_bytes()).hexdigest()
+    assert sha_a == sha_b, "Two-run EET aggregation produced different parquet bytes"
+
+
+# ── Schema parity ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("tf", SUPPORTED_TFS)
+def test_eet_aggregate_preserves_canonical_schema(m1_dst: pd.DataFrame, tf: str) -> None:
+    out = aggregate_m1_to_tf(m1_dst, tf, boundary_convention="5ers_eet")
+    assert list(out.columns) == M1_COLUMNS
+    assert out.index.tz is not None
+    assert str(out.index.tz) == "UTC", "Output bar index must be tz_convert'd back to UTC"

--- a/tests/test_feature_parity_mid.py
+++ b/tests/test_feature_parity_mid.py
@@ -1,0 +1,130 @@
+"""Feature-parity test (PR #187 signal-parity contract).
+
+Holds same mid-price across two synthetic bar frames but varies the
+bid/ask split. All v3 mid-price features must produce IDENTICAL output;
+only ``spread_close`` / ``spread_regime`` features may differ.
+
+Locks the contract: under PR #187, every feature the engine consumes
+for signal generation is venue-independent.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+import core.features.pipeline  # noqa: F401  (side-effect: registers features)
+from core.features.registry import all_specs, get
+
+
+def _synthetic_pair_df(spread_pips: float, n_bars: int = 200) -> pd.DataFrame:
+    """Build a 1H pair frame with constant mid-price walk; spread is variable.
+
+    ``spread_pips`` controls bid/ask split around a fixed mid.
+    """
+    idx = pd.date_range("2024-01-01 00:00", periods=n_bars, freq="1h", tz="UTC")
+    mid_close = 1.1000 + (pd.Series(range(n_bars), index=idx) % 13) * 0.0001
+    mid_open = mid_close.shift(1).fillna(1.1000)
+    mid_high = pd.concat([mid_open, mid_close], axis=1).max(axis=1) + 0.00015
+    mid_low = pd.concat([mid_open, mid_close], axis=1).min(axis=1) - 0.00010
+    half_spread = (spread_pips / 2.0) * 0.0001
+
+    df = pd.DataFrame(
+        {
+            "open_bid": mid_open - half_spread,
+            "high_bid": mid_high - half_spread,
+            "low_bid": mid_low - half_spread,
+            "close_bid": mid_close - half_spread,
+            "open_ask": mid_open + half_spread,
+            "high_ask": mid_high + half_spread,
+            "low_ask": mid_low + half_spread,
+            "close_ask": mid_close + half_spread,
+            "volume": [10] * n_bars,
+            "spread_close": [spread_pips * 0.0001] * n_bars,
+            "bid_ask_data_quality": ["ok"] * n_bars,
+        },
+        index=idx,
+    )
+    df.index.name = "timestamp_utc"
+    df.attrs["pair"] = "EURUSD"
+    return df
+
+
+# Features expected to be spread-INDEPENDENT (price-derived from mid).
+_MID_FEATURES = (
+    "atr_14",
+    "kijun_26_distance",
+    "swing_high_distance_14",
+    "swing_low_distance_14",
+    "range_close_ratio",
+    "atr_vs_trailing_100",
+    "atr_percentile_100",
+    "prior_session_high_distance",
+    "prior_session_low_distance",
+    "distance_to_round_number",
+    "hour_of_day",
+    "day_of_week",
+    "session_tokyo",
+    "session_london",
+    "session_ny",
+    "session_ldn_ny_overlap",
+    "session_dead",
+)
+
+# Features expected to be spread-DEPENDENT (structural regime).
+_SPREAD_FEATURES = ("spread_vs_trailing_100", "spread_percentile_100")
+
+
+def test_all_registered_mid_features_invariant_under_spread() -> None:
+    """Every registered mid-price feature must produce identical Series
+    whether the bid/ask spread is 0.5 pip or 5.0 pip, given identical
+    underlying mid OHLC. Spread-class features are exempt."""
+    df_tight = _synthetic_pair_df(spread_pips=0.5)
+    df_wide = _synthetic_pair_df(spread_pips=5.0)
+
+    registered = {spec.name for spec in all_specs()}
+    failures: list[tuple[str, str]] = []
+
+    for name in registered:
+        if name in _SPREAD_FEATURES:
+            continue
+        # Some features need cross-pair panel — skip those here; covered in
+        # tests/test_features_pipeline.py.
+        spec = get(name)
+        if spec.feature_class == "cross_pair":
+            continue
+        # Multi-TF features need an HTF panel injection; skip in this test.
+        if spec.feature_class == "multi_tf":
+            continue
+        try:
+            s_tight = spec.producer(df_tight)
+            s_wide = spec.producer(df_wide)
+        except Exception as e:  # noqa: BLE001
+            failures.append((name, f"producer raised: {e!r}"))
+            continue
+        # Compare with NaN-tolerant equality
+        try:
+            pd.testing.assert_series_equal(
+                s_tight, s_wide, check_names=False, check_exact=False, rtol=1e-9, atol=1e-12
+            )
+        except AssertionError as e:
+            failures.append((name, str(e)[:200]))
+
+    assert not failures, (
+        "Mid-price features differed when only spread changed (signal parity violation):\n"
+        + "\n".join(f"  - {n}: {msg}" for n, msg in failures)
+    )
+
+
+def test_spread_regime_features_use_spread_input() -> None:
+    """Negative-check: spread regime features must READ spread_close from the
+    pair frame (not infer it from bid/ask). Verifies the dispatch's note
+    that spread_regime is structural and exempt from mid-parity."""
+    df = _synthetic_pair_df(spread_pips=0.5)
+    for name in _SPREAD_FEATURES:
+        spec = get(name)
+        # Should run without error even when spread_close is explicitly
+        # the input. If the feature inferred spread from bid/ask, we'd
+        # break this contract by removing one of them — but spread_close
+        # is the canonical input. Smoke test only.
+        s = spec.producer(df)
+        assert s.index.equals(df.index), f"{name} did not align to input index"

--- a/tests/test_trail_close_driven.py
+++ b/tests/test_trail_close_driven.py
@@ -1,8 +1,14 @@
-"""Tests for the PR-E.1.6 trail mechanics rewrite.
+"""Tests for trail mechanics under PR #187 signal-parity convention.
 
-Verifies the EA pattern: trail activates on bid_close, exit fires when
-bar_close ≤ trail_level, fill at NEXT bar's open_bid (not intra-bar
-wick on the next bar).
+Trail activation + ratchet operate on MID close (supersedes PR-E.1.6's
+bid-only trail), so trail behaviour is venue-independent. Hit detection
+still uses bid-side close for worst-case-fill realism, and exit fills at
+NEXT bar's ``open_bid`` (not intra-bar wick on the next bar).
+
+Background: PR-E.1.6 switched the trail to bid-only to match the live
+EA's ``CopyClose(PERIOD_H4)`` (bid). PR #187 reverses that for the
+backtester so signals are venue-portable; the EA will be updated to mid
+in a parallel deployment PR.
 """
 
 from __future__ import annotations
@@ -43,25 +49,25 @@ def _panel_from_rows(pair: str, rows: list[tuple]) -> Panel:
     return Panel.from_frames({pair: df}, tf="H4")
 
 
-def test_trail_reads_bid_close_not_mid() -> None:
-    """Trail update should read close_bid, not (close_bid + close_ask)/2.
+def test_trail_reads_mid_close_per_signal_parity() -> None:
+    """Trail activation reads mid (close_bid + close_ask) / 2 per PR #187.
 
-    Construct a bar where close_bid = 1.10 and close_ask = 1.12. If trail
-    activation reads mid (1.11), trail activates; if it reads bid (1.10),
-    trail doesn't (threshold = 1.11). Verifies bid-side reading.
+    Construct a bar where close_bid = 1.10 and close_ask = 1.12. Activation
+    threshold is 1.11 (entry 1.10 + 2.0 × ATR 0.005). Mid = 1.11 → trail
+    activates. Under PR-E.1.6's pre-PR-187 bid-only trail, bid 1.10 < 1.11
+    would have left the trail inactive — this is the locked reversal.
     """
     pair = "EURUSD"
-    # Activation threshold at 1.11 (entry 1.10 + 2.0 × ATR 0.005 = 1.11)
     bar_with_wide_spread = (
         "2026-01-01 04:00:00",
         1.10,
         1.12,
         1.09,
-        1.10,  # bid: o, h, l, c=1.10 — JUST below activation 1.11
+        1.10,  # bid: c=1.10 — would NOT have activated under bid trail
         1.10,
         1.12,
         1.09,
-        1.12,  # ask: c=1.12 — mid=1.11 would activate
+        1.12,  # ask: c=1.12 — mid=1.11 activates under signal-parity trail
     )
     panel = _panel_from_rows(pair, [bar_with_wide_spread])
 
@@ -80,9 +86,10 @@ def test_trail_reads_bid_close_not_mid() -> None:
     bar = panel.pair_dfs[pair].iloc[0]
     tm.update_all_at_close({pair: bar}, acct)
     state = tm.get(pos.position_id)
-    # Bid close 1.10 < threshold 1.11 → trail must NOT have activated
-    assert state.activated is False, (
-        "Trail activated on bid_close=1.10 (threshold=1.11) — should have read bid, not mid"
+    # Mid close (1.10+1.12)/2 = 1.11 ≥ threshold 1.11 → trail activates
+    assert state.activated is True, (
+        "Trail did not activate on mid_close=1.11 (threshold=1.11) — should "
+        "have read mid per PR #187 signal parity"
     )
 
 


### PR DESCRIPTION
## Summary

Scoped-down delivery of [CC_15_SIGNAL_PARITY_ENGINE.md](../signal_parity_intent.md). Read-first audit found that V3 path already had ~95% of Sub-change A (mid features) and ~100% of Sub-change B (worst-case fills) shipped as side effects of PR #185 / #186. The actual remaining gaps were narrower than the dispatch assumed; per chat resolution this PR ships only the narrowed scope and queues the legacy-path retirement as a follow-up dispatch.

- **Mid-feature leaks fixed** in `core/features/distance.py` (2 functions) and `core/sim/trailing_stop.py` (trail activation + ratchet → mid; hit detection stays bid for worst-case fill).
- **5ers EET bar boundaries** added to `core/data/aggregator.py` via `boundary_convention="5ers_eet"`. UTC default unchanged → existing caches byte-identical. EET path handles DST automatically (Europe/Athens zone).
- **KH-24 live deployment untouched.** `core/backtester.py` + `core/signal_logic.py` remain in place (33 importers including `live/run_daily.py`); legacy retirement queued as separate dispatch in [TODO.md](TODO.md).

## Non-obvious findings surfaced to chat during PR

1. **V3 path already mostly mid-priced.** Most features in `core/features/` already computed `(close_bid + close_ask) / 2` pre-PR-#187. Only 2 functions in `distance.py` + the trail manager + the legacy `signal_logic.py` remained as leaks.
2. **V3 fills already worst-case.** `core/sim/fill.py` already shipped long-ask / short-bid entries + direction-correct SL/TP hits in V3 (PR-B). Sub-change B was effectively a no-op.
3. **`core/backtester.py` has 33 importers** including `live/run_daily.py` (the KH-24 MT5 live bridge). Moving to archive would break live; chat resolved to keep legacy untouched in this PR.
4. **PR-E.1.6 reversal**: `trailing_stop.py` was deliberately switched to bid-only in PR-E.1.6 to match the EA's `CopyClose(PERIOD_H4)` (bid). PR #187 reverses that for the backtester — venue independence wins. The EA must be updated to mid-trail in a parallel deployment PR; until then, EA↔backtest divergence on trail activation is expected.
5. **Pandas `origin="start_day"` doesn't re-anchor at DST.** For H4 EET aggregation we had to use per-local-date groupby + per-day resample. D1 and W1 use pandas' built-in DST-aware resample.
6. **Autumn DST extra short bar.** Per-local-date H4 groupby on the autumn fall-back day produces a 7th "+24h" bar containing 1 hour of M1 data (the "00:00 EET of next day" anchor falls inside the previous local day's groupby). Documented in `docs/calibration/histdata_mt5_aggregation_parity_2026_05.md §3.2`.

## What landed

### Code

| File | Change |
|---|---|
| `core/features/distance.py` | `_prior_session_high` / `_prior_session_low` now use `mid_high()` / `mid_low()` (was `high_bid` / `low_ask`) |
| `core/sim/trailing_stop.py` | Trail activation + ratchet read mid close; hit detection stays bid (dispatch B.3 strict reading) |
| `core/data/aggregator.py` | New `boundary_convention="5ers_eet"` parameter; UTC default byte-identical to pre-PR-#187 |
| `core/data/cache_keys.py` | `tf_cache_key()` accepts optional `boundary_convention` (default UTC = legacy key) |

### Tests

| File | Status |
|---|---|
| `tests/test_aggregator_5ers_eet.py` | NEW — 20 tests (EET anchors winter+summer; DST volume conservation; cache namespace + key separation; schema parity) |
| `tests/test_feature_parity_mid.py` | NEW — 2 tests (every registered mid-feature invariant when bid/ask split varies but mid held; spread_regime exempt) |
| `tests/fixtures/histdata_dst/` | NEW — DST-spanning M1 fixture (Mar 29-31 + Apr 1-2 + Oct 25-27 + Oct 28-29 of 2024) |
| `tests/test_trail_close_driven.py` | MODIFIED — `test_trail_reads_bid_close_not_mid` → `test_trail_reads_mid_close_per_signal_parity` (locks the reversal) |
| `tests/test_kh24_a1_equivalence.py` | unchanged — structural test still passes |
| `tests/test_trailing_stop.py` | unchanged — all 13 tests still pass |
| Full suite | 1155 passed, 305 skipped (need data not in CI), 0 failed |

### Docs

| File | Change |
|---|---|
| `docs/PROTOCOL_RUNTIME.md` | New §15 — Signal parity (mid features + worst-case fills + EET) |
| `docs/BACKTESTER_ARCHITECTURE.md` | Data layer + sim updated with PR-#187 references |
| `docs/templates/ARC_CLOSURE_TEMPLATE.md` | §4.11 deployment readiness checklist — added "signal parity verified against deployment venue" hard requirement |
| `docs/calibration/histdata_mt5_aggregation_parity_2026_05.md` | NEW — EET convention + DST findings + cross-broker comparison procedure (cross-broker run deferred to user MT5 data pull) |
| `docs/calibration/arc_10_signal_parity_rerun_2026_05.md` | NEW — Arc 10 re-run procedure + expected near-zero delta (load-bearing `L1_minus_L0_atr` already used mid) |
| `docs/audits/engine_capability_audit_2026_05.md` | Footer note — signal parity gap closed by PR #187 |
| `TODO.md` | Queued follow-up dispatches (legacy retirement, 5ers TZ verification, Arc 10 regression run, MT5 5-major comparison, 5ers_eet cache build, EA mid-trail update) |

## Out of scope (queued follow-ups)

- **Legacy engine retirement.** Migrate `live/run_daily.py` + 32 other importers off `core/backtester.py` + `core/signal_logic.py` onto V3 paths. KH-24 anchor preservation is the gate. Tracked in [TODO.md](TODO.md).
- **5ers timezone verification.** Assumed EET/EEST for this PR. User to verify against 5ers docs; if NY-close, separate small PR adjusts convention parameter.
- **Arc 10 re-run.** Workstation execution of `py -m scripts.l_arc_10_v3.step_5`. Procedure + expected near-zero delta in [docs/calibration/arc_10_signal_parity_rerun_2026_05.md](docs/calibration/arc_10_signal_parity_rerun_2026_05.md).
- **HistData↔5ers MT5 5-major comparison.** User to pull 5ers MT5 H4 closes from VPS; procedure in [docs/calibration/histdata_mt5_aggregation_parity_2026_05.md §5](docs/calibration/histdata_mt5_aggregation_parity_2026_05.md).
- **5ers_eet cache build for 28 pairs × 7 TFs.** One-time workstation operation.
- **EA mid-trail update.** Live MT5 EA still uses `CopyClose(PERIOD_H4)` (bid). To restore backtest↔EA parity post-PR-#187, EA needs mid-trail. Separate deployment PR.

## Test plan

- [x] `tests/test_aggregator_5ers_eet.py` passes (20 tests)
- [x] `tests/test_feature_parity_mid.py` passes (2 tests)
- [x] `tests/test_aggregator.py` (UTC byte-identity preserved) passes (25 tests)
- [x] `tests/test_trailing_stop.py` passes (13 tests)
- [x] `tests/test_trail_close_driven.py` passes (3 tests, including renamed mid-trail lock)
- [x] `tests/protocol_runtime/` passes (105 tests — KH-24 structural equivalence path intact)
- [x] Full suite: 1155 passed, 305 skipped, 0 failed
- [x] Ruff clean
- [ ] CI green (pending push)
- [ ] **Gate 0 KH-24 anchor**: full-data worst-fold ROI / DD within ±0.5pp / ±1pp (workstation run via `py -m scripts.anchor.run_anchor --mode A`; chat will surface if tolerance breaks per "not a blocker" resolution)
- [ ] **Arc 10 regression**: workstation re-run + delta documentation per [docs/calibration/arc_10_signal_parity_rerun_2026_05.md](docs/calibration/arc_10_signal_parity_rerun_2026_05.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)