### PR TITLE
[PROTOCOL] Amendment 5 — AUC-gated A2/A6 architecture selection + parser v1.3 field

### DIFF
--- a/L_PROTOCOL.md
+++ b/L_PROTOCOL.md
@@ -9,6 +9,7 @@
 > **Amendment 2 (2026-05-22):** ML architecture mechanics specified for A2, A3, A4, A6. See §2 Step 5 ML mechanics subsection.
 > **Amendment 3 (2026-05-22):** Risk-normalised gates. §3 constraints preserved 1:1; evaluation now occurs at scaled risk `r_safe` / `r_hard` rather than at the WFO base risk. Scalability bounds, per-day DD recount, and explicit evaluation order added. Full text archived at `archive/L_PROTOCOL_v3_0_AMENDMENT_3.md`. See §3.
 > **Amendment 4 (2026-05-24):** Step 6 causal-audit framework. Six audit categories (lookahead, selection bias, execution realism, statistical integrity, determinism, deployment readiness) as runnable engine code. Auto-dispatches post-gate on Top-1 PASS-tier candidate; manual CLI invokable on any closure. Critical failure downgrades verdict via `step6_causal_audit_fail`. Closure template bumped to v1.3 with `§1 tracker_payload.step_6` block; parser v1.3 + Phase 2 tightening (PR-186-merge cutoff). Full text archived at `archive/L_PROTOCOL_v3_0_AMENDMENT_4.md`. See §2 Step 6.
+> **Amendment 5 (2026-05-23):** AUC-gated A2/A6 architecture selection. Amendment 1's uniform archetype gating is split into four gates: Gate 1 preserves A3/A4 archetype gating; Gate 2 admits A2 + A6 whenever Step 4 mean OOS AUC ≥ 0.65 regardless of archetype; Gate 3 always admits A1; Gate 4 admits A5 when ≥2 candidate clusters survive Step 3. Choppy clusters skip all architectures. Enforcement is dispatch-time; engine unchanged (all six architectures wired post-PR-186). Closure template v1.3.1 adds optional `architectures_skipped_by_amendment_5` field; parser v1.3 accepts it and requires it for post-ratification PASS verdicts. Full text archived at `archive/L_PROTOCOL_v3_0_AMENDMENT_5.md`. See §2 Step 5 "Architecture selection (Amendment 5)".
 >
 > This protocol is the umbrella. It accepts any signal, any feature space, any architecture. Sub-protocols may layer on top to add signal-class-specific specificity. The overseer's gates and verdicts apply universally.
 
@@ -190,15 +191,22 @@ Inputs from Step 4 (per candidate cluster):
 
 Step 5 search rules:
 
-**Architecture selection:** 2-3 from {A1..A6} that fit the dominant cluster archetype:
-- Stepwise climber → A1 (system filter), A2 (classifier filter), A4 (trailing-exit Pipeline D)
-- V-shape recovery → A1, A3 (Pipeline DE — deferred entry), A6 (meta-labeling)
-- Bimodal → A1, A4 (per-archetype Pipeline D exits)
-- Monotonic up → A1, A2, A6
-- Choppy → no architectures expected to survive; arc typically dies at Step 3 before reaching Step 5
-- A5 (portfolio composition) → only applies if 2+ candidate clusters survive Step 3
+**Architecture selection (Amendment 5, ratified 2026-05-23):** the set of architectures evaluated per surviving cluster is the UNION over four independent gates. Replaces the Amendment 1 archetype-driven rule. Full text at [archive/L_PROTOCOL_v3_0_AMENDMENT_5.md](archive/L_PROTOCOL_v3_0_AMENDMENT_5.md).
+
+- **Gate 1 — Shape-required (archetype-driven):** adds A3 / A4 per archetype.
+  - V-shape recovery → A3
+  - Stepwise climber → A4
+  - Bimodal → A4
+  - Monotonic up / Monotonic down / Unclassified → (none)
+- **Gate 2 — Classifier-driven (AUC-driven):** if Step 4 mean OOS AUC ≥ 0.65 for the cluster → add A2 and A6. Fires REGARDLESS of archetype (A2 and A6 are archetype-agnostic by construction; the only relevant input quality is classifier predictive power).
+- **Gate 3 — Universal:** always add A1 (system-level filter). No shape or classifier dependence; baseline for every cluster.
+- **Gate 4 — Portfolio:** if ≥2 candidate clusters survive Step 3 within the arc → add A5 (portfolio composition).
+
+**Cluster skip condition:** Choppy clusters skip all architectures. Step 5 evaluation not performed for Choppy.
 
 If Step 4 produced NO usable filter/classifier (AUC at chance, no rule above noise), A1 still runs with "no filter" baseline (raw signal + system-level rules: exposure, SL, exit) — this tests whether the system works without filtering.
+
+The four-gate rule is enforced AT DISPATCH TIME, not engine time. Arc dispatches must list the architectures-tested set per cluster and cite the admitting gate (e.g. `A1: Gate 3; A3: Gate 1 V-shape; A2, A6: Gate 2 AUC=0.72`). Engine receives a fully-resolved set; engine does NOT apply the selection rule itself. Architectures admissible under the prior Amendment 1 rule but skipped under Amendment 5 are recorded in the closure's `architectures_skipped_by_amendment_5` field (optional pre-cutoff, required for post-cutoff PASS closures — see closure template v1.3.1).
 
 **SL multiplier:** centred on Step 3's per-cluster selected SL, ±1 step either side (typically 3 values total). Example: if Step 3 selected SL=2.5×ATR, Step 5 tests SL ∈ {2.0, 2.5, 3.0}.
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 > The operational todo list. Append, check off, delete as work completes.
 > Distinct from `ARC_TRACKER.md` (which is auto-updated arc state) and `ARC_HISTORY.md` (frozen pre-v3.0 record).
