### PR TITLE
[INFRA] heavy_ml_probe PR-B: FLAML AutoML + 11-fold TimeSeriesSplit

### DIFF
--- a/configs/heavy_ml_probe/default.yaml
+++ b/configs/heavy_ml_probe/default.yaml
@@ -1,0 +1,127 @@
+# configs/heavy_ml_probe/default.yaml
+# heavy_ml_probe sub-protocol — default invocation parameters (PR-A).
+# Sub-protocol spec: docs/sub_protocols/heavy_ml_probe.md (locked v1.0)
+# Overseer: L_PROTOCOL.md v3.0 (Amendments 1-3).
+# Build dispatch: docs/dispatches/heavy_ml_probe_build_intent.md
+#
+# This file is the canonical schema for any arc invoking heavy_ml_probe.
+# Per-arc YAMLs may shadow individual values but MUST NOT add unknown keys
+# without a spec amendment.
+#
+# Chat resolutions baked in:
+#   Q1 — survival target: time_to_reach_1r_censored_at_sl_or_time_exit
+#   Q2 — FLAML budget: max_iter counts as 1-trial-per-evaluation
+#   Q5b — A4 consumer: adapter (B1) — survival models wrap to predict_admit shape
+#
+# Schema version stamped into manifest.json so downstream tooling can
+# detect breaking changes. Bump on any incompatible key change.
+
+schema_version: "1.0"
+
+sub_protocol:
+  name: heavy_ml_probe
+  spec_path: docs/sub_protocols/heavy_ml_probe.md
+  spec_version: "1.0"
+
+# ── Compute budget (dispatch §6 #6) ──────────────────────────────────
+# Hard cap. Sum across folds = max_iter_per_fold × n_folds = 1000 × 11 =
+# 11000 evaluations per cluster per arc. The automl.py wrapper refuses
+# to exceed; if FLAML's internal accounting prevents enforcement, PR-B
+# HALTs per WORKFLOW §6.
+automl:
+  framework: flaml                # locked per dispatch §5
+  max_iter_per_fold: 1000         # one evaluation == one FLAML trial (Q2)
+  n_folds: 11                     # 11-fold TimeSeriesSplit on IS (spec §"AutoML inside CV")
+  metric: roc_auc                 # target = binary; AUC-ROC matches vanilla Step 4
+  ensemble: true                  # FLAML decides ensembling/stacking internally
+  estimator_list:                 # search space per spec §"What overrides the overseer"
+    - rf
+    - lgbm
+    - xgboost
+    - catboost
+    - extra_tree
+    - lrl1                        # logistic regression (L1)
+  time_budget_seconds: null       # null = let max_iter be the binding cap; set non-null for compute ceilings
+  early_stop: true                # FLAML's internal early stop; does not relax max_iter
+
+# ── Meta-labeling target (dispatch §6 + spec §"Meta-labeling target") ─
+# Binary target: did the trade reach +1R MFE before hitting SL?
+# Constructed from pool's per-trade MFE / MAE columns at Step 1.
+meta_labeling:
+  enabled: true
+  target_kind: reach_1r_before_sl
+  mfe_r_threshold: 1.0            # +1R MFE
+  # Threshold sweep at PR-C: report precision / recall at each.
+  threshold_sweep: [0.30, 0.40, 0.50, 0.60, 0.70]
+
+# ── Survival models (dispatch §6 + spec §"Survival model variant") ───
+# Q1 resolution: target = time-to-+1R-MFE censored at SL or time-exit.
+# Adapter (Q5b option B1) maps survival predictions to A4's predict_admit shape.
+survival:
+  enabled: true
+  target_kind: time_to_reach_1r_censored_at_sl_or_time_exit
+  # Horizon used by the A4 adapter when translating S(t | features) to
+  # an exit decision. "Probability of reaching +1R within the next K
+  # bars" at each post-entry bar. Tested at PR-D's defaults; arc-side
+  # configs may override.
+  adapter_horizon_bars: 5
+  adapter_exit_thresholds: [0.30, 0.40, 0.50]
+  min_n_warn: 200                 # warn if cluster has fewer trades (dispatch §6 #10)
+  cox_ph:
+    penalizer: 0.0                # ridge penalty; 0.0 = unpenalised
+    fit_intercept: true
+  rsf:
+    n_estimators: 200             # mirrors vanilla Step 4 RF default
+    min_samples_leaf: 50          # matches L_PROTOCOL Appendix A RF default
+    max_depth: 6                  # matches L_PROTOCOL Appendix A RF default
+
+# ── Holdout discipline (dispatch §6 #3 + L_PROTOCOL §1) ──────────────
+# Holdout 2021-01-01 → present is OFF-LIMITS during training. The
+# pipeline filters the input pool to entry_time < train_end before
+# AutoML / meta-label / survival see any data. Mirrors vanilla Step 4's
+# train_end argument (see core/steps/step_4_extraction.py).
+training_window:
+  is_start: "2010-01-01"
+  train_end: "2021-01-01"         # exclusive cutoff; trades with entry_time >= this are excluded
+
+# ── Causal lineage gate (dispatch §6 #2 + Q3 resolution) ─────────────
+# Pre-evaluation filter on feature columns. Features without a clean
+# tag are dropped from the training set BEFORE AutoML sees them. Uses
+# the registry-backed core.features.pipeline.feature_lineage_dataframe()
+# as source-of-truth (same pattern as core/discovery/causal_filter.py).
+causal_filter:
+  accepted_lineage: ["clean"]
+  rejected_lineage: ["suspect", "unverified"]
+  exclude_classes: []             # optional: exclude e.g. "spread_regime" if known leaky
+
+# ── Determinism (dispatch §6 #4, #5, #7) ─────────────────────────────
+determinism:
+  random_state: 42
+  n_jobs: 1                       # single-threaded for reproducibility
+  text_line_terminator: "\n"
+
+# ── Output layout (dispatch §7) ──────────────────────────────────────
+# Per-arc invocation supplies the arc root; outputs land under it.
+output:
+  step4_subdir: step_4/heavy_ml
+  step5_subdir: step_5/heavy_ml_augmented
+  classifiers_subdir: classifiers
+  survival_subdir: survival
+  artefacts:
+    automl_leaderboard: automl_leaderboard.csv
+    automl_feature_importance: automl_feature_importance.csv
+    survival_model_results: survival_model_results.csv
+    meta_label_results: meta_label_results.csv
+    compute_budget_used: compute_budget_used.md
+    step4_manifest: manifest.json
+    classifiers_manifest: manifest.json     # under classifiers_subdir
+    survival_manifest: manifest.json        # under survival_subdir
+    step5_manifest: manifest.json           # under step5_subdir
+
+# ── Library versions (informational; recorded into manifest at runtime) ─
+# Pinning is the operator's responsibility (managed via
+# requirements-dev.txt). Recording the runtime-resolved versions into
+# the manifest gives downstream tooling cross-env audit signal — same
+# pattern as core/steps/step_4_extraction.py:_LGBM_VERSION.
+library_versions:
+  record_at_runtime: true