-> Last updated: 2026-05-24 (post-PR-#189 signal parity state alignment)
+> Last updated: 2026-05-25 (post-L_PROTOCOL Amendment 5 ratification — AUC-gated A2/A6 architecture selection + parser v1.3.1 field)
 
 ---
 
@@ -25,7 +25,7 @@
 
 **HistData layer:** 🟢 DONE (28 pairs, 52 GB tick + 18 GB M1 derived; 2026-05-21 backup verified)
 **v3.0 backtester reconfig (CC_06):** 🟢 DONE (PR-A through PR-E.1.7 landed)
-**v3.0 protocol redesign:** 🟢 DONE (`L_PROTOCOL.md` finalised + Amendments 1, 2, 3, 4 inline)
+**v3.0 protocol redesign:** 🟢 DONE (`L_PROTOCOL.md` finalised + Amendments 1, 2, 3, 4, 5 inline)
 **Repo cleanup + consolidation:** 🟢 DONE (branches cleaned; inventory + arc history complete)
 
 ### Active parallel chat work
@@ -95,6 +95,8 @@
 | Build tracker parser `scripts/update_tracker_from_closure.py` | 🟢 | PR #179 built parser; PR #181 retrofitted Arcs 8/10/11 to template v1.2; PR #182 CC_11 follow-up backfilled parsed.log + parser registry |
 | Closure template v1.3 (Amendment 4 — Step 6) | 🟢 | PR #188 |
 | Parser v1.3 (template v1.3 detection + Phase 2 tightening, cutoff 2026-05-23T06:20:59Z) | 🟢 | PR #188 |
+| Closure template v1.3.1 (Amendment 5 — `architectures_skipped_by_amendment_5` field) | 🟢 | This PR |
+| Parser v1.3 Amendment-5 extension (optional field + Phase 2 enforcement, cutoff `AMENDMENT_5_CUTOFF_ISO` placeholder pending PR-merge backfill) | 🟢 | This PR |
 
 ### Round 6 — Engine consolidation (NEW)
 
@@ -165,9 +167,10 @@ path is Sections G (news filter) + H (post-fill SL anchor) per
 | Arc 7 v3.0.1 retry | 🔴 | Blocked on PR #180 closure + signal-parity engine merged |
 | Arc 10 re-run on signal-parity engine for definitive verdict | 🔴 | Procedure documented at [docs/calibration/arc_10_signal_parity_rerun_2026_05.md](docs/calibration/arc_10_signal_parity_rerun_2026_05.md); expected near-zero delta |
 | Wave 1 closes (cross-arc tracker review for patterns) | 🔴 | Gated on retries above |
-| Dispatch Wave 2 (6 arcs in parallel) | 🔴 | Gated on Wave 1 close |
+| Dispatch Wave 2 (6 arcs in parallel) | 🔴 | Gated on Wave 1 close. **Wave 2 dispatches must apply L_PROTOCOL Amendment 5 four-gate architecture-selection rule from first dispatch** (Phase 1 chat-side; out of scope for this PR). |
 | Wave 2 closes; cross-arc synthesis | 🔴 | |
 | Decision: any deployable found? | 🔴 | |
+| Retroactive audit Arc 8 v3.0 + Arc 11 v3.0 under L_PROTOCOL Amendment 5 | ⚪ | Deferred until Arc 7 v3.0.2 closes — verdict informs whether retroactive retries are worth running. Criterion per Amendment 5 §7: "FAIL closed with at least one Step 3 surviving cluster whose Step 4 AUC ≥ 0.65 was not evaluated under A2 AND A6 under prior protocol." Arc 10 v3.0 already evaluated A6 under Amendment 1's V-shape mapping; likely unaffected, verify at audit. |
 
 ---
 
@@ -213,6 +216,7 @@ All 🔴 NOT STARTED — defer to Phase 2 trigger.
 | Closure-writer YAML auto-emission | 🔴 | Currently hand-written; defer until orchestrator gains closure-emit capability |
 | Legacy engine retirement (migrate `live/run_daily.py` + 32 importers off `core/backtester.py` + `core/signal_logic.py`) | 🔴 | Gate: KH-24 anchor preservation (±0.5pp ROI / ±1pp DD). Out of scope for PR #189; separate dispatch needed. |
 | EA mid-trail update (live MT5 EA still uses bid-side `CopyClose`) | 🔴 | To restore backtest↔EA parity post-PR-#189; separate deployment PR |
+| Backfill `AMENDMENT_5_CUTOFF_ISO` in `scripts/tracker_parser/schema.py` with the actual PR-merge timestamp post-merge | 🔴 | Placeholder pinned at `2026-05-23T00:00:00Z` at landing time; mirror PR-186 / Amendment 3 backfill pattern. Trivial one-line follow-up PR. |
 
 ---
 
@@ -233,11 +237,11 @@ All 🔴 NOT STARTED — defer to Phase 2 trigger.
 ## Doc set state
 
 ### Locked / ready
-- `L_PROTOCOL.md` (v3.0 + Amendments 1, 2, 3, 4 inline) 🟢
+- `L_PROTOCOL.md` (v3.0 + Amendments 1, 2, 3, 4, 5 inline) 🟢
 - `ARC_HISTORY.md` (frozen) 🟢
-- `docs/templates/ARC_CLOSURE_TEMPLATE.md` v1.3 🟢
+- `docs/templates/ARC_CLOSURE_TEMPLATE.md` v1.3.1 🟢
 - `ARC_TRACKER.md` (parser-auto-updated) 🟢
-- `scripts/update_tracker_from_closure.py` (parser; supports template v1.0 / v1.1 / v1.2 / v1.3) 🟢
+- `scripts/update_tracker_from_closure.py` (parser; supports template v1.0 / v1.1 / v1.2 / v1.2.1 / v1.3 / v1.3.1) 🟢
 - `docs/sub_protocols/heavy_ml_probe.md` (spec; engine build in flight via PR #187) 🟢
 - `docs/sub_protocols/signal_discovery_probe.md` (spec + engine wired via PR #175) 🟢
 - `docs/audits/engine_capability_audit_2026_05.md` (PR #184; footer updated by PR #189 with signal-parity gap closure) 🟢
@@ -276,7 +280,7 @@ All 🔴 NOT STARTED — defer to Phase 2 trigger.
 |---|---|
 | `L_PROTOCOL.md` | Only at major redesign events (Amendments are inline) |
 | `docs/sub_protocols/*` | When sub-protocol is amended |
-| `docs/templates/ARC_CLOSURE_TEMPLATE.md` | Only at template version bump (locked at v1.3) |
+| `docs/templates/ARC_CLOSURE_TEMPLATE.md` | Only at template version bump (locked at v1.3.1) |
 | `ARC_TRACKER.md` | Auto on arc open/close via parser (`scripts/update_tracker_from_closure.py`) |
 | `ARC_HISTORY.md` | Never (frozen at v3.0 start) |
 | `TODO.md` (this file) | Manually as work progresses; full rewrites rare (every 2-3 months at major state transitions) |

--- a/archive/L_PROTOCOL_v3_0_AMENDMENT_5.md
+++ b/archive/L_PROTOCOL_v3_0_AMENDMENT_5.md
@@ -1,0 +1,180 @@
+# Amendment 5 — AUC-Gated A2/A6 Architecture Selection
+
+> **Status:** Ratified 2026-05-23. Landed into `L_PROTOCOL.md` §2 Step 5 architecture-selection rule.
+> **Supersedes:** Amendment 1 "Architecture-selection rule per Step 3 archetype" (partial — A2/A6 selection logic only; A3/A4 archetype gating preserved)
+> **Trigger:** Two-instance empirical evidence (Arc 7 v3.0 c0 Bimodal AUC 0.6758; Arc 7 v3.0.1 c1 Unclassified AUC 0.6642) of architecture-map gap producing false-negative arc verdicts
+> **Engine impact:** None. All six architectures wired post-PR-186. Selection is dispatch-time logic.
+
+---
+
+## Section 1 — Diagnosis
+
+L_PROTOCOL Amendment 1 introduced archetype-to-architecture mapping, gating each architecture's evaluation on Step 3 archetype tag. The rule conflated two structurally different architecture categories:
+
+**Category A — Shape-required architectures (mechanism depends on path shape):**
+- **A3 (deferred entry)** — Waits 3-5 bars, classifies dip-then-recover pattern. Mechanism requires a dip phase. Running on Monotonic-up = no dip exists, late entry costs.
+- **A4 (path-classifier exits)** — Exits when path classifier loses confidence. Designed for Stepwise/Bimodal give-back patterns. Running on V-shape = exits during dip phase right before recovery.
+
+For Category A, archetype gating is methodologically correct. Running on mismatched shapes produces misleading FAIL artefacts that pollute cross-arc evidence.
+
+**Category B — Classifier-driven architectures (mechanism depends on classifier quality):**
+- **A2 (admit/reject classifier filter)** — Consumes Step 4 classifier output, admits trades above threshold, rejects below.
+- **A6 (confidence-driven sizing)** — Consumes Step 4 classifier output, scales position size by predicted probability.
+
+For Category B, the architecture's mechanism is path-shape-agnostic by construction. The only relevant input quality measure is the classifier's predictive power — measured by AUC. Gating these architectures on archetype tags is a measurement-mechanism mismatch: using shape tags to make decisions that should depend on classifier quality.
+
+The original protocol-design conflated these categories under uniform archetype gating. Empirical surfacing has now confirmed the gap produces false-negative arc verdicts (Arc 7 v3.0 + v3.0.1).
+
+## Section 2 — Amended architecture selection rule
+
+The Amendment 1 architecture-selection rule is replaced with the following four-gate procedure. A cluster's architecture set equals the UNION of architectures qualifying under all gates.
+
+### Gate 1 — Shape-required architectures (archetype-driven)
+
+| Archetype | Architectures added by Gate 1 |
+|---|---|
+| V-shape recovery | A3 |
+| Stepwise climber | A4 |
+| Bimodal | A4 |
+| Monotonic up | (none) |
+| Monotonic down | (none) |
+| Choppy | (none) |
+| Unclassified | (none) |
+
+Gate 1 logic unchanged from Amendment 1 with respect to A3/A4 selection.
+
+### Gate 2 — Classifier-driven architectures (AUC-driven)
+
+If Step 4 mean OOS AUC ≥ 0.65 for the cluster: add A2 and A6.
+
+The 0.65 threshold matches Amendment 1's classifier deployability bar (same number, same purpose: classifier predictive power sufficient to act on).
+
+Gate 2 fires REGARDLESS of archetype. A2 and A6 are now archetype-agnostic.
+
+### Gate 3 — Universal architecture
+
+Always add A1 (system-level filter).
+
+A1 has no shape or classifier dependence; baseline architecture for every cluster.
+
+### Gate 4 — Portfolio architecture
+
+If two or more candidate clusters survive Step 3 within the arc: add A5 (portfolio composition).
+
+A5 selection logic unchanged from Amendment 1.
+
+### Cluster skip condition
+
+**Choppy clusters: skip all architectures.** Step 5 evaluation not performed. Choppy archetype indicates no structural edge worth extracting under any architecture.
+
+## Section 3 — Examples
+
+Worked examples for cluster classification under Amendment 5:
+
+| Cluster | Archetype | Step 4 AUC | Architectures (Gates 1+2+3) |
+|---|---|---|---|
+| V-shape recovery | V-shape | 0.72 | A1, A3, A2, A6 |
+| V-shape recovery, weak classifier | V-shape | 0.55 | A1, A3 |
+| Stepwise, strong classifier | Stepwise | 0.68 | A1, A4, A2, A6 |
+| Stepwise, weak classifier | Stepwise | 0.52 | A1, A4 |
+| Bimodal, strong classifier | Bimodal | 0.70 | A1, A4, A2, A6 |
+| Bimodal, weak classifier | Bimodal | 0.55 | A1, A4 |
+| Monotonic up, strong classifier | Monotonic up | 0.75 | A1, A2, A6 |
+| Monotonic up, weak classifier | Monotonic up | 0.50 | A1 |
+| Unclassified, strong classifier | Unclassified | 0.66 | A1, A2, A6 |
+| Unclassified, weak classifier | Unclassified | 0.50 | A1 |
+| Choppy | Choppy | anything | (skip all) |
+
+## Section 4 — What does NOT change
+
+- **Verdict gates** — Amendment 3 risk-normalised gates apply unchanged to all architectures evaluated under Amendment 5
+- **Failure-mode taxonomy** — no new failure modes
+- **A3, A4 archetype gating** — preserved; running on mismatched shapes still prohibited
+- **Step 4 classifier methodology** — unchanged; AUC computed per existing protocol
+- **Step 5 search space per architecture** — unchanged per-architecture config grids
+- **Closure template** — no schema change; `architectures_tested` field already captures the actual set
+- **Engine code** — zero changes required; all six architectures wired post-PR-186
+
+## Section 5 — Dispatch template updates
+
+Arc dispatches generated post-Amendment 5 must apply the four-gate selection rule when listing architectures to test. Specific updates:
+
+1. **Wave 2 dispatches** (in flight at time of ratification) — must reflect Amendment 5 from first dispatch
+2. **Phase 2 dispatches** — same
+3. **Discovery probe follow-up arcs** — same
+4. **Sub-protocol arcs (heavy_ml_probe, etc.)** — same
+
+Dispatches issued under prior protocol versions are not retrofitted; see Section 7 for retroactive policy.
+
+## Section 6 — Compute cost
+
+Amendment 5 typically adds A2 (1-6 configs depending on threshold grid) and A6 (12-18 configs depending on sizing curve grid) per qualifying cluster.
+
+Net effect on Step 5 search space per arc:
+- Arcs with no Unclassified / Monotonic / Bimodal clusters at AUC ≥ 0.65: zero change
+- Arcs with 1-2 such clusters: 20-50% increase in Step 5 configs
+- Arcs with 3+ such clusters: up to 70% increase
+
+Wave 2 arcs (6 arcs in parallel) compute increase: bounded by individual-arc factor, no cross-arc compounding.
+
+Acceptable cost. The compute spent is exactly the compute that should have been spent under Amendment 1's design intent.
+
+## Section 7 — Retroactive policy
+
+Closed arcs are audited for the criterion: "FAIL verdict closed with at least one Step 3 surviving cluster whose Step 4 AUC ≥ 0.65 was not evaluated under A2 AND A6 under prior protocol."
+
+| Arc | Status | Action |
+|---|---|---|
+| Arc 7 v3.0.2 | In flight under dispatch-scoped Amendment 5 override | Closes Amendment 5's empirical test case |
+| Arc 8 v3.0 (closed FAIL) | Audit at Amendment 5 ratification | Retry only if criterion met |
+| Arc 8 v3.0.1 (in progress) | Audit at closure | Apply Amendment 5 from current dispatch |
+| Arc 10 v3.0 (closed PROVISIONAL) | V-shape mapping already includes A6 | Likely unaffected; verify at audit |
+| Arc 10 v3.0.1 (queued post-CC_18 + CC_19) | Apply Amendment 5 from first run | Includes Amendment 5 by sequence |
+| Arc 11 v3.0 (closed FAIL) | Audit at Amendment 5 ratification | Retry only if criterion met |
+| Arc 11 v3.0.1 (in progress) | Audit at closure | Apply Amendment 5 from current dispatch |
+
+**Retroactive retries are not blanket.** Audit each closure; retry only where the criterion materially applies. If Arc 7 v3.0.2 produces a verdict change (FAIL → PASS-*), expand retroactive scope confidence. If Arc 7 v3.0.2 confirms FAIL despite Amendment 5, the protocol change is still methodologically correct but doesn't unlock prior arcs.
+
+Arc 7 v3.0 (the original Bimodal c0 instance) is queued for retroactive audit post-Amendment 5 ratification. Arc 7 v3.0.1 (Unclassified c1) is superseded by in-flight Arc 7 v3.0.2.
+
+**Operational ordering (per landing decision 2026-05-23):** Arc 8 v3.0 and Arc 11 v3.0 retroactive audits are queued in `TODO.md` but deferred until Arc 7 v3.0.2 closes. Arc 7 v3.0.2's verdict informs whether retroactive retries are worth running at all.
+
+## Section 8 — Ratification
+
+Amendment 5 ratified by mastermind decision dated **2026-05-23**.
+Author: mastermind chat with Phase 1 chat empirical evidence.
+Effective: from ratification timestamp for all new dispatches.
+Engine PR required: none.
+Documentation updates landed alongside:
+- L_PROTOCOL.md (this section)
+- Closure template v1.3.1 (`architectures_skipped_by_amendment_5` field added)
+- Parser v1.3 (optional field acceptance + Phase 2 enforcement for post-ratification PASS)
+- TODO.md (retroactive audit queued item)
+- Wave 2 dispatch templates (Phase 1 chat-side; separate from this PR)
+- Discovery probe follow-up dispatch templates (Phase 1 chat-side; separate from this PR)
+
+## Section 9 — Implementation discipline
+
+The four-gate selection rule is enforced AT DISPATCH TIME, not at engine time. Arc dispatches must:
+
+1. Explicitly list the architectures-tested set per cluster
+2. Cite the gate that admitted each architecture (e.g. `A1: Gate 3; A3: Gate 1 V-shape; A2, A6: Gate 2 AUC=0.72`)
+3. Include a Step 4 AUC summary in dispatch preamble for gate-2 transparency
+
+Engine receives a fully-resolved architecture set; engine does NOT apply the selection rule itself. This separation preserves engine determinism and allows the rule to evolve without engine PRs.
+
+## Section 10 — Audit trail
+
+Each arc closure §1 tracker_payload records:
+- `architectures_tested` (set of architecture IDs) — existing
+- `architectures_skipped_by_amendment_5` (set; empty list if none) — new informational field for cross-arc analytics
+
+No schema change to closure template structure beyond the new optional field; `architectures_tested` already exists.
+
+`architectures_skipped_by_amendment_5` rollout follows the Amendment 3 field pattern:
+- **Phase 1:** OPTIONAL on all closures (parser accepts presence or absence).
+- **Phase 2 (post-ratification):** REQUIRED for any PASS verdict whose `closed_timestamp > <PR-merge timestamp>Z`. Closures landed before the PR-merge timestamp are grandfathered.
+
+The exact cutoff timestamp is the merge timestamp of the PR landing this amendment, backfilled into `scripts/tracker_parser/schema.py::AMENDMENT_5_CUTOFF_ISO` post-merge. The placeholder value pinned at landing is `2026-05-23T00:00:00Z` (start of ratification day UTC) — functionally equivalent for all practical purposes since the PR cannot merge before that instant and no PASS closure will have a `closed_timestamp` between `2026-05-23T00:00:00Z` and the actual merge timestamp.
+
+End of Amendment 5.

--- a/docs/templates/ARC_CLOSURE_TEMPLATE.md
+++ b/docs/templates/ARC_CLOSURE_TEMPLATE.md
@@ -1,4 +1,4 @@
-# ARC_CLOSURE.md Template (Locked v1.3)
+# ARC_CLOSURE.md Template (Locked v1.3.1)
 
 > **Location:** `docs/templates/ARC_CLOSURE_TEMPLATE.md`
 > **Status:** locked. Every arc closure MUST follow this template.
@@ -12,6 +12,7 @@
 > **v1.1 (2026-05-22, L_PROTOCOL Amendment 3):** risk-normalised gate fields added to `best_architecture` block. Two fields renamed (see §"Schema versioning" at end of template). `primary_failure_mode` enum extended.
 > **v1.2 (2026-05-23, deployment-spec addition):** `config_artefact_path`, `deployment_spec_section_present`, `template_version` fields added to `best_architecture` block. New §4 deployment_spec section: REQUIRED for any PASS verdict, OPTIONAL for FAIL / HALT / DISCOVERY_COMPLETE. Parser enforces config path + §4 presence for PASS verdicts.
 > **v1.3 (2026-05-24, L_PROTOCOL Amendment 4):** Step 6 causal-audit framework. New `§1 tracker_payload.step_6` block. Step 6 auto-dispatches on any candidate that clears §3 constraints #1-9; manual CLI available for any closure. Step 6 critical-failure downgrades verdict to FAIL with `primary_failure_mode = step6_causal_audit_fail`. Parser v1.3 detection + Phase 2 tightening: for any PASS verdict with `closed_timestamp > 2026-05-23T06:20:59Z`, Amendment 3 fields required; for `template_version: v1.3` PASS, `step_6` block required.
+> **v1.3.1 (2026-05-23, L_PROTOCOL Amendment 5):** AUC-gated A2/A6 architecture selection. New top-level optional field `architectures_skipped_by_amendment_5` (subset of `{A1..A6}`, may be `[]`). Field is informational — captures architectures that would have been tested under Amendment 1's archetype-driven rule but were skipped under Amendment 5's four-gate AUC-driven rule. Phase 1: parser accepts presence or absence. Phase 2: parser REQUIRES the field for any PASS verdict whose `closed_timestamp > AMENDMENT_5_CUTOFF_ISO` (placeholder `2026-05-23T00:00:00Z`, to be backfilled with this PR's merge timestamp post-merge). v1.3 / v1.3.1 share the same `template_version: v1.3` declaration — the field's presence/absence is the v1.3.1 discriminator, not a separate version string. Mirrors the v1.2 / v1.2.1 `chained_dd_method` rollout pattern exactly.
 
 ---
 
@@ -150,6 +151,19 @@ tracker_payload:
     A1: {tested: true, won: false, worst_fold_ratio: <float or null>}
     A2: {tested: true, won: true,  worst_fold_ratio: <float>}
     # repeat per architecture tested
+
+  # ────── Architectures skipped under L_PROTOCOL Amendment 5 (v1.3.1) ──────
+  # Amendment 5 (ratified 2026-05-23) gates A2/A6 on Step 4 mean OOS AUC ≥ 0.65
+  # (instead of the prior Amendment 1 archetype-driven rule). Architectures that
+  # WOULD have been tested under the prior rule but are deliberately skipped
+  # under Amendment 5's four-gate procedure are recorded here as an informational
+  # signal for cross-arc analytics. Empty list `[]` means no architectures were
+  # skipped (the Amendment-5 set equals or supersets the Amendment-1 set).
+  # Phase 1: OPTIONAL on all closures. Phase 2 (post-Amendment-5-PR merge):
+  # REQUIRED for any PASS verdict whose `closed_timestamp` is strictly after
+  # `AMENDMENT_5_CUTOFF_ISO` (placeholder `2026-05-23T00:00:00Z`, backfilled
+  # to PR-merge timestamp post-merge). Pre-cutoff closures grandfathered.
+  architectures_skipped_by_amendment_5: []   # subset of {A1..A6}, may be []
 
   # ────── Archetypes observed ──────
   archetypes_observed: [<archetype_1>, <archetype_2>, ...]   # union across clusters
@@ -399,8 +413,9 @@ Parser specification (preserved here for reference):
 | v1.2 | 2026-05-23 | Deployment-spec addition. Three new fields in `best_architecture`: `config_artefact_path`, `deployment_spec_section_present`, `template_version` (the last was conventional in v1.1; locked at v1.2). New §4 deployment_spec section: REQUIRED for PASS-* verdicts (DEPLOYABLE, VIABLE, *-PROVISIONAL, *-PENDING-STEP6), OPTIONAL otherwise. Parser HALTs on PASS verdict if config path missing / file absent / §4 heading missing (Section 4-L). Pre-v1.2 closures unaffected. |
 | v1.2.1 | 2026-05-23 | `chained_dd_method` field added to `best_architecture` per PR-186 review item 1. Records the method used to reconstruct chained equity for `chained_max_dd_base_pct`: `"equity_stitching"` (v3.0.1 engine default) or `"full_window_sim"` (v3.0.2 follow-up). Phase 1: parser accepts as OPTIONAL. Phase 2 (post-Wave-2 first PASS arc): parser REQUIRES the field for any PASS verdict with `closed_timestamp > PR-186 merge date`. Older closures grandfathered by closed_timestamp check. v1.2 / v1.2.1 share the same `template_version: v1.2` declaration — the field's presence/absence is the v1.2.1 discriminator, not a separate version string. |
 | v1.3 | 2026-05-24 | L_PROTOCOL Amendment 4 — Step 6 causal-audit framework. New `§1 tracker_payload.step_6` block (`ran`, `trigger`, `overall_passed`, `manifest_path`, `categories`, `critical_failures`, `warnings_count`, `verdict_impact`). REQUIRED for any v1.3 PASS verdict. Parser v1.3 detection precedence: explicit `template_version: v1.3` → v1.3-exclusive `step_6` field → fall-through to v1.2 detection. Phase 2 tightening bundled (PR-186-merge-date cutoff): for any PASS verdict with `closed_timestamp > 2026-05-23T06:20:59Z` the parser REQUIRES Amendment 3 fields in `best_architecture`; for v1.3 PASS verdicts the parser ADDITIONALLY requires the `step_6` block + `step_6.overall_passed: true`. Closures landed before the cutoff (v1.0/v1.1/v1.2/v1.2.1) are grandfathered. |
+| v1.3.1 | 2026-05-23 | L_PROTOCOL Amendment 5 — AUC-gated A2/A6 architecture selection. New top-level optional field `architectures_skipped_by_amendment_5` (subset of `{A1..A6}`, may be `[]`). Captures architectures admissible under Amendment 1's archetype-driven rule but skipped under Amendment 5's four-gate AUC-driven rule. Phase 1: parser accepts presence or absence on all closures. Phase 2: parser REQUIRES the field on any PASS verdict whose `closed_timestamp > AMENDMENT_5_CUTOFF_ISO` (placeholder `2026-05-23T00:00:00Z`; backfilled with this PR's merge timestamp post-merge). v1.3 / v1.3.1 share the same `template_version: v1.3` declaration — the field's presence/absence is the v1.3.1 discriminator. Mirrors the v1.2 / v1.2.1 `chained_dd_method` rollout pattern. |
 
-Closures MUST reference the template version they were written against (e.g., `template_version: v1.2` near the top of `§1 tracker_payload` is the convention going forward — pre-v1.1 closures without this field are assumed v1.0; pre-v1.2 closures without `config_artefact_path` are assumed v1.1). v1.2.1 stays under the `v1.2` declaration; the `chained_dd_method` field is the only discriminator and is OPTIONAL during Phase 1.
+Closures MUST reference the template version they were written against (e.g., `template_version: v1.2` near the top of `§1 tracker_payload` is the convention going forward — pre-v1.1 closures without this field are assumed v1.0; pre-v1.2 closures without `config_artefact_path` are assumed v1.1). v1.2.1 stays under the `v1.2` declaration; the `chained_dd_method` field is the only discriminator and is OPTIONAL during Phase 1. v1.3.1 stays under the `v1.3` declaration; the `architectures_skipped_by_amendment_5` field is the only discriminator and is OPTIONAL during Phase 1.
 
 ---
 

--- a/scripts/tracker_parser/schema.py
+++ b/scripts/tracker_parser/schema.py
@@ -1,4 +1,4 @@
-"""Pydantic models for ARC_CLOSURE.md §1 tracker_payload — v1.0, v1.1, v1.2, and v1.3 schemas + normalisation.
+"""Pydantic models for ARC_CLOSURE.md §1 tracker_payload — v1.0, v1.1, v1.2, v1.3, and v1.3.1 schemas + normalisation.
 
 Schema versions:
 - v1.0 — pre-Amendment 3 (legacy field names `worst_fold_roi_pct`, `worst_fold_dd_pct`)
@@ -11,6 +11,12 @@ Schema versions:
   with ``closed_timestamp > 2026-05-23T06:20:59Z`` (PR-186 merge) MUST carry Amendment 3 fields
   in `best_architecture`; v1.3 PASS verdicts MUST additionally have a `step_6` block with
   `overall_passed: true`. Pre-cutoff closures grandfathered.
+- v1.3.1 — L_PROTOCOL Amendment 5 (AUC-gated A2/A6 architecture selection). Adds top-level
+  OPTIONAL field ``architectures_skipped_by_amendment_5`` (subset of ``{A1..A6}``, may be ``[]``).
+  v1.3.1 shares ``template_version: v1.3`` declaration with v1.3 — the field's presence is the
+  discriminator. Phase 2 tightening: any PASS verdict with ``closed_timestamp >
+  AMENDMENT_5_CUTOFF_ISO`` MUST carry the field. Pre-cutoff closures grandfathered. Cutoff
+  placeholder is the ratification date; backfill with this PR's merge timestamp post-merge.
 
 Detection precedence (see `detect_schema_version`):
 1. `template_version` field present → use that
@@ -35,6 +41,15 @@ SchemaVersion = Literal["1.0", "1.1", "1.2", "1.3"]
 # PR-186 merge cutoff for Phase 2 tightening (per chat Q7).
 # After this timestamp, PASS verdicts must carry Amendment 3 fields.
 PHASE_2_CUTOFF_ISO: str = "2026-05-23T06:20:59Z"
+
+# L_PROTOCOL Amendment 5 cutoff for Phase 2 tightening on
+# `architectures_skipped_by_amendment_5`. After this timestamp, PASS verdicts
+# MUST carry the field (may be `[]`). PLACEHOLDER pinned at ratification date;
+# backfill with the Amendment-5 PR's actual merge timestamp post-merge. The
+# placeholder is functionally equivalent for all practical purposes — the PR
+# cannot merge before this instant, and no PASS closure will have a
+# `closed_timestamp` between the placeholder and the actual merge timestamp.
+AMENDMENT_5_CUTOFF_ISO: str = "2026-05-23T00:00:00Z"
 
 V11_EXCLUSIVE_FIELDS = {
     "worst_fold_dd_base_pct",
@@ -287,6 +302,14 @@ class _TrackerPayloadBase(BaseModel):
     archetypes_observed: list[str]
     cross_arc_tags: list[str] = Field(default_factory=list)
 
+    # L_PROTOCOL Amendment 5 (v1.3.1). Architectures admissible under
+    # Amendment 1's archetype-driven rule but skipped under Amendment 5's
+    # four-gate AUC-driven rule. OPTIONAL on Phase 1; required for post-cutoff
+    # PASS verdicts (enforced at the CLI layer — needs closed_timestamp +
+    # cutoff context the model doesn't have). May be `[]` when the
+    # Amendment-5 set equals or supersets the Amendment-1 set.
+    architectures_skipped_by_amendment_5: list[str] | None = None
+
 
 class TrackerPayloadV10(_TrackerPayloadBase):
     """v1.0 payload — legacy field names in best_architecture."""
@@ -494,6 +517,15 @@ def parse_payload(payload: dict[str, Any]) -> dict[str, Any]:
             raise ValueError(
                 f"architecture {arch!r} not in {{A1…A6}}"
             )
+
+    # Amendment 5 (v1.3.1) field — enum-validate any entries when present.
+    skipped = norm.get("architectures_skipped_by_amendment_5")
+    if skipped is not None:
+        for arch in skipped:
+            if arch not in VALID_ARCHITECTURES:
+                raise ValueError(
+                    f"architectures_skipped_by_amendment_5 entry {arch!r} not in {{A1…A6}}"
+                )
 
     # v1.3 step_6 block enum validation
     step6 = norm.get("step_6")

--- a/scripts/update_tracker_from_closure.py
+++ b/scripts/update_tracker_from_closure.py
@@ -70,13 +70,12 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def _is_post_phase_2_cutoff(closed_ts: str | None) -> bool:
-    """Return True iff ``closed_ts`` is strictly after the PR-186 merge cutoff
-    (2026-05-23T06:20:59Z per chat Q7) and therefore subject to Phase 2 tightening.
+def _is_post_cutoff(closed_ts: str | None, cutoff_iso: str) -> bool:
+    """Return True iff ``closed_ts`` is strictly after ``cutoff_iso``.
 
     Closures missing or with malformed timestamps are treated as PRE-cutoff
     (grandfathered) — Phase 2 tightening kicks in only when we can confidently
-    determine the closure post-dates the merge.
+    determine the closure post-dates the cutoff.
     """
     if not closed_ts:
         return False
@@ -91,9 +90,24 @@ def _is_post_phase_2_cutoff(closed_ts: str | None) -> bool:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     dt_utc = dt.astimezone(timezone.utc)
-    cutoff_s = schema.PHASE_2_CUTOFF_ISO[:-1] + "+00:00"
+    cutoff_s = cutoff_iso[:-1] + "+00:00" if cutoff_iso.endswith("Z") else cutoff_iso
     cutoff_dt = datetime.fromisoformat(cutoff_s).astimezone(timezone.utc)
     return dt_utc > cutoff_dt
+
+
+def _is_post_phase_2_cutoff(closed_ts: str | None) -> bool:
+    """Return True iff ``closed_ts`` is strictly after the PR-186 merge cutoff
+    (2026-05-23T06:20:59Z per chat Q7) and therefore subject to Phase 2 tightening.
+    """
+    return _is_post_cutoff(closed_ts, schema.PHASE_2_CUTOFF_ISO)
+
+
+def _is_post_amendment_5_cutoff(closed_ts: str | None) -> bool:
+    """Return True iff ``closed_ts`` is strictly after the L_PROTOCOL Amendment 5
+    cutoff (placeholder pinned at the ratification date; backfilled with this PR's
+    actual merge timestamp post-merge — see ``schema.AMENDMENT_5_CUTOFF_ISO``).
+    """
+    return _is_post_cutoff(closed_ts, schema.AMENDMENT_5_CUTOFF_ISO)
 
 
 def _validate_phase_2_amendment_3_fields(payload: dict, closure_path: Path) -> int:
@@ -121,6 +135,29 @@ def _validate_phase_2_amendment_3_fields(payload: dict, closure_path: Path) -> i
             payload.get("closed_timestamp"),
             schema.PHASE_2_CUTOFF_ISO,
             missing,
+            closure_path,
+        )
+        return 1
+    return 0
+
+
+def _validate_amendment_5_field(payload: dict, closure_path: Path) -> int:
+    """L_PROTOCOL Amendment 5 Phase 2 tightening (template v1.3.1 Schema versioning row):
+    PASS verdicts closed strictly after the Amendment-5 cutoff MUST carry the
+    `architectures_skipped_by_amendment_5` field (may be `[]`).
+
+    Pre-cutoff closures grandfathered. The field is informational — it captures
+    architectures admissible under Amendment 1's archetype-driven rule but skipped
+    under Amendment 5's four-gate AUC-driven rule. `[]` indicates the Amendment-5
+    set equals or supersets the Amendment-1 set.
+    """
+    if payload.get("architectures_skipped_by_amendment_5") is None:
+        logging.error(
+            "L_PROTOCOL Amendment 5: PASS verdict at closed_timestamp=%r is post-Amendment-5-cutoff "
+            "(%s) but `architectures_skipped_by_amendment_5` is missing. Closure %s. "
+            "Use `[]` when no architectures were skipped under Amendment 5.",
+            payload.get("closed_timestamp"),
+            schema.AMENDMENT_5_CUTOFF_ISO,
             closure_path,
         )
         return 1
@@ -281,6 +318,14 @@ def main(argv: list[str] | None = None) -> int:
     # v1.3 PASS verdicts MUST have a step_6 block with overall_passed=true.
     if template_version == "1.3" and is_pass:
         rc = _validate_v13_pass_step6(payload, closure_path)
+        if rc != 0:
+            return rc
+
+    # L_PROTOCOL Amendment 5 (template v1.3.1 Schema versioning row):
+    # PASS verdicts closed after Amendment-5 cutoff MUST carry
+    # `architectures_skipped_by_amendment_5`.
+    if is_pass and _is_post_amendment_5_cutoff(payload.get("closed_timestamp")):
+        rc = _validate_amendment_5_field(payload, closure_path)
         if rc != 0:
             return rc
 

--- a/tests/tracker_parser/test_amendment_5_field.py
+++ b/tests/tracker_parser/test_amendment_5_field.py
@@ -19,7 +19,6 @@ from scripts.update_tracker_from_closure import (
     _validate_amendment_5_field,
 )
 
-
 _BASE_PAYLOAD: dict = {
     "template_version": "v1.3",
     "arc_name": "test_arc",

--- a/tests/tracker_parser/test_amendment_5_field.py
+++ b/tests/tracker_parser/test_amendment_5_field.py
@@ -1,0 +1,113 @@
+"""L_PROTOCOL Amendment 5 (v1.3.1) — `architectures_skipped_by_amendment_5` field.
+
+Coverage:
+- ``AMENDMENT_5_CUTOFF_ISO`` constant pinned at the ratification-date placeholder
+- Schema accepts the field as optional (presence or absence)
+- Schema accepts ``[]`` (Amendment-5 set ⊇ Amendment-1 set)
+- Schema enum-validates entries against ``{A1..A6}``
+- ``_is_post_amendment_5_cutoff`` cutoff semantics
+- ``_validate_amendment_5_field`` CLI helper behaviour
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.tracker_parser.schema import AMENDMENT_5_CUTOFF_ISO, parse_payload
+from scripts.update_tracker_from_closure import (
+    _is_post_amendment_5_cutoff,
+    _validate_amendment_5_field,
+)
+
+
+_BASE_PAYLOAD: dict = {
+    "template_version": "v1.3",
+    "arc_name": "test_arc",
+    "signal": "x",
+    "tf": "H4",
+    "sub_protocol": "vanilla",
+    "closed_timestamp": "2026-05-24T12:00:00Z",
+    "closure_doc_link": "results/test_arc/ARC_CLOSURE.md",
+    "verdict": "FAIL",
+    "one_line": "x",
+    "failed_at_step": "5",
+    "primary_failure_mode": "step5_not_scalable",
+    "pool_metadata": {
+        "total_n": 500,
+        "window_start": "2010",
+        "window_end": "2020",
+        "configs_evaluated_step5": 80,
+        "search_scope_flag": "normal",
+    },
+    "clusters": {},
+    "architectures_tested": ["A1"],
+    "architecture_results": {"A1": {"tested": True, "won": False, "worst_fold_ratio": 1.0}},
+    "archetypes_observed": [],
+}
+
+
+def test_amendment_5_cutoff_placeholder_locked():
+    """Cutoff is pinned at ratification-date placeholder pending PR-merge backfill."""
+    assert AMENDMENT_5_CUTOFF_ISO == "2026-05-23T00:00:00Z"
+
+
+def test_schema_accepts_field_absent():
+    """Field is OPTIONAL on Phase 1 — absence is valid."""
+    norm = parse_payload(dict(_BASE_PAYLOAD))
+    assert norm.get("architectures_skipped_by_amendment_5") is None
+
+
+def test_schema_accepts_empty_list():
+    """`[]` is the valid value when Amendment-5 set ⊇ Amendment-1 set."""
+    payload = dict(_BASE_PAYLOAD)
+    payload["architectures_skipped_by_amendment_5"] = []
+    norm = parse_payload(payload)
+    assert norm["architectures_skipped_by_amendment_5"] == []
+
+
+def test_schema_accepts_subset_of_architectures():
+    """Field accepts any subset of {A1..A6}."""
+    payload = dict(_BASE_PAYLOAD)
+    payload["architectures_skipped_by_amendment_5"] = ["A2", "A6"]
+    norm = parse_payload(payload)
+    assert norm["architectures_skipped_by_amendment_5"] == ["A2", "A6"]
+
+
+def test_schema_rejects_invalid_architecture_in_field():
+    """Enum-validation: only A1..A6 permitted."""
+    payload = dict(_BASE_PAYLOAD)
+    payload["architectures_skipped_by_amendment_5"] = ["A7"]
+    with pytest.raises(ValueError, match="architectures_skipped_by_amendment_5"):
+        parse_payload(payload)
+
+
+def test_is_post_amendment_5_cutoff_true_when_after():
+    """Closures strictly after the cutoff are post-cutoff."""
+    assert _is_post_amendment_5_cutoff("2026-05-24T00:00:00Z") is True
+    assert _is_post_amendment_5_cutoff("2026-05-23T12:00:00Z") is True
+
+
+def test_is_post_amendment_5_cutoff_false_when_at_or_before():
+    """Equality and strictly-before are pre-cutoff (grandfathered)."""
+    assert _is_post_amendment_5_cutoff("2026-05-23T00:00:00Z") is False
+    assert _is_post_amendment_5_cutoff("2026-05-22T23:59:59Z") is False
+
+
+def test_is_post_amendment_5_cutoff_missing_timestamp_grandfathered():
+    """Missing / malformed timestamps grandfathered — never trip the gate."""
+    assert _is_post_amendment_5_cutoff(None) is False
+    assert _is_post_amendment_5_cutoff("not-an-iso-string") is False
+
+
+def test_cli_validator_passes_when_field_present(tmp_path):
+    """Field present (even `[]`) satisfies Phase 2 requirement."""
+    payload = {"architectures_skipped_by_amendment_5": []}
+    assert _validate_amendment_5_field(payload, tmp_path / "ARC_CLOSURE.md") == 0
+    payload = {"architectures_skipped_by_amendment_5": ["A2", "A6"]}
+    assert _validate_amendment_5_field(payload, tmp_path / "ARC_CLOSURE.md") == 0
+
+
+def test_cli_validator_halts_when_field_absent(tmp_path):
+    """Missing field on a post-cutoff PASS closure → HALT (return 1)."""
+    payload: dict = {"closed_timestamp": "2026-06-01T00:00:00Z"}
+    assert _validate_amendment_5_field(payload, tmp_path / "ARC_CLOSURE.md") == 1


### PR DESCRIPTION
## Summary

- Lands **L_PROTOCOL Amendment 5** (ratified 2026-05-23): four-gate architecture selection replacing Amendment 1's uniform archetype gating. Gate 1 preserves A3/A4 archetype gating; Gate 2 admits A2 + A6 whenever Step 4 mean OOS AUC ≥ 0.65 (archetype-agnostic); Gate 3 always admits A1; Gate 4 admits A5 when ≥2 candidate clusters survive Step 3. Choppy skips all.
- Bumps closure template to **v1.3.1** with new optional top-level field `architectures_skipped_by_amendment_5` (subset of `{A1..A6}`, may be `[]`).
- Extends **parser v1.3** to accept + enum-validate the field; CLI Phase 2 tightening requires it for any PASS verdict closed strictly after `AMENDMENT_5_CUTOFF_ISO`.
- Cutoff is pinned at ratification-date placeholder `2026-05-23T00:00:00Z` and will be backfilled with this PR's merge timestamp post-merge (mirrors PR-186 / Amendment 3 pattern). Backfill follow-up tracked in `TODO.md`.
- Queues retroactive audit of Arc 8 v3.0 + Arc 11 v3.0 under Amendment 5, deferred until Arc 7 v3.0.2 closes.

## Trigger

Two-instance empirical evidence of false-negative arc verdicts from the Amendment-1 archetype gate map:
- Arc 7 v3.0 c0 Bimodal AUC 0.6758 — A2/A6 not evaluated under Bimodal mapping
- Arc 7 v3.0.1 c1 Unclassified AUC 0.6642 — A2/A6 not evaluated under Unclassified mapping

A2 and A6 are classifier-driven by construction — their mechanism is path-shape-agnostic. Gating them on archetype tags was a measurement-mechanism mismatch.

## Scope

- **Engine impact:** zero. All six architectures wired post-PR-186; enforcement is dispatch-time.
- **Wave 2 dispatch templates:** out of scope for this PR (Phase 1 chat-side, separate).
- **Retroactive retries:** queued only; gated on Arc 7 v3.0.2 closure verdict.

## Changes

- New: `archive/L_PROTOCOL_v3_0_AMENDMENT_5.md` (canonical amendment text)
- Updated: `L_PROTOCOL.md` (header amendment listing + §2 Step 5 architecture-selection rule)
- Updated: `docs/templates/ARC_CLOSURE_TEMPLATE.md` (v1.3 → v1.3.1 with new optional field + schema-versioning row)
- Updated: `scripts/tracker_parser/schema.py` (`AMENDMENT_5_CUTOFF_ISO`, optional field, enum validation)
- Updated: `scripts/update_tracker_from_closure.py` (`_is_post_amendment_5_cutoff` + `_validate_amendment_5_field` + main flow wiring)
- New: `tests/tracker_parser/test_amendment_5_field.py` (10 tests covering schema acceptance, enum validation, cutoff semantics, CLI validator)
- Updated: `TODO.md` (Amendment 5 status, retroactive audit queued item, post-merge backfill follow-up)

## Test plan

- [x] `tests/tracker_parser/test_amendment_5_field.py` (10 new tests)
- [x] Full tracker_parser + step_6 suites: 114/114 passing
- [ ] Manual sanity-check: parser CLI on a v1.3 PASS closure post-cutoff without the field → HALT with clear error
- [ ] Post-merge: backfill `AMENDMENT_5_CUTOFF_ISO` in `scripts/tracker_parser/schema.py` with this PR's merge timestamp (one-line follow-up PR, tracked in TODO.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)