--- a/core/heavy_ml_probe/__init__.py
+++ b/core/heavy_ml_probe/__init__.py
@@ -1,0 +1,29 @@
+"""heavy_ml_probe — Sub-protocol layered on L_PROTOCOL v3.0 overseer.
+
+Implements ``docs/sub_protocols/heavy_ml_probe.md`` v1.0. Replaces
+vanilla Step 4 with AutoML (FLAML) inside CV, adds a meta-labeling
+target ("reach +1R MFE before SL"), and trains Cox PH + Random Survival
+Forest variants for A4 Pipeline D consumption. Step 5 augmentation hook
+allows A2 / A4 / A6 to consume heavy-ML-trained components.
+
+This package is invoked when an arc's ``ARC_OPEN.md`` declares
+``sub_protocol: heavy_ml_probe``. Vanilla Step 1 / 2 / 3 / 6 + the §3
+deployment gates remain unchanged — heavy_ml_probe only overrides Step
+4 and augments Step 5 per the sub-protocol spec.
+
+PR-A scope (this commit): scaffolding + causal-lineage pre-evaluation
+gate + deterministic IO + sha256 manifest writer + metric stubs +
+orchestration skeleton + CLI stub. AutoML / meta-label / survival
+modules land in PR-B / PR-C / PR-D respectively.
+
+See:
+  - L_PROTOCOL.md §0 (project goal) + §2 Step 4-5 + §3 gates + §5 (sub-protocol mechanism)
+  - docs/sub_protocols/heavy_ml_probe.md (v1.0 spec)
+  - docs/sub_protocols/signal_discovery_probe.md (sibling reference)
+  - docs/dispatches/heavy_ml_probe_build_intent.md (build plan)
+  - configs/heavy_ml_probe/default.yaml (locked invocation parameters)
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"  # PR-A scaffolding; bumps per PR per build plan

--- a/core/heavy_ml_probe/automl.py
+++ b/core/heavy_ml_probe/automl.py
@@ -1,0 +1,754 @@
+"""FLAML AutoML wrapper for heavy_ml_probe Step 4 (PR-B).
+
+Per ``docs/sub_protocols/heavy_ml_probe.md`` v1.0 §"What overrides the
+overseer" + dispatch §1:
+
+  * CV: 11-fold ``TimeSeriesSplit`` on the IS slice (2010-01-01 →
+    2020-12-31). No random k-fold. Holdout (2021-01-01 → present)
+    untouched.
+  * Per-fold training: each fold runs its own ``flaml.AutoML.fit()``.
+    No "train once globally, evaluate per fold" — guarantees feature
+    selection + hyperparameter search happen inside the fold's
+    training window only.
+  * Budget cap: ``max_iter`` per fold per FLAML's native trial-
+    counting. PR-B empirical verification (see
+    ``docs/dispatches/heavy_ml_probe_pr_b_log.md`` §3a):
+    ``flaml.AutoML.modelcount`` == ``max_iter`` exactly when FLAML
+    runs to the cap. Ratio 1.0; locked.
+  * Determinism: ``seed=42`` propagated through FLAML + numpy +
+    pandas; ``n_jobs=1``; identical input pool → identical artefacts
+    across two runs.
+
+  * Estimator set: FLAML's default for binary classification on this
+    installation (FLAML 2.6.0):
+    ``['lgbm', 'rf', 'xgboost', 'extra_tree', 'xgb_limitdepth', 'sgd',
+    'catboost', 'lrl1']``. Captured at runtime into the leaderboard
+    artefact for cross-env audit.
+
+Single-class fold AUC handling (dispatch §3b): a fold whose validation
+slice contains only one class of the target yields an undefined ROC AUC.
+``sklearn.metrics.roc_auc_score`` returns NaN in that case in modern
+sklearn (verified at PR-B time); FLAML internally surfaces this as a
+sentinel loss but does not crash. This module's contract:
+
+  * Per-fold AUC is recorded as ``numpy.nan`` when the fold is
+    single-class. Confirmed by ``test_automl.py``.
+  * Aggregate AUC uses ``numpy.nanmean`` so a single bad fold does not
+    poison the whole estimate.
+  * ``n_folds_valid`` (folds with computable AUC) is reported
+    alongside the mean so downstream readers can tell whether the
+    aggregate spans all 11 folds or fewer.
+
+Holdout-guard (dispatch §5 #3): ``run_automl`` asserts the input
+pool's max ``entry_time`` is strictly less than the configured
+``train_end`` cutoff before calling FLAML. Violation raises
+:class:`HoldoutGuardViolation`.
+
+Lineage-rejects-all guard (dispatch §5 #2): if the lineage gate
+rejects every feature, :class:`AllFeaturesRejected` is raised before
+any AutoML call.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.inspection import permutation_importance
+from sklearn.model_selection import TimeSeriesSplit
+
+from core.heavy_ml_probe.metrics import auc_roc
+
+# Locked defaults — overridable via PipelineConfig/YAML but baked here
+# so internal callers (tests, integration) don't need to thread them
+# through every code path.
+DEFAULT_N_FOLDS: int = 11
+DEFAULT_MAX_ITER_PER_FOLD: int = 1000
+DEFAULT_PERMUTATION_REPEATS: int = 5
+DEFAULT_RANDOM_STATE: int = 42
+
+# FLAML's default binary-classification estimator list on this install
+# (FLAML 2.6.0). Recorded for cross-env audit; the actual list FLAML
+# uses at runtime is captured per-fold via ``automl.estimator_list`` so
+# we never log a stale value.
+DOCUMENTED_FLAML_2_6_0_ESTIMATORS: tuple[str, ...] = (
+    "lgbm",
+    "rf",
+    "xgboost",
+    "extra_tree",
+    "xgb_limitdepth",
+    "sgd",
+    "catboost",
+    "lrl1",
+)
+
+
+class HoldoutGuardViolation(RuntimeError):
+    """Raised when the input pool contains trades on/after ``train_end``.
+
+    Per L_PROTOCOL §1 (non-negotiable) + dispatch §5 #3: the 2021-01-01
+    → present holdout window is OFF-LIMITS during training. The guard
+    fires BEFORE any FLAML call so no holdout-tainted model ever lands
+    on disk.
+    """
+
+
+class AllFeaturesRejected(RuntimeError):
+    """Raised when the lineage gate rejects every column in the pool.
+
+    Per dispatch §5 #2: if no clean features remain, fail fast with a
+    clear error rather than calling AutoML with an empty design matrix.
+    """
+
+
+# ── Result types ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class FoldResult:
+    """One fold of the AutoML CV evaluation."""
+
+    fold: int                       # 1..n_folds
+    train_start: pd.Timestamp
+    train_end: pd.Timestamp
+    val_start: pd.Timestamp
+    val_end: pd.Timestamp
+    n_train: int
+    n_val: int
+    n_val_pos: int                  # positive-class count in val (for single-class diagnostic)
+    best_estimator: str             # FLAML's best_estimator name for this fold
+    best_loss: float                # FLAML's internal loss for the best config
+    auc_val: float                  # OOS AUC on the validation slice (NaN if single-class)
+    auc_train: float                # IS AUC on the training slice (NaN if single-class)
+    modelcount: int                 # FLAML's automl.modelcount (= actual trials run)
+    max_iter: int                   # the cap we passed in
+    estimator_list: tuple[str, ...] # FLAML's estimator_list for this fold
+    fit_wall_seconds: float
+
+
+@dataclass(frozen=True)
+class AutoMLResult:
+    """Aggregated AutoML output across all folds."""
+
+    fold_results: tuple[FoldResult, ...]
+    leaderboard: pd.DataFrame       # one row per (fold, estimator) — long-form
+    importance: pd.DataFrame        # mean + std permutation importance per feature
+    used_features: tuple[str, ...]  # post lineage-gate, in column-order passed to FLAML
+    n_folds_total: int
+    n_folds_valid: int              # folds with finite val AUC
+    auc_mean: float                 # nanmean of per-fold val AUCs
+    auc_std: float                  # nanstd of per-fold val AUCs
+    total_modelcount: int           # sum of per-fold modelcount values
+    total_fit_wall_seconds: float
+    flaml_version: str
+    metric: str
+
+
+# ── Internal helpers ─────────────────────────────────────────────────
+
+
+def _coerce_entry_time(pool: pd.DataFrame, column: str = "entry_time") -> pd.Series:
+    """Return ``pool[column]`` parsed as UTC pandas Timestamps.
+
+    Tests pass already-Timestamped columns; production pools come from
+    parquet with ISO strings or naive datetimes. Normalise both.
+    """
+    if column not in pool.columns:
+        raise ValueError(
+            f"pool must contain {column!r} column for TimeSeriesSplit ordering"
+        )
+    s = pool[column]
+    return pd.to_datetime(s, utc=True)
+
+
+def _assert_holdout_guard(
+    pool: pd.DataFrame,
+    train_end: pd.Timestamp,
+    *,
+    entry_time_col: str = "entry_time",
+) -> None:
+    """Per L_PROTOCOL §1: max ``entry_time`` in pool must be strictly
+    less than ``train_end``."""
+    ts = pd.Timestamp(train_end)
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    times = _coerce_entry_time(pool, entry_time_col)
+    if len(times) == 0:
+        return  # empty pool — nothing to guard
+    max_ts = times.max()
+    if max_ts >= ts:
+        raise HoldoutGuardViolation(
+            f"holdout-guard violated: pool max entry_time={max_ts.isoformat()} "
+            f"is >= train_end={ts.isoformat()}; filter the pool to IS-only "
+            f"before invoking AutoML"
+        )
+
+
+def _coerce_target(pool: pd.DataFrame, target_col: str = "y") -> np.ndarray:
+    """Return the target column as a binary int ndarray.
+
+    Tests and production pools both label the binary target ``y``. The
+    actual target-construction (cluster membership for PR-B; reach-1R
+    for PR-C) lives upstream — this module just consumes the array.
+    """
+    if target_col not in pool.columns:
+        raise ValueError(
+            f"pool must contain {target_col!r} column (binary target)"
+        )
+    y = pool[target_col].astype(int).values
+    uniq = set(int(v) for v in np.unique(y))
+    if not uniq.issubset({0, 1}):
+        raise ValueError(
+            f"target must be binary (0/1); found {sorted(uniq)}"
+        )
+    return y
+
+
+def _select_used_features(
+    pool: pd.DataFrame,
+    used_features: Sequence[str],
+) -> pd.DataFrame:
+    """Slice ``pool`` to the lineage-gate-cleared features in column order."""
+    if not used_features:
+        raise AllFeaturesRejected(
+            "lineage gate rejected every feature — cannot fit AutoML on an "
+            "empty design matrix. Inspect step_4/heavy_ml/manifest.json's "
+            "lineage_gate.rejection_reasons field for the per-feature reasons."
+        )
+    missing = [c for c in used_features if c not in pool.columns]
+    if missing:
+        raise ValueError(
+            f"pool missing lineage-gate-accepted columns: {missing[:10]}"
+            f"{'...' if len(missing) > 10 else ''}"
+        )
+    return pool[list(used_features)].copy()
+
+
+def _flaml_version() -> str:
+    try:
+        import flaml  # type: ignore
+
+        return str(flaml.__version__)
+    except ImportError:
+        return ""
+
+
+def _build_time_series_folds(
+    pool_sorted: pd.DataFrame,
+    n_folds: int,
+    entry_time_col: str = "entry_time",
+) -> list[tuple[int, int, int, int]]:
+    """Return ``[(train_start_idx, train_end_idx, val_start_idx, val_end_idx), ...]``.
+
+    Indices are half-open ranges into the time-sorted pool. Mirrors
+    ``sklearn.model_selection.TimeSeriesSplit`` exactly so the test
+    suite can assert behaviour without a second implementation.
+    """
+    cv = TimeSeriesSplit(n_splits=n_folds)
+    n = len(pool_sorted)
+    out: list[tuple[int, int, int, int]] = []
+    for train_idx, val_idx in cv.split(np.arange(n)):
+        if len(train_idx) == 0 or len(val_idx) == 0:
+            continue
+        out.append((int(train_idx[0]), int(train_idx[-1]) + 1,
+                    int(val_idx[0]), int(val_idx[-1]) + 1))
+    return out
+
+
+def _run_one_fold(
+    *,
+    fold_idx: int,
+    pool_sorted: pd.DataFrame,
+    used_features: Sequence[str],
+    y_all: np.ndarray,
+    train_s: int,
+    train_e: int,
+    val_s: int,
+    val_e: int,
+    times: pd.Series,
+    max_iter: int,
+    seed: int,
+    metric: str,
+    n_jobs: int,
+    permutation_repeats: int,
+) -> tuple[FoldResult, pd.DataFrame, pd.DataFrame]:
+    """Train + evaluate one fold. Returns (fold_result, leaderboard_rows,
+    importance_rows)."""
+    import time
+
+    from flaml import AutoML  # local import — heavy library, lazy load
+
+    X = pool_sorted[list(used_features)].values
+    X_train, X_val = X[train_s:train_e], X[val_s:val_e]
+    y_train, y_val = y_all[train_s:train_e], y_all[val_s:val_e]
+    n_val_pos = int((y_val == 1).sum())
+
+    # Per dispatch §3b: detect single-class fold up front so we can
+    # short-circuit the AutoML call. A single-class training fold breaks
+    # FLAML's internal CV; a single-class validation fold yields NaN
+    # AUC. Skip the fit when training is degenerate.
+    n_train_classes = len(np.unique(y_train))
+    if n_train_classes < 2:
+        warnings.warn(
+            f"fold {fold_idx} has single-class training slice "
+            f"(n_train={len(y_train)}, n_train_pos={int((y_train == 1).sum())}); "
+            f"skipping AutoML fit, AUC will be NaN",
+            UserWarning,
+            stacklevel=2,
+        )
+        fr = FoldResult(
+            fold=fold_idx,
+            train_start=times.iloc[train_s], train_end=times.iloc[train_e - 1],
+            val_start=times.iloc[val_s], val_end=times.iloc[val_e - 1],
+            n_train=int(train_e - train_s), n_val=int(val_e - val_s),
+            n_val_pos=n_val_pos,
+            best_estimator="<skipped:single_class_train>",
+            best_loss=float("nan"),
+            auc_val=float("nan"), auc_train=float("nan"),
+            modelcount=0, max_iter=int(max_iter),
+            estimator_list=(),
+            fit_wall_seconds=0.0,
+        )
+        return fr, pd.DataFrame(), pd.DataFrame()
+
+    t0 = time.perf_counter()
+    automl = AutoML()
+    # Per dispatch §1: FLAML's internal eval_method='cv' would do
+    # ANOTHER CV inside the training fold. That's expected — FLAML uses
+    # its own inner CV to pick hyperparameters; our outer 11-fold split
+    # is the OOS evaluation surface. n_splits=3 keeps inner-CV
+    # compute bounded.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        automl.fit(
+            X_train=X_train, y_train=y_train,
+            task="classification",
+            metric=metric,
+            max_iter=int(max_iter),
+            seed=int(seed),
+            n_jobs=int(n_jobs),
+            eval_method="cv",
+            n_splits=3,
+            verbose=0,
+        )
+    fit_wall = time.perf_counter() - t0
+
+    # Per dispatch §3a: automl.modelcount is the actual trial counter.
+    modelcount = int(getattr(automl, "modelcount", -1))
+    if modelcount < 0:
+        # Should not happen on FLAML 2.6.0; defensive fallback.
+        warnings.warn(
+            f"flaml.AutoML.modelcount unavailable; budget audit will be "
+            f"under-reported for fold {fold_idx}",
+            UserWarning,
+            stacklevel=2,
+        )
+        modelcount = 0
+    if modelcount > max_iter:
+        # PR-B HALT trigger per dispatch §3a if ratio ≥ 1.5×; we accept
+        # modelcount ≤ max_iter empirically (PR-B log §3a), but
+        # surface as a warning if it ever drifts.
+        warnings.warn(
+            f"fold {fold_idx} modelcount={modelcount} exceeds max_iter={max_iter}; "
+            f"FLAML budget accounting may have drifted — review PR-B log §3a",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    # OOS + IS AUCs
+    try:
+        proba_val = automl.predict_proba(X_val)[:, 1]
+    except Exception:
+        proba_val = np.full(len(y_val), np.nan)
+    try:
+        proba_train = automl.predict_proba(X_train)[:, 1]
+    except Exception:
+        proba_train = np.full(len(y_train), np.nan)
+    auc_val = auc_roc(y_val, proba_val) if np.all(np.isfinite(proba_val)) else float("nan")
+    auc_train = auc_roc(y_train, proba_train) if np.all(np.isfinite(proba_train)) else float("nan")
+
+    # Leaderboard rows: one per estimator FLAML evaluated. FLAML 2.6.0
+    # exposes ``best_loss_per_estimator``; use it as the leaderboard.
+    best_per_est: Mapping[str, Any] = dict(
+        getattr(automl, "best_loss_per_estimator", {}) or {}
+    )
+    leaderboard_rows = pd.DataFrame([
+        {
+            "fold": fold_idx,
+            "estimator": str(est),
+            "best_loss": float(loss) if loss is not None and np.isfinite(float(loss)) else float("nan"),
+            "is_overall_best": (str(est) == str(automl.best_estimator)),
+        }
+        for est, loss in sorted(best_per_est.items())
+    ])
+
+    # Permutation importance on the validation slice (dispatch §2).
+    # NaN-safe: if validation is single-class or sklearn raises,
+    # importance comes back NaN-filled.
+    #
+    # sklearn 1.5+'s permutation_importance refuses FLAML's outer
+    # AutoML wrapper because the wrapper does not advertise itself as
+    # a ClassifierMixin in a way sklearn's `_check_response_method`
+    # recognises. We pass the inner fitted estimator
+    # (``automl.model.estimator`` — e.g. ``LGBMClassifier``,
+    # ``XGBClassifier``, ``RandomForestClassifier``) instead, which IS
+    # a proper sklearn-compatible classifier. Predictions made through
+    # the inner estimator are byte-identical to the outer wrapper for
+    # standard pipelines per FLAML's docs.
+    importance_rows = pd.DataFrame()
+    inner_estimator = getattr(getattr(automl, "model", None), "estimator", None)
+    if len(np.unique(y_val)) >= 2 and inner_estimator is not None:
+        try:
+            pi = permutation_importance(
+                inner_estimator, X_val, y_val,
+                n_repeats=int(permutation_repeats),
+                random_state=int(seed),
+                n_jobs=int(n_jobs),
+                scoring="roc_auc",
+            )
+            importance_rows = pd.DataFrame({
+                "fold": fold_idx,
+                "feature": list(used_features),
+                "importance_mean": pi.importances_mean,
+                "importance_std": pi.importances_std,
+            })
+        except Exception as e:
+            warnings.warn(
+                f"fold {fold_idx}: permutation_importance raised "
+                f"{type(e).__name__}({e}); importance row will be empty",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    fr = FoldResult(
+        fold=fold_idx,
+        train_start=times.iloc[train_s], train_end=times.iloc[train_e - 1],
+        val_start=times.iloc[val_s], val_end=times.iloc[val_e - 1],
+        n_train=int(train_e - train_s), n_val=int(val_e - val_s),
+        n_val_pos=n_val_pos,
+        best_estimator=str(automl.best_estimator),
+        best_loss=float(automl.best_loss) if np.isfinite(automl.best_loss) else float("nan"),
+        auc_val=float(auc_val),
+        auc_train=float(auc_train),
+        modelcount=int(modelcount),
+        max_iter=int(max_iter),
+        estimator_list=tuple(automl.estimator_list or ()),
+        fit_wall_seconds=float(fit_wall),
+    )
+    return fr, leaderboard_rows, importance_rows
+
+
+# ── Public surface ───────────────────────────────────────────────────
+
+
+def run_automl(
+    pool: pd.DataFrame,
+    used_features: Sequence[str],
+    *,
+    train_end: pd.Timestamp,
+    n_folds: int = DEFAULT_N_FOLDS,
+    max_iter_per_fold: int = DEFAULT_MAX_ITER_PER_FOLD,
+    seed: int = DEFAULT_RANDOM_STATE,
+    metric: str = "roc_auc",
+    n_jobs: int = 1,
+    permutation_repeats: int = DEFAULT_PERMUTATION_REPEATS,
+    entry_time_col: str = "entry_time",
+    target_col: str = "y",
+) -> AutoMLResult:
+    """Run heavy_ml_probe AutoML across an 11-fold TimeSeriesSplit.
+
+    Parameters
+    ----------
+    pool
+        Step-1 trade pool. Must contain ``entry_time`` (or
+        ``entry_time_col``), the binary target ``y`` (or
+        ``target_col``), and every column listed in ``used_features``.
+    used_features
+        Column order to pass to FLAML. Caller is responsible for
+        applying the lineage gate first (see
+        :mod:`core.heavy_ml_probe.causal_lineage`).
+    train_end
+        Holdout-guard cutoff. Max ``entry_time`` in ``pool`` must be
+        strictly less than this timestamp; otherwise raises
+        :class:`HoldoutGuardViolation`.
+    n_folds
+        TimeSeriesSplit fold count. Default 11 per spec.
+    max_iter_per_fold
+        FLAML budget per fold. Default 1000 per spec.
+
+    Returns
+    -------
+    :class:`AutoMLResult` with per-fold ``FoldResult`` snapshots, a
+    long-form leaderboard DataFrame, an importance DataFrame, and
+    aggregate AUC + budget stats.
+
+    Raises
+    ------
+    HoldoutGuardViolation
+        If the input pool's max ``entry_time`` >= ``train_end``.
+    AllFeaturesRejected
+        If ``used_features`` is empty.
+    ValueError
+        If required columns are missing or the target is non-binary.
+    """
+    if not used_features:
+        raise AllFeaturesRejected(
+            "lineage gate rejected every feature — cannot fit AutoML on an "
+            "empty design matrix"
+        )
+    _assert_holdout_guard(pool, train_end, entry_time_col=entry_time_col)
+
+    # Sort by entry_time so TimeSeriesSplit indexing is causal.
+    times_all = _coerce_entry_time(pool, entry_time_col)
+    pool_sorted = pool.assign(_entry_ts=times_all).sort_values(
+        ["_entry_ts"], kind="mergesort"
+    ).drop(columns=["_entry_ts"]).reset_index(drop=True)
+    times = _coerce_entry_time(pool_sorted, entry_time_col).reset_index(drop=True)
+
+    y_all = _coerce_target(pool_sorted, target_col)
+    used_features = tuple(used_features)
+    # Validate column presence early — clearer error than FLAML's eventual KeyError.
+    _ = _select_used_features(pool_sorted, used_features)
+
+    folds = _build_time_series_folds(pool_sorted, n_folds, entry_time_col)
+    if not folds:
+        raise ValueError(
+            f"TimeSeriesSplit with n_folds={n_folds} produced no folds on "
+            f"a pool of size {len(pool_sorted)}; pool too small"
+        )
+
+    fold_results: list[FoldResult] = []
+    leaderboard_frames: list[pd.DataFrame] = []
+    importance_frames: list[pd.DataFrame] = []
+
+    for fold_idx, (train_s, train_e, val_s, val_e) in enumerate(folds, start=1):
+        fr, lb, imp = _run_one_fold(
+            fold_idx=fold_idx,
+            pool_sorted=pool_sorted,
+            used_features=used_features,
+            y_all=y_all,
+            train_s=train_s, train_e=train_e,
+            val_s=val_s, val_e=val_e,
+            times=times,
+            max_iter=max_iter_per_fold,
+            seed=seed,
+            metric=metric,
+            n_jobs=n_jobs,
+            permutation_repeats=permutation_repeats,
+        )
+        fold_results.append(fr)
+        if not lb.empty:
+            leaderboard_frames.append(lb)
+        if not imp.empty:
+            importance_frames.append(imp)
+
+    leaderboard = (
+        pd.concat(leaderboard_frames, ignore_index=True)
+        if leaderboard_frames
+        else pd.DataFrame(columns=["fold", "estimator", "best_loss", "is_overall_best"])
+    )
+    # Deterministic row order: (fold, estimator)
+    if not leaderboard.empty:
+        leaderboard = leaderboard.sort_values(
+            ["fold", "estimator"], kind="mergesort"
+        ).reset_index(drop=True)
+
+    importance = _aggregate_importance(importance_frames, used_features)
+
+    auc_vals = np.array([fr.auc_val for fr in fold_results], dtype=float)
+    finite_mask = np.isfinite(auc_vals)
+    n_valid = int(finite_mask.sum())
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # nanmean on all-NaN raises a RuntimeWarning
+        auc_mean = float(np.nanmean(auc_vals)) if n_valid > 0 else float("nan")
+        auc_std = float(np.nanstd(auc_vals, ddof=0)) if n_valid > 0 else float("nan")
+
+    return AutoMLResult(
+        fold_results=tuple(fold_results),
+        leaderboard=leaderboard,
+        importance=importance,
+        used_features=tuple(used_features),
+        n_folds_total=len(fold_results),
+        n_folds_valid=n_valid,
+        auc_mean=auc_mean,
+        auc_std=auc_std,
+        total_modelcount=int(sum(fr.modelcount for fr in fold_results)),
+        total_fit_wall_seconds=float(sum(fr.fit_wall_seconds for fr in fold_results)),
+        flaml_version=_flaml_version(),
+        metric=metric,
+    )
+
+
+def _aggregate_importance(
+    importance_frames: list[pd.DataFrame],
+    used_features: Sequence[str],
+) -> pd.DataFrame:
+    """Mean + std per feature across folds. ``n_folds_present`` records
+    how many folds contributed a finite importance for that feature."""
+    if not importance_frames:
+        return pd.DataFrame(columns=[
+            "feature", "importance_mean", "importance_std", "n_folds_present"
+        ])
+    cat = pd.concat(importance_frames, ignore_index=True)
+    agg = (
+        cat.groupby("feature")["importance_mean"]
+        .agg(["mean", "std", "count"])
+        .reset_index()
+        .rename(columns={
+            "mean": "importance_mean",
+            "std": "importance_std",
+            "count": "n_folds_present",
+        })
+    )
+    # Ensure every used feature appears (even if no fold had finite importance).
+    present = set(agg["feature"].tolist())
+    rows_to_add = [
+        {"feature": f, "importance_mean": float("nan"),
+         "importance_std": float("nan"), "n_folds_present": 0}
+        for f in used_features if f not in present
+    ]
+    if rows_to_add:
+        agg = pd.concat([agg, pd.DataFrame(rows_to_add)], ignore_index=True)
+    agg["n_folds_present"] = agg["n_folds_present"].astype(int)
+    # Sort by importance_mean desc, feature asc — deterministic.
+    agg = agg.sort_values(
+        ["importance_mean", "feature"],
+        ascending=[False, True], kind="mergesort", na_position="last",
+    ).reset_index(drop=True)
+    return agg
+
+
+# ── Artefact-shape helpers (consumed by io.py renderers) ─────────────
+
+
+def leaderboard_to_dataframe(result: AutoMLResult) -> pd.DataFrame:
+    """Long-form leaderboard CSV row layout. Columns:
+
+      fold, estimator, best_loss, is_overall_best, auc_val,
+      auc_train, modelcount, max_iter, best_estimator_for_fold
+
+    ``fit_wall_seconds`` is intentionally NOT included — wall-clock is
+    not deterministic across runs and would break the two-run
+    artefact-byte equality test. Wall-clock stays available on the
+    in-memory :class:`AutoMLResult` for log-doc / diagnostic use.
+    """
+    if not result.fold_results:
+        return pd.DataFrame(columns=[
+            "fold", "estimator", "best_loss", "is_overall_best",
+            "auc_val", "auc_train", "modelcount", "max_iter",
+            "best_estimator_for_fold",
+        ])
+    by_fold = {fr.fold: fr for fr in result.fold_results}
+    lb = result.leaderboard.copy()
+    if lb.empty:
+        # Build a synthetic leaderboard from fold results so callers
+        # always get a non-empty CSV when folds ran (even if FLAML did
+        # not produce best_loss_per_estimator on this install).
+        lb = pd.DataFrame([
+            {"fold": fr.fold, "estimator": fr.best_estimator,
+             "best_loss": fr.best_loss, "is_overall_best": True}
+            for fr in result.fold_results
+        ])
+    lb["auc_val"] = lb["fold"].map({k: v.auc_val for k, v in by_fold.items()})
+    lb["auc_train"] = lb["fold"].map({k: v.auc_train for k, v in by_fold.items()})
+    lb["modelcount"] = lb["fold"].map({k: v.modelcount for k, v in by_fold.items()})
+    lb["max_iter"] = lb["fold"].map({k: v.max_iter for k, v in by_fold.items()})
+    lb["best_estimator_for_fold"] = lb["fold"].map({k: v.best_estimator for k, v in by_fold.items()})
+    lb = lb[[
+        "fold", "estimator", "best_loss", "is_overall_best",
+        "auc_val", "auc_train", "modelcount", "max_iter",
+        "best_estimator_for_fold",
+    ]]
+    return lb.sort_values(["fold", "estimator"], kind="mergesort").reset_index(drop=True)
+
+
+def importance_to_dataframe(result: AutoMLResult) -> pd.DataFrame:
+    """Permutation importance CSV layout. Columns already set by
+    :func:`_aggregate_importance`."""
+    return result.importance.copy()
+
+
+def compute_budget_markdown(result: AutoMLResult, *, train_end: pd.Timestamp) -> str:
+    """Render the ``compute_budget_used.md`` artefact.
+
+    Stable formatting (no embedded timestamps, no wall-clock) so two-run
+    sha256 determinism holds. Wall-clock stays available on the
+    in-memory :class:`AutoMLResult` for log-doc / diagnostic use.
+    """
+    lines: list[str] = []
+    lines.append("# heavy_ml_probe — AutoML compute budget audit")
+    lines.append("")
+    lines.append(f"- FLAML version: `{result.flaml_version}`")
+    lines.append(f"- Metric: `{result.metric}`")
+    lines.append(f"- Folds total: **{result.n_folds_total}**")
+    lines.append(f"- Folds with valid OOS AUC: **{result.n_folds_valid}**")
+    if result.n_folds_total > 0:
+        max_iter = result.fold_results[0].max_iter
+        cap = max_iter * result.n_folds_total
+        ratio = (
+            float(result.total_modelcount) / float(cap)
+            if cap > 0 else float("nan")
+        )
+        lines.append(f"- `max_iter_per_fold`: **{max_iter}**")
+        lines.append(f"- Cap (max_iter × n_folds): **{cap}**")
+        lines.append(f"- Total modelcount across folds: **{result.total_modelcount}**")
+        lines.append(f"- Consumption ratio (actual/cap): **{ratio:.4f}**")
+    lines.append(
+        f"- Holdout cutoff (`train_end`): "
+        f"**{pd.Timestamp(train_end).strftime('%Y-%m-%dT%H:%M:%SZ')}**"
+    )
+    lines.append("")
+    lines.append(
+        "_Per dispatch §3a (PR-B empirical): `flaml.AutoML.modelcount` "
+        "equals `max_iter` exactly when FLAML runs to the cap; ratio 1.0. "
+        "Locked, proceed. Wall-clock measurements live on the in-memory "
+        "`AutoMLResult` (non-deterministic; excluded from artefacts)._"
+    )
+    lines.append("")
+    lines.append("## Per-fold trial counts")
+    lines.append("")
+    lines.append(
+        "| Fold | n_train | n_val | n_val_pos | best_estimator | modelcount | "
+        "max_iter | auc_val | auc_train |"
+    )
+    lines.append("|---:|---:|---:|---:|---|---:|---:|---:|---:|")
+    for fr in result.fold_results:
+        auc_v = "NaN" if not np.isfinite(fr.auc_val) else f"{fr.auc_val:.4f}"
+        auc_t = "NaN" if not np.isfinite(fr.auc_train) else f"{fr.auc_train:.4f}"
+        lines.append(
+            f"| {fr.fold} | {fr.n_train} | {fr.n_val} | {fr.n_val_pos} | "
+            f"{fr.best_estimator} | {fr.modelcount} | {fr.max_iter} | "
+            f"{auc_v} | {auc_t} |"
+        )
+    lines.append("")
+    lines.append("## Aggregate AUC (val, OOS)")
+    lines.append("")
+    auc_m = "NaN" if not np.isfinite(result.auc_mean) else f"{result.auc_mean:.4f}"
+    auc_s = "NaN" if not np.isfinite(result.auc_std) else f"{result.auc_std:.4f}"
+    lines.append(
+        f"- `nanmean` AUC: **{auc_m}** (across {result.n_folds_valid} "
+        f"valid folds; total {result.n_folds_total})"
+    )
+    lines.append(f"- `nanstd` AUC: **{auc_s}**")
+    lines.append("")
+    return "\n".join(lines)
+
+
+__all__ = (
+    "DEFAULT_N_FOLDS",
+    "DEFAULT_MAX_ITER_PER_FOLD",
+    "DEFAULT_PERMUTATION_REPEATS",
+    "DEFAULT_RANDOM_STATE",
+    "DOCUMENTED_FLAML_2_6_0_ESTIMATORS",
+    "HoldoutGuardViolation",
+    "AllFeaturesRejected",
+    "FoldResult",
+    "AutoMLResult",
+    "run_automl",
+    "leaderboard_to_dataframe",
+    "importance_to_dataframe",
+    "compute_budget_markdown",
+)

--- a/core/heavy_ml_probe/causal_lineage.py
+++ b/core/heavy_ml_probe/causal_lineage.py
@@ -1,0 +1,217 @@
+"""Pre-evaluation causal-lineage gate for heavy_ml_probe.
+
+Per ``docs/sub_protocols/heavy_ml_probe.md`` v1.0 §"Per-feature causal
+lineage" + dispatch §6 #2: every feature consumed by AutoML must carry
+a ``causal_lineage == "clean"`` tag from Step 1 (set at ``FeatureSpec``
+registration time, see ``core/features/lineage.py``). Features tagged
+``suspect`` or ``unverified`` are excluded from the training set
+*before* the AutoML run starts — not flagged after.
+
+This module mirrors ``core/discovery/causal_filter.py`` so the same
+filtering vocabulary appears across sub-protocols. The lineage source
+of truth is ``core.features.pipeline.feature_lineage_dataframe()``;
+this gate calls into it (or accepts the DataFrame directly for
+testability) and returns:
+
+  * the cleaned column list to pass to AutoML
+  * a rejection log (per-feature reason) for the manifest + audit trail
+
+Q3 resolution from build intent: lineage tags live on FeatureSpec, NOT
+embedded per-row in Step 1's pool parquet. Heavy ML's training matrix is
+columns × trades; the gate filters at column-level only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import pandas as pd
+
+# Lineage values that are accepted into training by default. Per spec
+# §"Per-feature causal lineage" only ``clean`` features pass. Tests may
+# override (e.g. to assert a hypothetical multi-tag policy) but
+# production callers should not.
+DEFAULT_ACCEPTED_LINEAGE: tuple[str, ...] = ("clean",)
+
+# Reason strings recorded in the rejection log. Stable + grep-able.
+REASON_NON_CLEAN_LINEAGE: str = "non_clean_lineage"
+REASON_EXCLUDED_CLASS: str = "excluded_feature_class"
+REASON_UNKNOWN_FEATURE: str = "unknown_feature"
+REASON_MISSING_FROM_MATRIX: str = "missing_from_training_matrix"
+
+
+@dataclass(frozen=True)
+class LineageGateResult:
+    """Outcome of running the pre-evaluation lineage gate.
+
+    Attributes
+    ----------
+    accepted_features
+        Sorted tuple of feature names cleared for training.
+    rejected
+        List of ``{"feature": <name>, "reason": <code>, "detail":
+        <str>}`` dicts in feature-name order. Empty when nothing was
+        rejected.
+    n_input_columns
+        Count of columns presented to the gate (post lineage_df join
+        but before filtering). Drives the rejection-fraction metric in
+        the manifest.
+    """
+
+    accepted_features: tuple[str, ...]
+    rejected: tuple[dict, ...]
+    n_input_columns: int
+
+    @property
+    def n_accepted(self) -> int:
+        return len(self.accepted_features)
+
+    @property
+    def n_rejected(self) -> int:
+        return len(self.rejected)
+
+
+def _normalise_lineage_df(lineage_df: pd.DataFrame) -> pd.DataFrame:
+    """Light shape-check on the lineage DataFrame.
+
+    Required columns: ``name``, ``causal_lineage``, ``feature_class``.
+    These match ``core.features.pipeline.feature_lineage_dataframe()``'s
+    output exactly. Other columns are ignored.
+
+    Raises ``ValueError`` with a precise diagnostic on missing columns;
+    callers passing a hand-built DataFrame in tests get a clear error
+    rather than a downstream KeyError.
+    """
+    required = {"name", "causal_lineage", "feature_class"}
+    missing = required - set(lineage_df.columns)
+    if missing:
+        raise ValueError(
+            f"lineage_df missing required columns: {sorted(missing)}; "
+            f"present: {sorted(lineage_df.columns)}"
+        )
+    return lineage_df
+
+
+def filter_training_columns(
+    training_columns: Iterable[str],
+    lineage_df: pd.DataFrame,
+    *,
+    accepted_lineage: Iterable[str] = DEFAULT_ACCEPTED_LINEAGE,
+    exclude_classes: Iterable[str] = (),
+) -> LineageGateResult:
+    """Pre-evaluation gate. Returns the column subset cleared for training.
+
+    Parameters
+    ----------
+    training_columns
+        Iterable of feature column names present in the training matrix.
+    lineage_df
+        Lineage table. Must have columns ``name``, ``causal_lineage``,
+        ``feature_class`` (see ``core.features.pipeline``).
+    accepted_lineage
+        Lineage values that pass the gate. Default ``("clean",)`` per
+        spec §"Per-feature causal lineage".
+    exclude_classes
+        Optional feature_class values to exclude regardless of lineage
+        (e.g. ``("spread_regime",)`` if a class is known leaky).
+    """
+    lineage_df = _normalise_lineage_df(lineage_df)
+    accepted_set = {s.lower() for s in accepted_lineage}
+    exclude_set = {s.lower() for s in exclude_classes}
+
+    cols = sorted(set(training_columns))
+    by_name = lineage_df.set_index("name", drop=False)
+    accepted: list[str] = []
+    rejected: list[dict] = []
+
+    for col in cols:
+        if col not in by_name.index:
+            rejected.append({
+                "feature": col,
+                "reason": REASON_UNKNOWN_FEATURE,
+                "detail": "no lineage row registered for this column",
+            })
+            continue
+        row = by_name.loc[col]
+        # by_name.loc returns a Series for unique index hits and a
+        # DataFrame for duplicates. The registry guarantees unique
+        # names, but for defensive parsing we always take the first row.
+        if isinstance(row, pd.DataFrame):
+            row = row.iloc[0]
+        lineage_val = str(row["causal_lineage"]).lower()
+        feat_class = str(row["feature_class"]).lower()
+        if feat_class in exclude_set:
+            rejected.append({
+                "feature": col,
+                "reason": REASON_EXCLUDED_CLASS,
+                "detail": f"feature_class={feat_class}",
+            })
+            continue
+        if lineage_val not in accepted_set:
+            rejected.append({
+                "feature": col,
+                "reason": REASON_NON_CLEAN_LINEAGE,
+                "detail": f"lineage={lineage_val}",
+            })
+            continue
+        accepted.append(col)
+
+    return LineageGateResult(
+        accepted_features=tuple(sorted(accepted)),
+        rejected=tuple(rejected),
+        n_input_columns=len(cols),
+    )
+
+
+def lineage_summary_markdown(result: LineageGateResult) -> str:
+    """Render a human-readable summary suitable for inclusion in the
+    Step 4 ``compute_budget_used.md`` or a dedicated lineage report.
+
+    Stable formatting for two-run sha256 determinism: feature lists
+    sorted, no timestamps embedded.
+    """
+    lines: list[str] = []
+    lines.append("# Causal lineage gate — heavy_ml_probe")
+    lines.append("")
+    lines.append(
+        f"- Input columns: **{result.n_input_columns}**"
+    )
+    lines.append(
+        f"- Accepted (clean): **{result.n_accepted}**"
+    )
+    lines.append(
+        f"- Rejected: **{result.n_rejected}**"
+    )
+    lines.append("")
+    if result.rejected:
+        # Aggregate by reason
+        from collections import Counter
+        reasons = Counter(r["reason"] for r in result.rejected)
+        lines.append("## Rejection breakdown")
+        lines.append("")
+        for reason, count in sorted(reasons.items()):
+            lines.append(f"- `{reason}`: {count}")
+        lines.append("")
+        lines.append("## Rejected features (sorted)")
+        lines.append("")
+        lines.append("| Feature | Reason | Detail |")
+        lines.append("|---|---|---|")
+        for r in sorted(result.rejected, key=lambda x: (x["reason"], x["feature"])):
+            lines.append(
+                f"| {r['feature']} | {r['reason']} | {r['detail']} |"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+__all__ = (
+    "DEFAULT_ACCEPTED_LINEAGE",
+    "REASON_NON_CLEAN_LINEAGE",
+    "REASON_EXCLUDED_CLASS",
+    "REASON_UNKNOWN_FEATURE",
+    "REASON_MISSING_FROM_MATRIX",
+    "LineageGateResult",
+    "filter_training_columns",
+    "lineage_summary_markdown",
+)

--- a/core/heavy_ml_probe/io.py
+++ b/core/heavy_ml_probe/io.py
@@ -1,0 +1,203 @@
+"""Deterministic IO for heavy_ml_probe artefacts + sha256 manifest.
+
+Mirrors ``core/discovery/io.py`` conventions exactly so the heavy_ml_probe
+artefact directory matches the sibling sub-protocol's manifest schema:
+
+  * sha256 sidecar manifest per output directory
+  * UTF-8 text writes always end in exactly one ``\\n``
+  * CSV writes use ``lineterminator='\\n'`` (cross-platform reproducibility,
+    per L_PROTOCOL §1)
+  * JSON writes use ``sort_keys=True`` + 2-space indent + trailing newline
+  * Parquet writes use ``compression='snappy'`` + sorted row order on a
+    declared key column
+
+The functions return the sha256 of every file written so the orchestrator
+can build the manifest payload without re-reading from disk.
+
+PR-A scope: manifest writer + text/CSV/parquet helpers + sha256 utility.
+The full per-artefact renderers (leaderboard, survival results, etc.)
+live in PR-B/C/D where the corresponding data exists.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import pandas as pd
+
+# Locked manifest schema version. Bump when a breaking key change ships.
+MANIFEST_SCHEMA_VERSION: str = "1.0"
+
+# Locked text encoding for every artefact this module writes.
+TEXT_ENCODING: str = "utf-8"
+TEXT_LINETERMINATOR: str = "\n"
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA256 hex digest of ``path``'s bytes."""
+    h = hashlib.sha256()
+    with Path(path).open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def write_text(path: Path, text: str) -> str:
+    """Write ``text`` to ``path`` as UTF-8 with exactly one trailing newline.
+
+    Returns the sha256 of the written file. Creates parent directories
+    as needed.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    if not text.endswith(TEXT_LINETERMINATOR):
+        text = text + TEXT_LINETERMINATOR
+    p.write_bytes(text.encode(TEXT_ENCODING))
+    return sha256_file(p)
+
+
+def write_csv(
+    path: Path,
+    df: pd.DataFrame,
+    *,
+    sort_by: Sequence[str] | None = None,
+    columns: Sequence[str] | None = None,
+) -> str:
+    """Write ``df`` to ``path`` as a deterministic CSV.
+
+    Optionally re-orders columns to ``columns`` (raises if a requested
+    column is missing) and sorts rows by ``sort_by`` (mergesort for
+    determinism). Uses ``lineterminator='\\n'`` per L_PROTOCOL §1.
+
+    Returns the sha256 of the written file.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    out = df.copy()
+    if columns is not None:
+        missing = [c for c in columns if c not in out.columns]
+        if missing:
+            raise ValueError(f"write_csv missing requested columns: {missing}")
+        out = out[list(columns)]
+    if sort_by:
+        out = out.sort_values(list(sort_by), kind="mergesort").reset_index(drop=True)
+    out.to_csv(p, index=False, lineterminator=TEXT_LINETERMINATOR)
+    return sha256_file(p)
+
+
+def write_parquet(
+    path: Path,
+    df: pd.DataFrame,
+    *,
+    sort_by: Sequence[str] | None = None,
+    columns: Sequence[str] | None = None,
+) -> str:
+    """Write ``df`` to ``path`` as a snappy-compressed parquet.
+
+    Row ordering determinism: callers should pass ``sort_by`` to lock
+    row order. Column ordering determinism: callers should pass
+    ``columns`` to lock column order; otherwise pandas' insertion order
+    is used.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    out = df.copy()
+    if columns is not None:
+        missing = [c for c in columns if c not in out.columns]
+        if missing:
+            raise ValueError(f"write_parquet missing requested columns: {missing}")
+        out = out[list(columns)]
+    if sort_by:
+        out = out.sort_values(list(sort_by), kind="mergesort").reset_index(drop=True)
+    out.to_parquet(p, compression="snappy", index=False)
+    return sha256_file(p)
+
+
+def write_manifest(
+    manifest_path: Path,
+    *,
+    arc_name: str,
+    step: str,
+    artefact_paths: Mapping[str, Path],
+    schema_version: str = MANIFEST_SCHEMA_VERSION,
+    extras: Mapping[str, object] | None = None,
+) -> str:
+    """Write the sha256 manifest sidecar and return its own sha256.
+
+    Manifest schema (matches ``core/discovery/io.py::write_manifest``
+    with a ``schema_version`` + ``sub_protocol`` field added so consumers
+    can detect breaking schema changes without diffing payloads):
+
+        {
+          "schema_version": "1.0",
+          "sub_protocol": "heavy_ml_probe",
+          "arc_name": "<arc>",
+          "step": "step_4/heavy_ml",
+          "created_at": "<UTC ISO>",
+          "artefacts": {
+            "<logical_name>": {
+              "path": "<relative-to-manifest-dir>",
+              "sha256": "<hex>"
+            }
+          },
+          ...extras
+        }
+
+    Paths in the manifest are recorded relative to the manifest's parent
+    directory (with forward-slash separators for cross-platform parity).
+    Callers pass absolute paths via ``artefact_paths``; the writer
+    handles the relativisation.
+    """
+    mp = Path(manifest_path)
+    artefacts: dict[str, dict] = {}
+    for logical_name, p in sorted(artefact_paths.items()):
+        abs_path = Path(p).resolve()
+        try:
+            rel = abs_path.relative_to(mp.parent.resolve())
+        except ValueError:
+            # Path is outside the manifest's parent — record as-is with
+            # forward slashes so downstream consumers don't break on
+            # Windows back-slashes. This is a fallback; typically all
+            # artefacts live alongside the manifest.
+            rel = abs_path
+        artefacts[logical_name] = {
+            "path": str(rel).replace("\\", "/"),
+            "sha256": sha256_file(abs_path),
+        }
+    payload: dict[str, object] = {
+        "schema_version": schema_version,
+        "sub_protocol": "heavy_ml_probe",
+        "arc_name": arc_name,
+        "step": step,
+        "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "artefacts": artefacts,
+    }
+    if extras:
+        for k, v in extras.items():
+            if k in payload:
+                raise ValueError(
+                    f"manifest extras key {k!r} collides with reserved field"
+                )
+            payload[k] = v
+    mp.parent.mkdir(parents=True, exist_ok=True)
+    blob = json.dumps(payload, sort_keys=True, indent=2)
+    if not blob.endswith(TEXT_LINETERMINATOR):
+        blob = blob + TEXT_LINETERMINATOR
+    mp.write_bytes(blob.encode(TEXT_ENCODING))
+    return sha256_file(mp)
+
+
+__all__ = (
+    "MANIFEST_SCHEMA_VERSION",
+    "TEXT_ENCODING",
+    "TEXT_LINETERMINATOR",
+    "sha256_file",
+    "write_text",
+    "write_csv",
+    "write_parquet",
+    "write_manifest",
+)

--- a/core/heavy_ml_probe/metrics.py
+++ b/core/heavy_ml_probe/metrics.py
@@ -1,0 +1,129 @@
+"""Metric wrappers for heavy_ml_probe.
+
+Thin wrappers around sklearn / lifelines / scikit-survival so the
+sub-protocol's per-model evaluation calls a single canonical surface.
+PR-A lands callable stubs that exercise the dependency imports
+defensively (so sklearn / lifelines / sksurv availability is detectable
+at module import without crashing scaffolding), with real bodies
+landing in PR-B/D where the data exists.
+
+Coverage:
+
+  * ``auc_roc(y_true, y_score)`` — wraps ``sklearn.metrics.roc_auc_score``.
+    Used by AutoML (PR-B) per-fold scoring and by meta-labeling (PR-C)
+    threshold sweeps.
+  * ``concordance(y_event, y_time, predicted_risk)`` — wraps lifelines'
+    concordance index. Used by Cox PH (PR-D).
+  * ``integrated_brier_score(...)`` — wraps scikit-survival's
+    ``integrated_brier_score``. Used by Random Survival Forest (PR-D).
+
+All metric functions return ``float`` and raise informatively on input
+shape mismatches; NaN / non-finite returns are propagated, not masked.
+
+Lifelines / scikit-survival are imported lazily so the rest of the
+sub-protocol can scaffold without them (matches the defensive
+``lightgbm`` import pattern in ``core/steps/_classifier_defaults.py``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from sklearn.metrics import roc_auc_score
+
+
+def auc_roc(y_true, y_score) -> float:
+    """Binary AUC-ROC. Identical semantics to ``sklearn.metrics.roc_auc_score``.
+
+    Returns ``float('nan')`` when the input set has < 2 classes
+    (sklearn raises in that case; we degrade to NaN since per-fold
+    AutoML can hit single-class folds for rare events).
+    """
+    y_true_arr = np.asarray(y_true)
+    y_score_arr = np.asarray(y_score)
+    if y_true_arr.shape != y_score_arr.shape:
+        raise ValueError(
+            f"auc_roc shape mismatch: y_true={y_true_arr.shape} y_score={y_score_arr.shape}"
+        )
+    if len(set(y_true_arr.tolist())) < 2:
+        return float("nan")
+    return float(roc_auc_score(y_true_arr, y_score_arr))
+
+
+def concordance(y_event, y_time, predicted_risk) -> float:
+    """C-index for survival models.
+
+    Wraps ``lifelines.utils.concordance_index``. Imports lifelines
+    lazily so PR-A scaffolding does not require the library to be
+    installed in environments that won't run the survival path.
+
+    Parameters
+    ----------
+    y_event : array-like of {0, 1}
+        Event indicator (1 = event observed, 0 = censored).
+    y_time : array-like of float
+        Observed time (event time if observed, censoring time otherwise).
+    predicted_risk : array-like of float
+        Higher = higher predicted risk.
+    """
+    try:
+        from lifelines.utils import concordance_index
+    except ImportError as e:  # pragma: no cover — environment-dependent
+        raise ImportError(
+            "lifelines is required for concordance(); install via "
+            "requirements-dev.txt"
+        ) from e
+
+    y_event_arr = np.asarray(y_event)
+    y_time_arr = np.asarray(y_time)
+    pred_arr = np.asarray(predicted_risk)
+    if not (y_event_arr.shape == y_time_arr.shape == pred_arr.shape):
+        raise ValueError(
+            f"concordance shape mismatch: y_event={y_event_arr.shape} "
+            f"y_time={y_time_arr.shape} predicted_risk={pred_arr.shape}"
+        )
+    # lifelines' concordance_index uses ``higher risk = lower expected
+    # survival time``. Pass risk directly; do NOT negate.
+    return float(concordance_index(y_time_arr, -pred_arr, y_event_arr))
+
+
+def integrated_brier_score(
+    survival_train,
+    survival_test,
+    survival_predictions,
+    times,
+) -> float:
+    """IBS for survival predictions.
+
+    Wraps ``sksurv.metrics.integrated_brier_score``. Imports sksurv
+    lazily for the same reason as :func:`concordance` above.
+
+    Parameters
+    ----------
+    survival_train : structured ndarray
+        Training survival data in sksurv's ``(event, time)`` structured
+        array shape (typically the output of
+        ``sksurv.util.Surv.from_arrays``).
+    survival_test : structured ndarray
+        Test survival data in the same shape.
+    survival_predictions : 2-D ndarray of shape (n_test, len(times))
+        Predicted survival probabilities at each evaluation time.
+    times : 1-D array of float
+        Time points at which IBS is evaluated.
+    """
+    try:
+        from sksurv.metrics import integrated_brier_score as _ibs
+    except ImportError as e:  # pragma: no cover — environment-dependent
+        raise ImportError(
+            "scikit-survival is required for integrated_brier_score(); "
+            "install via requirements-dev.txt"
+        ) from e
+    return float(
+        _ibs(survival_train, survival_test, survival_predictions, times)
+    )
+
+
+__all__ = (
+    "auc_roc",
+    "concordance",
+    "integrated_brier_score",
+)

--- a/core/heavy_ml_probe/pipeline.py
+++ b/core/heavy_ml_probe/pipeline.py
@@ -1,0 +1,324 @@
+"""Orchestration skeleton for the heavy_ml_probe sub-protocol.
+
+Owns the end-to-end flow: load pool → apply causal lineage gate →
+[future] AutoML → [future] meta-labeling → [future] survival → write
+artefact set + manifest. Steps not yet implemented HALT cleanly with
+``NotImplementedError`` carrying the PR they land in (per the build
+plan in ``docs/dispatches/heavy_ml_probe_build_intent.md`` §8).
+
+PR-A scope: load config + apply lineage gate + write skeleton manifest
++ summary. Returns enough context for the CLI to print actionable next
+steps.
+
+PR-B (automl), PR-C (meta_labeling), PR-D (survival) extend this
+module. The public ``run_pipeline`` surface is stable from PR-A; new PRs
+add fields to :class:`PipelineResult` and populate currently-empty
+artefact slots.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+import yaml
+
+from core.heavy_ml_probe import __version__ as HEAVY_ML_VERSION
+from core.heavy_ml_probe.causal_lineage import (
+    LineageGateResult,
+    filter_training_columns,
+    lineage_summary_markdown,
+)
+from core.heavy_ml_probe.io import (
+    MANIFEST_SCHEMA_VERSION,
+    write_manifest,
+    write_text,
+)
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """Resolved invocation parameters for one pipeline run.
+
+    Subset of ``configs/heavy_ml_probe/default.yaml``. Fields not used
+    by PR-A scaffolding are still parsed so the YAML schema stays
+    locked from this PR forward.
+    """
+
+    arc_name: str
+    cluster_id: int
+    pool_path: Path
+    output_root: Path
+    config_path: Path
+    raw_config: Mapping[str, Any]
+
+    @property
+    def step4_dir(self) -> Path:
+        sub = str(self.raw_config["output"]["step4_subdir"])
+        return self.output_root / sub
+
+    @property
+    def step5_dir(self) -> Path:
+        sub = str(self.raw_config["output"]["step5_subdir"])
+        return self.output_root / sub
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    """Aggregated outcome of one pipeline run.
+
+    PR-A populates ``lineage_gate``, ``step4_manifest_path``, and
+    ``stub_summary_path``. Later PRs fill the empty slots
+    (``automl_artefacts``, ``meta_label_artefacts``, ``survival_artefacts``,
+    ``step5_manifest_path``).
+    """
+
+    cfg: PipelineConfig
+    lineage_gate: LineageGateResult
+    step4_manifest_path: Path
+    stub_summary_path: Path
+    # Reserved for PR-B/C/D — empty in PR-A.
+    automl_artefacts: tuple[Path, ...] = field(default_factory=tuple)
+    meta_label_artefacts: tuple[Path, ...] = field(default_factory=tuple)
+    survival_artefacts: tuple[Path, ...] = field(default_factory=tuple)
+    step5_manifest_path: Path | None = None
+
+
+def load_config(
+    config_path: Path,
+    *,
+    arc_name: str,
+    cluster_id: int,
+    pool_path: Path,
+    output_root: Path,
+) -> PipelineConfig:
+    """Load + minimally-validate a heavy_ml_probe YAML config.
+
+    Validation is intentionally light at PR-A — full schema enforcement
+    lands when PR-B/C/D start consuming the AutoML / meta-labeling /
+    survival blocks.
+    """
+    cp = Path(config_path)
+    if not cp.exists():
+        raise FileNotFoundError(f"heavy_ml_probe config not found: {cp}")
+    with cp.open("r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"heavy_ml_probe config must be a YAML mapping; got {type(raw).__name__}"
+        )
+    required_top = {"schema_version", "sub_protocol", "automl",
+                    "meta_labeling", "survival", "training_window",
+                    "causal_filter", "determinism", "output"}
+    missing = required_top - set(raw.keys())
+    if missing:
+        raise ValueError(
+            f"heavy_ml_probe config missing top-level sections: {sorted(missing)}"
+        )
+    if str(raw["sub_protocol"]["name"]) != "heavy_ml_probe":
+        raise ValueError(
+            f"config sub_protocol.name must be 'heavy_ml_probe'; got "
+            f"{raw['sub_protocol']['name']!r}"
+        )
+    return PipelineConfig(
+        arc_name=arc_name,
+        cluster_id=int(cluster_id),
+        pool_path=Path(pool_path),
+        output_root=Path(output_root),
+        config_path=cp,
+        raw_config=raw,
+    )
+
+
+def load_pool(pool_path: Path) -> pd.DataFrame:
+    """Read the Step 1 pool parquet.
+
+    PR-A only reads the columns; the body of work happens in PR-B+.
+    Surfacing the load here gives PR-A's CLI a non-trivial smoke
+    capability — we can fail fast on a bad pool path before later PRs
+    add dependencies.
+    """
+    p = Path(pool_path)
+    if not p.exists():
+        raise FileNotFoundError(f"pool parquet not found: {p}")
+    return pd.read_parquet(p)
+
+
+def _build_lineage_dataframe() -> pd.DataFrame:
+    """Resolve the canonical lineage table.
+
+    Wraps ``core.features.pipeline.feature_lineage_dataframe`` so tests
+    can monkey-patch this thin shim without importing the full v3
+    features stack (which triggers panel + cache imports).
+    """
+    from core.features.pipeline import feature_lineage_dataframe
+    return feature_lineage_dataframe()
+
+
+def apply_lineage_gate(
+    pool_columns: list[str],
+    cfg: PipelineConfig,
+    *,
+    lineage_df: pd.DataFrame | None = None,
+) -> LineageGateResult:
+    """Run the pre-evaluation lineage gate over ``pool_columns``.
+
+    ``lineage_df`` defaults to the registry-backed table; pass in a
+    hand-built DataFrame for tests.
+    """
+    if lineage_df is None:
+        lineage_df = _build_lineage_dataframe()
+    cf_cfg = cfg.raw_config["causal_filter"]
+    return filter_training_columns(
+        pool_columns,
+        lineage_df,
+        accepted_lineage=tuple(cf_cfg.get("accepted_lineage", ["clean"])),
+        exclude_classes=tuple(cf_cfg.get("exclude_classes", []) or []),
+    )
+
+
+def _stub_summary_md(
+    cfg: PipelineConfig,
+    gate: LineageGateResult,
+    pool_size: int,
+) -> str:
+    """Render a deterministic stub summary for PR-A end-to-end runs.
+
+    No timestamps inside the artefact body (only in the manifest's
+    ``created_at`` field, which lives one indirection away) so the
+    summary stays byte-identical across two consecutive runs.
+    """
+    lines = [
+        "# heavy_ml_probe — Step 4 stub summary (PR-A)",
+        "",
+        f"- Arc: `{cfg.arc_name}`",
+        f"- Cluster ID: `{cfg.cluster_id}`",
+        f"- Pool path: `{cfg.pool_path.as_posix()}`",
+        f"- Config path: `{cfg.config_path.as_posix()}`",
+        f"- heavy_ml_probe version: `{HEAVY_ML_VERSION}`",
+        f"- Manifest schema version: `{MANIFEST_SCHEMA_VERSION}`",
+        "",
+        "## Pool",
+        "",
+        f"- Trade rows loaded: **{pool_size}**",
+        "",
+        "## Lineage gate",
+        "",
+        f"- Columns evaluated: **{gate.n_input_columns}**",
+        f"- Accepted (clean): **{gate.n_accepted}**",
+        f"- Rejected: **{gate.n_rejected}**",
+        "",
+        "## Pipeline stages",
+        "",
+        "- [x] PR-A: scaffolding + causal lineage gate + deterministic IO + sha256 manifest",
+        "- [ ] PR-B: AutoML (FLAML, 11-fold TimeSeriesSplit, 1000 evals/fold cap)",
+        "- [ ] PR-C: Meta-labeling target (reach +1R MFE before SL)",
+        "- [ ] PR-D: Survival models (Cox PH + RSF; A4 adapter)",
+        "- [ ] PR-E: Step 5 augmentation hook",
+        "- [ ] PR-F: Docs + polish",
+        "",
+        "_See `docs/dispatches/heavy_ml_probe_build_intent.md` for the full build plan._",
+        "",
+    ]
+    if gate.n_rejected > 0:
+        lines.append(lineage_summary_markdown(gate))
+    return "\n".join(lines)
+
+
+def _gate_extras_for_manifest(gate: LineageGateResult) -> dict:
+    """Serialise the gate result into the manifest extras block.
+
+    Sorted lists / dicts so the manifest stays byte-identical across
+    two runs. Reasons aggregated for quick scan; full per-feature
+    rejection list deferred to the stub summary artefact.
+    """
+    from collections import Counter
+    reasons = Counter(r["reason"] for r in gate.rejected)
+    return {
+        "lineage_gate": {
+            "n_input_columns": int(gate.n_input_columns),
+            "n_accepted": int(gate.n_accepted),
+            "n_rejected": int(gate.n_rejected),
+            "accepted_features": list(gate.accepted_features),
+            "rejection_reasons": dict(sorted(reasons.items())),
+        }
+    }
+
+
+def run_pipeline(
+    cfg: PipelineConfig,
+    *,
+    lineage_df: pd.DataFrame | None = None,
+) -> PipelineResult:
+    """Run the heavy_ml_probe pipeline end-to-end (PR-A: lineage gate
+    + skeleton manifest only).
+
+    Side effects:
+      * Writes ``<step4_dir>/stub_summary.md`` and
+        ``<step4_dir>/manifest.json`` to disk.
+      * Creates parent directories as needed.
+
+    The function is idempotent on identical inputs by construction
+    (deterministic writes via :mod:`core.heavy_ml_probe.io`). Two
+    consecutive invocations produce byte-identical artefacts (modulo
+    the manifest's ``created_at`` field, which the determinism tests
+    intentionally exclude from the sha256 comparison by hashing the
+    payload sans that field).
+    """
+    pool = load_pool(cfg.pool_path)
+    gate = apply_lineage_gate(list(pool.columns), cfg, lineage_df=lineage_df)
+
+    cfg.step4_dir.mkdir(parents=True, exist_ok=True)
+    stub_summary_path = cfg.step4_dir / "stub_summary.md"
+    write_text(stub_summary_path, _stub_summary_md(cfg, gate, pool_size=len(pool)))
+
+    manifest_path = cfg.step4_dir / str(cfg.raw_config["output"]["artefacts"]["step4_manifest"])
+    write_manifest(
+        manifest_path,
+        arc_name=cfg.arc_name,
+        step="step_4/heavy_ml",
+        artefact_paths={"stub_summary": stub_summary_path},
+        extras={
+            "heavy_ml_probe_version": HEAVY_ML_VERSION,
+            "cluster_id": int(cfg.cluster_id),
+            "pool_path": cfg.pool_path.as_posix(),
+            "pool_size": int(len(pool)),
+            **_gate_extras_for_manifest(gate),
+        },
+    )
+
+    return PipelineResult(
+        cfg=cfg,
+        lineage_gate=gate,
+        step4_manifest_path=manifest_path,
+        stub_summary_path=stub_summary_path,
+    )
+
+
+def stable_payload_sha256(manifest_path: Path) -> str:
+    """SHA256 of the manifest with the ``created_at`` field zeroed out.
+
+    Useful for two-run determinism tests where everything except the
+    timestamp must match byte-for-byte. Reads the manifest, replaces
+    ``created_at`` with a fixed sentinel, re-serialises, hashes.
+    """
+    payload = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    payload["created_at"] = "<determinism-test-sentinel>"
+    import hashlib
+
+    blob = json.dumps(payload, sort_keys=True, indent=2)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+__all__ = (
+    "PipelineConfig",
+    "PipelineResult",
+    "load_config",
+    "load_pool",
+    "apply_lineage_gate",
+    "run_pipeline",
+    "stable_payload_sha256",
+)

--- a/core/heavy_ml_probe/pipeline.py
+++ b/core/heavy_ml_probe/pipeline.py
@@ -1,19 +1,44 @@
-"""Orchestration skeleton for the heavy_ml_probe sub-protocol.
+"""Orchestration for the heavy_ml_probe sub-protocol.
 
-Owns the end-to-end flow: load pool → apply causal lineage gate →
-[future] AutoML → [future] meta-labeling → [future] survival → write
-artefact set + manifest. Steps not yet implemented HALT cleanly with
-``NotImplementedError`` carrying the PR they land in (per the build
-plan in ``docs/dispatches/heavy_ml_probe_build_intent.md`` §8).
+Owns the end-to-end flow:
 
-PR-A scope: load config + apply lineage gate + write skeleton manifest
-+ summary. Returns enough context for the CLI to print actionable next
-steps.
+  1. Load + validate config
+  2. Load Step 1 pool
+  3. Apply causal lineage gate (PR-A)
+  4. Run AutoML across an 11-fold TimeSeriesSplit (PR-B)
+  5. [future] Meta-labeling (PR-C)
+  6. [future] Survival (PR-D)
+  7. Write artefact set + sha256 manifest
 
-PR-B (automl), PR-C (meta_labeling), PR-D (survival) extend this
-module. The public ``run_pipeline`` surface is stable from PR-A; new PRs
-add fields to :class:`PipelineResult` and populate currently-empty
-artefact slots.
+PR-B adds steps 4 — AutoML — and the three new artefacts
+(``automl_leaderboard.csv``, ``automl_feature_importance.csv``,
+``compute_budget_used.md``). The AutoML stage is auto-skipped when the
+input pool lacks the required ``entry_time`` / target columns; this
+keeps PR-A's lineage-gate-only tests untouched. Production invocations
+always have these columns and AutoML runs.
+
+Skip-reason taxonomy (recorded in the manifest's ``automl`` extras
+block so downstream tooling can audit why a run shipped without the
+AutoML artefact set):
+
+  * ``ok`` — AutoML ran; artefacts present
+  * ``missing_entry_time`` — pool has no ``entry_time`` column; PR-A
+    smoke / synthetic-pool path
+  * ``missing_target`` — pool has no ``y`` column; same
+  * ``no_clean_features`` — lineage gate rejected every column;
+    raised as ``AllFeaturesRejected`` from automl.run_automl, recorded
+    here as well for the manifest narrative
+  * ``holdout_guard_violation`` — pool max ``entry_time`` >= train_end;
+    raised as ``HoldoutGuardViolation``; surfaces in the manifest
+    before the exception propagates to the CLI
+
+Public surface stable from PR-A:
+  - ``PipelineConfig`` (extended fields, additive only)
+  - ``PipelineResult`` (extended fields, additive only)
+  - ``load_config`` / ``load_pool`` / ``apply_lineage_gate``
+  - ``run_pipeline``
+  - ``stable_payload_sha256``  — intentional public API for downstream
+    determinism verification per PR-A flag-3 disposition.
 """
 
 from __future__ import annotations
@@ -27,6 +52,15 @@ import pandas as pd
 import yaml
 
 from core.heavy_ml_probe import __version__ as HEAVY_ML_VERSION
+from core.heavy_ml_probe.automl import (
+    AllFeaturesRejected,
+    AutoMLResult,
+    HoldoutGuardViolation,
+    compute_budget_markdown,
+    importance_to_dataframe,
+    leaderboard_to_dataframe,
+    run_automl,
+)
 from core.heavy_ml_probe.causal_lineage import (
     LineageGateResult,
     filter_training_columns,
@@ -34,6 +68,7 @@ from core.heavy_ml_probe.causal_lineage import (
 )
 from core.heavy_ml_probe.io import (
     MANIFEST_SCHEMA_VERSION,
+    write_csv,
     write_manifest,
     write_text,
 )
@@ -43,9 +78,8 @@ from core.heavy_ml_probe.io import (
 class PipelineConfig:
     """Resolved invocation parameters for one pipeline run.
 
-    Subset of ``configs/heavy_ml_probe/default.yaml``. Fields not used
-    by PR-A scaffolding are still parsed so the YAML schema stays
-    locked from this PR forward.
+    Mirrors ``configs/heavy_ml_probe/default.yaml``. Fields not used at
+    this PR are still parsed so the YAML schema stays locked.
     """
 
     arc_name: str
@@ -65,23 +99,55 @@ class PipelineConfig:
         sub = str(self.raw_config["output"]["step5_subdir"])
         return self.output_root / sub
 
+    @property
+    def train_end(self) -> pd.Timestamp:
+        """Holdout cutoff per L_PROTOCOL §1 + dispatch §5 #3."""
+        return pd.Timestamp(
+            str(self.raw_config["training_window"]["train_end"])
+        ).tz_localize("UTC")
+
+    @property
+    def automl_max_iter_per_fold(self) -> int:
+        return int(self.raw_config["automl"]["max_iter_per_fold"])
+
+    @property
+    def automl_n_folds(self) -> int:
+        return int(self.raw_config["automl"]["n_folds"])
+
+    @property
+    def automl_metric(self) -> str:
+        return str(self.raw_config["automl"].get("metric", "roc_auc"))
+
+    @property
+    def random_state(self) -> int:
+        return int(self.raw_config["determinism"]["random_state"])
+
+    @property
+    def n_jobs(self) -> int:
+        return int(self.raw_config["determinism"]["n_jobs"])
+
 
 @dataclass(frozen=True)
 class PipelineResult:
     """Aggregated outcome of one pipeline run.
 
-    PR-A populates ``lineage_gate``, ``step4_manifest_path``, and
-    ``stub_summary_path``. Later PRs fill the empty slots
-    (``automl_artefacts``, ``meta_label_artefacts``, ``survival_artefacts``,
-    ``step5_manifest_path``).
+    PR-A: ``lineage_gate``, ``step4_manifest_path``, ``stub_summary_path``.
+    PR-B adds: ``automl_result``, ``automl_skip_reason``,
+    ``automl_leaderboard_path``, ``automl_importance_path``,
+    ``compute_budget_path``.
     """
 
     cfg: PipelineConfig
     lineage_gate: LineageGateResult
     step4_manifest_path: Path
     stub_summary_path: Path
-    # Reserved for PR-B/C/D — empty in PR-A.
-    automl_artefacts: tuple[Path, ...] = field(default_factory=tuple)
+    # PR-B fields (None when AutoML was skipped or upstream guards fired)
+    automl_result: AutoMLResult | None = None
+    automl_skip_reason: str = "ok"
+    automl_leaderboard_path: Path | None = None
+    automl_importance_path: Path | None = None
+    compute_budget_path: Path | None = None
+    # Reserved for PR-C/D — empty in PR-B.
     meta_label_artefacts: tuple[Path, ...] = field(default_factory=tuple)
     survival_artefacts: tuple[Path, ...] = field(default_factory=tuple)
     step5_manifest_path: Path | None = None
@@ -95,12 +161,7 @@ def load_config(
     pool_path: Path,
     output_root: Path,
 ) -> PipelineConfig:
-    """Load + minimally-validate a heavy_ml_probe YAML config.
-
-    Validation is intentionally light at PR-A — full schema enforcement
-    lands when PR-B/C/D start consuming the AutoML / meta-labeling /
-    survival blocks.
-    """
+    """Load + minimally-validate a heavy_ml_probe YAML config."""
     cp = Path(config_path)
     if not cp.exists():
         raise FileNotFoundError(f"heavy_ml_probe config not found: {cp}")
@@ -134,13 +195,7 @@ def load_config(
 
 
 def load_pool(pool_path: Path) -> pd.DataFrame:
-    """Read the Step 1 pool parquet.
-
-    PR-A only reads the columns; the body of work happens in PR-B+.
-    Surfacing the load here gives PR-A's CLI a non-trivial smoke
-    capability — we can fail fast on a bad pool path before later PRs
-    add dependencies.
-    """
+    """Read the Step 1 pool parquet."""
     p = Path(pool_path)
     if not p.exists():
         raise FileNotFoundError(f"pool parquet not found: {p}")
@@ -164,11 +219,7 @@ def apply_lineage_gate(
     *,
     lineage_df: pd.DataFrame | None = None,
 ) -> LineageGateResult:
-    """Run the pre-evaluation lineage gate over ``pool_columns``.
-
-    ``lineage_df`` defaults to the registry-backed table; pass in a
-    hand-built DataFrame for tests.
-    """
+    """Run the pre-evaluation lineage gate over ``pool_columns``."""
     if lineage_df is None:
         lineage_df = _build_lineage_dataframe()
     cf_cfg = cfg.raw_config["causal_filter"]
@@ -180,19 +231,106 @@ def apply_lineage_gate(
     )
 
 
+# ── PR-B: AutoML stage skip / run decision ───────────────────────────
+
+
+# Columns the AutoML stage requires. Skip cleanly if either is absent
+# rather than crashing — this lets PR-A's lineage-gate-only smoke pools
+# coexist with PR-B production pools in the same code path.
+AUTOML_REQUIRED_COLUMNS: tuple[str, str] = ("entry_time", "y")
+
+
+def _should_run_automl(
+    pool: pd.DataFrame,
+    gate: LineageGateResult,
+) -> tuple[bool, str]:
+    """Decide whether to run the AutoML stage. Returns (should_run, reason)."""
+    if gate.n_accepted == 0:
+        return False, "no_clean_features"
+    for col in AUTOML_REQUIRED_COLUMNS:
+        if col not in pool.columns:
+            return False, f"missing_{col}"
+    return True, "ok"
+
+
+def _run_automl_stage(
+    cfg: PipelineConfig,
+    pool: pd.DataFrame,
+    gate: LineageGateResult,
+) -> tuple[AutoMLResult | None, str, dict[str, Path]]:
+    """Run AutoML + write the three new artefacts. Returns
+    (result_or_none, skip_reason, {logical_name: path})."""
+    should_run, reason = _should_run_automl(pool, gate)
+    if not should_run:
+        return None, reason, {}
+
+    try:
+        result = run_automl(
+            pool=pool,
+            used_features=gate.accepted_features,
+            train_end=cfg.train_end,
+            n_folds=cfg.automl_n_folds,
+            max_iter_per_fold=cfg.automl_max_iter_per_fold,
+            seed=cfg.random_state,
+            metric=cfg.automl_metric,
+            n_jobs=cfg.n_jobs,
+        )
+    except HoldoutGuardViolation:
+        # Propagate after recording in the manifest narrative — but the
+        # current orchestrator can't write the manifest after raising.
+        # So we record the skip reason and re-raise; the CLI surfaces
+        # the error via stderr + exit code 1. The manifest's
+        # ``automl.skip_reason`` field will reflect ``holdout_guard_violation``
+        # only on a SUCCESSFUL guard-violation pre-check path; an
+        # actual violation kills the pipeline cleanly.
+        raise
+    except AllFeaturesRejected:
+        # Same: the caller (run_pipeline) catches this and folds it
+        # into the manifest. Re-raise here for the orchestrator to
+        # handle.
+        raise
+
+    paths: dict[str, Path] = {}
+    art_cfg = cfg.raw_config["output"]["artefacts"]
+    lb_path = cfg.step4_dir / str(art_cfg["automl_leaderboard"])
+    imp_path = cfg.step4_dir / str(art_cfg["automl_feature_importance"])
+    budget_path = cfg.step4_dir / str(art_cfg["compute_budget_used"])
+
+    write_csv(
+        lb_path,
+        leaderboard_to_dataframe(result),
+        sort_by=["fold", "estimator"],
+    )
+    write_csv(
+        imp_path,
+        importance_to_dataframe(result),
+        sort_by=["feature"],
+    )
+    write_text(
+        budget_path,
+        compute_budget_markdown(result, train_end=cfg.train_end),
+    )
+    paths["automl_leaderboard"] = lb_path
+    paths["automl_feature_importance"] = imp_path
+    paths["compute_budget_used"] = budget_path
+    return result, "ok", paths
+
+
 def _stub_summary_md(
     cfg: PipelineConfig,
     gate: LineageGateResult,
     pool_size: int,
+    automl_result: AutoMLResult | None,
+    automl_skip_reason: str,
 ) -> str:
-    """Render a deterministic stub summary for PR-A end-to-end runs.
+    """Render the Step 4 stub summary.
 
-    No timestamps inside the artefact body (only in the manifest's
-    ``created_at`` field, which lives one indirection away) so the
-    summary stays byte-identical across two consecutive runs.
+    Stable formatting: no embedded timestamps. PR-A behaviour preserved
+    when AutoML is skipped; PR-B appends a stage-status block when
+    AutoML ran.
     """
     lines = [
-        "# heavy_ml_probe — Step 4 stub summary (PR-A)",
+        "# heavy_ml_probe — Step 4 summary",
         "",
         f"- Arc: `{cfg.arc_name}`",
         f"- Cluster ID: `{cfg.cluster_id}`",
@@ -211,10 +349,30 @@ def _stub_summary_md(
         f"- Accepted (clean): **{gate.n_accepted}**",
         f"- Rejected: **{gate.n_rejected}**",
         "",
+        "## AutoML stage",
+        "",
+        f"- Status: **{automl_skip_reason}**",
+    ]
+    if automl_result is not None:
+        ar = automl_result
+        lines += [
+            f"- FLAML version: `{ar.flaml_version}`",
+            f"- Folds total: **{ar.n_folds_total}** (valid AUC: **{ar.n_folds_valid}**)",
+            (
+                f"- AUC (nanmean ± nanstd): **{ar.auc_mean:.4f} ± {ar.auc_std:.4f}**"
+                if pd.notna(ar.auc_mean)
+                else "- AUC (nanmean ± nanstd): **NaN ± NaN** (no valid folds)"
+            ),
+            f"- Total modelcount across folds: **{ar.total_modelcount}**",
+            # Wall-clock intentionally NOT logged here — non-deterministic;
+            # available on the in-memory AutoMLResult for log/diagnostic use.
+        ]
+    lines += [
+        "",
         "## Pipeline stages",
         "",
         "- [x] PR-A: scaffolding + causal lineage gate + deterministic IO + sha256 manifest",
-        "- [ ] PR-B: AutoML (FLAML, 11-fold TimeSeriesSplit, 1000 evals/fold cap)",
+        f"- [{'x' if automl_result is not None else ' '}] PR-B: AutoML (FLAML, 11-fold TimeSeriesSplit, 1000 evals/fold cap)",
         "- [ ] PR-C: Meta-labeling target (reach +1R MFE before SL)",
         "- [ ] PR-D: Survival models (Cox PH + RSF; A4 adapter)",
         "- [ ] PR-E: Step 5 augmentation hook",
@@ -232,8 +390,7 @@ def _gate_extras_for_manifest(gate: LineageGateResult) -> dict:
     """Serialise the gate result into the manifest extras block.
 
     Sorted lists / dicts so the manifest stays byte-identical across
-    two runs. Reasons aggregated for quick scan; full per-feature
-    rejection list deferred to the stub summary artefact.
+    two runs.
     """
     from collections import Counter
     reasons = Counter(r["reason"] for r in gate.rejected)
@@ -248,45 +405,113 @@ def _gate_extras_for_manifest(gate: LineageGateResult) -> dict:
     }
 
 
+def _automl_extras_for_manifest(
+    result: AutoMLResult | None,
+    skip_reason: str,
+) -> dict:
+    """Serialise the AutoML stage result for the manifest.
+
+    Floats are coerced to native Python; NaN serialised via ``None`` so
+    the JSON is strict-spec compliant (JSON does not have NaN).
+    """
+    def _f(x: float) -> float | None:
+        if x is None:
+            return None
+        try:
+            if not pd.notna(x):
+                return None
+        except TypeError:
+            return None
+        return float(x)
+
+    if result is None:
+        return {"automl": {"skip_reason": str(skip_reason)}}
+    return {
+        "automl": {
+            "skip_reason": str(skip_reason),
+            "flaml_version": str(result.flaml_version),
+            "metric": str(result.metric),
+            "n_folds_total": int(result.n_folds_total),
+            "n_folds_valid": int(result.n_folds_valid),
+            "auc_mean": _f(result.auc_mean),
+            "auc_std": _f(result.auc_std),
+            "total_modelcount": int(result.total_modelcount),
+            # Wall-clock intentionally omitted — non-deterministic.
+            "n_features_used": int(len(result.used_features)),
+        }
+    }
+
+
 def run_pipeline(
     cfg: PipelineConfig,
     *,
     lineage_df: pd.DataFrame | None = None,
 ) -> PipelineResult:
-    """Run the heavy_ml_probe pipeline end-to-end (PR-A: lineage gate
-    + skeleton manifest only).
+    """Run the heavy_ml_probe pipeline end-to-end.
 
-    Side effects:
-      * Writes ``<step4_dir>/stub_summary.md`` and
-        ``<step4_dir>/manifest.json`` to disk.
-      * Creates parent directories as needed.
+    PR-A stages: lineage gate + skeleton manifest + stub summary.
+    PR-B stages: AutoML across an 11-fold TimeSeriesSplit (when the
+    input pool supports it) + AutoML artefacts in the manifest.
 
-    The function is idempotent on identical inputs by construction
-    (deterministic writes via :mod:`core.heavy_ml_probe.io`). Two
-    consecutive invocations produce byte-identical artefacts (modulo
-    the manifest's ``created_at`` field, which the determinism tests
-    intentionally exclude from the sha256 comparison by hashing the
-    payload sans that field).
+    Determinism: identical config + identical pool → byte-identical
+    artefacts and (modulo ``created_at``) byte-identical manifest. The
+    determinism tests use :func:`stable_payload_sha256` to verify the
+    payload sans timestamp.
     """
     pool = load_pool(cfg.pool_path)
     gate = apply_lineage_gate(list(pool.columns), cfg, lineage_df=lineage_df)
-
     cfg.step4_dir.mkdir(parents=True, exist_ok=True)
-    stub_summary_path = cfg.step4_dir / "stub_summary.md"
-    write_text(stub_summary_path, _stub_summary_md(cfg, gate, pool_size=len(pool)))
 
+    # ── PR-B AutoML stage ────────────────────────────────────────────
+    automl_result: AutoMLResult | None = None
+    automl_skip_reason: str = "ok"
+    automl_paths: dict[str, Path] = {}
+    try:
+        automl_result, automl_skip_reason, automl_paths = _run_automl_stage(cfg, pool, gate)
+    except HoldoutGuardViolation:
+        # Record the skip reason in the manifest, then re-raise.
+        automl_skip_reason = "holdout_guard_violation"
+        _emit_partial_manifest(
+            cfg, gate, pool_size=len(pool),
+            automl_result=None, automl_skip_reason=automl_skip_reason,
+            automl_paths={},
+        )
+        raise
+    except AllFeaturesRejected:
+        automl_skip_reason = "no_clean_features"
+        _emit_partial_manifest(
+            cfg, gate, pool_size=len(pool),
+            automl_result=None, automl_skip_reason=automl_skip_reason,
+            automl_paths={},
+        )
+        raise
+
+    # ── Stub summary (PR-A artefact, PR-B extended content) ──────────
+    stub_summary_path = cfg.step4_dir / "stub_summary.md"
+    write_text(
+        stub_summary_path,
+        _stub_summary_md(
+            cfg, gate, pool_size=len(pool),
+            automl_result=automl_result,
+            automl_skip_reason=automl_skip_reason,
+        ),
+    )
+
+    # ── Manifest ─────────────────────────────────────────────────────
+    artefact_paths: dict[str, Path] = {"stub_summary": stub_summary_path, **automl_paths}
     manifest_path = cfg.step4_dir / str(cfg.raw_config["output"]["artefacts"]["step4_manifest"])
     write_manifest(
         manifest_path,
         arc_name=cfg.arc_name,
         step="step_4/heavy_ml",
-        artefact_paths={"stub_summary": stub_summary_path},
+        artefact_paths=artefact_paths,
         extras={
             "heavy_ml_probe_version": HEAVY_ML_VERSION,
             "cluster_id": int(cfg.cluster_id),
             "pool_path": cfg.pool_path.as_posix(),
             "pool_size": int(len(pool)),
             **_gate_extras_for_manifest(gate),
+            **_automl_extras_for_manifest(automl_result, automl_skip_reason),
         },
     )
 
@@ -295,15 +520,65 @@ def run_pipeline(
         lineage_gate=gate,
         step4_manifest_path=manifest_path,
         stub_summary_path=stub_summary_path,
+        automl_result=automl_result,
+        automl_skip_reason=automl_skip_reason,
+        automl_leaderboard_path=automl_paths.get("automl_leaderboard"),
+        automl_importance_path=automl_paths.get("automl_feature_importance"),
+        compute_budget_path=automl_paths.get("compute_budget_used"),
+    )
+
+
+def _emit_partial_manifest(
+    cfg: PipelineConfig,
+    gate: LineageGateResult,
+    *,
+    pool_size: int,
+    automl_result: AutoMLResult | None,
+    automl_skip_reason: str,
+    automl_paths: dict[str, Path],
+) -> None:
+    """Write a manifest reflecting the partial run before re-raising.
+
+    Used when a guard fires after the lineage gate but before the
+    AutoML artefacts land — gives downstream tooling something to
+    inspect even on the failure path.
+    """
+    cfg.step4_dir.mkdir(parents=True, exist_ok=True)
+    stub_summary_path = cfg.step4_dir / "stub_summary.md"
+    write_text(
+        stub_summary_path,
+        _stub_summary_md(
+            cfg, gate, pool_size=pool_size,
+            automl_result=automl_result,
+            automl_skip_reason=automl_skip_reason,
+        ),
+    )
+    artefact_paths: dict[str, Path] = {"stub_summary": stub_summary_path, **automl_paths}
+    manifest_path = cfg.step4_dir / str(cfg.raw_config["output"]["artefacts"]["step4_manifest"])
+    write_manifest(
+        manifest_path,
+        arc_name=cfg.arc_name,
+        step="step_4/heavy_ml",
+        artefact_paths=artefact_paths,
+        extras={
+            "heavy_ml_probe_version": HEAVY_ML_VERSION,
+            "cluster_id": int(cfg.cluster_id),
+            "pool_path": cfg.pool_path.as_posix(),
+            "pool_size": int(pool_size),
+            **_gate_extras_for_manifest(gate),
+            **_automl_extras_for_manifest(automl_result, automl_skip_reason),
+        },
     )
 
 
 def stable_payload_sha256(manifest_path: Path) -> str:
     """SHA256 of the manifest with the ``created_at`` field zeroed out.
 
-    Useful for two-run determinism tests where everything except the
-    timestamp must match byte-for-byte. Reads the manifest, replaces
-    ``created_at`` with a fixed sentinel, re-serialises, hashes.
+    Intentional public API for downstream determinism verification per
+    PR-A flag-3 disposition. Two consecutive ``run_pipeline`` calls on
+    identical inputs produce manifests whose ``stable_payload_sha256``
+    values match — the only varying field is ``created_at``, which is
+    excluded here.
     """
     payload = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
     payload["created_at"] = "<determinism-test-sentinel>"
@@ -314,6 +589,7 @@ def stable_payload_sha256(manifest_path: Path) -> str:
 
 
 __all__ = (
+    "AUTOML_REQUIRED_COLUMNS",
     "PipelineConfig",
     "PipelineResult",
     "load_config",

--- a/docs/dispatches/heavy_ml_probe_build_intent.md
+++ b/docs/dispatches/heavy_ml_probe_build_intent.md
@@ -1,0 +1,346 @@
+# heavy_ml_probe — Build Intent Doc
+
+> **Authoring CC session:** worktree `elegant-ride-ad9a57` on branch `claude/elegant-ride-ad9a57`.
+> **Status:** intent doc only; no code, config, or branch changes this turn. End-of-turn for chat review per WORKFLOW §2 + dispatch §11.
+> **Dispatch reference:** `CC Dispatch — Build heavy_ml_probe Sub-Protocol` (this conversation).
+> **Source of truth being implemented:** `docs/sub_protocols/heavy_ml_probe.md` v1.0 (locked).
+> **Sibling reference consumed:** `core/discovery/**`, `scripts/arc_discovery_01/**`, `configs/arc_discovery_01.yaml`, `docs/dispatches/arc_discovery_01_intent.md`, `tests/discovery/**`.
+> **Predecessor docs read in order per §11:** `L_PROTOCOL.md` (full, with focus on §1 / §2 Step 1 / §2 Step 4 / §2 Step 5 incl. Amendment 2 retraining policy + Amendment 3 risk-normalised gates / §3 / §5 sub-protocol mechanism); `docs/sub_protocols/heavy_ml_probe.md` v1.0; `docs/sub_protocols/signal_discovery_probe.md` v1.0; `WORKFLOW.md` §2 + §6; `ARC_TRACKER.md` (read-only — no row to touch).
+> **Engine-consumer modules surveyed:** `core/steps/step_4_extraction.py`, `core/steps/classifier_persistence.py`, `core/steps/path_classifier_per_fold.py`, `core/architectures/{a1,a2,a4,a6}*.py`, `core/architectures/_path_classifier.py`, `core/features/{lineage,pipeline,registry}.py`.
+
+---
+
+## §1 Goal restatement (one paragraph)
+
+Build the `heavy_ml_probe` sub-protocol so a future arc can declare `sub_protocol: heavy_ml_probe` in its `ARC_OPEN.md` and run the overseer's Step 4 + Step 5 with: (a) FLAML AutoML in 11-fold TimeSeriesSplit replacing the vanilla three-classifier Step 4, (b) a meta-labeling target (`reach +1R MFE before SL`) trained via the same AutoML path, (c) Cox PH + Random Survival Forest fed into A4 (Pipeline D exits), and (d) Step 5 augmentation hook so A2 / A4 / A6 consume heavy-ML-trained components. No arc dispatched against this; build-now-so-ready-when-needed. Overseer Step 1 / 2 / 3 / 6 + §3 gates untouched.
+
+---
+
+## §2 Prerequisites verified
+
+| Prerequisite | Status | Where |
+|---|---|---|
+| L_PROTOCOL v3.0 + Amendments 1-3 locked | ✅ | `L_PROTOCOL.md` header + §3 risk-normalised gates locked. heavy_ml_probe does NOT touch gates per spec §"Discipline rules". |
+| Sub-protocol v1.0 doc | ✅ | `docs/sub_protocols/heavy_ml_probe.md` (read; spec is the bind). |
+| Sibling sub-protocol implemented | ✅ | `core/discovery/**` (10 modules) + `scripts/arc_discovery_01/run_discovery.py` + `tests/discovery/**` (9 test modules). Conventions to mirror: IO layout, manifest schema, lineterminator='\n', sorted JSON, sha256, random_state=42, n_jobs=1, locked YAML config. |
+| Feature lineage source-of-truth | ✅ | `core/features/lineage.py::CausalLineage` (CLEAN/SUSPECT/UNVERIFIED) attached at `FeatureSpec` construction. `core/features/pipeline.py::feature_lineage_dataframe()` returns columns `name, feature_class, causal_lineage, needs_panel, description`. Already consumed by `core/discovery/causal_filter.py` — heavy_ml_probe reuses the same read pattern (see §4 Q3 resolution). |
+| Step 4 classifier persistence + manifest convention | ✅ | `core/steps/step_4_extraction.py::_persist_best_classifier` + `_write_manifest` (joblib.dump compress=3, sha256, classifier_type/feature_order/best_threshold/auc_oos_cv5 entries). `core/steps/classifier_persistence.py::load_classifier` with SHA256 verification + version-drift warning. A heavy-ML augmented artefact set can land in a parallel directory using the exact same manifest schema. |
+| A2 / A6 consumer wiring exists | ✅ | `build_a2_config_from_step4`, `build_a6_config_from_step4` already load a `predict_proba`-shaped classifier and wrap it in `A2Config` / `A6Config`. Heavy-ML AutoML output IS `predict_proba`-shaped (FLAML's best estimator exposes `predict_proba`) — drop-in compatible. |
+| A4 consumer wiring exists for binary classifier | ✅ partial — see §4 Q5b | `core/architectures/a4_pipeline_d_exits.py::_A4ExitPredicate` consults `PathClassifierFit` via `predict_admit(...)`. Cox PH / RSF do NOT emit a binary admit decision — they emit hazards / survival probabilities. Spec §"Survival model variant for Pipeline D" says "predicted hazard at each post-entry bar feeds Step 5 Pipeline D exit policy." Translation rule (hazard → exit decision) is not yet specified at the consumer interface. Surface as Q5b open question. |
+| WORKFLOW §2 intent → log → PR pattern | ✅ | Followed for sibling (`arc_discovery_01_intent.md` / `_log.md`). This doc is the heavy_ml_probe equivalent. |
+| `docs/dispatches/` write convention | ✅ | All prior dispatch artefacts follow `<work>_intent.md` / `<work>_log.md` / `<work>_diagnostic.md` naming. This doc lands at `docs/dispatches/heavy_ml_probe_build_intent.md`. |
+| Branch strategy | ✅ | Build branch `infra/heavy_ml_probe_build` cut from main; per-PR branches off it (`infra/heavy_ml_probe_pr_a` ... `_pr_f`). Final merge to main after PR-F. Per dispatch §12. |
+
+---
+
+## §3 Confirmed module structure (dispatch §4)
+
+Dispatch §4's proposed tree is adopted verbatim with no deviations. Mirrors `core/discovery/**` shape so reviewers can navigate by analogy:
+
+```
+core/heavy_ml_probe/
+  __init__.py                # version + public API surface
+  automl.py                  # FLAML wrapper, evaluation-count enforcement, 11-fold CV loop
+  meta_labeling.py           # reach-1R-before-SL target construction + AutoML training reuse
+  survival.py                # Cox PH (lifelines) + RSF (scikit-survival); n < 200 warning per dispatch §6.10
+  pipeline.py                # orchestration: Step 1 pool in → Step 4 heavy-ML artefacts out
+  metrics.py                 # AUC + concordance + IBS wrappers
+  io.py                      # manifest writer, deterministic CSV/parquet writers, sha256 utility
+  causal_lineage.py          # pre-evaluation gate per spec §"Per-feature causal lineage"
+
+scripts/heavy_ml_probe/
+  __init__.py
+  run_probe.py               # CLI: --arc <name> --pool <path> --config <yaml> --cluster-id <id>
+
+configs/heavy_ml_probe/
+  default.yaml               # AutoML budget, model search space, CV folds, thresholds, library versions
+
+tests/heavy_ml_probe/
+  __init__.py
+  test_automl.py
+  test_meta_labeling.py
+  test_survival.py
+  test_causal_lineage.py
+  test_io_manifest.py        # added: same coverage gap noticed in sibling, worth filling proactively
+  test_pipeline_integration.py   # renamed from dispatch's `test_integration.py` for clarity
+```
+
+**Two minor additions to dispatch §4** (flagged here for chat sign-off rather than silently changing):
+
+1. `tests/heavy_ml_probe/test_io_manifest.py` — sibling has determinism-artefact tests (`tests/discovery/test_determinism_artefacts.py`); same pattern fits here. Keeps PR-A test surface honest without inflating PR-A.
+2. `scripts/heavy_ml_probe/__init__.py` — matches `scripts/arc_discovery_01/__init__.py` (an empty marker so the script package imports cleanly). Trivial; included for parity.
+
+Nothing else changes from dispatch §4.
+
+---
+
+## §4 Open question resolutions (dispatch §9)
+
+Dispatch §11 asks me to answer each §9 question from the codebase where possible and explicitly list the rest for chat. Working through them in order:
+
+### Q1 — Survival model target (CHAT, unresolvable from code)
+
+Dispatch §9.1 lists three plausible framings:
+- (a) time-to-SL-or-time-exit (realised exit event)
+- (b) time-to-MFE-peak (time at which MFE was maximised)
+- (c) time-to-reach-1R-MFE (event = +1R hit, censored at SL/time-exit)
+
+The codebase doesn't choose. Each has different downstream A4 implications:
+
+| Framing | What A4 does at each bar | Failure mode |
+|---|---|---|
+| (a) time-to-exit | Predict survival probability past horizon h; exit if S(h) drops below threshold. Maximally generic. | Lumps profitable runners and SL-flushes into one hazard, blunts signal. |
+| (b) time-to-MFE-peak | Predict bars-until-MFE-peak; exit when t > predicted peak. | Requires MFE-peak in the training label (uses full path), which is fine for IS labels but A4 needs to behave at OOS bars where MFE-peak is unknown — only a prediction is used, but the target is path-dependent and noisy. |
+| (c) time-to-reach-1R-MFE censored at SL/time-exit | Predict probability of reaching +1R within remaining horizon; exit when probability drops below threshold. Aligns directly with the meta-labeling target (reach-1R-before-SL). | Cleanest semantically; same event definition as the meta-labeling target → fewer concept mismatches. |
+
+**CC recommendation: (c)** — it aligns the survival target with the meta-labeling target (both events = "reach +1R before SL"). One semantic story across heavy_ml_probe. (a) is the safe fallback; (b) is the most novel but most fragile. Chat to confirm before PR-D.
+
+### Q2 — FLAML evaluation-count granularity (PARTIAL — default reading, chat to confirm strict reading)
+
+FLAML's `max_iter` counts hyperparameter combinations evaluated, not "model evaluations" in the abstract. One `max_iter=1000` call typically spans multiple base learners with the budget divided across them by FLAML's bandit-style scheduler. **Default reading: 1 trial = 1 evaluation; `max_iter=1000` per fold = 1000 evaluations per fold = 11,000 per cluster.** This matches FLAML's `max_iter` semantics and is the cleanest mapping to dispatch §6 #6.
+
+Stricter reading (1 base-learner × 1 hyperparam config = 1 evaluation; multi-learner FLAML run with `max_iter=1000` counts as N × 1000 where N = number of base learners) is possible but would force `max_iter ≈ 167` per fold (1000 / 6 learners), which materially reduces FLAML's search depth.
+
+CC recommendation: default reading. Surface to chat; if stricter reading is required, set `max_iter = floor(1000 / n_estimators_searched)` in YAML and document.
+
+HALT trigger: if FLAML cannot enforce a hard upper bound under either reading (e.g. internal warm-start trials are uncounted), HALT per dispatch §5 and surface for library swap.
+
+### Q3 — Causal lineage tag schema (RESOLVED FROM CODEBASE — no chat needed)
+
+Resolved by reading `core/features/lineage.py`, `core/features/pipeline.py`, `core/discovery/causal_filter.py`:
+
+- Lineage tags are attached at `FeatureSpec` registration time via the `lineage: CausalLineage` field (`CLEAN` / `SUSPECT` / `UNVERIFIED`). Registry-resident; NOT embedded in Step 1's `pool.parquet` per-row.
+- `feature_lineage_dataframe()` returns a DataFrame with columns `name, feature_class, causal_lineage, needs_panel, description`. This is the canonical lineage table.
+- `core/discovery/causal_filter.py::clean_feature_pool(lineage_df, accepted=("clean",), exclude_classes=())` returns the filtered feature-name tuple.
+- `core/steps/step_4_extraction.py::_filter_lineage` does the same job inside vanilla Step 4 (also keying on `lineage["causal_lineage"] == "clean"`).
+
+**heavy_ml_probe convention (mirroring sibling):** `core/heavy_ml_probe/causal_lineage.py` consumes `feature_lineage_dataframe()`, filters the feature pool to `causal_lineage == "clean"`, and logs the rejection list with the same reason vocabulary as `core.discovery.causal_filter` (`non_clean_lineage`, `excluded_class`, `unknown_feature`). The CC layer enforces the pre-evaluation gate per dispatch §6 #2 by filtering training-set columns BEFORE the AutoML run starts. No new schema invented; no separate metadata file.
+
+### Q4 — Per-cluster invocation pattern (RESOLVED — CC recommends single-cluster CLI)
+
+Dispatch §9.4's default — `run_probe.py` takes a single cluster ID as input, orchestration over clusters is the caller's responsibility — is what CC will implement unless chat redirects. Reasons:
+
+1. Keeps `run_probe.py` unit-testable in isolation (`test_pipeline_integration.py` only needs one cluster's worth of synthetic data).
+2. Compute budget (8-24h per arc per spec §"Expected compute cost") is dominated by the per-cluster AutoML run — coarse-grained parallelism over clusters is best done at the caller layer (a shell loop or future orchestrator hook), not buried inside the script.
+3. Matches sibling pattern: `scripts/arc_discovery_01/run_discovery.py` runs one arc's worth of search, not multi-arc auto-iteration.
+
+If chat prefers auto-iteration over all candidate clusters from a Step 3 output, that's a one-flag change (`--all-candidate-clusters` reading `step_3/capturability_summary.md`). Mention in PR-A if chat redirects.
+
+### Q5 — Step 5 architecture-layer interface (PARTIAL — A2/A6 work today, A4 needs a small interface decision)
+
+**Q5a (A2 / A6 — RESOLVED FROM CODEBASE):** `core/steps/classifier_persistence.py` already exposes `build_a2_config_from_step4` / `build_a6_config_from_step4`. Both load a `predict_proba`-shaped fitted estimator from a directory layout `step_4/classifiers/<cluster_id>.pkl` + `step_4/classifiers/manifest.json`. FLAML's best estimator exposes `predict_proba`, so a heavy-ML artefact directory at `step_4/heavy_ml/classifiers/<cluster_id>.pkl` + sibling manifest is plug-and-play. PR-E will provide thin wrappers (`build_a2_config_from_heavy_ml`, `build_a6_config_from_heavy_ml`) that point at the heavy-ML directory instead of the vanilla one; same downstream `A2Config` / `A6Config` consumed.
+
+**Q5b (A4 / survival — NEEDS CHAT DECISION):** A4's consumer interface today expects a `PathClassifierFit` with `.model.predict_proba` and a binary "exit if prob < threshold" rule (`_A4ExitPredicate.__call__` in `core/architectures/a4_pipeline_d_exits.py:110-159`). Survival models (Cox PH, RSF) don't fit this shape — they predict a hazard rate or a survival probability over a horizon, not a single "should-exit" probability.
+
+Three options to bridge:
+
+| Option | What changes | Pros | Cons |
+|---|---|---|---|
+| **B1.** Wrap survival prediction in a `PathClassifierFit`-shaped adapter that maps `S(h | features) < threshold` to a binary exit at the calling bar. | New `SurvivalPathClassifierAdapter` class with `.predict_admit(features) -> (admit, proba)`. A4 unchanged. | Zero engine surface change. Fits the dispatch §3 "out-of-scope" boundary. | Hides the survival semantics — debuggers see "AUC 0.X" but the underlying object is computing a hazard. Threshold tuning is at one horizon only. |
+| **B2.** Extend A4 with an opt-in `SurvivalExitPredicate` alongside `_A4ExitPredicate`. Heavy_ml_probe builds the new predicate; vanilla A4 keeps `_A4ExitPredicate`. | Cleaner separation of survival vs. binary semantics. | Touches `core/architectures/a4_pipeline_d_exits.py` — dispatch §3 says that file is out-of-scope. Engine-team would have to approve. | Wider scope; needs a chat-decided "engine extension allowed?" sign-off. |
+| **B3.** Surface the survival model in the Step 4 manifest only; A4 augmentation deferred to a follow-up engine PR; heavy_ml_probe ships with AutoML + meta-labeling consuming A2/A6 only, and A4 closure on heavy-ML stays a TODO. | Cleanest scope-wise. Matches dispatch §3 boundary literally. | Spec §"A4 (Pipeline D) uses the survival-model-predicted exit timing" not honored by this build; A4 heavy-ML augmentation becomes a follow-up. |
+
+**CC recommendation: B1 (adapter pattern).** Keeps A4 untouched per dispatch §3, gives heavy_ml_probe a complete A4 path. The adapter's threshold is the hyperparam chat tunes at Step 5. If chat prefers B2 (cleaner) or B3 (most conservative scope), the impact is on PR-D's design — flag at PR-D intent.
+
+PR-E will flag this in the PR description regardless of which option is chosen, per dispatch §9.5: "if that consumer code doesn't exist yet, this build can't be end-to-end-verified against A2/A4/A6 — only against the Step 4 artefact set."
+
+---
+
+## §5 Library choices (dispatch §5)
+
+| Component | Library | Confirmed? | Notes |
+|---|---|---|---|
+| AutoML | **FLAML** | ✅ confirmed | Native `max_iter` budget enforcement maps to dispatch §6 #6 cleanly. HALT trigger reaffirmed: if `max_iter` cannot enforce the hard 1000-eval/fold cap under either reading from Q2, HALT and surface to chat for library swap. |
+| Cox Proportional Hazards | **lifelines** | ✅ confirmed | Canonical Python implementation. Returns concordance, log-likelihood. |
+| Random Survival Forest + IBS | **scikit-survival** (`sksurv`) | ✅ confirmed | Standard RSF + Integrated Brier Score. |
+| Base learners inside FLAML search | RF, LightGBM, XGBoost, CatBoost, ExtraTrees, LR | ⚠️ partial — see §6 dep bump | LightGBM already in vanilla Step 4 (via `core.steps._classifier_defaults`); XGBoost + CatBoost NOT installed. |
+| Determinism | stdlib + `random_state=42` | ✅ confirmed | n_jobs=1; lineterminator='\n'; sha256 sidecar manifests. Same convention as `core/discovery/io.py`. |
+
+**Dependency bump required in PR-A:**
+
+`requirements-dev.txt` currently lists: `numpy, pandas, pyarrow, pytest, ruff, pyyaml, pydantic, scipy, scikit-learn, joblib`. Missing for heavy_ml_probe: **`flaml`, `lifelines`, `scikit-survival`, `xgboost`, `catboost`, `lightgbm`** (lightgbm imports defensively in `core.steps._classifier_defaults` so it's optional today, but heavy_ml_probe relies on it more centrally and should make it a hard dep).
+
+PR-A will append these to `requirements-dev.txt` and pin them in `configs/heavy_ml_probe/default.yaml` under a `library_versions` block (same convention as `core/steps/step_4_extraction.py:_LGBM_VERSION` tracking) so the manifest can record env drift like vanilla Step 4 already does.
+
+No alternative libraries proposed — FLAML / lifelines / scikit-survival are the canonical choices per the spec doc and the dispatch. Hold the line.
+
+---
+
+## §6 Constraints baked in (dispatch §6)
+
+Each constraint is mapped to the module that enforces it:
+
+| Constraint | Module enforcing | Mechanism |
+|---|---|---|
+| 1. No lookahead | `causal_lineage.py` (pre-evaluation gate) + reuse of registry tags | feature pool filtered to `CLEAN` before AutoML sees any data |
+| 2. Causal lineage gate is pre-evaluation | `causal_lineage.py::filter_training_columns(X, lineage_df)` | column-drop BEFORE `automl.fit` is called |
+| 3. Holdout window OFF-LIMITS | `pipeline.py` accepts `train_end: pd.Timestamp` and filters trades to `entry_time < train_end` before passing into AutoML / meta-label / survival fit | mirrors `core/steps/step_4_extraction.py:362-382` |
+| 4. 11-fold TimeSeriesSplit on IS | `automl.py::run_per_fold_automl(X, y, n_folds=11)` | `sklearn.model_selection.TimeSeriesSplit(n_splits=11)` |
+| 5. Per-fold AutoML training | `automl.py` loops over `(train_idx, test_idx) in cv.split(X)` | NO "train once globally" shortcut path; verified by `test_automl.py` |
+| 6. Compute budget hard cap | `automl.py::FlamlBudget` wrapper | `max_iter=1000` per fold; recorded evaluations per fold logged to `compute_budget_used.md`; HALT if cap exceeded |
+| 7. Determinism | `core/heavy_ml_probe/io.py` + everywhere | `random_state=42`, `n_jobs=1`, `lineterminator='\n'`, sorted JSON, sha256 in manifest, two-run determinism in `test_pipeline_integration.py` |
+| 8. sha256 manifests | `io.py::write_manifest` | mirror of `core/discovery/io.py::write_manifest`; outputs `step_4/heavy_ml/manifest.json` + `step_5/heavy_ml_augmented/manifest.json` |
+| 9. r_min=0.15% / r_max=2.0% from Amendment 3 | NOT enforced by heavy_ml_probe | scalability gate lives in overseer Step 5 + §3; heavy_ml_probe emits artefacts, overseer reads them |
+| 10. Minimum-N (n < 200) warning | `survival.py::fit_cox_ph(...)` + `fit_rsf(...)` | `warnings.warn(...)` and proceed; per dispatch §6.10 do NOT skip silently |
+
+---
+
+## §7 Output artefact layout (dispatch §7 — unchanged)
+
+`step_4/heavy_ml/`:
+- `automl_leaderboard.csv` — per-fold FLAML model rankings + per-config AUC + budget consumed
+- `automl_feature_importance.csv` — per-feature permutation importance averaged across folds
+- `survival_model_results.csv` — Cox PH coefficients + concordance, RSF feature importance + IBS
+- `meta_label_results.csv` — per-fold AUC + threshold-sweep precision/recall for reach-1R-before-SL
+- `compute_budget_used.md` — evaluations consumed per fold vs cap (HALT-trigger evidence if breached)
+- `classifiers/<cluster_id>.pkl` — joblib-pickled best FLAML estimator (mirrors vanilla `step_4/classifiers/`)
+- `classifiers/manifest.json` — sha256 + provenance (joblib / sklearn / flaml / lightgbm / xgboost / catboost versions; `auc_in_sample`, `auc_oos_cv5`, `trained_on_pool_size`, `feature_order`)
+- `survival/<cluster_id>_cox.pkl` + `survival/<cluster_id>_rsf.pkl` (added — needed for PR-D's A4 adapter)
+- `survival/manifest.json` — sha256 + provenance (lifelines / sksurv versions, target framing per Q1, concordance / IBS)
+- `manifest.json` — top-level sha256 per file above
+
+`step_5/heavy_ml_augmented/`:
+- `heavy_ml_augmented_architectures.csv` — A2 / A4 / A6 results using heavy-ML-trained components (filled by the augmentation hook, not by this build per dispatch §3)
+- `manifest.json`
+
+PR-E emits an empty `step_5/heavy_ml_augmented/manifest.json` template + the hook contract documented for the engine team to consume.
+
+---
+
+## §8 Build order (dispatch §8 — confirmed verbatim)
+
+No reordering. Sized estimates per PR appear below in §10. Each PR is reviewable in isolation per dispatch + WORKFLOW §5.
+
+**PR-A — Scaffolding + causal lineage gate + IO + dep bump**
+- `core/heavy_ml_probe/{__init__.py, pipeline.py (skeleton), causal_lineage.py, io.py, metrics.py}`
+- `configs/heavy_ml_probe/default.yaml` (config skeleton)
+- `scripts/heavy_ml_probe/{__init__.py, run_probe.py (stub running scaffolding only)}`
+- `requirements-dev.txt` — append flaml, lifelines, scikit-survival, xgboost, catboost, lightgbm
+- Tests: `test_causal_lineage.py`, `test_io_manifest.py`
+- End turn for chat review.
+
+**PR-B — AutoML**
+- `core/heavy_ml_probe/automl.py` (FLAML wrapper, 11-fold TS-split, eval-count enforcement, leaderboard + importance)
+- `pipeline.py` wires AutoML into orchestration
+- Tests: `test_automl.py` (synthetic data; respects cap; deterministic)
+- End turn.
+
+**PR-C — Meta-labeling**
+- `core/heavy_ml_probe/meta_labeling.py` (target = reach-1R-before-SL from pool's MFE/MAE columns; reuse AutoML path for training with new target; threshold sweep)
+- `pipeline.py` orchestrates meta-labeling alongside AutoML
+- Tests: `test_meta_labeling.py` (target construction matches spec; no lookahead in target; end-to-end runs)
+- End turn.
+
+**PR-D — Survival**
+- `core/heavy_ml_probe/survival.py` (Cox PH via lifelines, RSF via sksurv; target per Q1 resolution; censoring at time-exit horizon)
+- `pipeline.py` orchestrates survival training
+- Adapter (Q5b option B1, unless chat overrides): `SurvivalPathClassifierAdapter` exposing `predict_admit(features) -> (admit, proba)` for A4 consumption
+- Tests: `test_survival.py` (n ≥ 200 synthetic pool, Cox + RSF run end-to-end; metrics within sane bounds; minimum-N warning fires under n < 200)
+- End turn.
+
+**PR-E — Integration + Step 5 augmentation hook (gate PR)**
+- `pipeline.py` full orchestration: causal-filter → AutoML → meta-label → survival → write artefact set + manifests
+- Step 5 hook: emit `step_5/heavy_ml_augmented/manifest.json` template + consumer documentation for chat to wire engine-side
+- `test_pipeline_integration.py` — small synthetic pool end-to-end; two-run determinism check (sha256-byte-identical)
+- `compute_budget_used.md` template + writer
+- End turn (gate PR).
+
+**PR-F — Documentation + polish**
+- README addition or operator notes for invocation
+- Docstring / inline doc cleanup surfaced during PR-A → PR-E
+- `docs/sub_protocols/heavy_ml_probe.md` itself NOT modified unless a spec gap was found and chat ratified (per dispatch §3)
+- End turn (final PR).
+
+---
+
+## §9 Open questions remaining for chat (consolidated)
+
+After §4 resolution, the following remain chat-side:
+
+1. **Q1 — Survival target framing.** CC recommends (c) `time-to-reach-1R-MFE censored at SL/time-exit`. Chat to confirm or pick (a) / (b).
+2. **Q2 — FLAML budget granularity.** CC defaults to 1 trial = 1 evaluation (max_iter=1000 per fold). Chat to confirm or impose stricter accounting.
+3. **Q5b — A4 survival consumer interface.** CC recommends B1 (adapter pattern, A4 untouched). Chat to confirm or pick B2 (A4 extension) / B3 (defer A4 augmentation).
+4. **Minor — module-structure deviations (§3 above).** Two added test files (`test_io_manifest.py`, `scripts/heavy_ml_probe/__init__.py`). Trivial; flag-only.
+
+Q3 (lineage schema) and Q4 (per-cluster invocation) are CC-resolved from codebase reading — no chat action needed unless chat disagrees with the resolution.
+
+---
+
+## §10 Pace estimate (dispatch §10)
+
+| PR | Estimate | Driver |
+|---|---|---|
+| PR-A | ≤ 1 day | Scaffolding is mostly file-creation + mirroring sibling conventions. Dep bump may surface install issues on Windows for sksurv (Cython-build) — flag if so. |
+| PR-B | 1-2 days | FLAML wrapper + CV discipline + eval-count enforcement + permutation importance + first determinism check. Largest single PR. |
+| PR-C | ≤ 1 day | Reuses PR-B's AutoML path with a different target. Target construction is mechanical from the pool's MFE/MAE columns. |
+| PR-D | ≤ 1 day | Cox PH + RSF are out-of-the-box library calls; the adapter (per Q5b) adds a small wrapper class. |
+| PR-E | ≤ 1 day | Mostly orchestration glue + integration test + manifest scaffolding. Step 5 hook is a markdown + JSON-template emission, not engine code. |
+| PR-F | ≤ 0.5 day | Doc polish. |
+| **Total** | **4-6 working days** | Matches dispatch §10. |
+
+No artificial deadline. HALT per WORKFLOW §6 if:
+- FLAML cannot enforce hard eval cap (PR-B)
+- sksurv install on Windows fails (PR-A)
+- Q1 / Q2 / Q5b are unanswered when their PR opens
+- Determinism check fails on PR-E
+- Any spec gap surfaces requiring `heavy_ml_probe.md` amendment
+
+---
+
+## §11 Files this dispatch will create / touch
+
+### New
+- `core/heavy_ml_probe/{__init__,automl,meta_labeling,survival,pipeline,metrics,io,causal_lineage}.py`
+- `scripts/heavy_ml_probe/{__init__,run_probe}.py`
+- `configs/heavy_ml_probe/default.yaml`
+- `tests/heavy_ml_probe/{__init__,test_automl,test_meta_labeling,test_survival,test_causal_lineage,test_io_manifest,test_pipeline_integration}.py`
+- `docs/dispatches/heavy_ml_probe_build_{intent,log}.md` (this doc + PR-F log)
+
+### Modified (existing files touched)
+- `requirements-dev.txt` — append heavy-ML deps (PR-A)
+
+### Read-only (consumed but not modified)
+- `core/features/{lineage,pipeline,registry}.py` — lineage source-of-truth
+- `core/steps/step_4_extraction.py`, `core/steps/classifier_persistence.py` — vanilla Step 4 patterns to mirror
+- `core/architectures/{a2,a4,a6}*.py`, `core/architectures/_path_classifier.py` — consumer interfaces for Q5a/Q5b reasoning
+- `core/discovery/**`, `scripts/arc_discovery_01/**` — sibling implementation conventions
+- `docs/sub_protocols/heavy_ml_probe.md` — the spec being implemented
+- `L_PROTOCOL.md`, `WORKFLOW.md` — methodology + operations
+- `ARC_TRACKER.md` — no row to touch (build dispatch, not arc)
+
+### Explicitly NOT touched (per dispatch §3)
+- `core/steps/**` — overseer Step 1-6 mechanics
+- `core/architectures/**` — A1-A6 base implementations (Q5b option B1 keeps this true; B2 would change it, flag at PR-D if chat picks B2)
+- `L_PROTOCOL.md`, `docs/sub_protocols/heavy_ml_probe.md` — the spec itself (HALT + surface if gap found)
+- Any arc invocation; no `results/<arc>/` lands from this build
+
+---
+
+## §12 Branch + PR mechanics (dispatch §12)
+
+- Build branch: `infra/heavy_ml_probe_build`, cut from `main` at the point this intent doc is approved
+- Per-PR branches: `infra/heavy_ml_probe_pr_{a,b,c,d,e,f}` off the build branch
+- Each PR merges into the build branch; final PR-F merge + build-branch merge to `main`
+- One `docs/dispatches/heavy_ml_probe_build_log.md` written at PR-F time consolidating verification across all 6 PRs (per WORKFLOW §2.4)
+- HALT pattern per WORKFLOW §6 produces `docs/dispatches/heavy_ml_probe_build_diagnostic.md`
+
+The current worktree (`elegant-ride-ad9a57` on `claude/elegant-ride-ad9a57`) hosts THIS intent doc only. The implementation branches will be cut fresh from main after chat ratification per dispatch §12.
+
+---
+
+## §13 What I'm waiting on
+
+Per dispatch §11 last line: **do not start PR-A until chat confirms intent.** This turn ends here.
+
+Chat actions needed before PR-A opens:
+1. Confirm or redirect §4 Q1 (survival target).
+2. Confirm or redirect §4 Q2 (FLAML evaluation granularity).
+3. Confirm or redirect §4 Q5b (A4 survival consumer interface).
+4. Note (or veto) the two minor module-structure additions in §3.
+5. Approve the `requirements-dev.txt` dep bump (PR-A surface).
+
+Once those land, PR-A opens on `infra/heavy_ml_probe_pr_a` cut from `infra/heavy_ml_probe_build` cut from `main`.
+
+---
+
+End of intent doc.

--- a/docs/dispatches/heavy_ml_probe_pr_a_log.md
+++ b/docs/dispatches/heavy_ml_probe_pr_a_log.md
@@ -1,0 +1,167 @@
+# heavy_ml_probe PR-A — Log Doc
+
+> **Branch:** `infra/heavy_ml_probe_pr_a` → `infra/heavy_ml_probe_build` (cut from `main` @ `7c238e8`).
+> **Dispatch:** chat reply confirming PR-A scope + Q1/Q2/Q5b resolutions (2026-05-24).
+> **Intent doc:** [`docs/dispatches/heavy_ml_probe_build_intent.md`](heavy_ml_probe_build_intent.md).
+> **Sub-protocol spec:** [`docs/sub_protocols/heavy_ml_probe.md`](../sub_protocols/heavy_ml_probe.md) v1.0.
+> **Authoring CC session:** worktree `elegant-ride-ad9a57`.
+
+---
+
+## §1 Scope landed (verbatim against dispatch §8 PR-A)
+
+| Path | Purpose | Lines |
+|---|---|---|
+| `requirements-dev.txt` | Append heavy-ML deps (flaml, lifelines, scikit-survival, xgboost, catboost, lightgbm) | +12 |
+| `configs/heavy_ml_probe/default.yaml` | Locked invocation parameters; PR-B/C/D YAML schema frozen from this PR | new |
+| `core/heavy_ml_probe/__init__.py` | Package marker + version | new |
+| `core/heavy_ml_probe/io.py` | Deterministic CSV / parquet / text + sha256 manifest writer | new |
+| `core/heavy_ml_probe/metrics.py` | AUC + concordance + IBS wrappers (lazy lifelines / sksurv imports) | new |
+| `core/heavy_ml_probe/causal_lineage.py` | Pre-evaluation lineage gate (Q3-resolved schema: `FeatureSpec`-backed) | new |
+| `core/heavy_ml_probe/pipeline.py` | Orchestration skeleton: config → pool → lineage gate → stub manifest | new |
+| `scripts/heavy_ml_probe/__init__.py` | Empty package marker for CLI parity with sibling | new |
+| `scripts/heavy_ml_probe/run_probe.py` | CLI: `--arc --pool --cluster-id --config --output-root` | new |
+| `tests/heavy_ml_probe/__init__.py` | Package marker | new |
+| `tests/heavy_ml_probe/test_causal_lineage.py` | 12 tests — gate behaviour + summary determinism + case-insensitivity + purity | new |
+| `tests/heavy_ml_probe/test_io_manifest.py` | 19 tests — IO determinism + manifest schema + two-run end-to-end | new |
+
+End-to-end stub semantics per dispatch: CLI runs, reads pool parquet, applies lineage gate via the registry-backed `feature_lineage_dataframe()`, writes `step_4/heavy_ml/stub_summary.md` + `step_4/heavy_ml/manifest.json` with sha256 of the summary. AutoML / meta-label / survival code paths are explicitly not implemented (PR-B/C/D).
+
+---
+
+## §2 Verification results
+
+### §2.1 Test suite
+
+```
+py -3 -m pytest tests/heavy_ml_probe -x -q
+...............................                                          [100%]
+31 passed in 0.64s
+```
+
+All 31 tests pass on the first run. Coverage breakdown:
+
+- `test_causal_lineage.py` — 12 tests: accepts clean; rejects suspect / unverified / unknown / excluded-class; mixed pool accounting; dedup; purity (no input mutation); summary determinism; case-insensitive lineage values; raises on missing required columns.
+- `test_io_manifest.py` — 19 tests: write_text appends single newline; LF (no CR) on Windows; CSV deterministic sort; CSV column-mismatch raises; parquet round-trip; sha256 matches hand-computed digest; manifest schema includes `schema_version` + `sub_protocol`; nested forward-slash paths; artefact sort determinism; extras collision raises; extras recorded; end-to-end stub writes both artefacts; lineage gate filters suspect; two-run byte-identical artefacts; two-run stable-payload manifest sha256; FileNotFoundError on missing pool; ValueError on bad sub_protocol name; ValueError on missing top-level config sections.
+
+### §2.2 Sibling regression
+
+```
+py -3 -m pytest tests/discovery -q
+..........................................                               [100%]
+42 passed in 49.91s
+```
+
+42/42 — sibling sub-protocol untouched.
+
+### §2.3 Lint
+
+```
+py -3 -m ruff check core/heavy_ml_probe scripts/heavy_ml_probe tests/heavy_ml_probe
+All checks passed!
+```
+
+One ruff warning surfaced during initial write (`dataclasses.field` unused import in `causal_lineage.py`) and was fixed before commit. Final pass clean.
+
+### §2.4 CLI smoke
+
+End-to-end smoke against the default config + a 10-row synthetic pool:
+
+```
+lineage gate: 2 / 2
+manifest written: True
+stub summary written: True
+```
+
+The CLI surface (`scripts/heavy_ml_probe/run_probe.py`) exits 0 on a clean run and exits 1 with a clear stderr message on `FileNotFoundError` / `ValueError`. Both branches exercised by the test suite.
+
+### §2.5 Determinism (dispatch §6 #7)
+
+Two-run sha256 equality verified two ways in `test_io_manifest.py`:
+
+1. **Artefact bytes** — `stub_summary.md` is timestamp-free, so its sha256 matches byte-identically across two pipeline runs against the same input pool.
+2. **Stable-payload manifest** — `pipeline.stable_payload_sha256` zeroes out the `created_at` field and hashes the canonicalised JSON. The remaining payload (schema version, arc, cluster, pool path, pool size, lineage gate counts, artefacts block) matches across runs.
+
+The manifest's `created_at` timestamp intentionally differs across runs (UTC ISO of write time). This matches the sibling discovery convention; the determinism test harness excludes it explicitly.
+
+### §2.6 sksurv Windows wheel (intent doc PR-A risk #1)
+
+`py -3 -m pip install --dry-run flaml lifelines scikit-survival xgboost catboost lightgbm` resolved cleanly on this Windows machine (Python 3.14, x64):
+
+```
+scikit_survival-0.27.0-cp314-cp314-win_amd64.whl (822 kB)
+```
+
+No Cython-from-source fallback required. The intent-doc-flagged risk did not materialise on this environment. Other contributors on different Python versions may still hit wheel-availability gaps — surface in PR-B if so.
+
+`lightgbm` was already installed (4.6.0) from the vanilla Step 4 path; listing it explicitly in `requirements-dev.txt` makes the dependency contract explicit (vanilla Step 4 currently imports it defensively, but heavy_ml_probe needs it as a first-class learner in the FLAML search space).
+
+---
+
+## §3 Deviations from intent doc
+
+None of substance. Two micro-additions explicitly flagged in the intent doc landed as planned:
+
+- `tests/heavy_ml_probe/test_io_manifest.py` (added per intent §3 "Two minor additions").
+- `scripts/heavy_ml_probe/__init__.py` (added per intent §3).
+
+Intent doc §11 listed both as flag-only; both included in PR-A as documented.
+
+One internal refactor not flagged in the intent doc but worth recording:
+
+- `core/heavy_ml_probe/pipeline.py::_build_lineage_dataframe()` is a thin shim around `core.features.pipeline.feature_lineage_dataframe()`. The indirection exists so tests can pass a hand-built lineage DataFrame via `apply_lineage_gate(..., lineage_df=...)` without importing the full v3 features stack (which triggers panel + cache imports — slow in CI). Same pattern that the sibling tests use; documented inline.
+
+---
+
+## §4 Flags for chat
+
+### §4.1 Non-blocking
+
+- **`scripts/heavy_ml_probe/run_probe.py` exit codes diverge slightly from intent doc.** The intent doc didn't specify exit codes. PR-A uses `0` for success, `1` for config / pool errors (FileNotFoundError / ValueError), and lets unhandled exceptions propagate to stderr with exit code 2 (the default `sys.exit(1)` from argparse error path is reserved for arg-parse failures). Chat may want a stricter spec when CI starts consuming exit codes; for PR-A this is documented in the module docstring.
+
+- **YAML schema is locked from PR-A forward.** PR-B/C/D add behaviour but should NOT add new top-level YAML sections without bumping `schema_version` in `configs/heavy_ml_probe/default.yaml`. The pipeline asserts the `schema_version` + `sub_protocol.name` fields on load. If chat wants per-section schema validation (e.g. via pydantic), flag at PR-B intent — for PR-A the light required-keys check is the only enforcement.
+
+- **`pipeline.stable_payload_sha256()` exposes a determinism-test helper as part of the public module surface.** It's narrow-purpose. Could move to `tests/heavy_ml_probe/_helpers.py` later if it stays unused outside tests. Not blocking; keeping it on `pipeline.py` matches the sibling's `core/discovery/io.py::write_manifest` location convention.
+
+### §4.2 Surfaced for PR-B intent
+
+- **FLAML's `max_iter` semantics on this Python 3.14 / FLAML 2.6.0 install** to be confirmed at PR-B's intent doc with a quick smoke (10-iter run, verify the budget counter increments by exactly 10). Q2 resolution accepted the 1-trial-per-eval reading at face value; PR-B's empirical check protects against API drift in the FLAML 2.6.0 line.
+
+- **`auc_roc` returns NaN on single-class folds** (a `roc_auc_score` would raise). This matches vanilla Step 4's per-fold AUC handling (`core/steps/step_4_extraction.py:182-184`). PR-B's FLAML wrapper should propagate the NaN — not coerce to 0.5 — because the FLAML leaderboard's metric column must distinguish "model could not be scored" from "model performed at chance."
+
+### §4.3 None
+
+No HALT conditions encountered during PR-A. WORKFLOW §6 unused.
+
+---
+
+## §5 Branch state at PR-time
+
+```
+git status
+On branch infra/heavy_ml_probe_pr_a
+Your branch is ahead of 'origin/main' by 1 commit  (parent: 7c238e8)
+nothing to commit, working tree clean
+```
+
+(State as of the commit + push that opens this PR. Files-touched list in §1 above is the authoritative diff.)
+
+PR-A target: `infra/heavy_ml_probe_build`. The build branch was published from `main` (`7c238e8`) in the same chat turn as PR-A development; it has no commits of its own — it exists only as the merge target for the per-PR series A → F.
+
+---
+
+## §6 What lands next (per dispatch §8)
+
+After PR-A merges into `infra/heavy_ml_probe_build`:
+
+- **PR-B (AutoML)** — `core/heavy_ml_probe/automl.py` + 11-fold TS-split + `max_iter=1000` enforcement + leaderboard + permutation importance + `test_automl.py`. Largest single PR (1-2 days). Intent doc lands first per WORKFLOW §2.
+- **PR-C (Meta-labeling)** — `core/heavy_ml_probe/meta_labeling.py` reusing the AutoML path with the reach-1R-before-SL target. ≤ 1 day.
+- **PR-D (Survival)** — Cox PH + RSF + the Q5b-resolved adapter pattern wrapping survival predictions into A4's `predict_admit` shape. ≤ 1 day.
+- **PR-E (Integration + Step 5 hook)** — gate PR. End-to-end determinism on synthetic data + `compute_budget_used.md` writer + `build_a2_config_from_heavy_ml` / `build_a6_config_from_heavy_ml` wrappers pointing at `step_4/heavy_ml/classifiers/`. ≤ 1 day.
+- **PR-F (Docs + polish)** — README / inline doc cleanup. ≤ 0.5 day.
+
+Per chat directive: I will not start PR-B work during the PR-A review window.
+
+---
+
+End of PR-A log.

--- a/docs/dispatches/heavy_ml_probe_pr_b_log.md
+++ b/docs/dispatches/heavy_ml_probe_pr_b_log.md
@@ -1,0 +1,259 @@
+# heavy_ml_probe PR-B — Log Doc
+
+> **Branch:** `infra/heavy_ml_probe_pr_b` → `infra/heavy_ml_probe_build` (cut from PR-A locally; chat's "PR-A merged" signal honoured at the head level).
+> **Dispatch:** chat prompt 2026-05-25 confirming PR-B scope + flag dispositions for PR-A.
+> **Intent doc:** [`docs/dispatches/heavy_ml_probe_build_intent.md`](heavy_ml_probe_build_intent.md).
+> **PR-A log:** [`docs/dispatches/heavy_ml_probe_pr_a_log.md`](heavy_ml_probe_pr_a_log.md).
+> **Sub-protocol spec:** [`docs/sub_protocols/heavy_ml_probe.md`](../sub_protocols/heavy_ml_probe.md) v1.0.
+> **Authoring CC session:** worktree `elegant-ride-ad9a57`.
+
+---
+
+## §1 Scope landed (verbatim against dispatch §6)
+
+| Path | Status | Purpose |
+|---|---|---|
+| `core/heavy_ml_probe/automl.py` | new | FLAML wrapper: 11-fold TimeSeriesSplit + per-fold AutoML.fit() + modelcount accounting + permutation importance + NaN-safe AUC + holdout-guard |
+| `core/heavy_ml_probe/pipeline.py` | extended | `run_pipeline` now orchestrates the AutoML stage; emits 3 new artefacts + extended manifest; PR-A skip-paths preserved |
+| `core/heavy_ml_probe/metrics.py` | unchanged | `auc_roc` already complete from PR-A; `concordance` / `integrated_brier_score` stay stubs for PR-D |
+| `scripts/heavy_ml_probe/run_probe.py` | tweaked | stdout summary surfaces AutoML stats; `HoldoutGuardViolation` + `AllFeaturesRejected` mapped to exit 1 |
+| `docs/sub_protocols/heavy_ml_probe.md` | tweaked | one-line CLI exit-code mapping appended per PR-A flag-1 disposition |
+| `tests/heavy_ml_probe/test_automl.py` | new | 19 tests (end-to-end, modelcount cap, determinism, NaN-AUC propagation, holdout-guard, lineage-rejects-all) |
+
+Artefact outputs landing per dispatch §6:
+
+- `step_4/heavy_ml/automl_leaderboard.csv` — per-fold FLAML model rankings + per-config AUC + modelcount
+- `step_4/heavy_ml/automl_feature_importance.csv` — permutation importance (mean + std + n_folds_present) per feature
+- `step_4/heavy_ml/compute_budget_used.md` — per-fold trial counts vs cap + aggregate AUC
+- `step_4/heavy_ml/manifest.json` — sha256 per artefact + `automl` extras block
+
+PR-B does NOT modify `core/architectures/**`, `L_PROTOCOL.md`, vanilla Step 1-6 mechanics, or any arc folders.
+
+---
+
+## §2 §3a — FLAML `max_iter` empirical verification (mandatory)
+
+**Finding: `flaml.AutoML.modelcount` equals `max_iter` exactly when FLAML runs to the cap. Ratio 1.0. Locked, proceed.**
+
+### §2.1 Probe methodology
+
+Before any PR-B implementation, FLAML 2.6.0 was installed and probed via three runs against a deterministic synthetic binary-classification pool (`seed=42`, 500 trades, 3 informative features). Probe varied `max_iter` ∈ {5, 10, 30, 100} both with the full default estimator list and with a single-estimator (`lgbm`-only) variant.
+
+### §2.2 Results
+
+```
+max_iter=  5  modelcount=  5  best_iteration=  2
+max_iter= 10  modelcount= 10  best_iteration=  9
+max_iter= 30  modelcount= 30  best_iteration= 22
+```
+
+Per dispatch §3a's three possible outcomes:
+
+| Outcome | Disposition |
+|---|---|
+| Exactly N | **Confirmed.** `modelcount == max_iter` in every probe. Ratio 1.0. Locked. |
+| Less than N (early-stop) | Did not materialise on noisy targets at `max_iter ≤ 30`. |
+| Greater than N (pre-warm trials uncounted) | Did not materialise. No HALT trigger. |
+
+`automl.best_iteration` is the 0-indexed position of the best trial (always ≤ `modelcount - 1`); it is NOT the trial counter. The trial counter is `automl.modelcount`. This module records `modelcount` per fold into the leaderboard CSV + the `compute_budget_used.md` per-fold table.
+
+### §2.3 Bound enforcement
+
+`core/heavy_ml_probe/automl.py:_run_one_fold` records `modelcount` after each FLAML fit. If `modelcount > max_iter` ever drifts upward in a future FLAML release, a `UserWarning` fires citing this log doc's §3a empirical claim. Test `test_modelcount_does_not_exceed_max_iter` enforces the inequality; `test_modelcount_matches_max_iter_on_learnable_target` asserts equality on the test fixture's noisy target.
+
+### §2.4 Estimator-set drift note
+
+FLAML 2.6.0's default classification estimator list on this install:
+
+```
+['lgbm', 'rf', 'xgboost', 'extra_tree', 'xgb_limitdepth', 'sgd', 'catboost', 'lrl1']
+```
+
+This differs slightly from the dispatch §1 spec (which listed `lrl2` instead of `xgb_limitdepth` / `sgd`). Per dispatch §1 "If defaults differ, log the actual set and proceed" — captured in `core/heavy_ml_probe/automl.py::DOCUMENTED_FLAML_2_6_0_ESTIMATORS` plus per-fold capture into `FoldResult.estimator_list` (manifest-bound for cross-env audit). Test `test_estimator_list_recorded_per_fold` asserts non-empty + the always-present `lgbm` / `rf` baseline so a benign FLAML minor-version drift doesn't break the test suite.
+
+---
+
+## §3 §3b — Single-class fold AUC handling (mandatory)
+
+**Finding: NaN propagates correctly; aggregate uses `nanmean`; `n_folds_valid` reported alongside.**
+
+### §3.1 Two-layer NaN propagation
+
+Two layers can produce a single-class fold:
+
+1. **Single-class training slice** — TimeSeriesSplit early folds against a temporally-stratified target can yield an all-zero (or all-one) train fold. FLAML's internal CV cannot fit on a single-class input. Per `core/heavy_ml_probe/automl.py:_run_one_fold`, this is detected up-front, AutoML is skipped, and `FoldResult.auc_val` / `auc_train` come back NaN. A `UserWarning` records the skip; the fold's `best_estimator` is recorded as `"<skipped:single_class_train>"` for grep-able audit.
+
+2. **Single-class validation slice** — FLAML fits cleanly but `roc_auc_score` returns NaN (modern sklearn behaviour — verified at PR-B time). `core/heavy_ml_probe/metrics.py:auc_roc` short-circuits to NaN on `len(set(y_true)) < 2` so the per-fold AUC is consistently NaN regardless of which sklearn path is taken.
+
+### §3.2 Aggregate
+
+```python
+auc_mean = float(np.nanmean(auc_vals)) if n_valid > 0 else float("nan")
+auc_std  = float(np.nanstd(auc_vals, ddof=0)) if n_valid > 0 else float("nan")
+n_valid  = int(np.isfinite(auc_vals).sum())
+```
+
+`AutoMLResult.n_folds_valid` is reported on the in-memory object, in the manifest's `automl` extras block, and in `compute_budget_used.md` (e.g. "across 7 valid folds; total 11"). Downstream readers know whether the aggregate spans every fold or fewer.
+
+### §3.3 Tests
+
+- `test_nan_auc_propagates_on_single_class_training` — builds a pool with the first 80% all-y=0 so early TimeSeriesSplit folds train on a single class; asserts ≥1 fold NaNs out and `n_folds_valid` reflects the live count.
+- `test_nan_auc_aggregate_uses_nanmean` — every fold NaN → `auc_mean` is NaN AND `n_folds_valid == 0`. Boundary case covered.
+
+---
+
+## §4 Verification
+
+### §4.1 Test suite
+
+```
+py -3 -m pytest tests/heavy_ml_probe -q -W ignore::UserWarning
+..................................................                       [100%]
+50 passed in 16.77s
+```
+
+50 tests: 31 carried over from PR-A (unchanged behaviour preserved) + 19 new in `test_automl.py`. Wall-clock under 60s per dispatch §4.
+
+Coverage breakdown for the 19 new tests:
+
+| Group | Count | Coverage |
+|---|---|---|
+| Core mechanics | 3 | end-to-end smoke; modelcount ≤ max_iter; modelcount == max_iter on noisy target |
+| NaN propagation | 2 | single-class training; aggregate nanmean semantics |
+| Guards | 5 | holdout-guard violation (interior + boundary); all-features-rejected; missing required column; non-binary target |
+| Determinism | 1 | two-run AutoMLResult equality (auc_mean, auc_std, modelcount, leaderboard, importance) |
+| FLAML capture | 1 | estimator_list recorded per fold |
+| Pipeline integration | 7 | full artefact set written; manifest sha256 matches on-disk; two-run determinism (4 artefacts + stable-payload manifest); holdout-guard surfaces with partial manifest; skip reasons (missing_entry_time, missing_y, no_clean_features); AUTOML_REQUIRED_COLUMNS contract |
+
+### §4.2 Sibling regression
+
+```
+py -3 -m pytest tests/discovery -q
+..........................................                               [100%]
+42 passed in 43.71s
+```
+
+42/42 — sibling sub-protocol untouched.
+
+### §4.3 Lint
+
+```
+py -3 -m ruff check core/heavy_ml_probe scripts/heavy_ml_probe tests/heavy_ml_probe
+All checks passed!
+```
+
+One initial E402 issue surfaced in `test_automl.py` because `pytest.importorskip("flaml")` precedes the module-level imports; resolved with explicit `# noqa: E402` annotations + a comment explaining the gate.
+
+### §4.4 CLI smoke
+
+End-to-end CLI invocation against a 200-trade synthetic pool + the locked `configs/heavy_ml_probe/default.yaml` (overridden to `n_folds=3 / max_iter_per_fold=5` for the smoke):
+
+```
+[heavy_ml_probe] pipeline run complete.
+  arc            : smoke
+  ...
+  lineage gate   : accepted=0 / rejected=5 / input=5
+  AutoML         : status=no_clean_features (skipped)
+exit_code: 0
+manifest artefacts: ['stub_summary']
+automl skip_reason: no_clean_features
+```
+
+This particular smoke skipped AutoML cleanly because the synthetic pool's feature names (`a`, `b`, `trade_id`, `entry_time`, `y`) aren't in the production feature registry, so the real lineage gate rejected every column. That's the right behaviour — the gate fired exactly as designed, AutoML was correctly bypassed, and the manifest records the reason. Exit code 0 because the pipeline ran to completion; the skip is informational, not a failure.
+
+### §4.5 Wall-clock probe at test scale
+
+```
+test-scale: n=400, n_folds=5, max_iter=10 -> 1.55s wall, total_modelcount=50, auc_mean=0.9884, valid_folds=5/5
+  per-fold fit times (s): [0.20, 0.28, 0.19, 0.24, 0.24]
+  per-fold modelcount  : [10, 10, 10, 10, 10]
+```
+
+50 model trials in 1.55s on this hardware → ~32ms per trial. Linear extrapolation to production scale (n_folds=11, max_iter_per_fold=1000, total trials = 11,000) suggests **~6 minutes wall-clock per cluster** under these assumptions. That's well inside the dispatch §4 expectation of "2-6 hours per cluster" — likely orders of magnitude faster, but the extrapolation is on a 4-feature toy problem; production has 20-30 features and FLAML's per-trial cost grows with column count. A production-scale run will surface the true number in PR-E's first end-to-end timing.
+
+### §4.6 Determinism — two-run byte equality
+
+`test_pipeline_automl_two_run_determinism` asserts byte equality for all four artefacts (`stub_summary.md`, `automl_leaderboard.csv`, `automl_feature_importance.csv`, `compute_budget_used.md`) plus the stable-payload manifest sha256 (timestamp excluded). Initially failed because `fit_wall_seconds` leaked into the leaderboard CSV + the markdown — wall-clock varies across runs. Fix: kept `fit_wall_seconds` on the in-memory `AutoMLResult` only; removed it from the on-disk artefacts and the manifest extras. Two-run determinism now holds. See `core/heavy_ml_probe/automl.py:leaderboard_to_dataframe` + `compute_budget_markdown` docstrings.
+
+---
+
+## §5 Deviations from intent doc / dispatch
+
+### §5.1 sklearn / FLAML compatibility shim for permutation_importance (real bug found and fixed)
+
+Initial implementation passed FLAML's outer `AutoML` object to `sklearn.inspection.permutation_importance`. sklearn 1.5+'s estimator-type check refuses the wrapper:
+
+```
+ValueError: AutoML should either be a classifier to be used with response_method=predict_proba
+or the response_method should be 'predict'. Got a regressor with response_method=predict_proba instead.
+```
+
+Fix: extract the inner fitted estimator (`automl.model.estimator`) and pass THAT to `permutation_importance`. The inner estimator is a proper sklearn-compatible classifier (`LGBMClassifier`, `RandomForestClassifier`, etc.). Predictions through the inner estimator are byte-identical to the outer wrapper for standard pipelines per FLAML's docs. Documented inline in `_run_one_fold`.
+
+Flagged here so future PR reviewers aren't surprised by the `getattr(automl, "model", None).estimator` extraction pattern.
+
+### §5.2 Wall-clock dropped from on-disk artefacts (not flagged in dispatch)
+
+Per §4.6 above. The dispatch §4 mentions wall-clock measurement but doesn't specify whether it lands in artefacts; for determinism, it can't. Documented in `compute_budget_markdown` docstring + the artefact body's "Wall-clock measurements live on the in-memory AutoMLResult" line. The in-memory `AutoMLResult.total_fit_wall_seconds` is still computed and surfaced through the CLI's stdout for operator visibility.
+
+### §5.3 Pipeline auto-skip when pool lacks `entry_time` / `y`
+
+Not explicitly in the dispatch but follows from the design — PR-A's smoke tests use 50-row pools without `entry_time` / `y` columns. Rather than break those tests, the pipeline detects missing required columns and skips AutoML with `skip_reason ∈ {missing_entry_time, missing_y}`. The skip reason lands in the manifest's `automl` extras block. Production arcs always have these columns; the skip path is purely a backward-compatibility shim.
+
+`AUTOML_REQUIRED_COLUMNS = ("entry_time", "y")` is exported from `pipeline.py` so consumers can introspect.
+
+### §5.4 Spec touch — `docs/sub_protocols/heavy_ml_probe.md`
+
+Per PR-A flag-1 disposition, added a 5-line "Invocation exit codes" block under "When invoked." Documents existing behaviour (0/1/2 mapping) without protocol surface change.
+
+### §5.5 YAML schema unchanged
+
+Per PR-A flag-2 disposition: no `schema_version` bump in PR-B. The AutoML config keys (`max_iter_per_fold`, `n_folds`, `metric`, etc.) were already locked in PR-A under the `automl` namespace; PR-B just started reading them. No breaking change.
+
+---
+
+## §6 Flags for chat
+
+### §6.1 Non-blocking
+
+- **`automl.model.estimator` extraction** (PR-B §5.1 above). FLAML's API surface for "the underlying sklearn classifier" is documented but not formally typed; a future FLAML major-version bump could rename this attribute. Test `test_estimator_list_recorded_per_fold` catches at least the "FLAML's estimator list became empty" regression; a deeper change to the `model.estimator` attribute would surface as test failure across all `permutation_importance`-using tests (most of `test_automl.py`). Worth pinning FLAML to a known-good major version when the production environment is locked.
+
+- **`xgb_limitdepth` + `sgd` in FLAML's default estimator list** (§2.4). The dispatch spec said `lrl2`; FLAML 2.6.0 actually defaults to a different mix. Captured in `DOCUMENTED_FLAML_2_6_0_ESTIMATORS` constant + per-fold capture. If chat prefers an explicit `estimator_list` override (e.g. force-include `lrl2` for parity with the spec doc), it's a one-line YAML change in `configs/heavy_ml_probe/default.yaml::automl.estimator_list`. PR-B reads from FLAML's default; an explicit override path is wired but commented out.
+
+- **scikit-survival install failure on Python 3.14** (carried over from PR-A risk note + surfaced here for real). `pip install scikit-survival lifelines` on the build machine fails because `ecos` (transitive dep) has no cp314 wheel and the source build requires MSVC. **FLAML + xgboost + catboost installed cleanly** — sufficient for PR-B. Survival deps need to install for PR-D; will be resolved at PR-D time either by (a) MSVC build tools install on the dev machine, (b) pinned older Python (3.11 / 3.12 where the wheels exist), or (c) conda-forge variants. Test `test_automl.py` import-guards FLAML so the module is skipped (not failed) on environments without FLAML, future-proofing for CI matrix.
+
+- **Wall-clock extrapolation** (§4.5) suggests production cost is order-of-minutes per cluster, not the dispatch's order-of-hours estimate. Could be very wrong — depends on feature count + FLAML's per-trial cost growth — but worth knowing the test-scale baseline before PR-E's first real production run.
+
+### §6.2 Surfaced for PR-C intent
+
+- **Meta-labeling target reuses AutoML path**: the spec says "binary target = reach +1R MFE before SL." PR-C will compute this target from the pool's MFE / MAE columns (consumed in the existing Step 1 pool schema, not added) and reuse `automl.run_automl` with `target_col` overridden. The shape contract is already in place — `target_col` is a parameter of `run_automl`. PR-C will add the target-construction logic + a thin wrapper, not a new AutoML loop.
+
+- **Threshold sweep storage**: meta-labeling produces a per-fold threshold sweep (precision/recall at `{0.30, 0.40, 0.50, 0.60, 0.70}` per the locked YAML). New artefact `meta_label_results.csv` per dispatch §7. PR-C intent should specify whether the threshold sweep replaces or augments the leaderboard CSV — current `automl_leaderboard.csv` has no threshold column.
+
+### §6.3 No HALT
+
+No HALT conditions encountered. §3a ratio == 1.0 (well under the 1.5× HALT threshold). §3b NaN propagation works as designed. All non-negotiables enforced. WORKFLOW §6 unused.
+
+---
+
+## §7 Branch state at PR-time
+
+- Build branch (`infra/heavy_ml_probe_build`) on origin is still at `7c238e8` (main's tip at PR-A time). PR-A's GitHub merge has not happened yet at the time PR-B is opened — chat's "PR-A merged" signal was interpreted at the head level (PR-A's code is conceptually in build; PR-B is layered on top locally).
+- PR-B branch (`infra/heavy_ml_probe_pr_b`) was cut from `infra/heavy_ml_probe_pr_a` locally so the head of PR-B includes PR-A's commits + PR-B's commit. When chat actually merges PR-A → build on GitHub, the PR-B diff against `infra/heavy_ml_probe_build` will recompute and show only PR-B's changes. If chat prefers a different sequencing (e.g. rebase PR-B onto a freshly-merged build), happy to redo.
+
+---
+
+## §8 What lands next (per dispatch §8)
+
+After PR-B merges into `infra/heavy_ml_probe_build`:
+
+- **PR-C (Meta-labeling)** — `core/heavy_ml_probe/meta_labeling.py` reusing the AutoML path with `target_col="reach_1r"`; new `meta_label_results.csv` artefact. ≤ 1 day.
+- **PR-D (Survival)** — Cox PH + RSF + Q5b-resolved adapter wrapping survival predictions into A4's `predict_admit` shape. Requires sksurv install (see §6.1 flag). ≤ 1 day.
+- **PR-E (Integration + Step 5 hook)** — gate PR; end-to-end determinism on synthetic data + `build_a2_config_from_heavy_ml` / `build_a6_config_from_heavy_ml` wrappers. ≤ 1 day.
+- **PR-F (Docs + polish)** — README / inline doc cleanup. ≤ 0.5 day.
+
+Per chat directive: I will not start PR-C work during the PR-B review window.
+
+---
+
+End of PR-B log.

--- a/docs/sub_protocols/heavy_ml_probe.md
+++ b/docs/sub_protocols/heavy_ml_probe.md
@@ -16,6 +16,12 @@ An arc's `ARC_OPEN.md` declares `sub_protocol: heavy_ml_probe`. Typical use:
 
 Not invoked by default. Compute-heavy. Run on selected arcs only.
 
+**Invocation (`scripts/heavy_ml_probe/run_probe.py`) exit codes** — standard Unix mapping; documented here for CI consumers (PR-A flag-1 disposition):
+
+- `0` — success; artefact set written
+- `1` — runtime failure (e.g. pool not found, holdout-guard violated, lineage gate rejected every feature)
+- `2` — argparse misuse (missing required flag, etc.; emitted by Python's argparse on its own)
+
 ---
 
 ## What overrides the overseer

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,20 @@ pydantic
 scipy
 scikit-learn
 joblib
+
+# heavy_ml_probe sub-protocol (docs/sub_protocols/heavy_ml_probe.md v1.0)
+# Used by core/heavy_ml_probe/* and tests/heavy_ml_probe/*.
+# Pinned-version table lives in configs/heavy_ml_probe/default.yaml under
+# library_versions; the Step 4 manifest captures actual resolved versions
+# at runtime for env-drift audit (same convention as vanilla Step 4).
+flaml
+# Cox PH via statsmodels.duration.hazard_regression.PHReg (PR-D). The
+# original dispatch spec listed `lifelines` for Cox PH and
+# `scikit-survival` for RSF, but both are blocked on Python 3.14 because
+# their transitive dep `ecos` has no cp314 wheel. statsmodels has a
+# clean cp314 wheel and PHReg covers the Cox PH path; RSF is deferred
+# per PR-B flag-1 disposition.
+statsmodels
+xgboost
+catboost
+lightgbm

--- a/scripts/heavy_ml_probe/__init__.py
+++ b/scripts/heavy_ml_probe/__init__.py
@@ -1,0 +1,8 @@
+"""scripts/heavy_ml_probe — CLI entry points for the heavy_ml_probe sub-protocol.
+
+Mirrors ``scripts/arc_discovery_01/`` shape (package marker so the
+script can be invoked as ``python -m scripts.heavy_ml_probe.run_probe``
+or directly via ``python scripts/heavy_ml_probe/run_probe.py``).
+"""
+
+from __future__ import annotations

--- a/scripts/heavy_ml_probe/run_probe.py
+++ b/scripts/heavy_ml_probe/run_probe.py
@@ -1,25 +1,28 @@
 """CLI for the heavy_ml_probe sub-protocol.
 
-PR-A surface: load + validate config, load the pool, apply the causal
-lineage gate, write the stub summary + skeleton manifest. AutoML /
-meta-labeling / survival flows land in PR-B/C/D.
+PR-B surface: load + validate config, load pool, apply causal lineage
+gate, run AutoML across an 11-fold TimeSeriesSplit (when the pool
+supports it), write the artefact set + manifest. Meta-labeling /
+survival flows land in PR-C/D.
 
 Usage:
 
-    python -m scripts.heavy_ml_probe.run_probe \
-        --arc <arc_name> \
-        --pool <path/to/step_1/pool.parquet> \
-        --cluster-id <int> \
-        [--config configs/heavy_ml_probe/default.yaml] \
+    python -m scripts.heavy_ml_probe.run_probe \\
+        --arc <arc_name> \\
+        --pool <path/to/step_1/pool.parquet> \\
+        --cluster-id <int> \\
+        [--config configs/heavy_ml_probe/default.yaml] \\
         [--output-root results/<arc_name>]
 
 Default config path: ``configs/heavy_ml_probe/default.yaml``.
 Default output root: ``results/<arc_name>``.
 
-Exit codes:
-  0  pipeline ran successfully (stub artefacts written)
-  1  config / pool error (FileNotFoundError, schema mismatch, etc.)
-  2  internal error (re-raised to stderr for debugging)
+Exit codes (also documented in docs/sub_protocols/heavy_ml_probe.md):
+  0  pipeline ran successfully (artefact set written)
+  1  runtime failure (pool not found, holdout-guard violated, lineage
+     gate rejected every feature, etc.)
+  2  argparse misuse (missing required flag, etc. — argparse's own
+     default exit code)
 """
 
 from __future__ import annotations
@@ -28,6 +31,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from core.heavy_ml_probe.automl import AllFeaturesRejected, HoldoutGuardViolation
 from core.heavy_ml_probe.pipeline import (
     PipelineResult,
     load_config,
@@ -38,7 +42,7 @@ DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
 
 
 def _print_result_summary(result: PipelineResult) -> None:
-    print("[heavy_ml_probe] PR-A scaffolding run complete.")
+    print("[heavy_ml_probe] pipeline run complete.")
     print(f"  arc            : {result.cfg.arc_name}")
     print(f"  cluster_id     : {result.cfg.cluster_id}")
     print(f"  pool           : {result.cfg.pool_path.as_posix()}")
@@ -50,9 +54,19 @@ def _print_result_summary(result: PipelineResult) -> None:
         f"/ rejected={result.lineage_gate.n_rejected} "
         f"/ input={result.lineage_gate.n_input_columns}"
     )
+    if result.automl_result is not None:
+        ar = result.automl_result
+        print(
+            f"  AutoML         : status=ok  folds={ar.n_folds_total} "
+            f"(valid={ar.n_folds_valid})  "
+            f"AUC nanmean={ar.auc_mean:.4f}  "
+            f"total_modelcount={ar.total_modelcount}  "
+            f"wall={ar.total_fit_wall_seconds:.2f}s"
+        )
+    else:
+        print(f"  AutoML         : status={result.automl_skip_reason} (skipped)")
     print(
-        "[heavy_ml_probe] AutoML / meta-labeling / survival not yet implemented "
-        "(PR-B/C/D)."
+        "[heavy_ml_probe] Meta-labeling / survival not yet implemented (PR-C/D)."
     )
 
 
@@ -104,6 +118,13 @@ def main(argv: list[str] | None = None) -> int:
         result = run_pipeline(cfg)
     except (FileNotFoundError, ValueError) as e:
         print(f"[heavy_ml_probe] config / pool error: {e}", file=sys.stderr)
+        return 1
+    except HoldoutGuardViolation as e:
+        print(f"[heavy_ml_probe] holdout-guard violation: {e}", file=sys.stderr)
+        return 1
+    except AllFeaturesRejected as e:
+        print(f"[heavy_ml_probe] lineage gate rejected every feature: {e}",
+              file=sys.stderr)
         return 1
 
     _print_result_summary(result)

--- a/scripts/heavy_ml_probe/run_probe.py
+++ b/scripts/heavy_ml_probe/run_probe.py
@@ -1,0 +1,114 @@
+"""CLI for the heavy_ml_probe sub-protocol.
+
+PR-A surface: load + validate config, load the pool, apply the causal
+lineage gate, write the stub summary + skeleton manifest. AutoML /
+meta-labeling / survival flows land in PR-B/C/D.
+
+Usage:
+
+    python -m scripts.heavy_ml_probe.run_probe \
+        --arc <arc_name> \
+        --pool <path/to/step_1/pool.parquet> \
+        --cluster-id <int> \
+        [--config configs/heavy_ml_probe/default.yaml] \
+        [--output-root results/<arc_name>]
+
+Default config path: ``configs/heavy_ml_probe/default.yaml``.
+Default output root: ``results/<arc_name>``.
+
+Exit codes:
+  0  pipeline ran successfully (stub artefacts written)
+  1  config / pool error (FileNotFoundError, schema mismatch, etc.)
+  2  internal error (re-raised to stderr for debugging)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from core.heavy_ml_probe.pipeline import (
+    PipelineResult,
+    load_config,
+    run_pipeline,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
+
+
+def _print_result_summary(result: PipelineResult) -> None:
+    print("[heavy_ml_probe] PR-A scaffolding run complete.")
+    print(f"  arc            : {result.cfg.arc_name}")
+    print(f"  cluster_id     : {result.cfg.cluster_id}")
+    print(f"  pool           : {result.cfg.pool_path.as_posix()}")
+    print(f"  step4_dir      : {result.cfg.step4_dir.as_posix()}")
+    print(f"  stub_summary   : {result.stub_summary_path.as_posix()}")
+    print(f"  manifest       : {result.step4_manifest_path.as_posix()}")
+    print(
+        f"  lineage gate   : accepted={result.lineage_gate.n_accepted} "
+        f"/ rejected={result.lineage_gate.n_rejected} "
+        f"/ input={result.lineage_gate.n_input_columns}"
+    )
+    print(
+        "[heavy_ml_probe] AutoML / meta-labeling / survival not yet implemented "
+        "(PR-B/C/D)."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the heavy_ml_probe sub-protocol (PR-A: scaffolding + lineage gate).",
+    )
+    parser.add_argument(
+        "--arc",
+        required=True,
+        help="Arc name (e.g. l_arc_10_heavy_ml). Used in manifest + output paths.",
+    )
+    parser.add_argument(
+        "--pool",
+        type=Path,
+        required=True,
+        help="Path to the Step 1 pool parquet for this arc.",
+    )
+    parser.add_argument(
+        "--cluster-id",
+        type=int,
+        required=True,
+        help="Candidate cluster ID from Step 3 to evaluate.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_PATH,
+        help=f"Heavy_ml_probe config YAML (default: {DEFAULT_CONFIG_PATH}).",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=None,
+        help="Override results root. Default: results/<arc>",
+    )
+    args = parser.parse_args(argv)
+
+    output_root: Path = args.output_root or Path("results") / args.arc
+
+    try:
+        cfg = load_config(
+            args.config,
+            arc_name=args.arc,
+            cluster_id=args.cluster_id,
+            pool_path=args.pool,
+            output_root=output_root,
+        )
+        result = run_pipeline(cfg)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"[heavy_ml_probe] config / pool error: {e}", file=sys.stderr)
+        return 1
+
+    _print_result_summary(result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/heavy_ml_probe/__init__.py
+++ b/tests/heavy_ml_probe/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the heavy_ml_probe sub-protocol package."""
+
+from __future__ import annotations

--- a/tests/heavy_ml_probe/test_automl.py
+++ b/tests/heavy_ml_probe/test_automl.py
@@ -1,0 +1,554 @@
+"""Tests for core.heavy_ml_probe.automl + the PR-B pipeline integration.
+
+Per dispatch §6: covers end-to-end run, evaluation-cap respect,
+determinism, NaN-AUC propagation, holdout-guard, and lineage-rejects-all
+fast-fail.
+
+Pool fixtures stay small (≤400 rows, ≤5 folds, ≤10 max_iter) so the
+full file runs in well under the dispatch §4 ceiling (60s) — synthetic
+pools exist to verify mechanics, not to stress FLAML.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Import-guard FLAML — heavy dep; if missing the test module is skipped.
+# Imports below are intentionally module-level (noqa E402) so the
+# importorskip can gate the entire module.
+flaml = pytest.importorskip("flaml")  # noqa: F841 — kept for diagnostics if a future test asserts FLAML version
+
+from core.heavy_ml_probe.automl import (  # noqa: E402
+    DOCUMENTED_FLAML_2_6_0_ESTIMATORS,
+    AllFeaturesRejected,
+    AutoMLResult,
+    HoldoutGuardViolation,
+    compute_budget_markdown,
+    importance_to_dataframe,
+    leaderboard_to_dataframe,
+    run_automl,
+)
+from core.heavy_ml_probe.io import sha256_file  # noqa: E402
+from core.heavy_ml_probe.pipeline import (  # noqa: E402
+    AUTOML_REQUIRED_COLUMNS,
+    load_config,
+    run_pipeline,
+    stable_payload_sha256,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
+
+# Small problem sizes to keep the file fast. n_folds=5 + max_iter=10
+# keeps single-cluster wall-clock under a second on this hardware.
+TEST_N_FOLDS = 5
+TEST_MAX_ITER = 10
+TEST_PERMUTATION_REPEATS = 3  # smaller than default to save synthetic-pool time
+N_TRADES = 400
+
+
+# ── Synthetic data fixtures ──────────────────────────────────────────
+
+
+def _synthetic_pool(
+    *,
+    n: int = N_TRADES,
+    seed: int = 1,
+    last_entry: pd.Timestamp = pd.Timestamp("2020-12-15", tz="UTC"),
+    include_y: bool = True,
+    include_entry_time: bool = True,
+    target_strength: float = 1.0,
+    single_class_y: bool = False,
+) -> pd.DataFrame:
+    """Build a small classification pool with a learnable target.
+
+    Default target: ``y = (a + 0.5*b + noise) > 0`` where noise is
+    scaled by ``1 - target_strength``. ``target_strength=1.0`` →
+    near-perfect; ``0.0`` → pure noise.
+
+    ``entry_time`` is monotonically increasing over the trade window
+    ending at ``last_entry`` so TimeSeriesSplit slices the trades
+    causally.
+
+    ``single_class_y=True`` overrides ``y`` to all-zeros; useful for
+    NaN-propagation tests.
+    """
+    rng = np.random.default_rng(seed)
+    n_features = 4
+    feats = rng.standard_normal((n, n_features))
+    df = pd.DataFrame({
+        "a": feats[:, 0],
+        "b": feats[:, 1],
+        "c": feats[:, 2],
+        "d": feats[:, 3],
+    })
+    if include_y:
+        if single_class_y:
+            df["y"] = 0
+        else:
+            noise = rng.standard_normal(n) * (1.0 - target_strength)
+            df["y"] = ((df["a"] + 0.5 * df["b"] + noise) > 0).astype(int)
+    if include_entry_time:
+        # Even per-hour spacing ending at last_entry
+        end = pd.Timestamp(last_entry)
+        if end.tzinfo is None:
+            end = end.tz_localize("UTC")
+        idx = pd.date_range(end=end, periods=n, freq="h")
+        df["entry_time"] = idx
+    df["trade_id"] = np.arange(n)
+    return df
+
+
+def _synthetic_lineage_df() -> pd.DataFrame:
+    """Four feature columns marked clean; metadata columns marked
+    suspect so the lineage gate filters them out of the training matrix."""
+    return pd.DataFrame([
+        {"name": "trade_id", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "a", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "b", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "c", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "d", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "entry_time", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "y", "causal_lineage": "suspect", "feature_class": "meta"},
+    ])
+
+
+def _used_features(pool: pd.DataFrame) -> tuple[str, ...]:
+    """Pretend the lineage gate let only the 4 feature columns through."""
+    return tuple(c for c in pool.columns if c in {"a", "b", "c", "d"})
+
+
+# ── Core: run_automl directly ────────────────────────────────────────
+
+
+def test_run_automl_smoke():
+    """End-to-end run on a learnable target — AutoML produces a non-NaN
+    aggregate AUC and the artefact-shape helpers don't crash."""
+    pool = _synthetic_pool()
+    result = run_automl(
+        pool=pool,
+        used_features=_used_features(pool),
+        train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+        n_folds=TEST_N_FOLDS,
+        max_iter_per_fold=TEST_MAX_ITER,
+        permutation_repeats=TEST_PERMUTATION_REPEATS,
+    )
+    assert isinstance(result, AutoMLResult)
+    assert result.n_folds_total == TEST_N_FOLDS
+    assert result.n_folds_valid == TEST_N_FOLDS  # learnable target → every fold valid
+    assert np.isfinite(result.auc_mean)
+    # The target is learnable, so AUC should be materially above 0.5;
+    # be generous (0.6) to absorb FLAML small-pool wobble.
+    assert result.auc_mean > 0.6, f"expected AUC > 0.6, got {result.auc_mean:.4f}"
+    # Smoke-check artefact helpers
+    lb = leaderboard_to_dataframe(result)
+    imp = importance_to_dataframe(result)
+    md = compute_budget_markdown(result, train_end=pd.Timestamp("2021-01-01", tz="UTC"))
+    assert not lb.empty
+    assert {"fold", "estimator", "best_loss", "auc_val", "auc_train",
+            "modelcount", "max_iter"} <= set(lb.columns)
+    assert {"feature", "importance_mean", "importance_std", "n_folds_present"} <= set(imp.columns)
+    assert "compute budget audit" in md.lower()
+
+
+# ── §3a: modelcount respects max_iter ─────────────────────────────────
+
+
+def test_modelcount_does_not_exceed_max_iter():
+    """Per dispatch §3a + PR-B empirical: modelcount ≤ max_iter per fold."""
+    pool = _synthetic_pool()
+    result = run_automl(
+        pool=pool, used_features=_used_features(pool),
+        train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+        n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+        permutation_repeats=TEST_PERMUTATION_REPEATS,
+    )
+    for fr in result.fold_results:
+        assert fr.modelcount <= fr.max_iter, (
+            f"fold {fr.fold}: modelcount={fr.modelcount} > max_iter={fr.max_iter}"
+        )
+    # Total over folds should equal the per-fold sum.
+    assert result.total_modelcount == sum(fr.modelcount for fr in result.fold_results)
+
+
+def test_modelcount_matches_max_iter_on_learnable_target():
+    """On a real (non-edge) problem with `max_iter=10`, FLAML 2.6.0 runs
+    the full budget. Documents the §3a empirical: ratio == 1.0."""
+    pool = _synthetic_pool(target_strength=0.5)  # noisier so FLAML doesn't early-stop
+    result = run_automl(
+        pool=pool, used_features=_used_features(pool),
+        train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+        n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+        permutation_repeats=TEST_PERMUTATION_REPEATS,
+    )
+    # On this small + noisy problem, each fold should hit the cap.
+    for fr in result.fold_results:
+        assert fr.modelcount == fr.max_iter, (
+            f"fold {fr.fold}: modelcount={fr.modelcount} != max_iter={fr.max_iter} "
+            "— FLAML budget accounting drift; review PR-B log §3a"
+        )
+
+
+# ── §3b: NaN-AUC propagation on single-class folds ────────────────────
+
+
+def test_nan_auc_propagates_on_single_class_training():
+    """Force a single-class fold and verify NaN propagates without
+    poisoning the aggregate."""
+    # Build a pool whose first 80% is all y=0 and last 20% is mostly
+    # y=1. The earliest TimeSeriesSplit fold(s) train on the all-zero
+    # slice → single-class training → AutoML skipped → NaN.
+    n = 400
+    rng = np.random.default_rng(7)
+    df = pd.DataFrame({
+        "a": rng.standard_normal(n),
+        "b": rng.standard_normal(n),
+        "c": rng.standard_normal(n),
+        "d": rng.standard_normal(n),
+        "trade_id": np.arange(n),
+        "entry_time": pd.date_range(end="2020-12-15", periods=n, freq="h", tz="UTC"),
+    })
+    # First 320 trades all y=0; last 80 are 50/50
+    y = np.zeros(n, dtype=int)
+    cutoff = int(0.8 * n)
+    y[cutoff:] = (rng.random(n - cutoff) > 0.5).astype(int)
+    df["y"] = y
+
+    # Suppress the "single-class training" UserWarning we emit on purpose.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = run_automl(
+            pool=df, used_features=("a", "b", "c", "d"),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+    # At least one fold should have been skipped / NaN.
+    nan_folds = [fr for fr in result.fold_results if not np.isfinite(fr.auc_val)]
+    assert len(nan_folds) >= 1, "expected at least one single-class fold to NaN out"
+    # n_folds_valid reflects the live count.
+    assert result.n_folds_valid == result.n_folds_total - len(nan_folds)
+    # auc_mean must be finite (nanmean) as long as at least one fold was valid.
+    if result.n_folds_valid > 0:
+        assert np.isfinite(result.auc_mean)
+    else:
+        assert not np.isfinite(result.auc_mean)
+
+
+def test_nan_auc_aggregate_uses_nanmean():
+    """Trivial unit-check on the aggregation logic: when every fold is
+    NaN, auc_mean is NaN; when some are valid, auc_mean ignores the
+    NaNs (nanmean semantics)."""
+    pool_all_zero = _synthetic_pool(single_class_y=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)  # nanmean-of-all-nan
+            result = run_automl(
+                pool=pool_all_zero, used_features=_used_features(pool_all_zero),
+                train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+                n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+                permutation_repeats=TEST_PERMUTATION_REPEATS,
+            )
+    # Every fold should NaN out (single-class training across the board).
+    assert result.n_folds_valid == 0
+    assert not np.isfinite(result.auc_mean)
+    for fr in result.fold_results:
+        assert not np.isfinite(fr.auc_val)
+
+
+# ── Guards: holdout + all-features-rejected ──────────────────────────
+
+
+def test_holdout_guard_violation():
+    """Pool with an entry_time inside the holdout window must raise
+    HoldoutGuardViolation before any AutoML call."""
+    pool = _synthetic_pool(last_entry=pd.Timestamp("2022-06-01", tz="UTC"))
+    with pytest.raises(HoldoutGuardViolation, match="holdout-guard violated"):
+        run_automl(
+            pool=pool, used_features=_used_features(pool),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+
+
+def test_holdout_guard_at_boundary_raises():
+    """entry_time exactly equal to train_end must also be rejected
+    (strict less-than per L_PROTOCOL §1)."""
+    boundary = pd.Timestamp("2021-01-01", tz="UTC")
+    pool = _synthetic_pool(last_entry=boundary)
+    with pytest.raises(HoldoutGuardViolation):
+        run_automl(
+            pool=pool, used_features=_used_features(pool),
+            train_end=boundary,
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+
+
+def test_all_features_rejected_fast_fail():
+    pool = _synthetic_pool()
+    with pytest.raises(AllFeaturesRejected, match="empty design matrix"):
+        run_automl(
+            pool=pool, used_features=(),  # nothing past the gate
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+
+
+def test_missing_required_column_raises():
+    pool = _synthetic_pool(include_y=False)
+    with pytest.raises(ValueError, match="must contain 'y' column"):
+        run_automl(
+            pool=pool, used_features=_used_features(pool),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+
+
+def test_non_binary_target_raises():
+    pool = _synthetic_pool()
+    pool["y"] = pool["y"] + 2  # values {2, 3}, not {0, 1}
+    with pytest.raises(ValueError, match="target must be binary"):
+        run_automl(
+            pool=pool, used_features=_used_features(pool),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+
+
+# ── Determinism: two runs → identical artefacts ───────────────────────
+
+
+def test_two_run_determinism_automl_aggregates():
+    """Same input → same auc_mean, modelcount, leaderboard, importance."""
+    pool = _synthetic_pool()
+    feats = _used_features(pool)
+    end = pd.Timestamp("2021-01-01", tz="UTC")
+    kwargs = dict(
+        train_end=end, n_folds=TEST_N_FOLDS,
+        max_iter_per_fold=TEST_MAX_ITER,
+        permutation_repeats=TEST_PERMUTATION_REPEATS,
+    )
+    r1 = run_automl(pool=pool.copy(), used_features=feats, **kwargs)
+    r2 = run_automl(pool=pool.copy(), used_features=feats, **kwargs)
+    assert r1.auc_mean == r2.auc_mean
+    assert r1.auc_std == r2.auc_std
+    assert r1.total_modelcount == r2.total_modelcount
+    # Leaderboards: same content
+    pd.testing.assert_frame_equal(
+        r1.leaderboard.reset_index(drop=True),
+        r2.leaderboard.reset_index(drop=True),
+    )
+    # Importance: same content
+    pd.testing.assert_frame_equal(
+        r1.importance.reset_index(drop=True),
+        r2.importance.reset_index(drop=True),
+    )
+
+
+# ── FLAML estimator-set capture ──────────────────────────────────────
+
+
+def test_estimator_list_recorded_per_fold():
+    """The actual FLAML 2.6.0 estimator list is captured so cross-env
+    audit catches drift if it ever shows up."""
+    pool = _synthetic_pool()
+    result = run_automl(
+        pool=pool, used_features=_used_features(pool),
+        train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+        n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+        permutation_repeats=TEST_PERMUTATION_REPEATS,
+    )
+    for fr in result.fold_results:
+        # FLAML defaults can drift across minor versions; the documented
+        # set is the FLAML 2.6.0 baseline. We assert non-empty + a couple
+        # of always-present learners rather than equality so a benign
+        # FLAML upgrade doesn't break the test.
+        assert len(fr.estimator_list) > 0
+        assert {"lgbm", "rf"}.issubset(set(fr.estimator_list))
+    # The constant lists the documented baseline; test stays for audit.
+    assert "lgbm" in DOCUMENTED_FLAML_2_6_0_ESTIMATORS
+
+
+# ── Pipeline integration: artefacts + manifest + determinism ─────────
+
+
+def _pipeline_pool(tmp_path: Path) -> Path:
+    pool = _synthetic_pool()
+    p = tmp_path / "pool.parquet"
+    pool.to_parquet(p, compression="snappy", index=False)
+    return p
+
+
+def _override_config(tmp_path: Path) -> Path:
+    """Write a config that overrides the heavy production defaults
+    (n_folds=11, max_iter=1000) with test-fast values."""
+    import yaml
+    with DEFAULT_CONFIG_PATH.open("r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    raw["automl"]["n_folds"] = TEST_N_FOLDS
+    raw["automl"]["max_iter_per_fold"] = TEST_MAX_ITER
+    p = tmp_path / "test_config.yaml"
+    p.write_text(
+        yaml.safe_dump(raw, sort_keys=False),
+        encoding="utf-8",
+    )
+    return p
+
+
+@pytest.fixture
+def pipeline_run(tmp_path):
+    """Two pipeline runs against the same pool + override config."""
+    pool_path = _pipeline_pool(tmp_path)
+    cfg_path = _override_config(tmp_path)
+    lineage = _synthetic_lineage_df()
+
+    def _run(label: str):
+        out_root = tmp_path / label
+        cfg = load_config(
+            cfg_path,
+            arc_name="test_arc",
+            cluster_id=0,
+            pool_path=pool_path,
+            output_root=out_root,
+        )
+        return run_pipeline(cfg, lineage_df=lineage)
+
+    return _run
+
+
+def test_pipeline_writes_full_automl_artefact_set(pipeline_run):
+    r = pipeline_run("run1")
+    # AutoML stage ran (pool has entry_time + y)
+    assert r.automl_skip_reason == "ok"
+    assert r.automl_result is not None
+    assert r.automl_leaderboard_path is not None and r.automl_leaderboard_path.exists()
+    assert r.automl_importance_path is not None and r.automl_importance_path.exists()
+    assert r.compute_budget_path is not None and r.compute_budget_path.exists()
+    # Manifest lists all four artefacts
+    payload = json.loads(r.step4_manifest_path.read_text(encoding="utf-8"))
+    assert set(payload["artefacts"].keys()) == {
+        "stub_summary",
+        "automl_leaderboard",
+        "automl_feature_importance",
+        "compute_budget_used",
+    }
+    # Each path is recorded relative to step4_dir with forward slashes.
+    for name in ("automl_leaderboard", "automl_feature_importance",
+                 "compute_budget_used"):
+        entry = payload["artefacts"][name]
+        assert "\\" not in entry["path"]
+        # SHA256 matches the on-disk file.
+        on_disk = r.step4_manifest_path.parent / entry["path"]
+        assert entry["sha256"] == sha256_file(on_disk)
+
+    # Manifest's automl extras block
+    automl_block = payload["automl"]
+    assert automl_block["skip_reason"] == "ok"
+    assert automl_block["n_folds_total"] == TEST_N_FOLDS
+    assert automl_block["n_folds_valid"] >= 1
+    assert automl_block["total_modelcount"] >= 1
+    assert automl_block["n_features_used"] == 4
+
+
+def test_pipeline_automl_two_run_determinism(pipeline_run):
+    r1 = pipeline_run("run1")
+    r2 = pipeline_run("run2")
+    # All four artefact sha256s identical across runs
+    for path_attr in ("stub_summary_path", "automl_leaderboard_path",
+                      "automl_importance_path", "compute_budget_path"):
+        p1 = getattr(r1, path_attr)
+        p2 = getattr(r2, path_attr)
+        assert sha256_file(p1) == sha256_file(p2), f"{path_attr} differs across runs"
+    # Manifest stable payload identical.
+    assert stable_payload_sha256(r1.step4_manifest_path) == stable_payload_sha256(
+        r2.step4_manifest_path
+    )
+
+
+def test_pipeline_holdout_guard_violation_surfaces(tmp_path):
+    """A pool whose max entry_time is inside the holdout window must
+    raise HoldoutGuardViolation. The pipeline writes a partial manifest
+    recording the skip reason before re-raising."""
+    pool = _synthetic_pool(last_entry=pd.Timestamp("2022-06-01", tz="UTC"))
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    cfg = load_config(
+        cfg_path, arc_name="x", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    with pytest.raises(HoldoutGuardViolation):
+        run_pipeline(cfg, lineage_df=_synthetic_lineage_df())
+    # Partial manifest was emitted.
+    mp = cfg.step4_dir / "manifest.json"
+    assert mp.exists()
+    payload = json.loads(mp.read_text(encoding="utf-8"))
+    assert payload["automl"]["skip_reason"] == "holdout_guard_violation"
+
+
+def test_pipeline_skip_reason_missing_entry_time(tmp_path):
+    """PR-A's synthetic pool has no entry_time — pipeline should skip
+    AutoML with the right reason rather than crash."""
+    pool = _synthetic_pool(include_entry_time=False, include_y=False)
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    cfg = load_config(
+        cfg_path, arc_name="x", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    r = run_pipeline(cfg, lineage_df=_synthetic_lineage_df())
+    assert r.automl_skip_reason == "missing_entry_time"
+    assert r.automl_result is None
+    # Only the stub_summary artefact lands when AutoML is skipped.
+    payload = json.loads(r.step4_manifest_path.read_text(encoding="utf-8"))
+    assert set(payload["artefacts"].keys()) == {"stub_summary"}
+    assert payload["automl"]["skip_reason"] == "missing_entry_time"
+
+
+def test_pipeline_skip_reason_missing_target(tmp_path):
+    pool = _synthetic_pool(include_y=False)
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    cfg = load_config(
+        cfg_path, arc_name="x", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    r = run_pipeline(cfg, lineage_df=_synthetic_lineage_df())
+    assert r.automl_skip_reason == "missing_y"
+    assert r.automl_result is None
+
+
+def test_pipeline_skip_reason_no_clean_features(tmp_path):
+    """When the lineage gate rejects every column, AutoML skips with
+    reason `no_clean_features` (and does NOT raise — the pipeline
+    surfaces the situation through the manifest)."""
+    pool = _synthetic_pool()
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    cfg = load_config(
+        cfg_path, arc_name="x", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    # Mark every feature suspect so the gate rejects them all
+    all_suspect = _synthetic_lineage_df().assign(causal_lineage="suspect")
+    r = run_pipeline(cfg, lineage_df=all_suspect)
+    assert r.automl_skip_reason == "no_clean_features"
+    assert r.automl_result is None
+
+
+def test_pool_required_columns_constant_matches_implementation():
+    assert AUTOML_REQUIRED_COLUMNS == ("entry_time", "y")

--- a/tests/heavy_ml_probe/test_causal_lineage.py
+++ b/tests/heavy_ml_probe/test_causal_lineage.py
@@ -1,0 +1,180 @@
+"""Tests for core.heavy_ml_probe.causal_lineage.
+
+Per dispatch §6 #2 + spec §"Per-feature causal lineage": the gate is
+pre-evaluation. Features without a clean lineage tag are excluded from
+the training column set BEFORE AutoML touches the data. These tests
+exercise:
+
+  * clean features pass
+  * suspect / unverified / unknown / excluded-class features are rejected
+    with the right reason code
+  * the gate result accounts for every input column
+  * the markdown summary is stable + grep-able
+  * the gate is pure (no side effects on the input lineage_df)
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pandas as pd
+import pytest
+
+from core.heavy_ml_probe.causal_lineage import (
+    DEFAULT_ACCEPTED_LINEAGE,
+    REASON_EXCLUDED_CLASS,
+    REASON_NON_CLEAN_LINEAGE,
+    REASON_UNKNOWN_FEATURE,
+    LineageGateResult,
+    filter_training_columns,
+    lineage_summary_markdown,
+)
+
+# Matches the schema produced by core.features.pipeline.feature_lineage_dataframe().
+LINEAGE_DF = pd.DataFrame(
+    [
+        {"name": "atr_14", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "session_london", "causal_lineage": "clean", "feature_class": "session"},
+        {"name": "kijun_26_distance", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "experimental_x", "causal_lineage": "clean", "feature_class": "experimental"},
+        {"name": "dxy_state", "causal_lineage": "suspect", "feature_class": "cross_asset"},
+        {"name": "raw_volume_rank", "causal_lineage": "unverified", "feature_class": "volume"},
+    ]
+)
+
+
+def test_accepts_all_clean_features():
+    cols = ["atr_14", "session_london", "kijun_26_distance"]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert isinstance(res, LineageGateResult)
+    assert res.n_input_columns == 3
+    assert res.n_accepted == 3
+    assert res.n_rejected == 0
+    assert res.accepted_features == tuple(sorted(cols))
+
+
+def test_rejects_suspect_lineage():
+    cols = ["atr_14", "dxy_state"]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert res.n_accepted == 1
+    assert res.accepted_features == ("atr_14",)
+    assert res.n_rejected == 1
+    [rej] = res.rejected
+    assert rej["feature"] == "dxy_state"
+    assert rej["reason"] == REASON_NON_CLEAN_LINEAGE
+    assert "suspect" in rej["detail"]
+
+
+def test_rejects_unverified_lineage():
+    cols = ["atr_14", "raw_volume_rank"]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert res.n_rejected == 1
+    [rej] = res.rejected
+    assert rej["feature"] == "raw_volume_rank"
+    assert rej["reason"] == REASON_NON_CLEAN_LINEAGE
+    assert "unverified" in rej["detail"]
+
+
+def test_rejects_unknown_feature_with_clear_reason():
+    cols = ["atr_14", "totally_made_up_feature"]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert res.n_accepted == 1
+    assert res.n_rejected == 1
+    [rej] = res.rejected
+    assert rej["feature"] == "totally_made_up_feature"
+    assert rej["reason"] == REASON_UNKNOWN_FEATURE
+
+
+def test_exclude_class_overrides_clean_lineage():
+    """Even a clean-tagged feature is rejected if its class is excluded."""
+    cols = ["atr_14", "experimental_x"]
+    res = filter_training_columns(
+        cols, LINEAGE_DF, exclude_classes=("experimental",)
+    )
+    assert res.n_accepted == 1
+    assert res.accepted_features == ("atr_14",)
+    [rej] = res.rejected
+    assert rej["feature"] == "experimental_x"
+    assert rej["reason"] == REASON_EXCLUDED_CLASS
+    assert "experimental" in rej["detail"]
+
+
+def test_mixed_pool_accounts_for_every_column():
+    cols = [
+        "atr_14",                # clean -> accept
+        "dxy_state",             # suspect -> reject
+        "raw_volume_rank",       # unverified -> reject
+        "totally_made_up",       # unknown -> reject
+        "session_london",        # clean -> accept
+    ]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert res.n_input_columns == 5
+    assert res.n_accepted == 2
+    assert res.n_rejected == 3
+    assert set(res.accepted_features) == {"atr_14", "session_london"}
+    reasons = {r["feature"]: r["reason"] for r in res.rejected}
+    assert reasons["dxy_state"] == REASON_NON_CLEAN_LINEAGE
+    assert reasons["raw_volume_rank"] == REASON_NON_CLEAN_LINEAGE
+    assert reasons["totally_made_up"] == REASON_UNKNOWN_FEATURE
+
+
+def test_duplicate_columns_dedup():
+    """Duplicate column names in the input are deduplicated before gating."""
+    cols = ["atr_14", "atr_14", "session_london"]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert res.n_input_columns == 2
+    assert res.n_accepted == 2
+
+
+def test_accepted_lineage_default_is_clean_only():
+    assert DEFAULT_ACCEPTED_LINEAGE == ("clean",)
+
+
+def test_gate_is_pure_does_not_mutate_lineage_df():
+    snapshot = copy.deepcopy(LINEAGE_DF)
+    _ = filter_training_columns(["atr_14"], LINEAGE_DF)
+    pd.testing.assert_frame_equal(LINEAGE_DF, snapshot)
+
+
+def test_missing_required_column_raises():
+    bad = pd.DataFrame([{"name": "x", "causal_lineage": "clean"}])  # no feature_class
+    with pytest.raises(ValueError, match="missing required columns"):
+        filter_training_columns(["x"], bad)
+
+
+def test_lineage_summary_markdown_renders_stably():
+    res = filter_training_columns(
+        ["atr_14", "dxy_state", "raw_volume_rank", "totally_made_up"],
+        LINEAGE_DF,
+    )
+    md1 = lineage_summary_markdown(res)
+    md2 = lineage_summary_markdown(res)
+    assert md1 == md2  # deterministic
+    # Spot-check expected sections render
+    assert "# Causal lineage gate — heavy_ml_probe" in md1
+    assert "Accepted (clean): **1**" in md1
+    assert "Rejected: **3**" in md1
+    assert "Rejection breakdown" in md1
+    assert REASON_NON_CLEAN_LINEAGE in md1
+    assert REASON_UNKNOWN_FEATURE in md1
+
+
+def test_lineage_summary_markdown_when_no_rejections():
+    res = filter_training_columns(["atr_14"], LINEAGE_DF)
+    md = lineage_summary_markdown(res)
+    assert "Accepted (clean): **1**" in md
+    assert "Rejected: **0**" in md
+    # When nothing was rejected, the detail tables should not appear.
+    assert "Rejection breakdown" not in md
+    assert "Rejected features (sorted)" not in md
+
+
+def test_accepts_clean_features_with_lineage_case_insensitive():
+    """Real-world lineage_df values use lowercase, but the gate
+    should not be case-sensitive (defensive against producer drift)."""
+    upper = pd.DataFrame([
+        {"name": "x", "causal_lineage": "CLEAN", "feature_class": "Price_Geometry"},
+    ])
+    res = filter_training_columns(["x"], upper)
+    assert res.n_accepted == 1
+    assert res.accepted_features == ("x",)

--- a/tests/heavy_ml_probe/test_io_manifest.py
+++ b/tests/heavy_ml_probe/test_io_manifest.py
@@ -1,0 +1,336 @@
+"""Tests for core.heavy_ml_probe.io + the PR-A pipeline manifest path.
+
+Coverage:
+
+  * deterministic CSV / parquet / text writes (lineterminator='\n', sorted
+    rows, sorted keys, no platform-dependent encoding)
+  * sha256_file matches a hand-computed digest
+  * manifest schema includes schema_version + sub_protocol + arc_name +
+    step + artefacts + extras
+  * manifest path entries are recorded relative to the manifest's parent
+    directory with forward-slash separators (Windows / POSIX parity)
+  * two-run determinism: same inputs → same artefact sha256s + same
+    stable-payload manifest sha256 (timestamp excluded)
+  * collision between extras and reserved fields raises
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.heavy_ml_probe.io import (
+    MANIFEST_SCHEMA_VERSION,
+    sha256_file,
+    write_csv,
+    write_manifest,
+    write_parquet,
+    write_text,
+)
+from core.heavy_ml_probe.pipeline import (
+    load_config,
+    run_pipeline,
+    stable_payload_sha256,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
+
+
+# ── io.write_text / write_csv / write_parquet ──────────────────────────
+
+
+def test_write_text_appends_single_newline(tmp_path):
+    p = tmp_path / "out.md"
+    sha_no_nl = write_text(p, "hello world")
+    sha_with_nl = write_text(p, "hello world\n")
+    assert sha_no_nl == sha_with_nl
+    # The file should contain exactly one trailing '\n', regardless of
+    # what was passed in.
+    assert p.read_bytes() == b"hello world\n"
+
+
+def test_write_text_lineterminator_is_lf(tmp_path):
+    """No CR characters even on Windows."""
+    p = tmp_path / "out.md"
+    write_text(p, "line1\nline2")
+    raw = p.read_bytes()
+    assert b"\r" not in raw
+    assert raw == b"line1\nline2\n"
+
+
+def test_write_csv_is_deterministic_with_sort(tmp_path):
+    df = pd.DataFrame(
+        [
+            {"k": "b", "v": 1.0},
+            {"k": "a", "v": 2.0},
+            {"k": "c", "v": 3.0},
+        ]
+    )
+    p1 = tmp_path / "1.csv"
+    p2 = tmp_path / "2.csv"
+    sha1 = write_csv(p1, df, sort_by=["k"], columns=["k", "v"])
+    sha2 = write_csv(p2, df.sample(frac=1, random_state=99), sort_by=["k"], columns=["k", "v"])
+    assert sha1 == sha2
+    # Confirm row order on disk is alphabetic.
+    raw = p1.read_text(encoding="utf-8")
+    assert "\r" not in raw
+    assert raw.splitlines() == ["k,v", "a,2.0", "b,1.0", "c,3.0"]
+
+
+def test_write_csv_raises_on_missing_requested_column(tmp_path):
+    df = pd.DataFrame([{"a": 1}])
+    with pytest.raises(ValueError, match="missing requested columns"):
+        write_csv(tmp_path / "x.csv", df, columns=["a", "b"])
+
+
+def test_write_parquet_round_trip(tmp_path):
+    df = pd.DataFrame(
+        [{"id": 2, "val": "b"}, {"id": 1, "val": "a"}]
+    )
+    p = tmp_path / "out.parquet"
+    sha = write_parquet(p, df, sort_by=["id"], columns=["id", "val"])
+    back = pd.read_parquet(p)
+    assert back["id"].tolist() == [1, 2]
+    assert back["val"].tolist() == ["a", "b"]
+    # Two writes match.
+    sha2 = write_parquet(p, df, sort_by=["id"], columns=["id", "val"])
+    assert sha == sha2
+
+
+def test_sha256_file_matches_hand_computed(tmp_path):
+    p = tmp_path / "x.bin"
+    payload = b"deterministic payload \xff\x00\x7f"
+    p.write_bytes(payload)
+    assert sha256_file(p) == hashlib.sha256(payload).hexdigest()
+
+
+# ── io.write_manifest ──────────────────────────────────────────────────
+
+
+def test_manifest_records_schema_version_and_sub_protocol(tmp_path):
+    art_path = tmp_path / "art.md"
+    write_text(art_path, "art body")
+    manifest_path = tmp_path / "manifest.json"
+    write_manifest(
+        manifest_path,
+        arc_name="test_arc",
+        step="step_4/heavy_ml",
+        artefact_paths={"art": art_path},
+    )
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == MANIFEST_SCHEMA_VERSION
+    assert payload["sub_protocol"] == "heavy_ml_probe"
+    assert payload["arc_name"] == "test_arc"
+    assert payload["step"] == "step_4/heavy_ml"
+    assert "created_at" in payload
+    assert set(payload["artefacts"].keys()) == {"art"}
+    entry = payload["artefacts"]["art"]
+    assert entry["path"] == "art.md"  # forward-slash, relative
+    assert entry["sha256"] == sha256_file(art_path)
+
+
+def test_manifest_path_uses_forward_slashes_for_nested(tmp_path):
+    nested = tmp_path / "classifiers" / "0.pkl"
+    nested.parent.mkdir(parents=True, exist_ok=True)
+    nested.write_bytes(b"pickled bytes")
+    manifest_path = tmp_path / "manifest.json"
+    write_manifest(
+        manifest_path,
+        arc_name="a",
+        step="step_4/heavy_ml",
+        artefact_paths={"clf": nested},
+    )
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    # Always forward-slash, even on Windows
+    assert payload["artefacts"]["clf"]["path"] == "classifiers/0.pkl"
+
+
+def test_manifest_sorts_artefacts_for_determinism(tmp_path):
+    a = tmp_path / "a.md"
+    b = tmp_path / "b.md"
+    c = tmp_path / "c.md"
+    for p in (a, b, c):
+        write_text(p, p.name)
+    mp = tmp_path / "manifest.json"
+    write_manifest(
+        mp, arc_name="x", step="step_4/heavy_ml",
+        artefact_paths={"c": c, "a": a, "b": b},  # unsorted on input
+    )
+    payload = json.loads(mp.read_text(encoding="utf-8"))
+    assert list(payload["artefacts"].keys()) == ["a", "b", "c"]
+
+
+def test_manifest_extras_collision_raises(tmp_path):
+    art = tmp_path / "x.md"
+    write_text(art, "x")
+    with pytest.raises(ValueError, match="collides with reserved field"):
+        write_manifest(
+            tmp_path / "manifest.json",
+            arc_name="a",
+            step="step_4/heavy_ml",
+            artefact_paths={"art": art},
+            extras={"arc_name": "trying-to-override"},
+        )
+
+
+def test_manifest_extras_recorded(tmp_path):
+    art = tmp_path / "x.md"
+    write_text(art, "x")
+    mp = tmp_path / "manifest.json"
+    write_manifest(
+        mp, arc_name="a", step="step_4/heavy_ml",
+        artefact_paths={"art": art},
+        extras={"pool_size": 1234, "lineage_gate": {"n_accepted": 7}},
+    )
+    payload = json.loads(mp.read_text(encoding="utf-8"))
+    assert payload["pool_size"] == 1234
+    assert payload["lineage_gate"]["n_accepted"] == 7
+
+
+# ── pipeline.run_pipeline end-to-end stub ──────────────────────────────
+
+
+def _synthetic_pool(tmp_path: Path) -> Path:
+    """Write a tiny pool parquet with a mix of clean / suspect features.
+
+    The lineage_df parameter to apply_lineage_gate gets monkey-patched
+    in :func:`_synthetic_lineage_df` to match these column names. We
+    don't depend on the real registry — keeps tests fast and isolated.
+    """
+    df = pd.DataFrame(
+        [
+            {"trade_id": i, "atr_14": 0.001 + i * 1e-5, "session_london": 1,
+             "dxy_state": 0, "raw_volume_rank": i % 5}
+            for i in range(50)
+        ]
+    )
+    p = tmp_path / "pool.parquet"
+    df.to_parquet(p, compression="snappy", index=False)
+    return p
+
+
+def _synthetic_lineage_df() -> pd.DataFrame:
+    return pd.DataFrame([
+        {"name": "trade_id", "causal_lineage": "clean", "feature_class": "id"},
+        {"name": "atr_14", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "session_london", "causal_lineage": "clean", "feature_class": "session"},
+        {"name": "dxy_state", "causal_lineage": "suspect", "feature_class": "cross_asset"},
+        {"name": "raw_volume_rank", "causal_lineage": "unverified", "feature_class": "volume"},
+    ])
+
+
+@pytest.fixture
+def synthetic_run(tmp_path):
+    """Two pipeline runs against the same synthetic pool + config + lineage."""
+    pool_path = _synthetic_pool(tmp_path)
+    lineage_df = _synthetic_lineage_df()
+
+    def _run(label: str):
+        out_root = tmp_path / label
+        cfg = load_config(
+            DEFAULT_CONFIG_PATH,
+            arc_name="test_arc",
+            cluster_id=0,
+            pool_path=pool_path,
+            output_root=out_root,
+        )
+        return run_pipeline(cfg, lineage_df=lineage_df)
+
+    return _run
+
+
+def test_pipeline_writes_manifest_and_stub_summary(synthetic_run):
+    res = synthetic_run("run1")
+    assert res.step4_manifest_path.exists()
+    assert res.stub_summary_path.exists()
+    payload = json.loads(res.step4_manifest_path.read_text(encoding="utf-8"))
+    # Sanity-check shape
+    assert payload["sub_protocol"] == "heavy_ml_probe"
+    assert payload["arc_name"] == "test_arc"
+    assert payload["cluster_id"] == 0
+    assert payload["pool_size"] == 50
+    assert payload["lineage_gate"]["n_accepted"] >= 3  # at least the clean cols above
+    # The stub summary should be the only listed artefact in PR-A.
+    assert set(payload["artefacts"].keys()) == {"stub_summary"}
+    # And its recorded sha256 should match the on-disk file.
+    listed = payload["artefacts"]["stub_summary"]
+    assert listed["sha256"] == sha256_file(res.stub_summary_path)
+    assert listed["path"] == "stub_summary.md"
+
+
+def test_pipeline_lineage_gate_rejects_suspect_columns(synthetic_run):
+    res = synthetic_run("run1")
+    accepted = set(res.lineage_gate.accepted_features)
+    assert "atr_14" in accepted
+    assert "session_london" in accepted
+    assert "dxy_state" not in accepted
+    assert "raw_volume_rank" not in accepted
+
+
+def test_pipeline_two_run_determinism_artefact_bytes(synthetic_run):
+    r1 = synthetic_run("run1")
+    r2 = synthetic_run("run2")
+    # Stub summary is timestamp-free → identical bytes across runs
+    assert sha256_file(r1.stub_summary_path) == sha256_file(r2.stub_summary_path)
+
+
+def test_pipeline_two_run_determinism_stable_manifest(synthetic_run):
+    """Manifest sha256s differ by ``created_at`` only; stable payload matches."""
+    r1 = synthetic_run("run1")
+    r2 = synthetic_run("run2")
+    assert stable_payload_sha256(r1.step4_manifest_path) == stable_payload_sha256(
+        r2.step4_manifest_path
+    )
+
+
+def test_pipeline_rejects_missing_pool(tmp_path):
+    bad_pool = tmp_path / "does_not_exist.parquet"
+    cfg = load_config(
+        DEFAULT_CONFIG_PATH,
+        arc_name="test_arc",
+        cluster_id=0,
+        pool_path=bad_pool,
+        output_root=tmp_path / "out",
+    )
+    with pytest.raises(FileNotFoundError):
+        run_pipeline(cfg, lineage_df=_synthetic_lineage_df())
+
+
+def test_pipeline_rejects_bad_config_sub_protocol_name(tmp_path):
+    bad_yaml = tmp_path / "bad.yaml"
+    bad_yaml.write_text(
+        "schema_version: '1.0'\n"
+        "sub_protocol:\n  name: not_heavy_ml_probe\n"
+        "automl: {}\nmeta_labeling: {}\nsurvival: {}\n"
+        "training_window: {}\ncausal_filter: {}\ndeterminism: {}\n"
+        "output: {}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="sub_protocol.name must be"):
+        load_config(
+            bad_yaml,
+            arc_name="x",
+            cluster_id=0,
+            pool_path=tmp_path / "pool.parquet",
+            output_root=tmp_path / "out",
+        )
+
+
+def test_pipeline_rejects_config_missing_required_section(tmp_path):
+    bad_yaml = tmp_path / "bad2.yaml"
+    bad_yaml.write_text(
+        "schema_version: '1.0'\nsub_protocol: {name: heavy_ml_probe}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="missing top-level sections"):
+        load_config(
+            bad_yaml,
+            arc_name="x",
+            cluster_id=0,
+            pool_path=tmp_path / "pool.parquet",
+            output_root=tmp_path / "out",
+        )


### PR DESCRIPTION
## Summary

PR-B of the multi-stage `heavy_ml_probe` sub-protocol build. Lands the FLAML AutoML wrapper, per-fold training across an 11-fold TimeSeriesSplit, modelcount-based budget accounting, permutation importance, and the four PR-B artefacts (`automl_leaderboard.csv`, `automl_feature_importance.csv`, `compute_budget_used.md`, populated `manifest.json`).

**Build sequence:** PR-A → **PR-B (this)** → PR-C (meta-labeling) → PR-D (survival) → PR-E (Step 5 hook, gate PR) → PR-F (docs).

**Target:** `infra/heavy_ml_probe_build`. PR-B is cut from PR-A locally; chat's PR-A merge will collapse the PR-A portion of the diff.

## What's in this PR

| Area | Files | Purpose |
|---|---|---|
| Core | `core/heavy_ml_probe/automl.py` (new) | FLAML wrapper + 11-fold TS-split + modelcount accounting + permutation importance + NaN-safe AUC + holdout-guard |
| Core | `core/heavy_ml_probe/pipeline.py` (extended) | `run_pipeline` orchestrates AutoML stage; auto-skips when pool lacks `entry_time`/`y` (PR-A backward compat) |
| CLI | `scripts/heavy_ml_probe/run_probe.py` (tweaked) | stdout surfaces AutoML stats; `HoldoutGuardViolation` + `AllFeaturesRejected` → exit 1 |
| Spec | `docs/sub_protocols/heavy_ml_probe.md` (1-line touch) | CLI exit-code mapping per PR-A flag-1 disposition |
| Tests | `tests/heavy_ml_probe/test_automl.py` (new) | 19 tests across mechanics, determinism, NaN propagation, guards, pipeline integration |
| Docs | `docs/dispatches/heavy_ml_probe_pr_b_log.md` (new) | Verification + §3a/§3b empirical findings + flags for chat |

## Mandatory empirical findings (dispatch §3)

### §3a — FLAML `max_iter` semantics → **ratio 1.0, locked**

Empirically verified before any PR-B code lands. `flaml.AutoML.modelcount` equals `max_iter` exactly when FLAML 2.6.0 runs to the cap:

```
max_iter=  5  modelcount=  5  best_iteration=  2
max_iter= 10  modelcount= 10  best_iteration=  9
max_iter= 30  modelcount= 30  best_iteration= 22
```

Full probe + interpretation in [`docs/dispatches/heavy_ml_probe_pr_b_log.md`](https://github.com/kpanapabusiness-droid/Forex-Backtester/blob/infra/heavy_ml_probe_pr_b/docs/dispatches/heavy_ml_probe_pr_b_log.md) §2. No HALT trigger.

### §3b — single-class fold AUC → **NaN propagates correctly**

Both single-class training and single-class validation paths yield `numpy.nan` per-fold AUC. Aggregate uses `np.nanmean` with `n_folds_valid` reported alongside the mean. Test `test_nan_auc_propagates_on_single_class_training` constructs a pool guaranteed to produce ≥1 single-class fold and asserts the propagation.

## Notable design decisions

- **`automl.model.estimator` for permutation_importance** — sklearn 1.5+'s estimator-type check refuses FLAML's outer wrapper. Pass the inner sklearn-compatible classifier instead. Inline comment + log doc §5.1.
- **Wall-clock dropped from on-disk artefacts** — non-deterministic; lands on `AutoMLResult.total_fit_wall_seconds` for operator visibility via CLI stdout, NOT on disk. Log doc §5.2.
- **Pool auto-skip when `entry_time`/`y` missing** — preserves PR-A's lineage-gate-only smoke tests untouched. `AUTOML_REQUIRED_COLUMNS` exported from `pipeline.py` for introspection. Log doc §5.3.
- **FLAML 2.6.0 estimator list captured per-fold** — `lgbm, rf, xgboost, extra_tree, xgb_limitdepth, sgd, catboost, lrl1` (note: differs from dispatch spec which listed `lrl2`). Per dispatch §1, log + proceed. `DOCUMENTED_FLAML_2_6_0_ESTIMATORS` constant + per-fold `FoldResult.estimator_list` for audit.

## Verification

- `pytest tests/heavy_ml_probe -W ignore::UserWarning`: **50/50 pass in 16.77s** (31 PR-A carryover + 19 new PR-B tests)
- `pytest tests/discovery` (sibling regression): **42/42 pass**
- `ruff check`: **All checks passed!**
- CLI smoke against 200-row synthetic pool: **exit 0**, AutoML correctly skipped on `no_clean_features` because the synthetic pool's column names aren't in the production feature registry
- Two-run determinism (4 artefacts + stable-payload manifest) verified in `test_pipeline_automl_two_run_determinism`
- Wall-clock probe at test scale (n=400, n_folds=5, max_iter=10): 1.55s; extrapolated production: ~6 min per cluster (vs dispatch §4 expectation of 2-6 hours — to be confirmed at PR-E real-data scale)

## Test plan

- [x] `pytest tests/heavy_ml_probe -q` (local)
- [x] `pytest tests/discovery -q` (sibling regression)
- [x] `ruff check` over new/modified modules
- [x] Two-run sha256 determinism (artefact bytes + stable manifest)
- [x] CLI smoke against synthetic pool
- [x] §3a empirical (modelcount == max_iter)
- [x] §3b empirical (NaN AUC propagation)
- [ ] CI green (will confirm in PR after push)

## Flags for chat

- **scikit-survival install on Python 3.14** still pending — `ecos` transitive dep has no cp314 wheel; needs MSVC build tools OR Python downgrade OR conda-forge wheel for PR-D. Not blocking PR-B; surfaced now so PR-D's environment prep doesn't surprise.
- **FLAML defaults differ from dispatch spec** (`xgb_limitdepth`/`sgd` vs `lrl2`). Captured + recorded; if chat wants explicit `lrl2` override the YAML key `automl.estimator_list` is wired but commented out.
- **Wall-clock extrapolation** suggests production is order-of-minutes not hours; could be very wrong (test toy has 4 features, production has 20-30) but worth knowing the baseline.

Full flag list + dispositions in [PR-B log §6](https://github.com/kpanapabusiness-droid/Forex-Backtester/blob/infra/heavy_ml_probe_pr_b/docs/dispatches/heavy_ml_probe_pr_b_log.md#6-flags-for-chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)