### PR TITLE
[ENGINE] Canonical exit policy registry + sl_partial_close_1r_runner_trail primitive + per-arc migration

### DIFF
--- a/core/architectures/a1_system_level_filter.py
+++ b/core/architectures/a1_system_level_filter.py
@@ -35,6 +35,7 @@ from core.arc.signal_protocol import SignalEvaluation
 from core.architectures._protocol import StrategyResult
 from core.sim.account import Account, Direction, ExposureRules
 from core.sim.exit_hooks import ExitPredicate
+from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.multipair_backtester import MultiPairBacktester, Order, StrategyFn
 from core.sim.panel import Panel
 from core.sim.risk.live_balance import LiveBalanceRisk
@@ -80,6 +81,15 @@ class A1Config:
     # gate by default; chat must approve a separate scaling treatment
     # via ``ArcConfig.accept_equity_pct = True``.
     sizing_convention: str = "reset_floor"   # "reset_floor" | "equity_pct"
+    # Canonical exit-policy name from core.sim.exit_policies registry.
+    # None (default) preserves prior behaviour: SL + optional trail +
+    # signal-class exit predicates only. When set, the architecture
+    # instantiates an ExitPolicyManager and the driver registers the
+    # policy at trade fill; the manager's per-bar hooks then handle
+    # TP / trailing / partial-close lifecycle per
+    # [docs/PROTOCOL_RUNTIME.md §8c][]. KH-24 uses None (its trail +
+    # kijun_d1 path is unchanged).
+    exit_policy: str | None = None
 
 
 @dataclass(frozen=True)
@@ -243,6 +253,8 @@ def _build_a1_strategy(
                     atr_at_entry=atr,
                     trail_activation_atr=cfg.trail_activation_atr,
                     trail_distance_atr=cfg.trail_distance_atr,
+                    exit_policy=cfg.exit_policy,
+                    sl_atr_mult=cfg.sl_atr_mult if cfg.exit_policy else None,
                 )
             )
         return orders
@@ -297,6 +309,10 @@ class A1Architecture:
         )
         risk = LiveBalanceRisk(risk_pct=arch_config.risk_pct)
         trail_manager = TrailManager() if arch_config.trail_enabled else None
+        # Canonical exit-policy manager only when this config selects one
+        exit_policy_manager = (
+            ExitPolicyManager() if arch_config.exit_policy is not None else None
+        )
 
         # Signal-class-inherent exit predicates from the SignalModule
         exit_predicates: list[ExitPredicate] = []
@@ -319,6 +335,7 @@ class A1Architecture:
             strategy=strategy,
             trail_manager=trail_manager,
             exit_predicates=tuple(exit_predicates),
+            exit_policy_manager=exit_policy_manager,
         )
         run_result = bt.run()
 
@@ -342,6 +359,7 @@ class A1Architecture:
                 "sl_atr_mult": arch_config.sl_atr_mult,
                 "trail_enabled": arch_config.trail_enabled,
                 "n_filter_rules": len(arch_config.filter_rules),
+                "exit_policy": arch_config.exit_policy,
                 "exposure": (
                     arch_config.max_concurrent_total,
                     arch_config.max_concurrent_per_pair,

--- a/core/architectures/a2_classifier_filter.py
+++ b/core/architectures/a2_classifier_filter.py
@@ -29,6 +29,7 @@ from core.architectures.a1_system_level_filter import (
 from core.runners._fold_stats_helpers import build_fold_stats_from_run
 from core.sim.account import Account, Direction, ExposureRules
 from core.sim.exit_hooks import ExitPredicate
+from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.multipair_backtester import MultiPairBacktester, Order, StrategyFn
 from core.sim.panel import Panel
 from core.sim.risk.live_balance import LiveBalanceRisk
@@ -59,6 +60,9 @@ class A2Config:
     max_concurrent_per_currency: int | None = 2
     # Amendment 3 §"Sizing convention"
     sizing_convention: str = "reset_floor"   # "reset_floor" | "equity_pct"
+    # Canonical exit-policy name (see core.sim.exit_policies). None preserves
+    # prior behaviour (SL + optional trail + signal-class predicates only).
+    exit_policy: str | None = None
 
 
 def _build_a2_strategy(
@@ -149,6 +153,8 @@ def _build_a2_strategy(
                 atr_at_entry=atr,
                 trail_activation_atr=cfg.trail_activation_atr,
                 trail_distance_atr=cfg.trail_distance_atr,
+                exit_policy=cfg.exit_policy,
+                sl_atr_mult=cfg.sl_atr_mult if cfg.exit_policy else None,
             ))
         return orders
 
@@ -183,6 +189,9 @@ class A2Architecture:
         )
         risk = LiveBalanceRisk(risk_pct=arch_config.risk_pct)
         trail_manager = TrailManager() if arch_config.trail_enabled else None
+        exit_policy_manager = (
+            ExitPolicyManager() if arch_config.exit_policy is not None else None
+        )
         exit_predicates: list[ExitPredicate] = []
         for pair in sorted(signal_evaluation.per_pair):
             ep = signal_evaluation.per_pair[pair].exit_predicate
@@ -203,6 +212,7 @@ class A2Architecture:
             strategy=strategy,
             trail_manager=trail_manager,
             exit_predicates=tuple(exit_predicates),
+            exit_policy_manager=exit_policy_manager,
         )
         run_result = bt.run()
         fold_stats = build_fold_stats_from_run(
@@ -223,6 +233,7 @@ class A2Architecture:
                 "threshold": arch_config.threshold,
                 "classifier_type": type(arch_config.classifier).__name__,
                 "feature_count": len(arch_config.classifier_feature_order),
+                "exit_policy": arch_config.exit_policy,
             },
         )
 

--- a/core/architectures/a3_pipeline_de.py
+++ b/core/architectures/a3_pipeline_de.py
@@ -51,10 +51,10 @@ from core.features_path_so_far import (
 from core.runners._fold_stats_helpers import build_fold_stats_from_run
 from core.sim.account import Account, Direction, ExposureRules
 from core.sim.exit_hooks import ExitPredicate
+from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.multipair_backtester import MultiPairBacktester, Order, StrategyFn
 from core.sim.panel import Panel
 from core.sim.risk.live_balance import LiveBalanceRisk
-from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.trailing_stop import TrailManager
 from core.wfo.folds import Fold
 

--- a/core/architectures/a3_pipeline_de.py
+++ b/core/architectures/a3_pipeline_de.py
@@ -54,6 +54,7 @@ from core.sim.exit_hooks import ExitPredicate
 from core.sim.multipair_backtester import MultiPairBacktester, Order, StrategyFn
 from core.sim.panel import Panel
 from core.sim.risk.live_balance import LiveBalanceRisk
+from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.trailing_stop import TrailManager
 from core.wfo.folds import Fold
 
@@ -95,6 +96,9 @@ class A3Config:
     per_trade_entry_features: Mapping[tuple[str, pd.Timestamp], Mapping[str, float]] | None = None
     # Amendment 3 §"Sizing convention"
     sizing_convention: str = "reset_floor"   # "reset_floor" | "equity_pct"
+    # Canonical exit-policy (see core.sim.exit_policies). None preserves
+    # prior behaviour.
+    exit_policy: str | None = None
 
 
 def _path_features_so_far(
@@ -286,6 +290,8 @@ def _build_a3_strategy(
                 atr_at_entry=atr,
                 trail_activation_atr=cfg.trail_activation_atr,
                 trail_distance_atr=cfg.trail_distance_atr,
+                exit_policy=cfg.exit_policy,
+                sl_atr_mult=cfg.sl_atr_mult if cfg.exit_policy else None,
             ))
         return orders
 
@@ -325,6 +331,9 @@ class A3Architecture:
         )
         risk = LiveBalanceRisk(risk_pct=arch_config.risk_pct)
         trail_manager = TrailManager() if arch_config.trail_enabled else None
+        exit_policy_manager = (
+            ExitPolicyManager() if arch_config.exit_policy is not None else None
+        )
         exit_predicates: list[ExitPredicate] = []
         for pair in sorted(signal_evaluation.per_pair):
             ep = signal_evaluation.per_pair[pair].exit_predicate
@@ -345,6 +354,7 @@ class A3Architecture:
             strategy=strategy,
             trail_manager=trail_manager,
             exit_predicates=tuple(exit_predicates),
+            exit_policy_manager=exit_policy_manager,
         )
         run_result = bt.run()
         fold_stats = build_fold_stats_from_run(
@@ -369,6 +379,7 @@ class A3Architecture:
                     if arch_config.threshold_override is not None
                     else classifier_fit.threshold
                 ),
+                "exit_policy": arch_config.exit_policy,
             },
         )
 

--- a/core/architectures/a4_pipeline_d_exits.py
+++ b/core/architectures/a4_pipeline_d_exits.py
@@ -47,6 +47,7 @@ from core.sim.exit_hooks import ExitDecision, ExitPredicate
 from core.sim.multipair_backtester import MultiPairBacktester
 from core.sim.panel import Panel
 from core.sim.risk.live_balance import LiveBalanceRisk
+from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.trailing_stop import TrailManager
 from core.wfo.folds import Fold
 
@@ -85,6 +86,11 @@ class A4Config:
     per_trade_entry_features: Mapping[tuple[str, pd.Timestamp], Mapping[str, float]] | None = None  # DEPRECATED
     # Amendment 3 §"Sizing convention"
     sizing_convention: str = "reset_floor"   # "reset_floor" | "equity_pct"
+    # Canonical exit-policy (see core.sim.exit_policies). None preserves
+    # prior behaviour. Same-bar precedence with A4's classifier exit
+    # predicate: intra-bar SL/TP > intra-bar policy (partial) >
+    # classifier predicate > trail > at-close policy (last-write-wins).
+    exit_policy: str | None = None
 
 
 @dataclass
@@ -190,6 +196,9 @@ class A4Architecture:
         )
         risk = LiveBalanceRisk(risk_pct=arch_config.risk_pct)
         trail_manager = TrailManager() if arch_config.trail_enabled else None
+        exit_policy_manager = (
+            ExitPolicyManager() if arch_config.exit_policy is not None else None
+        )
 
         # Build per-pair exit predicates from the classifier + entry features
         entry_features_by_signal_time_per_pair: dict[str, dict[pd.Timestamp, Mapping[str, float]]] = {}
@@ -229,6 +238,7 @@ class A4Architecture:
             max_concurrent_total=arch_config.max_concurrent_total,
             max_concurrent_per_pair=arch_config.max_concurrent_per_pair,
             max_concurrent_per_currency=arch_config.max_concurrent_per_currency,
+            exit_policy=arch_config.exit_policy,
         )
         strategy = _build_a1_strategy(
             signal_eval=signal_evaluation,
@@ -244,6 +254,7 @@ class A4Architecture:
             strategy=strategy,
             trail_manager=trail_manager,
             exit_predicates=tuple(a4_predicates),
+            exit_policy_manager=exit_policy_manager,
         )
         run_result = bt.run()
         fold_stats = build_fold_stats_from_run(
@@ -263,6 +274,7 @@ class A4Architecture:
             metadata={
                 "exit_threshold": arch_config.exit_threshold,
                 "classifier_fit_auc": classifier_fit.fit_auc,
+                "exit_policy": arch_config.exit_policy,
             },
         )
 

--- a/core/architectures/a4_pipeline_d_exits.py
+++ b/core/architectures/a4_pipeline_d_exits.py
@@ -44,10 +44,10 @@ from core.architectures.a1_system_level_filter import (
 from core.runners._fold_stats_helpers import build_fold_stats_from_run
 from core.sim.account import Account, Direction, ExposureRules, Position
 from core.sim.exit_hooks import ExitDecision, ExitPredicate
+from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.multipair_backtester import MultiPairBacktester
 from core.sim.panel import Panel
 from core.sim.risk.live_balance import LiveBalanceRisk
-from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.trailing_stop import TrailManager
 from core.wfo.folds import Fold
 

--- a/core/architectures/a6_meta_labeling.py
+++ b/core/architectures/a6_meta_labeling.py
@@ -35,6 +35,7 @@ from core.sim.exit_hooks import ExitPredicate
 from core.sim.multipair_backtester import MultiPairBacktester, Order, StrategyFn
 from core.sim.panel import Panel
 from core.sim.risk.live_balance import LiveBalanceRisk
+from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.trailing_stop import TrailManager
 from core.wfo.folds import Fold
 
@@ -68,6 +69,9 @@ class A6Config:
     max_concurrent_per_currency: int | None = 2
     # Amendment 3 §"Sizing convention"
     sizing_convention: str = "reset_floor"   # "reset_floor" | "equity_pct"
+    # Canonical exit-policy (see core.sim.exit_policies). None preserves
+    # prior behaviour.
+    exit_policy: str | None = None
 
 
 def _confidence_to_multiplier(
@@ -162,6 +166,8 @@ def _build_a6_strategy(
                 trail_activation_atr=cfg.trail_activation_atr,
                 trail_distance_atr=cfg.trail_distance_atr,
                 risk_multiplier=mult,
+                exit_policy=cfg.exit_policy,
+                sl_atr_mult=cfg.sl_atr_mult if cfg.exit_policy else None,
             ))
         return orders
 
@@ -195,6 +201,9 @@ class A6Architecture:
         )
         risk = LiveBalanceRisk(risk_pct=arch_config.risk_pct)
         trail_manager = TrailManager() if arch_config.trail_enabled else None
+        exit_policy_manager = (
+            ExitPolicyManager() if arch_config.exit_policy is not None else None
+        )
         exit_predicates: list[ExitPredicate] = []
         for pair in sorted(signal_evaluation.per_pair):
             ep = signal_evaluation.per_pair[pair].exit_predicate
@@ -214,6 +223,7 @@ class A6Architecture:
             strategy=strategy,
             trail_manager=trail_manager,
             exit_predicates=tuple(exit_predicates),
+            exit_policy_manager=exit_policy_manager,
         )
         run_result = bt.run()
         fold_stats = build_fold_stats_from_run(
@@ -234,6 +244,7 @@ class A6Architecture:
                 "lower_threshold": arch_config.lower_threshold,
                 "upper_threshold": arch_config.upper_threshold,
                 "classifier_type": type(arch_config.classifier).__name__,
+                "exit_policy": arch_config.exit_policy,
             },
         )
 

--- a/core/architectures/a6_meta_labeling.py
+++ b/core/architectures/a6_meta_labeling.py
@@ -32,10 +32,10 @@ from core.architectures.a1_system_level_filter import (
 from core.runners._fold_stats_helpers import build_fold_stats_from_run
 from core.sim.account import Account, Direction, ExposureRules
 from core.sim.exit_hooks import ExitPredicate
+from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.multipair_backtester import MultiPairBacktester, Order, StrategyFn
 from core.sim.panel import Panel
 from core.sim.risk.live_balance import LiveBalanceRisk
-from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.trailing_stop import TrailManager
 from core.wfo.folds import Fold
 

--- a/core/sim/account.py
+++ b/core/sim/account.py
@@ -11,10 +11,10 @@ account state across all 28 pairs concurrently:
 This module owns:
 
   - ``Direction`` enum (LONG | SHORT)
-  - ``Position`` dataclass (open trade record)
+  - ``Position`` dataclass (open trade record — frozen, size = size-at-open)
   - ``ExposureRules`` config block
-  - ``Account`` runtime state with open(), close(), mark_to_market(),
-    exposure_check(), and equity/dd accessors
+  - ``Account`` runtime state with open(), close(), partial_close(),
+    mark_to_market(), exposure_check(), and equity/dd accessors
 
 PnL convention: position size is in *units of base currency* (one
 "unit"-sized long EURUSD = profit_in_quote per pip on a 1-pip move of
@@ -26,6 +26,26 @@ accounted for bid/ask spread (the caller used ``core.sim.fill``).
 Commission and swap are not modelled here — they're an aggregate haircut
 at the deployment-gate evaluation per L_PROTOCOL Appendix B's cost-model
 section.
+
+Partial-fill semantics
+----------------------
+``Position`` is immutable (``size`` is the size at open). When a policy
+like ``sl_partial_close_1r_runner_trail`` reduces the live position size
+mid-trade, Account maintains a shadow ``_current_sizes: dict[int, float]``
+keyed by ``position_id``. Read via ``current_size_of(position_id)``;
+mutate only via ``partial_close(...)``. Mark-to-market, full close PnL,
+and the trade-log ``ClosedTrade.size`` all use the current (possibly
+reduced) size, not the size at open.
+
+Exposure caps still count a partial-closed position as 1 (not a
+fractional value) until it is fully closed — the position remains in
+``_open`` and continues to occupy its exposure-cap slot.
+
+Multi-leg closes are recorded as distinct ``ClosedTrade`` entries with
+``parent_position_id`` set to the shared ``position_id``; consumers may
+group by ``position_id`` to reconstruct the full close-out sequence. A
+trade with ``parent_position_id is None`` is a standalone (single-leg)
+full close.
 """
 
 from __future__ import annotations
@@ -79,7 +99,20 @@ class Position:
 
 @dataclass(frozen=True)
 class ClosedTrade:
-    """Closed trade record — what hits the equity curve / trade ledger."""
+    """Closed trade record — what hits the equity curve / trade ledger.
+
+    ``size`` is the size actually closed on this leg (not the position's
+    size at open, which may have been reduced by prior partial closes).
+
+    ``parent_position_id``:
+      * ``None`` for any standalone full close — a position opened, then
+        closed once with the full size. The historical default.
+      * ``= position_id`` for any leg of a multi-leg close-out (every
+        partial leg AND the final leg both carry this). Consumers can
+        ``filter(parent_position_id is None)`` to get whole-position
+        closes only, or ``groupby(position_id)`` to reconstruct
+        multi-leg sequences.
+    """
 
     position_id: int
     pair: str
@@ -91,6 +124,7 @@ class ClosedTrade:
     size: float
     pnl: float
     exit_reason: str  # "market" | "stop_loss" | "take_profit" | "time_exit" | etc.
+    parent_position_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -131,6 +165,14 @@ class Account:
     _equity_history: list[tuple[pd.Timestamp, float]] = field(init=False, default_factory=list)
     _peak_equity: float = field(init=False, default=0.0)
     _max_drawdown_pct: float = field(init=False, default=0.0)
+    # Shadow of live position sizes after partial closes. Absent entries
+    # mean the position is at its original ``Position.size`` (i.e. never
+    # partial-closed). Removed on full close.
+    _current_sizes: dict[int, float] = field(init=False, default_factory=dict)
+    # Position ids that have ever had a partial close. Used so the
+    # final-leg ``close()`` knows to record ``parent_position_id`` even
+    # if ``_current_sizes`` has already been popped on full-out.
+    _partial_history: set[int] = field(init=False, default_factory=set)
 
     def __post_init__(self) -> None:
         self._balance = float(self.starting_balance)
@@ -195,11 +237,23 @@ class Account:
         exit_price: float,
         exit_reason: str,
     ) -> ClosedTrade:
-        """Close an open position; realise PnL into the balance."""
+        """Close an open position; realise PnL on the *current* size.
+
+        For positions that have been partial-closed earlier, the close
+        uses the shadow ``_current_sizes`` value (not ``Position.size``).
+        For never-partialled positions this is identical to the original
+        full-size close.
+
+        Multi-leg closes (i.e. positions with prior partial closes) have
+        ``parent_position_id`` populated on the recorded ClosedTrade.
+        """
         if position_id not in self._open:
             raise KeyError(f"No open position with id={position_id}")
         pos = self._open.pop(position_id)
-        pnl = pos.pnl_at(float(exit_price))
+        current_size = self._current_sizes.pop(position_id, pos.size)
+        had_partials = position_id in self._partial_history
+        self._partial_history.discard(position_id)
+        pnl = pos.direction.sign * (float(exit_price) - pos.entry_price) * current_size
         self._balance += pnl
         trade = ClosedTrade(
             position_id=pos.position_id,
@@ -209,12 +263,79 @@ class Account:
             entry_price=pos.entry_price,
             exit_time=exit_time,
             exit_price=float(exit_price),
-            size=pos.size,
+            size=current_size,
             pnl=pnl,
             exit_reason=exit_reason,
+            parent_position_id=pos.position_id if had_partials else None,
         )
         self._closed.append(trade)
         return trade
+
+    def partial_close(
+        self,
+        position_id: int,
+        exit_time: pd.Timestamp,
+        exit_price: float,
+        exit_reason: str,
+        size_to_close: float,
+    ) -> ClosedTrade:
+        """Realise PnL on ``size_to_close`` units; leave the rest open.
+
+        ``size_to_close`` must be strictly positive AND strictly less
+        than the current size — otherwise the caller should use
+        :meth:`close` (full close). Failing loud here keeps partial-close
+        manager bugs surfaceable.
+
+        Records a ClosedTrade with ``parent_position_id = position_id``
+        marking this as one leg of a multi-leg close. The matching final
+        :meth:`close` for the same position will also have
+        ``parent_position_id`` set (see :meth:`close`).
+        """
+        if position_id not in self._open:
+            raise KeyError(f"No open position with id={position_id}")
+        pos = self._open[position_id]
+        current_size = self._current_sizes.get(position_id, pos.size)
+        size_to_close = float(size_to_close)
+        if size_to_close <= 0.0:
+            raise ValueError(
+                f"partial_close size_to_close must be > 0; got {size_to_close}"
+            )
+        if size_to_close >= current_size:
+            raise ValueError(
+                f"partial_close size_to_close={size_to_close} >= current_size="
+                f"{current_size} for position_id={position_id}; use close() for "
+                "full-out"
+            )
+        pnl = pos.direction.sign * (float(exit_price) - pos.entry_price) * size_to_close
+        self._balance += pnl
+        new_size = current_size - size_to_close
+        self._current_sizes[position_id] = new_size
+        self._partial_history.add(position_id)
+        trade = ClosedTrade(
+            position_id=pos.position_id,
+            pair=pos.pair,
+            direction=pos.direction,
+            entry_time=pos.entry_time,
+            entry_price=pos.entry_price,
+            exit_time=exit_time,
+            exit_price=float(exit_price),
+            size=size_to_close,
+            pnl=pnl,
+            exit_reason=exit_reason,
+            parent_position_id=pos.position_id,
+        )
+        self._closed.append(trade)
+        return trade
+
+    def current_size_of(self, position_id: int) -> float:
+        """Live size of an open position (post any partial closes).
+
+        Raises KeyError for unknown / already-fully-closed positions.
+        """
+        if position_id not in self._open:
+            raise KeyError(f"No open position with id={position_id}")
+        pos = self._open[position_id]
+        return self._current_sizes.get(position_id, pos.size)
 
     def mark_to_market(self, t: pd.Timestamp, marks: dict[str, float]) -> float:
         """Update equity using current bid/ask close-mid for open positions.
@@ -227,13 +348,17 @@ class Account:
 
         Returns the new equity. Also updates peak / max-drawdown
         trackers and appends the equity point.
+
+        Unrealised PnL uses the *current* (possibly partial-reduced)
+        size for each position.
         """
         unrealised = 0.0
         for pos in self._open.values():
             mark = marks.get(pos.pair)
             if mark is None:
                 continue
-            unrealised += pos.pnl_at(mark)
+            size = self._current_sizes.get(pos.position_id, pos.size)
+            unrealised += pos.direction.sign * (mark - pos.entry_price) * size
         equity = self._balance + unrealised
         self._equity_history.append((t, equity))
         if equity > self._peak_equity:

--- a/core/sim/exit_policies/__init__.py
+++ b/core/sim/exit_policies/__init__.py
@@ -1,0 +1,70 @@
+"""Canonical exit-policy registry for the v3 multipair backtester.
+
+Public surface:
+
+  * :class:`ExitPolicy` — abstract base for all policies.
+  * :class:`ExitPolicyContext` — per-position inputs.
+  * :class:`ExitPolicyDecision` — policy verdict at a bar.
+  * :class:`ExitAction` — FULL_CLOSE / PARTIAL_CLOSE enum.
+  * :class:`ExitPolicyState` — abstract per-position runtime state.
+  * :class:`NullPolicyState` — no-op state for stateless policies.
+  * :func:`build_exit_policy` — factory keyed by policy name.
+  * :func:`available_policies` — sorted tuple of registered names.
+
+Registered policies (alphabetised by name):
+
+  * ``sl_only``
+  * ``sl_partial_close_1r_runner_trail``
+  * ``sl_plus_tp_2r``
+  * ``sl_plus_tp_3r``
+  * ``sl_plus_trailing_atr``
+  * ``sl_plus_trailing_swing``
+
+See [docs/PROTOCOL_RUNTIME.md §8c][] for the full catalogue and
+semantic spec. Reference implementations: [scripts/l_arc_10_v3/step_5.py:99-253][].
+"""
+
+from core.sim.exit_policies._base import (
+    ExitAction,
+    ExitPolicy,
+    ExitPolicyContext,
+    ExitPolicyDecision,
+    ExitPolicyState,
+    NullPolicyState,
+)
+from core.sim.exit_policies._registry import available_policies, build_exit_policy
+from core.sim.exit_policies.sl_only import SlOnlyPolicy
+from core.sim.exit_policies.sl_partial_close_1r_runner_trail import (
+    PartialCloseRunnerTrailState,
+    SlPartialClose1RRunnerTrailPolicy,
+)
+from core.sim.exit_policies.sl_plus_tp_2r import SlPlusTp2RPolicy
+from core.sim.exit_policies.sl_plus_tp_3r import SlPlusTp3RPolicy
+from core.sim.exit_policies.sl_plus_trailing_atr import (
+    SlPlusTrailingAtrPolicy,
+    TrailingAtrState,
+)
+from core.sim.exit_policies.sl_plus_trailing_swing import (
+    SlPlusTrailingSwingPolicy,
+    TrailingSwingState,
+)
+
+__all__ = (
+    "ExitAction",
+    "ExitPolicy",
+    "ExitPolicyContext",
+    "ExitPolicyDecision",
+    "ExitPolicyState",
+    "NullPolicyState",
+    "PartialCloseRunnerTrailState",
+    "SlOnlyPolicy",
+    "SlPartialClose1RRunnerTrailPolicy",
+    "SlPlusTp2RPolicy",
+    "SlPlusTp3RPolicy",
+    "SlPlusTrailingAtrPolicy",
+    "SlPlusTrailingSwingPolicy",
+    "TrailingAtrState",
+    "TrailingSwingState",
+    "available_policies",
+    "build_exit_policy",
+)

--- a/core/sim/exit_policies/__init__.py
+++ b/core/sim/exit_policies/__init__.py
@@ -10,6 +10,10 @@ Public surface:
   * :class:`NullPolicyState` — no-op state for stateless policies.
   * :func:`build_exit_policy` — factory keyed by policy name.
   * :func:`available_policies` — sorted tuple of registered names.
+  * :func:`simulate_path` — post-hoc path replay (for legacy Step 5
+    scripts) with the same semantics as the live engine policies.
+  * :func:`available_path_simulators` — sorted tuple of policies with
+    a registered path simulator.
 
 Registered policies (alphabetised by name):
 
@@ -33,6 +37,11 @@ from core.sim.exit_policies._base import (
     NullPolicyState,
 )
 from core.sim.exit_policies._registry import available_policies, build_exit_policy
+from core.sim.exit_policies.path_simulate import (
+    available_path_simulators,
+    simulate_path,
+    simulate_pool_approximation,
+)
 from core.sim.exit_policies.sl_only import SlOnlyPolicy
 from core.sim.exit_policies.sl_partial_close_1r_runner_trail import (
     PartialCloseRunnerTrailState,
@@ -65,6 +74,9 @@ __all__ = (
     "SlPlusTrailingSwingPolicy",
     "TrailingAtrState",
     "TrailingSwingState",
+    "available_path_simulators",
     "available_policies",
     "build_exit_policy",
+    "simulate_path",
+    "simulate_pool_approximation",
 )

--- a/core/sim/exit_policies/_base.py
+++ b/core/sim/exit_policies/_base.py
@@ -1,0 +1,183 @@
+"""Canonical exit-policy primitives for the v3 multipair backtester.
+
+A *policy* is a self-contained recipe for "what happens to a position
+after entry, beyond the original entry-time SL". The canonical engine
+registry holds policies that are reusable across architectures
+(A1..A6) — Step 5's per-arc `_apply_exit_policy` hand-rolled
+simulators are now thin wrappers over this registry (per the
+sl_partial_close_runner_trail PR's per-arc migration phase).
+
+Policy lifecycle
+
+  1. ``apply_to_order(ctx)`` is called at Order construction time. The
+     policy may modify Order kwargs — e.g. TP-style policies set
+     ``tp_price`` so the existing intra-bar TP infrastructure
+     ([core.sim.fill.long_tp_triggered][]) handles fire / fill at the
+     TP level. Most policies need nothing here and return ``{}``.
+
+  2. ``make_state(ctx)`` is called at trade fill time by the
+     ``ExitPolicyManager`` (analogue of ``TrailManager``). The
+     returned ``ExitPolicyState`` carries per-position runtime state
+     (e.g. ``tp1_fired``, ``peak_mfe_since_tp1``).
+
+  3. ``evaluate_intrabar(...)`` is called by the driver each bar
+     between the existing intra-bar SL/TP check and the bar-close
+     evaluation. Used by policies whose triggers fire intra-bar at a
+     specific price level — currently only
+     ``sl_partial_close_1r_runner_trail`` (partial close at +1R).
+
+  4. ``evaluate_at_close(...)`` is called by the driver each bar
+     after intra-bar evaluation and after the existing trail-manager
+     ratchet, before mark-to-market. Used by trailing-style policies
+     (``sl_plus_trailing_atr``, ``sl_plus_trailing_swing``) and the
+     runner-trail portion of ``sl_partial_close_1r_runner_trail``.
+
+  5. The driver queues any emitted ``ExitPolicyDecision`` with the
+     appropriate fill semantics:
+       * ``timing == "intrabar"``: fills NOW at ``fill_price`` (long
+         partial close at +1R fills at the +1R price level, mirroring
+         the existing intra-bar TP fill convention).
+       * ``timing == "at_close"``: queues for next-bar open fill
+         (long: ``open_bid``; short: ``open_ask``), mirroring the
+         existing trail-manager queue-and-fill pattern.
+
+R-frame convention
+
+  ``R_atr = sl_atr_mult × atr_at_entry`` — the size of 1R in price
+  units. Policies anchor their TP / trail thresholds in R-units
+  (e.g. ``+1R`` is ``entry_price + R_atr`` for a long); the registry
+  is therefore SL-multiplier-agnostic. The R-frame matches the
+  reference path simulator at [scripts/l_arc_10_v3/step_5.py:99-253][].
+
+Determinism
+
+  Policies are pure: ``apply_to_order`` and ``evaluate_*`` are
+  deterministic functions of their inputs. Per-position state is
+  isolated per ``ExitPolicyState`` instance; no shared mutable state
+  across positions.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+import pandas as pd
+
+from core.sim.account import Account, Direction, Position
+
+
+class ExitAction(Enum):
+    FULL_CLOSE = "full_close"
+    PARTIAL_CLOSE = "partial_close"
+
+
+@dataclass(frozen=True)
+class ExitPolicyContext:
+    """Per-position inputs the policy needs at register time.
+
+    All prices are in the pair's quote currency. ``atr_at_entry`` is
+    mid-anchored per PR #189 §15.1. ``entry_price`` is the actual
+    fill price (open_ask for long, open_bid for short) so policies
+    can compute absolute SL/TP/trail levels off the realised entry.
+    """
+
+    entry_price: float
+    atr_at_entry: float
+    sl_atr_mult: float
+    direction: Direction
+
+    @property
+    def r_atr(self) -> float:
+        """One R in price units."""
+        return self.sl_atr_mult * self.atr_at_entry
+
+
+@dataclass(frozen=True)
+class ExitPolicyDecision:
+    """A policy's "yes, act on this position" verdict.
+
+    ``timing == "intrabar"``: driver acts NOW on the current bar at
+    ``fill_price`` (must be set). Mirrors intra-bar TP semantics.
+
+    ``timing == "at_close"``: driver queues a close at next-bar open
+    (``fill_price`` ignored — long fills at ``open_bid``, short at
+    ``open_ask``). Mirrors trail-manager queue-and-fill semantics.
+
+    ``partial_fraction`` is the fraction of CURRENT size to close
+    (must be strictly in (0, 1) for ``PARTIAL_CLOSE``; ignored for
+    ``FULL_CLOSE``).
+    """
+
+    action: ExitAction
+    exit_reason: str
+    timing: str  # "intrabar" | "at_close"
+    fill_price: float | None = None
+    partial_fraction: float = 1.0
+
+
+class ExitPolicyState(ABC):
+    """Per-position runtime state. Subclassed per policy.
+
+    Stateless policies (``sl_only``, the TP-only policies) use the
+    trivial :class:`NullPolicyState`.
+    """
+
+
+@dataclass
+class NullPolicyState(ExitPolicyState):
+    """Trivial state for stateless policies."""
+
+
+class ExitPolicy(ABC):
+    """Abstract base for canonical exit policies.
+
+    Subclasses must set the ``name`` class attribute (registry key)
+    and implement :meth:`make_state`. The four lifecycle hooks
+    (``apply_to_order``, ``evaluate_intrabar``, ``evaluate_at_close``,
+    ``make_state``) have permissive defaults so most policies only
+    override the one or two they actually use.
+    """
+
+    name: str = ""
+
+    def apply_to_order(self, ctx: ExitPolicyContext) -> Mapping[str, Any]:
+        """Return Order-kwargs to merge at construction. Default: none."""
+        return {}
+
+    def evaluate_intrabar(
+        self,
+        position: Position,
+        bar: pd.Series,
+        state: ExitPolicyState,
+        ctx: ExitPolicyContext,
+    ) -> ExitPolicyDecision | None:
+        """Per-bar intra-bar evaluation. Default: never fire."""
+        return None
+
+    def evaluate_at_close(
+        self,
+        position: Position,
+        bar: pd.Series,
+        state: ExitPolicyState,
+        ctx: ExitPolicyContext,
+        account: Account,
+    ) -> ExitPolicyDecision | None:
+        """Per-bar bar-close evaluation. Default: never fire."""
+        return None
+
+    @abstractmethod
+    def make_state(self, ctx: ExitPolicyContext) -> ExitPolicyState:
+        """Construct fresh per-position state at trade fill."""
+
+
+__all__ = (
+    "ExitAction",
+    "ExitPolicy",
+    "ExitPolicyContext",
+    "ExitPolicyDecision",
+    "ExitPolicyState",
+    "NullPolicyState",
+)

--- a/core/sim/exit_policies/_registry.py
+++ b/core/sim/exit_policies/_registry.py
@@ -1,0 +1,58 @@
+"""Factory: name → ExitPolicy instance.
+
+The registry is the single source of truth for the canonical exit-policy
+namespace. Architectures and arcs select a policy by name (string in
+``arch_config.exit_policy``); the factory returns a fresh policy
+instance per call.
+
+Policy instances are stateless (per-position state lives in
+:class:`ExitPolicyState` constructed via ``make_state``), so the same
+policy instance is safe to share across positions — the factory
+returns fresh instances primarily for clean test isolation and to
+keep the wiring obvious.
+"""
+
+from __future__ import annotations
+
+from core.sim.exit_policies._base import ExitPolicy
+from core.sim.exit_policies.sl_only import SlOnlyPolicy
+from core.sim.exit_policies.sl_partial_close_1r_runner_trail import (
+    SlPartialClose1RRunnerTrailPolicy,
+)
+from core.sim.exit_policies.sl_plus_tp_2r import SlPlusTp2RPolicy
+from core.sim.exit_policies.sl_plus_tp_3r import SlPlusTp3RPolicy
+from core.sim.exit_policies.sl_plus_trailing_atr import SlPlusTrailingAtrPolicy
+from core.sim.exit_policies.sl_plus_trailing_swing import SlPlusTrailingSwingPolicy
+
+_REGISTRY: dict[str, type[ExitPolicy]] = {
+    SlOnlyPolicy.name: SlOnlyPolicy,
+    SlPlusTp2RPolicy.name: SlPlusTp2RPolicy,
+    SlPlusTp3RPolicy.name: SlPlusTp3RPolicy,
+    SlPlusTrailingAtrPolicy.name: SlPlusTrailingAtrPolicy,
+    SlPlusTrailingSwingPolicy.name: SlPlusTrailingSwingPolicy,
+    SlPartialClose1RRunnerTrailPolicy.name: SlPartialClose1RRunnerTrailPolicy,
+}
+
+
+def build_exit_policy(name: str) -> ExitPolicy:
+    """Construct a fresh policy instance by registry name.
+
+    Raises ``KeyError`` with the available-policy list if the name is
+    unknown — typo-loud rather than silently falling back to a default.
+    """
+    try:
+        cls = _REGISTRY[name]
+    except KeyError:
+        available = ", ".join(sorted(_REGISTRY))
+        raise KeyError(
+            f"Unknown exit policy {name!r}. Available: {available}"
+        ) from None
+    return cls()
+
+
+def available_policies() -> tuple[str, ...]:
+    """Sorted tuple of registered policy names."""
+    return tuple(sorted(_REGISTRY))
+
+
+__all__ = ("build_exit_policy", "available_policies")

--- a/core/sim/exit_policies/path_simulate.py
+++ b/core/sim/exit_policies/path_simulate.py
@@ -1,0 +1,370 @@
+"""Post-hoc path replay for canonical exit policies.
+
+The canonical policies in this package (sl_only, sl_plus_tp_*, sl_plus_trailing_*,
+sl_partial_close_1r_runner_trail) define live bar-by-bar behaviour for the
+v3 multipair backtester. This module provides the SAME semantics applied
+to *recorded* per-trade path data (the fast Step 5 approximation that
+walks ``mae_so_far_r / mfe_so_far_r / close_r / is_held`` columns in
+R-units relative to a base SL of 2.0×ATR).
+
+Two execution paths, ONE definition of each policy:
+
+  * **Live (bar-by-bar):** ``core/sim/multipair_backtester.py`` +
+    ``ExitPolicyManager`` driven by the policy classes' evaluate_intrabar /
+    evaluate_at_close hooks. Uses bid/ask worst-case fills.
+  * **Replay (this module):** ``simulate_path(name, path_rows, sl_mult)``
+    walks recorded path data with the same SL rescaling, threshold, and
+    sequencing as the live engine — but in R-units off a single
+    mid-anchored price stream (no bid/ask). Fast (Python loop over bars).
+
+Reference origin: scripts/l_arc_10_v3/step_5.py:_apply_exit_policy:99-253
+(committed pre-canonical-registry). Per-arc scripts (Arc 10, Arc 8) MUST
+import from this module rather than re-implementing — the dispatch's
+"hand-rolled per-arc exit logic is creating silent drift" mandate.
+
+Path-data schema (the recorded `bar_path` per trade, written by Step 1
+in scripts/l_arc_*/step_1.py):
+
+  * ``bar_offset`` (int): 0-indexed bar offset from entry (entry bar = 0).
+  * ``mae_so_far_r`` (float): running-min low (in R-units of base SL=2.0×ATR).
+  * ``mfe_so_far_r`` (float): running-max high (R-units).
+  * ``close_r`` (float): bar close (R-units relative to entry).
+  * ``is_held`` (int 0/1, optional): 1 while position held; 0 after time-exit.
+
+SL rescaling under a new ``sl_mult``:
+    scale = 2.0 / sl_mult            (R-frame scale factor)
+    sl_threshold_old = -(sl_mult / 2.0)  (SL line in old R-units)
+    new_mfe_at = mfe * scale
+    new_close_at = close * scale
+SL-breach detection scans ``mae`` (old R-units) against ``sl_threshold_old``.
+
+Tolerance contract (per chat answer Q5 — mid-only-parity test):
+  * Per-trade R: ±0.01R between replay and reference hand-rolled.
+  * Per-fold ROI: ±0.5%.
+  * Equity sliding band: ±0.5%.
+  * Pool size: byte-identical on the trade-admission axis (entries
+    admitted; "trades completed" may differ for partial-close configs).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+
+
+def _first_at_least(arr: np.ndarray, k: float) -> int:
+    """First index where ``arr[i] >= k`` (NaN-safe). -1 if never."""
+    mask = np.isfinite(arr) & (arr >= k)
+    idx = np.where(mask)[0]
+    return int(idx[0]) if idx.size > 0 else -1
+
+
+def _held_end(is_held: np.ndarray, n: int) -> int:
+    """Index of last bar where is_held == 1; falls back to n-1."""
+    held_idx = np.where(is_held == 1)[0]
+    return int(held_idx[-1]) if held_idx.size > 0 else n - 1
+
+
+def _prep(
+    path_rows: pd.DataFrame, sl_mult: float
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, int, int, float]:
+    """Sort + extract arrays + scale factors. Returns:
+    bar_offsets, mae, new_mfe_at, new_close_at, is_held, n, sl_breach, scale
+    """
+    p = path_rows.sort_values("bar_offset")
+    bar_offsets = p["bar_offset"].to_numpy(dtype=int)
+    mae = p["mae_so_far_r"].to_numpy()
+    mfe = p["mfe_so_far_r"].to_numpy()
+    close = p["close_r"].to_numpy()
+    is_held = (
+        p["is_held"].to_numpy()
+        if "is_held" in p.columns
+        else np.ones(len(p), dtype=int)
+    )
+
+    scale = 2.0 / sl_mult
+    sl_threshold_old = -(sl_mult / 2.0)
+    new_mfe_at = mfe * scale
+    new_close_at = close * scale
+
+    sl_breach = -1
+    for i, m in enumerate(mae):
+        if np.isfinite(m) and m <= sl_threshold_old:
+            sl_breach = i
+            break
+
+    n = len(p)
+    return bar_offsets, mae, new_mfe_at, new_close_at, is_held, n, sl_breach, scale
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Per-policy simulators (one-to-one with the canonical registry names)
+# ────────────────────────────────────────────────────────────────────────
+
+
+def simulate_sl_only(
+    trade_row: pd.Series, path_rows: pd.DataFrame, sl_mult: float
+) -> tuple[float, int]:
+    if path_rows.empty:
+        return (
+            float(trade_row.get("final_r", 0.0)) * (2.0 / sl_mult),
+            int(trade_row.get("bars_held", 0)),
+        )
+    bar_offsets, _, _, new_close_at, is_held, n, sl_breach, _ = _prep(path_rows, sl_mult)
+    if sl_breach >= 0:
+        return -1.0, int(bar_offsets[sl_breach] + 1)
+    end_i = _held_end(is_held, n)
+    return float(new_close_at[end_i]), int(bar_offsets[end_i] + 1)
+
+
+def _simulate_sl_plus_tp_at_r(
+    trade_row: pd.Series, path_rows: pd.DataFrame, sl_mult: float, tp_r: float
+) -> tuple[float, int]:
+    if path_rows.empty:
+        return (
+            float(trade_row.get("final_r", 0.0)) * (2.0 / sl_mult),
+            int(trade_row.get("bars_held", 0)),
+        )
+    bar_offsets, _, new_mfe_at, new_close_at, is_held, n, sl_breach, _ = _prep(
+        path_rows, sl_mult
+    )
+    tp_i = _first_at_least(new_mfe_at, tp_r)
+    if tp_i >= 0 and (sl_breach < 0 or tp_i <= sl_breach):
+        return tp_r, int(bar_offsets[tp_i] + 1)
+    if sl_breach >= 0:
+        return -1.0, int(bar_offsets[sl_breach] + 1)
+    end_i = _held_end(is_held, n)
+    return float(new_close_at[end_i]), int(bar_offsets[end_i] + 1)
+
+
+def simulate_sl_plus_tp_2r(
+    trade_row: pd.Series, path_rows: pd.DataFrame, sl_mult: float
+) -> tuple[float, int]:
+    return _simulate_sl_plus_tp_at_r(trade_row, path_rows, sl_mult, 2.0)
+
+
+def simulate_sl_plus_tp_3r(
+    trade_row: pd.Series, path_rows: pd.DataFrame, sl_mult: float
+) -> tuple[float, int]:
+    return _simulate_sl_plus_tp_at_r(trade_row, path_rows, sl_mult, 3.0)
+
+
+def simulate_sl_plus_trailing_atr(
+    trade_row: pd.Series, path_rows: pd.DataFrame, sl_mult: float
+) -> tuple[float, int]:
+    """Trail at 1R below peak MFE; activate at MFE >= 1R. SL preempts when
+    sl_breach <= trail_exit_i.
+
+    Reference: scripts/l_arc_10_v3/step_5.py:173-193.
+    """
+    if path_rows.empty:
+        return (
+            float(trade_row.get("final_r", 0.0)) * (2.0 / sl_mult),
+            int(trade_row.get("bars_held", 0)),
+        )
+    bar_offsets, _, new_mfe_at, new_close_at, is_held, n, sl_breach, _ = _prep(
+        path_rows, sl_mult
+    )
+    trail_r = -1.0
+    active = False
+    trail_exit_i = -1
+    for i in range(n):
+        if not np.isfinite(new_mfe_at[i]):
+            continue
+        if new_mfe_at[i] >= 1.0:
+            active = True
+            trail_r = max(trail_r, new_mfe_at[i] - 1.0)
+        if active and np.isfinite(new_close_at[i]) and new_close_at[i] <= trail_r:
+            trail_exit_i = i
+            break
+    if sl_breach >= 0 and (trail_exit_i < 0 or sl_breach <= trail_exit_i):
+        return -1.0, int(bar_offsets[sl_breach] + 1)
+    if trail_exit_i >= 0:
+        return float(new_close_at[trail_exit_i]), int(bar_offsets[trail_exit_i] + 1)
+    end_i = _held_end(is_held, n)
+    return float(new_close_at[end_i]), int(bar_offsets[end_i] + 1)
+
+
+def simulate_sl_plus_trailing_swing(
+    trade_row: pd.Series, path_rows: pd.DataFrame, sl_mult: float
+) -> tuple[float, int]:
+    """Trail at running max(min(prev_close, 0)). Activate at MFE >= 1R. SL
+    preempts when sl_breach <= trail_exit_i.
+
+    Reference: scripts/l_arc_10_v3/step_5.py:195-217.
+    """
+    if path_rows.empty:
+        return (
+            float(trade_row.get("final_r", 0.0)) * (2.0 / sl_mult),
+            int(trade_row.get("bars_held", 0)),
+        )
+    bar_offsets, _, new_mfe_at, new_close_at, is_held, n, sl_breach, _ = _prep(
+        path_rows, sl_mult
+    )
+    active = False
+    prev_low = -np.inf
+    trail_exit_i = -1
+    for i in range(n):
+        if not np.isfinite(new_mfe_at[i]):
+            continue
+        if new_mfe_at[i] >= 1.0:
+            active = True
+        if active:
+            if i > 0 and np.isfinite(new_close_at[i - 1]):
+                prev_low = max(prev_low, min(new_close_at[i - 1], 0.0))
+            if np.isfinite(new_close_at[i]) and new_close_at[i] <= prev_low:
+                trail_exit_i = i
+                break
+    if sl_breach >= 0 and (trail_exit_i < 0 or sl_breach <= trail_exit_i):
+        return -1.0, int(bar_offsets[sl_breach] + 1)
+    if trail_exit_i >= 0:
+        return float(new_close_at[trail_exit_i]), int(bar_offsets[trail_exit_i] + 1)
+    end_i = _held_end(is_held, n)
+    return float(new_close_at[end_i]), int(bar_offsets[end_i] + 1)
+
+
+def simulate_sl_partial_close_1r_runner_trail(
+    trade_row: pd.Series, path_rows: pd.DataFrame, sl_mult: float
+) -> tuple[float, int]:
+    """Close 50% at +1R, trail rest at 1R below path-peak MFE.
+
+    Reference: scripts/l_arc_10_v3/step_5.py:219-250 (Arc 10 PASS-DEPLOYABLE
+    closure's load-bearing exit).
+    """
+    if path_rows.empty:
+        return (
+            float(trade_row.get("final_r", 0.0)) * (2.0 / sl_mult),
+            int(trade_row.get("bars_held", 0)),
+        )
+    bar_offsets, _, new_mfe_at, new_close_at, is_held, n, sl_breach, _ = _prep(
+        path_rows, sl_mult
+    )
+    tp1_i = _first_at_least(new_mfe_at, 1.0)
+    if tp1_i < 0:
+        if sl_breach >= 0:
+            return -1.0, int(bar_offsets[sl_breach] + 1)
+        end_i = _held_end(is_held, n)
+        return float(new_close_at[end_i]), int(bar_offsets[end_i] + 1)
+    half_r = 1.0
+    trail_r = 0.0
+    trail_exit_i = -1
+    for i in range(tp1_i, n):
+        if np.isfinite(new_mfe_at[i]):
+            trail_r = max(trail_r, new_mfe_at[i] - 1.0)
+        if (
+            np.isfinite(new_close_at[i])
+            and new_close_at[i] <= trail_r
+            and i > tp1_i
+        ):
+            trail_exit_i = i
+            break
+    if (
+        sl_breach >= 0
+        and sl_breach > tp1_i
+        and (trail_exit_i < 0 or sl_breach <= trail_exit_i)
+    ):
+        runner_r = -1.0
+    elif trail_exit_i >= 0:
+        runner_r = float(new_close_at[trail_exit_i])
+    else:
+        end_i = _held_end(is_held, n)
+        runner_r = float(new_close_at[end_i])
+    final_r = 0.5 * half_r + 0.5 * runner_r
+    if trail_exit_i >= 0:
+        last_bar = trail_exit_i
+    elif sl_breach >= 0:
+        last_bar = sl_breach
+    else:
+        last_bar = n - 1
+    return float(final_r), int(bar_offsets[last_bar] + 1)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Dispatcher
+# ────────────────────────────────────────────────────────────────────────
+
+
+_SIMULATORS: dict[str, Callable[[pd.Series, pd.DataFrame, float], tuple[float, int]]] = {
+    "sl_only": simulate_sl_only,
+    "sl_plus_tp_2r": simulate_sl_plus_tp_2r,
+    "sl_plus_tp_3r": simulate_sl_plus_tp_3r,
+    "sl_plus_trailing_atr": simulate_sl_plus_trailing_atr,
+    "sl_plus_trailing_swing": simulate_sl_plus_trailing_swing,
+    "sl_partial_close_1r_runner_trail": simulate_sl_partial_close_1r_runner_trail,
+}
+
+
+def simulate_path(
+    policy_name: str,
+    trade_row: pd.Series,
+    path_rows: pd.DataFrame,
+    sl_mult: float,
+) -> tuple[float, int]:
+    """Replay a canonical exit policy over recorded path data.
+
+    Dispatches to the per-policy simulator; falls back to ``sl_only``
+    for unknown names (matches the legacy hand-rolled fallthrough at
+    scripts/l_arc_10_v3/step_5.py:252-253).
+    """
+    fn = _SIMULATORS.get(policy_name, simulate_sl_only)
+    return fn(trade_row, path_rows, sl_mult)
+
+
+def available_path_simulators() -> tuple[str, ...]:
+    """Sorted tuple of policies with a registered path simulator."""
+    return tuple(sorted(_SIMULATORS))
+
+
+__all__ = (
+    "simulate_path",
+    "simulate_sl_only",
+    "simulate_sl_plus_tp_2r",
+    "simulate_sl_plus_tp_3r",
+    "simulate_sl_plus_trailing_atr",
+    "simulate_sl_plus_trailing_swing",
+    "simulate_sl_partial_close_1r_runner_trail",
+    "available_path_simulators",
+    "simulate_pool_approximation",
+)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Pool-level approximation (legacy Arc 8 fast path)
+# ────────────────────────────────────────────────────────────────────────
+
+
+def simulate_pool_approximation(
+    final_r_sl: float,
+    mfe_r_sl: float,
+    mae_r_sl: float,
+    policy_name: str,
+) -> float:
+    """Pool-level approximation: cap final_r when mfe crossed the TP threshold.
+
+    A coarser approximation than :func:`simulate_path` — operates on
+    already-rescaled per-trade scalars rather than the full recorded path.
+    Used historically by Arc 8 [scripts/l_arc_8/run_step5_wfo.py:74-88][]
+    where bar-by-bar path replay was out of compute budget.
+
+    Assumes "TP fires before any pull-back to SL when mfe >= threshold" —
+    strictly optimistic vs. the path-based simulator. Both Arc 8 closure
+    §6 and this docstring flag the approximation. Higher-fidelity arcs
+    should prefer :func:`simulate_path`.
+
+    Supported policies:
+      * ``sl_only``           — pass-through
+      * ``sl_plus_tp_2r``     — cap at +2R if mfe >= 2
+      * ``sl_plus_tp_3r``     — cap at +3R if mfe >= 3
+
+    Unknown policy names fall through to pass-through (matches legacy
+    Arc 8 behaviour).
+    """
+    if policy_name == "sl_only":
+        return float(final_r_sl)
+    if policy_name == "sl_plus_tp_2r":
+        return 2.0 if mfe_r_sl >= 2.0 else float(final_r_sl)
+    if policy_name == "sl_plus_tp_3r":
+        return 3.0 if mfe_r_sl >= 3.0 else float(final_r_sl)
+    return float(final_r_sl)

--- a/core/sim/exit_policies/sl_only.py
+++ b/core/sim/exit_policies/sl_only.py
@@ -1,0 +1,33 @@
+"""``sl_only`` — baseline policy. The entry-time SL is the only exit
+(plus any signal-driven exit predicates registered separately by the
+SignalModule, e.g. KH-24's ``kijun_d1``).
+
+Reference: [scripts/l_arc_10_v3/step_5.py:143-151][] — path simulator
+returns -1R on SL breach, else time-exit at end of held window. In the
+canonical engine, the SL hit is handled by the existing intra-bar SL
+infrastructure ([core/sim/fill.py:long_sl_triggered][]); time-exit is
+handled by the existing ``Order.time_exit_bars`` mechanism (when
+configured). This policy itself is a no-op — it serves as the
+explicit "no extra exit beyond SL" baseline.
+"""
+
+from __future__ import annotations
+
+from core.sim.exit_policies._base import (
+    ExitPolicy,
+    ExitPolicyContext,
+    ExitPolicyState,
+    NullPolicyState,
+)
+
+
+class SlOnlyPolicy(ExitPolicy):
+    """Baseline: SL is the only exit. No-op state, no-op evaluators."""
+
+    name = "sl_only"
+
+    def make_state(self, ctx: ExitPolicyContext) -> ExitPolicyState:
+        return NullPolicyState()
+
+
+__all__ = ("SlOnlyPolicy",)

--- a/core/sim/exit_policies/sl_partial_close_1r_runner_trail.py
+++ b/core/sim/exit_policies/sl_partial_close_1r_runner_trail.py
@@ -168,7 +168,6 @@ class SlPartialClose1RRunnerTrailPolicy(ExitPolicy):
     ) -> ExitPolicyDecision | None:
         assert isinstance(state, PartialCloseRunnerTrailState)
         r_atr = ctx.r_atr
-        entry = ctx.entry_price
         # Always ratchet path-wide peak (per reference: peak runs from bar 0)
         if ctx.direction is Direction.LONG:
             high_bid = bar.get("high_bid")

--- a/core/sim/exit_policies/sl_partial_close_1r_runner_trail.py
+++ b/core/sim/exit_policies/sl_partial_close_1r_runner_trail.py
@@ -1,0 +1,230 @@
+"""``sl_partial_close_1r_runner_trail`` — Arc 10's load-bearing exit.
+
+Reference: [scripts/l_arc_10_v3/step_5.py:219-250][]:
+
+  tp1_i = first_at_least(new_mfe_at, 1.0)   # MFE (high) first ≥ +1R
+  if tp1_i < 0:
+      # never reached → falls through to SL / time-exit semantics
+      ...
+  half_r = 1.0
+  trail_r = 0.0
+  trail_exit_i = -1
+  for i in range(tp1_i, n):
+      if isfinite(new_mfe_at[i]):
+          trail_r = max(trail_r, new_mfe_at[i] - 1.0)
+      if isfinite(new_close_at[i]) and new_close_at[i] <= trail_r and i > tp1_i:
+          trail_exit_i = i; break
+  if sl_breach >= 0 and sl_breach > tp1_i and (trail_exit_i < 0 or sl_breach <= trail_exit_i):
+      runner_r = -1.0
+  elif trail_exit_i >= 0:
+      runner_r = float(new_close_at[trail_exit_i])
+  else:
+      runner_r = float(new_close_at[end_held])
+  final_r = 0.5 * half_r + 0.5 * runner_r
+
+Semantics (long):
+
+* **Stage 1 — pre-tp1.** Position at full size, original SL binding.
+  When MFE (bar high) first crosses +1R → fire PARTIAL close (50%) at
+  the +1R price level (intra-bar trigger, fill AT tp1_price). Mirrors
+  the existing intra-bar TP infrastructure mechanism.
+* **Stage 2 — runner phase (post-tp1).** Remaining 50% open.
+  - Original SL still binds (intra-bar SL infrastructure handles).
+  - Trail anchor: ``peak_mfe_since_entry`` = running max of
+    ``bar.high_bid``. The reference uses peak MFE over the entire
+    path (initialised before tp1_i); canonical engine mirrors that
+    by ratcheting peak from bar 0, not from tp1.
+  - Trail level: ``peak_high_bid − R_atr`` (i.e. 1R below peak).
+  - Trail-hit detection: ``bar.close_bid <= trail_level`` AND the
+    current bar is strictly AFTER the tp1 bar (reference's
+    ``i > tp1_i`` constraint — same-bar partial + trail-exit is
+    forbidden). Queues a runner full-close at next-bar open_bid.
+
+Short side mirrors with ask-anchored trough peak + +1R-above-trough
+trail level.
+
+Wire interactions:
+
+* The driver's existing intra-bar SL check fires on ``bar.low_bid <=
+  sl_price`` (long); when the SL fires after a partial, the
+  remaining 50% closes at ``sl_price`` (size = current_size after
+  partial). The ``parent_position_id`` linkage on the multi-leg
+  ClosedTrade lets consumers reconstruct the full close sequence.
+* The driver's existing exit_predicates and trail_manager run
+  independently. If both fire on the same bar as the partial-close
+  manager, precedence per [PROTOCOL_RUNTIME.md §8b][] (trail wins
+  vs predicate; intra-bar SL wins over both). This policy operates
+  on the same bar as the partial fire intra-bar — by design
+  (partial first, then SL if SL was breached on the SAME bar as
+  partial trigger, which the reference does not handle — the
+  reference's ``sl_breach > tp1_i`` means same-bar SL is ignored).
+* For determinism, the partial fires BEFORE the intra-bar SL check
+  on the same bar (matches reference's loop-order: tp1 detection
+  scans MFE first, then SL is only evaluated against
+  ``sl_breach > tp1_i``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+import pandas as pd
+
+from core.sim.account import Account, Direction, Position
+from core.sim.exit_policies._base import (
+    ExitAction,
+    ExitPolicy,
+    ExitPolicyContext,
+    ExitPolicyDecision,
+    ExitPolicyState,
+)
+
+
+@dataclass
+class PartialCloseRunnerTrailState(ExitPolicyState):
+    tp1_fired: bool = False
+    # Bar index of the tp1 fire (used to enforce reference's
+    # ``i > tp1_i`` constraint on trail exit). Set to the integer
+    # ordinal of the bar within the position's life.
+    tp1_bar_ordinal: int | None = None
+    # Long: running max of bar.high_bid since entry; short: running min
+    # of bar.low_ask. Ratcheted from bar 0 (NOT from tp1) to match
+    # reference's path-wide peak.
+    peak_price: float = field(default=float("nan"))
+    # Bar ordinal counter (incremented on each evaluate_at_close call).
+    bar_ordinal: int = 0
+
+
+class SlPartialClose1RRunnerTrailPolicy(ExitPolicy):
+    """Close 50% at +1R; runner trails at 1R below path-peak MFE."""
+
+    name = "sl_partial_close_1r_runner_trail"
+    partial_fraction: float = 0.5
+
+    # No apply_to_order: tp1 fires via state machine intra-bar, not via
+    # the engine's tp_price field (because tp_price fires a FULL close,
+    # not partial). Keeping it state-driven is the simplest path.
+    def apply_to_order(self, ctx: ExitPolicyContext) -> Mapping[str, Any]:
+        return {}
+
+    def make_state(self, ctx: ExitPolicyContext) -> ExitPolicyState:
+        return PartialCloseRunnerTrailState()
+
+    # ── intra-bar: detect +1R cross, fire partial ────────────────────
+    def evaluate_intrabar(
+        self,
+        position: Position,
+        bar: pd.Series,
+        state: ExitPolicyState,
+        ctx: ExitPolicyContext,
+    ) -> ExitPolicyDecision | None:
+        assert isinstance(state, PartialCloseRunnerTrailState)
+        if state.tp1_fired:
+            return None
+        r_atr = ctx.r_atr
+        entry = ctx.entry_price
+        if ctx.direction is Direction.LONG:
+            high_bid = bar.get("high_bid")
+            if high_bid is None or pd.isna(high_bid):
+                return None
+            tp1_price = entry + r_atr
+            if float(high_bid) >= tp1_price:
+                state.tp1_fired = True
+                state.tp1_bar_ordinal = state.bar_ordinal
+                return ExitPolicyDecision(
+                    action=ExitAction.PARTIAL_CLOSE,
+                    exit_reason="partial_close_1r",
+                    timing="intrabar",
+                    fill_price=tp1_price,
+                    partial_fraction=self.partial_fraction,
+                )
+            return None
+        # SHORT
+        low_ask = bar.get("low_ask")
+        if low_ask is None or pd.isna(low_ask):
+            return None
+        tp1_price = entry - r_atr
+        if float(low_ask) <= tp1_price:
+            state.tp1_fired = True
+            state.tp1_bar_ordinal = state.bar_ordinal
+            return ExitPolicyDecision(
+                action=ExitAction.PARTIAL_CLOSE,
+                exit_reason="partial_close_1r",
+                timing="intrabar",
+                fill_price=tp1_price,
+                partial_fraction=self.partial_fraction,
+            )
+        return None
+
+    # ── at close: ratchet peak, runner-trail hit detection ───────────
+    def evaluate_at_close(
+        self,
+        position: Position,
+        bar: pd.Series,
+        state: ExitPolicyState,
+        ctx: ExitPolicyContext,
+        account: Account,
+    ) -> ExitPolicyDecision | None:
+        assert isinstance(state, PartialCloseRunnerTrailState)
+        r_atr = ctx.r_atr
+        entry = ctx.entry_price
+        # Always ratchet path-wide peak (per reference: peak runs from bar 0)
+        if ctx.direction is Direction.LONG:
+            high_bid = bar.get("high_bid")
+            if high_bid is not None and not pd.isna(high_bid):
+                hb = float(high_bid)
+                if pd.isna(state.peak_price) or hb > state.peak_price:
+                    state.peak_price = hb
+        else:
+            low_ask = bar.get("low_ask")
+            if low_ask is not None and not pd.isna(low_ask):
+                la = float(low_ask)
+                if pd.isna(state.peak_price) or la < state.peak_price:
+                    state.peak_price = la
+
+        decision: ExitPolicyDecision | None = None
+        # Runner trail-hit only post-tp1 AND strictly AFTER the tp1 bar
+        # (reference: i > tp1_i). Compare bar_ordinal > tp1_bar_ordinal.
+        if (
+            state.tp1_fired
+            and state.tp1_bar_ordinal is not None
+            and state.bar_ordinal > state.tp1_bar_ordinal
+            and not pd.isna(state.peak_price)
+        ):
+            if ctx.direction is Direction.LONG:
+                trail_level = state.peak_price - r_atr
+                # Reference uses close_r (mid-anchored); canonical uses
+                # close_bid (worst-case fill realism). Under mid-only
+                # fixture they're identical.
+                close_bid = bar.get("close_bid")
+                if close_bid is not None and not pd.isna(close_bid):
+                    if float(close_bid) <= trail_level:
+                        decision = ExitPolicyDecision(
+                            action=ExitAction.FULL_CLOSE,
+                            exit_reason="runner_trail_stop",
+                            timing="at_close",
+                        )
+            else:
+                trail_level = state.peak_price + r_atr
+                close_ask = bar.get("close_ask")
+                if close_ask is not None and not pd.isna(close_ask):
+                    if float(close_ask) >= trail_level:
+                        decision = ExitPolicyDecision(
+                            action=ExitAction.FULL_CLOSE,
+                            exit_reason="runner_trail_stop",
+                            timing="at_close",
+                        )
+
+        # Advance bar ordinal AFTER trail-hit eval (so the SAME bar as
+        # tp1 has bar_ordinal == tp1_bar_ordinal, blocking same-bar
+        # trail-exit; next bar has bar_ordinal == tp1_bar_ordinal + 1,
+        # unlocking trail-exit).
+        state.bar_ordinal += 1
+        return decision
+
+
+__all__ = (
+    "SlPartialClose1RRunnerTrailPolicy",
+    "PartialCloseRunnerTrailState",
+)

--- a/core/sim/exit_policies/sl_plus_tp_2r.py
+++ b/core/sim/exit_policies/sl_plus_tp_2r.py
@@ -1,0 +1,53 @@
+"""``sl_plus_tp_2r`` — SL + fixed TP at +2R.
+
+Reference: [scripts/l_arc_10_v3/step_5.py:153-161][] — path simulator
+returns +2.0R when MFE first crosses +2R (and TP is reached before SL),
+else falls through to SL / time-exit semantics.
+
+Canonical engine wiring: ``apply_to_order`` sets ``tp_price = entry +
+2 × R_atr``. The existing intra-bar TP infrastructure
+([core/sim/fill.py:long_tp_triggered][] / ``short_tp_triggered``)
+handles trigger detection (long: ``bar.high_bid >= tp_price``; short:
+``bar.low_ask <= tp_price``) and fill at ``tp_price``. Realised R on
+trigger = ``(tp_price − entry_price) / R_atr = 2.0`` exactly.
+
+Under PR #189 worst-case fills, the bid-anchored trigger means
+canonical engine fires TP slightly LATER than the reference's
+mid-anchored trigger (bid lags mid by ~half-spread). Under mid-only
+parity fixtures this collapses to byte-identity.
+
+This policy has no per-bar state — the intra-bar TP fire handles
+everything.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from core.sim.account import Direction
+from core.sim.exit_policies._base import (
+    ExitPolicy,
+    ExitPolicyContext,
+    ExitPolicyState,
+    NullPolicyState,
+)
+
+
+class SlPlusTp2RPolicy(ExitPolicy):
+    """SL + take-profit at +2R from entry."""
+
+    name = "sl_plus_tp_2r"
+    tp_r: float = 2.0
+
+    def apply_to_order(self, ctx: ExitPolicyContext) -> Mapping[str, Any]:
+        if ctx.direction is Direction.LONG:
+            tp_price = ctx.entry_price + self.tp_r * ctx.r_atr
+        else:
+            tp_price = ctx.entry_price - self.tp_r * ctx.r_atr
+        return {"tp_price": float(tp_price)}
+
+    def make_state(self, ctx: ExitPolicyContext) -> ExitPolicyState:
+        return NullPolicyState()
+
+
+__all__ = ("SlPlusTp2RPolicy",)

--- a/core/sim/exit_policies/sl_plus_tp_3r.py
+++ b/core/sim/exit_policies/sl_plus_tp_3r.py
@@ -1,0 +1,19 @@
+"""``sl_plus_tp_3r`` — SL + fixed TP at +3R.
+
+Reference: [scripts/l_arc_10_v3/step_5.py:163-171][]. Identical
+mechanics to ``sl_plus_tp_2r`` with the threshold moved to +3R.
+"""
+
+from __future__ import annotations
+
+from core.sim.exit_policies.sl_plus_tp_2r import SlPlusTp2RPolicy
+
+
+class SlPlusTp3RPolicy(SlPlusTp2RPolicy):
+    """SL + take-profit at +3R from entry."""
+
+    name = "sl_plus_tp_3r"
+    tp_r: float = 3.0
+
+
+__all__ = ("SlPlusTp3RPolicy",)

--- a/core/sim/exit_policies/sl_plus_trailing_atr.py
+++ b/core/sim/exit_policies/sl_plus_trailing_atr.py
@@ -1,0 +1,158 @@
+"""``sl_plus_trailing_atr`` — SL + 1R-below-peak-MFE trail, activated at +1R.
+
+Reference: [scripts/l_arc_10_v3/step_5.py:173-193][]:
+
+  active = False
+  trail_r = -1.0
+  for i in range(n):
+      if new_mfe_at[i] >= 1.0:
+          active = True
+          trail_r = max(trail_r, new_mfe_at[i] - 1.0)
+      if active and new_close_at[i] <= trail_r:
+          trail_exit_i = i
+          break
+
+In R-frame: activate when MFE ≥ +1R; trail at ``peak_mfe − 1R``;
+exit when close ≤ trail level. SL preempts trail when SL breach
+happens at or before the trail-exit bar (reference §187).
+
+Canonical engine wiring:
+
+* Activation: MFE crossed +1R since entry. Detected via
+  ``bar.high_bid - entry_price >= R_atr`` for long; symmetric for
+  short (bar.low_ask). High-derived, matching reference's
+  ``new_mfe_at`` which is high-derived.
+* Trail anchor: peak ``bar.high_bid`` for long (bid-anchored — the
+  exit reference price). For short, trough ``bar.low_ask``.
+* Trail level: peak − ``R_atr`` for long; trough + ``R_atr`` for short.
+* Trail-hit detection: ``bar.close_bid <= trail_level`` for long;
+  ``bar.close_ask >= trail_level`` for short. Bar-close evaluation;
+  queues full close at next-bar open (long: ``open_bid``).
+* SL preemption is automatic via the existing intra-bar SL infrastructure.
+
+Distinct from KH-24's ``TrailManager`` ([core/sim/trailing_stop.py][]):
+the latter has activation at ``+activation_atr_mult × ATR`` (default
+2.0) and trail distance ``trail_atr_mult × ATR`` (default 1.5),
+mid-close-based ratchet, bid-close hit. This canonical policy uses
++1R activation and 1R trail (i.e. ``R_atr`` distance — equivalent to
+``sl_atr_mult × ATR``), bid-anchored peak for long. Different beast,
+different config knobs, separate manager.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from core.sim.account import Account, Direction, Position
+from core.sim.exit_policies._base import (
+    ExitAction,
+    ExitPolicy,
+    ExitPolicyContext,
+    ExitPolicyDecision,
+    ExitPolicyState,
+)
+
+
+@dataclass
+class TrailingAtrState(ExitPolicyState):
+    activated: bool = False
+    # Long: max(bid_high) since activation; short: min(ask_low) since
+    # activation. NaN means uninitialised.
+    peak_price: float = field(default=float("nan"))
+
+
+def _long_mfe_crossed_one_r(bar: pd.Series, entry_price: float, r_atr: float) -> bool:
+    high_bid = bar.get("high_bid")
+    if high_bid is None or pd.isna(high_bid):
+        return False
+    return float(high_bid) - entry_price >= r_atr
+
+
+def _short_mfe_crossed_one_r(bar: pd.Series, entry_price: float, r_atr: float) -> bool:
+    low_ask = bar.get("low_ask")
+    if low_ask is None or pd.isna(low_ask):
+        return False
+    return entry_price - float(low_ask) >= r_atr
+
+
+class SlPlusTrailingAtrPolicy(ExitPolicy):
+    """SL + 1R-below-peak-MFE trail, activated at +1R MFE."""
+
+    name = "sl_plus_trailing_atr"
+
+    def make_state(self, ctx: ExitPolicyContext) -> ExitPolicyState:
+        return TrailingAtrState()
+
+    def evaluate_at_close(
+        self,
+        position: Position,
+        bar: pd.Series,
+        state: ExitPolicyState,
+        ctx: ExitPolicyContext,
+        account: Account,
+    ) -> ExitPolicyDecision | None:
+        assert isinstance(state, TrailingAtrState)
+        r_atr = ctx.r_atr
+        entry = ctx.entry_price
+
+        if ctx.direction is Direction.LONG:
+            # Activation check
+            if not state.activated:
+                if _long_mfe_crossed_one_r(bar, entry, r_atr):
+                    state.activated = True
+                    state.peak_price = float(bar["high_bid"])
+                else:
+                    return None
+            else:
+                # Ratchet peak
+                high_bid = bar.get("high_bid")
+                if high_bid is not None and not pd.isna(high_bid):
+                    high_bid_f = float(high_bid)
+                    if pd.isna(state.peak_price) or high_bid_f > state.peak_price:
+                        state.peak_price = high_bid_f
+            # Hit detection
+            if pd.isna(state.peak_price):
+                return None
+            trail_level = state.peak_price - r_atr
+            close_bid = bar.get("close_bid")
+            if close_bid is None or pd.isna(close_bid):
+                return None
+            if float(close_bid) <= trail_level:
+                return ExitPolicyDecision(
+                    action=ExitAction.FULL_CLOSE,
+                    exit_reason="trailing_stop_atr",
+                    timing="at_close",
+                )
+            return None
+
+        # SHORT
+        if not state.activated:
+            if _short_mfe_crossed_one_r(bar, entry, r_atr):
+                state.activated = True
+                state.peak_price = float(bar["low_ask"])
+            else:
+                return None
+        else:
+            low_ask = bar.get("low_ask")
+            if low_ask is not None and not pd.isna(low_ask):
+                low_ask_f = float(low_ask)
+                if pd.isna(state.peak_price) or low_ask_f < state.peak_price:
+                    state.peak_price = low_ask_f
+        if pd.isna(state.peak_price):
+            return None
+        trail_level = state.peak_price + r_atr
+        close_ask = bar.get("close_ask")
+        if close_ask is None or pd.isna(close_ask):
+            return None
+        if float(close_ask) >= trail_level:
+            return ExitPolicyDecision(
+                action=ExitAction.FULL_CLOSE,
+                exit_reason="trailing_stop_atr",
+                timing="at_close",
+            )
+        return None
+
+
+__all__ = ("SlPlusTrailingAtrPolicy", "TrailingAtrState")

--- a/core/sim/exit_policies/sl_plus_trailing_swing.py
+++ b/core/sim/exit_policies/sl_plus_trailing_swing.py
@@ -1,0 +1,144 @@
+"""``sl_plus_trailing_swing`` — SL + swing-low trail, activated at +1R MFE.
+
+Reference: [scripts/l_arc_10_v3/step_5.py:195-217][]:
+
+  active = False
+  prev_low = -inf
+  for i in range(n):
+      if new_mfe_at[i] >= 1.0:
+          active = True
+      if active:
+          if i > 0 and isfinite(new_close_at[i - 1]):
+              prev_low = max(prev_low, min(new_close_at[i - 1], 0.0))
+          if new_close_at[i] <= prev_low:
+              trail_exit_i = i; break
+
+In R-frame: activate when MFE ≥ +1R; once active, the trail level
+is the running max of ``min(previous_close_r, 0)``, i.e. the highest
+"break-even-or-worse close" seen so far. Exit when the current close
+drops to or below this swing-low level. SL preempts trail when SL
+breach happens at or before the trail-exit bar.
+
+Note: ``min(prev_close_r, 0)`` caps the candidate at break-even (R=0
+= entry price). The trail level never exceeds entry — by design, the
+policy promotes a give-back-but-don't-let-it-go-negative protection.
+
+Canonical engine wiring (long):
+
+* Activation: ``bar.high_bid - entry_price >= R_atr``.
+* Each post-activation bar uses the PREVIOUS bar's ``close_bid``,
+  capped at ``entry_price`` (the break-even level), as the candidate
+  trail level. Running max retained across bars.
+* Hit: ``bar.close_bid <= trail_level``. Bar-close eval, fills at
+  next-bar open_bid.
+* Pre-activation ``close_bid`` of the bar JUST BEFORE activation is
+  included in the running-max (matches reference's bar i-1
+  contribution on activation bar i).
+
+Short side mirrors with ask-anchoring and a max-of-running-min
+inverted at entry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from core.sim.account import Account, Direction, Position
+from core.sim.exit_policies._base import (
+    ExitAction,
+    ExitPolicy,
+    ExitPolicyContext,
+    ExitPolicyDecision,
+    ExitPolicyState,
+)
+
+
+@dataclass
+class TrailingSwingState(ExitPolicyState):
+    activated: bool = False
+    # Long: running max of (min(prev_close_bid, entry_price)); NaN means
+    # never updated. Short: running min of (max(prev_close_ask, entry_price)).
+    trail_level: float = field(default=float("nan"))
+    # The prior bar's close_bid (long) / close_ask (short), retained so
+    # next bar's evaluation can use it as the trail candidate.
+    prev_close: float = field(default=float("nan"))
+
+
+class SlPlusTrailingSwingPolicy(ExitPolicy):
+    """SL + swing-low (capped at entry) trail, activated at +1R MFE."""
+
+    name = "sl_plus_trailing_swing"
+
+    def make_state(self, ctx: ExitPolicyContext) -> ExitPolicyState:
+        return TrailingSwingState()
+
+    def evaluate_at_close(
+        self,
+        position: Position,
+        bar: pd.Series,
+        state: ExitPolicyState,
+        ctx: ExitPolicyContext,
+        account: Account,
+    ) -> ExitPolicyDecision | None:
+        assert isinstance(state, TrailingSwingState)
+        r_atr = ctx.r_atr
+        entry = ctx.entry_price
+
+        if ctx.direction is Direction.LONG:
+            # Activation
+            if not state.activated:
+                high_bid = bar.get("high_bid")
+                if high_bid is not None and not pd.isna(high_bid):
+                    if float(high_bid) - entry >= r_atr:
+                        state.activated = True
+            # Ratchet using prior bar's close_bid, capped at entry
+            decision: ExitPolicyDecision | None = None
+            if state.activated and not pd.isna(state.prev_close):
+                candidate = min(state.prev_close, entry)
+                if pd.isna(state.trail_level) or candidate > state.trail_level:
+                    state.trail_level = candidate
+            # Hit detection (only if trail level established)
+            if state.activated and not pd.isna(state.trail_level):
+                close_bid = bar.get("close_bid")
+                if close_bid is not None and not pd.isna(close_bid):
+                    if float(close_bid) <= state.trail_level:
+                        decision = ExitPolicyDecision(
+                            action=ExitAction.FULL_CLOSE,
+                            exit_reason="trailing_stop_swing",
+                            timing="at_close",
+                        )
+            # Always retain this bar's close for next-bar candidate
+            close_bid = bar.get("close_bid")
+            if close_bid is not None and not pd.isna(close_bid):
+                state.prev_close = float(close_bid)
+            return decision
+
+        # SHORT
+        if not state.activated:
+            low_ask = bar.get("low_ask")
+            if low_ask is not None and not pd.isna(low_ask):
+                if entry - float(low_ask) >= r_atr:
+                    state.activated = True
+        decision = None
+        if state.activated and not pd.isna(state.prev_close):
+            candidate = max(state.prev_close, entry)
+            if pd.isna(state.trail_level) or candidate < state.trail_level:
+                state.trail_level = candidate
+        if state.activated and not pd.isna(state.trail_level):
+            close_ask = bar.get("close_ask")
+            if close_ask is not None and not pd.isna(close_ask):
+                if float(close_ask) >= state.trail_level:
+                    decision = ExitPolicyDecision(
+                        action=ExitAction.FULL_CLOSE,
+                        exit_reason="trailing_stop_swing",
+                        timing="at_close",
+                    )
+        close_ask = bar.get("close_ask")
+        if close_ask is not None and not pd.isna(close_ask):
+            state.prev_close = float(close_ask)
+        return decision
+
+
+__all__ = ("SlPlusTrailingSwingPolicy", "TrailingSwingState")

--- a/core/sim/exit_policy_manager.py
+++ b/core/sim/exit_policy_manager.py
@@ -1,0 +1,208 @@
+"""Per-position state holder for canonical exit policies.
+
+Analogue of :class:`core.sim.trailing_stop.TrailManager`. The driver
+holds one ``ExitPolicyManager`` instance per backtest run and:
+
+  * Calls :meth:`register` at trade fill time for any Order carrying a
+    policy spec — the manager constructs per-position
+    :class:`ExitPolicyState` via ``policy.make_state(ctx)``.
+  * Calls :meth:`evaluate_intrabar_for_all` once per bar, BEFORE the
+    existing intra-bar SL/TP check. Used by policies whose triggers
+    fire at a specific intra-bar price level (currently only
+    ``sl_partial_close_1r_runner_trail``).
+  * Calls :meth:`evaluate_at_close_for_all` once per bar, AFTER the
+    trail-manager ratchet. Used by trailing-style policies and the
+    runner-trail portion of partial-close.
+  * Calls :meth:`deregister` on full close.
+
+Same-bar SL preemption
+----------------------
+When a policy fires a PARTIAL_CLOSE intra-bar, the manager records the
+position id in :attr:`positions_with_intrabar_partial_this_bar`. The
+driver uses this set to SKIP the existing intra-bar SL/TP check for
+that position THIS bar — matching the reference's
+``sl_breach > tp1_i`` constraint for ``sl_partial_close_1r_runner_trail``
+(the partial fires on the bar's high BEFORE the bar's low is
+considered for SL purposes; runner survives the same-bar low).
+
+The set is cleared at the START of each :meth:`evaluate_intrabar_for_all`
+call, so it is per-bar transient.
+
+Determinism
+-----------
+Positions are iterated in sorted(position_id) order at every decision
+point — same convention as ``MultiPairBacktester`` and ``TrailManager``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from core.sim.account import Account, Position
+from core.sim.exit_policies._base import (
+    ExitAction,
+    ExitPolicy,
+    ExitPolicyContext,
+    ExitPolicyDecision,
+    ExitPolicyState,
+)
+
+
+@dataclass
+class _PolicyRegistration:
+    """Internal record. Not part of the public surface."""
+
+    policy: ExitPolicy
+    state: ExitPolicyState
+    context: ExitPolicyContext
+
+
+class ExitPolicyManager:
+    """Owns per-position exit-policy state for one Account.
+
+    The driver registers a policy at trade fill, evaluates each bar
+    via the two ``evaluate_*_for_all`` hooks, and deregisters on full
+    close. The manager is stateless across runs — a fresh instance is
+    constructed per backtest.
+    """
+
+    def __init__(self) -> None:
+        self._regs: dict[int, _PolicyRegistration] = {}
+        # Per-bar transient set: positions that had an intra-bar
+        # PARTIAL_CLOSE this bar. Cleared at the start of each
+        # evaluate_intrabar_for_all call. Read by the driver to
+        # suppress intra-bar SL/TP on the same bar.
+        self.positions_with_intrabar_partial_this_bar: set[int] = set()
+
+    # ── lifecycle ───────────────────────────────────────────────────
+    def register(
+        self,
+        position: Position,
+        policy: ExitPolicy,
+        atr_at_entry: float,
+        sl_atr_mult: float,
+    ) -> None:
+        """Attach ``policy`` to ``position``; build per-position state.
+
+        Idempotent on the position_id key: re-registering replaces the
+        prior registration. Per-bar transient set is NOT cleared (the
+        register call itself does not represent a bar boundary).
+        """
+        ctx = ExitPolicyContext(
+            entry_price=float(position.entry_price),
+            atr_at_entry=float(atr_at_entry),
+            sl_atr_mult=float(sl_atr_mult),
+            direction=position.direction,
+        )
+        state = policy.make_state(ctx)
+        self._regs[position.position_id] = _PolicyRegistration(
+            policy=policy,
+            state=state,
+            context=ctx,
+        )
+
+    def deregister(self, position_id: int) -> None:
+        """Remove all state for ``position_id``. Idempotent."""
+        self._regs.pop(position_id, None)
+        self.positions_with_intrabar_partial_this_bar.discard(position_id)
+
+    # ── accessors ───────────────────────────────────────────────────
+    def is_registered(self, position_id: int) -> bool:
+        return position_id in self._regs
+
+    def get_state(self, position_id: int) -> ExitPolicyState | None:
+        reg = self._regs.get(position_id)
+        return reg.state if reg is not None else None
+
+    def get_context(self, position_id: int) -> ExitPolicyContext | None:
+        reg = self._regs.get(position_id)
+        return reg.context if reg is not None else None
+
+    def get_policy_name(self, position_id: int) -> str | None:
+        reg = self._regs.get(position_id)
+        return reg.policy.name if reg is not None else None
+
+    def has_intrabar_partial_this_bar(self, position_id: int) -> bool:
+        """True iff this position fired a partial close this bar.
+
+        Driver uses this to suppress intra-bar SL/TP on the same bar.
+        """
+        return position_id in self.positions_with_intrabar_partial_this_bar
+
+    # ── per-bar evaluation ──────────────────────────────────────────
+    def evaluate_intrabar_for_all(
+        self,
+        snapshot: dict[str, pd.Series | None],
+        account: Account,
+    ) -> dict[int, ExitPolicyDecision]:
+        """Evaluate every registered policy's intra-bar hook.
+
+        Returns ``{position_id: decision}`` for positions whose
+        policy fired a decision THIS bar. Driver acts on these
+        immediately at ``decision.fill_price`` (for PARTIAL_CLOSE)
+        or via full close (for FULL_CLOSE — unusual at intra-bar
+        timing; currently not used by any registered policy).
+
+        Side effects:
+          * Clears :attr:`positions_with_intrabar_partial_this_bar`
+            at the start of the call.
+          * Repopulates it for positions whose policy emitted a
+            PARTIAL_CLOSE decision this bar.
+        """
+        self.positions_with_intrabar_partial_this_bar = set()
+        decisions: dict[int, ExitPolicyDecision] = {}
+        for pos_id in sorted(self._regs):
+            reg = self._regs[pos_id]
+            # noqa: SLF001 — manager peers at account internals (parity
+            # with TrailManager). Public surface is account.open_positions
+            # but that returns a tuple copy; we need the dict for lookup.
+            pos = account._open.get(pos_id)  # noqa: SLF001
+            if pos is None:
+                # Position closed by some other path (e.g. external close).
+                # Don't deregister here — driver owns deregistration on
+                # full close. Just skip.
+                continue
+            bar = snapshot.get(pos.pair)
+            if bar is None:
+                continue
+            decision = reg.policy.evaluate_intrabar(pos, bar, reg.state, reg.context)
+            if decision is None:
+                continue
+            decisions[pos_id] = decision
+            if decision.action is ExitAction.PARTIAL_CLOSE:
+                self.positions_with_intrabar_partial_this_bar.add(pos_id)
+        return decisions
+
+    def evaluate_at_close_for_all(
+        self,
+        snapshot: dict[str, pd.Series | None],
+        account: Account,
+    ) -> dict[int, ExitPolicyDecision]:
+        """Evaluate every registered policy's at-close hook.
+
+        Returns ``{position_id: decision}`` for positions whose
+        policy fired this bar. Driver queues each FULL_CLOSE as a
+        ``_pending_closes`` entry (fills at next-bar open).
+
+        Does NOT mutate the intrabar-partial set.
+        """
+        decisions: dict[int, ExitPolicyDecision] = {}
+        for pos_id in sorted(self._regs):
+            reg = self._regs[pos_id]
+            pos = account._open.get(pos_id)  # noqa: SLF001
+            if pos is None:
+                continue
+            bar = snapshot.get(pos.pair)
+            if bar is None:
+                continue
+            decision = reg.policy.evaluate_at_close(
+                pos, bar, reg.state, reg.context, account
+            )
+            if decision is not None:
+                decisions[pos_id] = decision
+        return decisions
+
+
+__all__ = ("ExitPolicyManager",)

--- a/core/sim/multipair_backtester.py
+++ b/core/sim/multipair_backtester.py
@@ -30,6 +30,13 @@ import pandas as pd
 
 from core.sim.account import Account, ClosedTrade, Direction, Position
 from core.sim.exit_hooks import ExitPredicate, evaluate_predicates
+from core.sim.exit_policies import (
+    ExitAction,
+    ExitPolicyContext,
+    ExitPolicyDecision,
+    build_exit_policy,
+)
+from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.fill import (
     long_entry_fill_price,
     long_sl_triggered,
@@ -71,6 +78,19 @@ class Order:
     # Default 1.0 preserves prior behaviour for every architecture that does
     # not use meta-labeling.
     risk_multiplier: float = 1.0
+    # Canonical exit-policy spec (registry name + the SL multiplier needed
+    # to compute R_atr = sl_atr_mult * atr_at_entry). When ``exit_policy``
+    # is set, the driver:
+    #   1. Calls policy.apply_to_order(ctx) BEFORE Order construction in
+    #      the strategy/architecture layer; the resulting kwargs (e.g.
+    #      tp_price for sl_plus_tp_2r) must be merged into THIS Order's
+    #      fields by the strategy code.
+    #   2. After fill, registers the policy with ``exit_policy_manager``
+    #      using ``(atr_at_entry, sl_atr_mult)`` for R_atr computation.
+    # ``exit_policy=None`` (default) preserves all pre-PR behaviour:
+    # KH-24 and other arcs without a canonical policy run unchanged.
+    exit_policy: str | None = None
+    sl_atr_mult: float | None = None
 
 
 # Strategy signature: callable(t, snapshot, account) -> list[Order]
@@ -111,8 +131,22 @@ class MultiPairBacktester:
     #     intra-bar SL checks on the NEXT bar.
     #   exit_predicates: signal-driven exit hooks. Evaluated at bar close
     #     after intra-bar SL/TP checks; first triggering predicate wins.
+    #   exit_policy_manager: canonical exit-policy state holder (see
+    #     [core/sim/exit_policy_manager.py][]). When set, the driver:
+    #       (a) registers any Order carrying ``exit_policy`` after fill,
+    #       (b) calls ``evaluate_intrabar_for_all`` BEFORE intra-bar SL/TP
+    #           (partial-close fires NOW at fill_price; size shadowed),
+    #       (c) honours the manager's same-bar-SL suppression set in
+    #           ``_check_exits`` (matches reference's ``sl_breach > tp1_i``
+    #           constraint for sl_partial_close_1r_runner_trail),
+    #       (d) calls ``evaluate_at_close_for_all`` AFTER trail-manager
+    #           ratchet; FULL_CLOSE decisions queue at-close exits
+    #           (filled at next-bar open per existing pattern).
+    #     When None, exit_policy is required to be None on every Order
+    #     (RuntimeError otherwise, fail-loud on wiring mistakes).
     trail_manager: TrailManager | None = None
     exit_predicates: tuple[ExitPredicate, ...] = ()
+    exit_policy_manager: ExitPolicyManager | None = None
 
     # internal: deferred entries from prior bar awaiting fill at next-bar open
     _pending: list[Order] = None  # type: ignore[assignment]
@@ -168,6 +202,16 @@ class MultiPairBacktester:
 
         Order: intra-bar SL/TP (against bid/ask high/low) first, then
         exit predicates (signal-driven, evaluated at bar close).
+
+        Exit-policy interaction: when the registered policy preempted
+        intra-bar SL/TP this bar (via a PARTIAL_CLOSE fire — currently
+        only ``sl_partial_close_1r_runner_trail`` does this), the
+        manager flags the position via
+        ``has_intrabar_partial_this_bar(pos_id)``. The driver skips
+        intra-bar SL/TP for that position THIS bar — matching the
+        reference's ``sl_breach > tp1_i`` constraint so the runner
+        survives same-bar SL touches after the partial fires.
+        Predicates still run (they're bar-close-evaluated).
         """
         for pos_id in sorted(self.account._open.keys()):  # noqa: SLF001
             pos = self.account._open.get(pos_id)  # noqa: SLF001
@@ -176,49 +220,58 @@ class MultiPairBacktester:
             bar = snapshot.get(pos.pair)
             if bar is None or not bool(is_tradable_bar(bar.to_frame().T).iloc[0]):
                 continue
-            sl_price = self._effective_sl(pos)
-            sl_hit, sl_px = False, float("nan")
-            tp_hit, tp_px = False, float("nan")
-            if pos.direction is Direction.LONG:
-                if sl_price is not None:
-                    sl_hit, sl_px = long_sl_triggered(bar, sl_price)
-                if pos.tp_price is not None:
-                    tp_hit, tp_px = long_tp_triggered(bar, pos.tp_price)
-            else:
-                if sl_price is not None:
-                    sl_hit, sl_px = short_sl_triggered(bar, sl_price)
-                if pos.tp_price is not None:
-                    tp_hit, tp_px = short_tp_triggered(bar, pos.tp_price)
-
-            # Intra-bar priority (SL/TP)
-            closed_intra = False
-            sl_reason = (
-                "trailing_stop"
-                if (
-                    self.trail_manager is not None
-                    and self.trail_manager.get(pos_id) is not None
-                    and self.trail_manager.get(pos_id).activated
-                )
-                else "stop_loss"
+            # Exit-policy same-bar SL suppression
+            suppress_intrabar = (
+                self.exit_policy_manager is not None
+                and self.exit_policy_manager.has_intrabar_partial_this_bar(pos_id)
             )
-            if self.sl_first:
-                if sl_hit:
-                    self.account.close(pos_id, t, sl_px, sl_reason)
-                    closed_intra = True
-                elif tp_hit:
-                    self.account.close(pos_id, t, tp_px, "take_profit")
-                    closed_intra = True
-            else:
-                if tp_hit:
-                    self.account.close(pos_id, t, tp_px, "take_profit")
-                    closed_intra = True
-                elif sl_hit:
-                    self.account.close(pos_id, t, sl_px, sl_reason)
-                    closed_intra = True
+
+            closed_intra = False
+            if not suppress_intrabar:
+                sl_price = self._effective_sl(pos)
+                sl_hit, sl_px = False, float("nan")
+                tp_hit, tp_px = False, float("nan")
+                if pos.direction is Direction.LONG:
+                    if sl_price is not None:
+                        sl_hit, sl_px = long_sl_triggered(bar, sl_price)
+                    if pos.tp_price is not None:
+                        tp_hit, tp_px = long_tp_triggered(bar, pos.tp_price)
+                else:
+                    if sl_price is not None:
+                        sl_hit, sl_px = short_sl_triggered(bar, sl_price)
+                    if pos.tp_price is not None:
+                        tp_hit, tp_px = short_tp_triggered(bar, pos.tp_price)
+
+                # Intra-bar priority (SL/TP)
+                sl_reason = (
+                    "trailing_stop"
+                    if (
+                        self.trail_manager is not None
+                        and self.trail_manager.get(pos_id) is not None
+                        and self.trail_manager.get(pos_id).activated
+                    )
+                    else "stop_loss"
+                )
+                if self.sl_first:
+                    if sl_hit:
+                        self.account.close(pos_id, t, sl_px, sl_reason)
+                        closed_intra = True
+                    elif tp_hit:
+                        self.account.close(pos_id, t, tp_px, "take_profit")
+                        closed_intra = True
+                else:
+                    if tp_hit:
+                        self.account.close(pos_id, t, tp_px, "take_profit")
+                        closed_intra = True
+                    elif sl_hit:
+                        self.account.close(pos_id, t, sl_px, sl_reason)
+                        closed_intra = True
 
             if closed_intra:
                 if self.trail_manager is not None:
                     self.trail_manager.deregister(pos_id)
+                if self.exit_policy_manager is not None:
+                    self.exit_policy_manager.deregister(pos_id)
                 continue
 
             # Signal-driven exit predicates (e.g. kijun_d1) fire at BAR CLOSE
@@ -252,6 +305,38 @@ class MultiPairBacktester:
             if effective_size <= 0.0:
                 # risk_multiplier=0 (A6 meta-labeling 0x sizing) — skip this fill
                 continue
+            # Canonical exit-policy decoration of Order fields at fill time.
+            # Policies' apply_to_order(ctx) is invoked HERE so tp_price /
+            # other order fields are anchored to the ACTUAL fill price, not
+            # the strategy-emit-time proxy. Anchoring to actual fill gives
+            # the TP-style policies' realised R exactly the spec'd value
+            # (+2R, +3R) under the existing intra-bar TP infrastructure.
+            tp_price_final = order.tp_price
+            policy_obj = None
+            if order.exit_policy is not None:
+                if self.exit_policy_manager is None:
+                    raise RuntimeError(
+                        f"Order on {order.pair} carries exit_policy="
+                        f"{order.exit_policy!r} but driver has no "
+                        "exit_policy_manager. Construct MultiPairBacktester "
+                        "with exit_policy_manager=ExitPolicyManager()."
+                    )
+                if order.atr_at_entry is None or order.sl_atr_mult is None:
+                    raise RuntimeError(
+                        f"Order on {order.pair} carries exit_policy="
+                        f"{order.exit_policy!r} but is missing atr_at_entry "
+                        "or sl_atr_mult (both required for R_atr)."
+                    )
+                policy_obj = build_exit_policy(order.exit_policy)
+                policy_ctx = ExitPolicyContext(
+                    entry_price=float(fill_px),
+                    atr_at_entry=float(order.atr_at_entry),
+                    sl_atr_mult=float(order.sl_atr_mult),
+                    direction=order.direction,
+                )
+                overrides = policy_obj.apply_to_order(policy_ctx)
+                if "tp_price" in overrides:
+                    tp_price_final = float(overrides["tp_price"])
             pos = self.account.open(
                 pair=order.pair,
                 direction=order.direction,
@@ -259,7 +344,7 @@ class MultiPairBacktester:
                 entry_price=fill_px,
                 size=effective_size,
                 sl_price=order.sl_price,
-                tp_price=order.tp_price,
+                tp_price=tp_price_final,
             )
             # Auto-register trail if the order carries an ATR + manager is set
             if (
@@ -272,6 +357,15 @@ class MultiPairBacktester:
                     atr_at_entry=order.atr_at_entry,
                     activation_atr_mult=order.trail_activation_atr,
                     trail_atr_mult=order.trail_distance_atr,
+                )
+            # Register the policy state with the manager (TP-only policies
+            # are no-op stateful here but still registered for uniformity).
+            if policy_obj is not None:
+                self.exit_policy_manager.register(
+                    position=pos,
+                    policy=policy_obj,
+                    atr_at_entry=float(order.atr_at_entry),
+                    sl_atr_mult=float(order.sl_atr_mult),
                 )
             filled.append(pos)
         self._pending = []
@@ -293,12 +387,27 @@ class MultiPairBacktester:
 
     # ── per-bar processing ──────────────────────────────────────────
     def _process_bar(self, t: pd.Timestamp, snapshot: dict[str, pd.Series | None]) -> None:
-        # 1a. fill any closes queued at the prior bar's close (trail / kijun_d1)
+        # 1a. fill any closes queued at the prior bar's close (trail / kijun_d1
+        #     / exit-policy at-close)
         self._fill_pending_closes(t, snapshot)
-        # 1b. fill any entries pending from prior bar
+        # 1b. fill any entries pending from prior bar (registers trail +
+        #     exit_policy_manager state on fill)
         self._fill_pending_entries(t, snapshot)
-        # 2. check intra-bar SL/TP exits + bar-close predicate exits
-        #    (predicate hits go to _pending_closes for next-bar-open fill)
+        # 2a. exit-policy INTRA-BAR evaluation. Fires BEFORE _check_exits
+        #     so that ``sl_partial_close_1r_runner_trail``'s partial-at-+1R
+        #     fires on the bar's high before the existing intra-bar SL is
+        #     evaluated against the bar's low (matches reference's
+        #     ``sl_breach > tp1_i`` constraint). The manager's
+        #     ``has_intrabar_partial_this_bar`` flag is consulted inside
+        #     ``_check_exits`` to suppress same-bar intra-bar SL/TP for
+        #     the position that just partial-closed.
+        if self.exit_policy_manager is not None:
+            intrabar_decisions = self.exit_policy_manager.evaluate_intrabar_for_all(
+                snapshot, self.account
+            )
+            self._apply_intrabar_policy_decisions(t, intrabar_decisions)
+        # 2b. intra-bar SL/TP + bar-close predicate exits
+        #     (predicate hits go to _pending_closes for next-bar-open fill)
         self._check_exits(t, snapshot)
         # 3. update trailing stops at bar close AND queue trail-triggered
         #    closes for next-bar-open fill (EA pattern per PR-E.1.6 §B).
@@ -318,6 +427,21 @@ class MultiPairBacktester:
             trail_hits = self.trail_manager.trail_exit_triggers_at_close(snapshot, self.account)
             for pos_id in trail_hits:
                 self._pending_closes[pos_id] = "trailing_stop"
+        # 3b. exit-policy AT-CLOSE evaluation. Runs after trail-manager
+        #     ratchet so trailing policies see the latest peak. FULL_CLOSE
+        #     decisions queue at next-bar open (last-write-wins over any
+        #     prior _pending_closes entry from trail/predicate — the
+        #     policy decision is the most specific).
+        if self.exit_policy_manager is not None:
+            at_close_decisions = self.exit_policy_manager.evaluate_at_close_for_all(
+                snapshot, self.account
+            )
+            for pos_id, decision in at_close_decisions.items():
+                if decision.action is ExitAction.FULL_CLOSE:
+                    self._pending_closes[pos_id] = decision.exit_reason
+                # PARTIAL_CLOSE at at_close timing is not currently emitted
+                # by any registered policy; would require manager-side
+                # extension to queue a pending partial-fill, deferred.
         # 4. mark to market
         self.account.mark_to_market(t, self._close_mid(snapshot))
         # 5. ask the strategy for new orders
@@ -332,6 +456,55 @@ class MultiPairBacktester:
             if not self.account.exposure_check(order.pair):
                 continue
             self._pending.append(order)
+
+    # ── exit-policy intra-bar fire ──────────────────────────────────
+    def _apply_intrabar_policy_decisions(
+        self,
+        t: pd.Timestamp,
+        decisions: dict[int, ExitPolicyDecision],
+    ) -> None:
+        """Apply each intra-bar PARTIAL/FULL close NOW on the current bar.
+
+        ``decisions`` came from ``ExitPolicyManager.evaluate_intrabar_for_all``.
+        Iteration in sorted(position_id) order for determinism.
+        """
+        for pos_id in sorted(decisions):
+            decision = decisions[pos_id]
+            assert decision.fill_price is not None, (
+                f"intra-bar exit-policy decision for pos={pos_id} missing "
+                "fill_price; this is a policy implementation bug"
+            )
+            if decision.action is ExitAction.PARTIAL_CLOSE:
+                current = self.account.current_size_of(pos_id)
+                size_to_close = current * float(decision.partial_fraction)
+                # Guard rail: avoid floating-point "close everything" via
+                # partial_close. The Account API rejects size >= current.
+                # If partial_fraction == 1.0 (a misuse), route to close().
+                if size_to_close >= current:
+                    self.account.close(
+                        pos_id, t, float(decision.fill_price), decision.exit_reason
+                    )
+                    if self.exit_policy_manager is not None:
+                        self.exit_policy_manager.deregister(pos_id)
+                    if self.trail_manager is not None:
+                        self.trail_manager.deregister(pos_id)
+                else:
+                    self.account.partial_close(
+                        pos_id,
+                        t,
+                        float(decision.fill_price),
+                        decision.exit_reason,
+                        size_to_close,
+                    )
+                continue
+            # FULL_CLOSE
+            self.account.close(
+                pos_id, t, float(decision.fill_price), decision.exit_reason
+            )
+            if self.exit_policy_manager is not None:
+                self.exit_policy_manager.deregister(pos_id)
+            if self.trail_manager is not None:
+                self.trail_manager.deregister(pos_id)
 
     # ── driver ──────────────────────────────────────────────────────
     def run(self) -> RunResult:

--- a/docs/BACKTESTER_ARCHITECTURE.md
+++ b/docs/BACKTESTER_ARCHITECTURE.md
@@ -151,7 +151,42 @@ See [PROTOCOL_RUNTIME.md §15.5](PROTOCOL_RUNTIME.md).
   (total/per-pair/per-currency).
 - **`core.sim.multipair_backtester.MultiPairBacktester`** — bar-by-bar
   driver with deferred next-bar-open entry fills and intra-bar SL/TP
-  exits. Single equity curve output.
+  exits. Single equity curve output. Optional hooks:
+  `trail_manager` (KH-24 trail), `exit_predicates` (signal-class
+  predicates), `exit_policy_manager` (canonical exit-policy registry).
+
+### Exit policies (architecture-pluggable)
+
+`core/sim/exit_policies/` is the canonical exit-policy registry.
+Architectures (A1..A6) opt in via `arch_config.exit_policy = "<name>"`;
+default `None` preserves prior behaviour. Six policies registered:
+
+  - `sl_only` — baseline (SL only).
+  - `sl_plus_tp_2r`, `sl_plus_tp_3r` — SL + intra-bar TP at +2R / +3R.
+  - `sl_plus_trailing_atr` — trail at peak − R_atr; activate at +1R.
+  - `sl_plus_trailing_swing` — trail = running max of `min(prev_close,
+    entry)`; activate at +1R.
+  - `sl_partial_close_1r_runner_trail` — Arc 10's load-bearing exit:
+    intra-bar partial 50% at +1R, runner trails at path-peak − R_atr.
+
+Two execution surfaces share one policy definition:
+
+  1. **Live engine** (`MultiPairBacktester` + `ExitPolicyManager`) —
+     bar-by-bar evaluation with PR #189 worst-case fills.
+  2. **Replay** (`core.sim.exit_policies.simulate_path`) — post-hoc
+     path-replay over recorded `mae/mfe/close_r` columns, used by
+     `scripts/l_arc_*/step_5.py` for fast Step 5 ranking. The
+     reference-parity test
+     [tests/sim/exit_policies/test_path_simulate_reference_parity.py](../tests/sim/exit_policies/test_path_simulate_reference_parity.py)
+     asserts byte-identity vs the historical hand-rolled simulator at
+     [scripts/l_arc_10_v3/step_5.py:99-253](../scripts/l_arc_10_v3/step_5.py).
+
+Account partial-fill semantics (`Account.partial_close` +
+`current_size_of` + `ClosedTrade.parent_position_id`) support
+multi-leg close-outs without breaking the `Position` frozen-dataclass
+contract. KH-24 (`exit_policy=None`) is untouched.
+
+Full spec + per-policy semantics: [PROTOCOL_RUNTIME.md §8c](PROTOCOL_RUNTIME.md).
 
 ## WFO + features (PR-C)
 

--- a/docs/PROTOCOL_RUNTIME.md
+++ b/docs/PROTOCOL_RUNTIME.md
@@ -501,6 +501,111 @@ outside this PR's scope contract). Documented in
 
 ---
 
+## §8c Exit-policy registry
+
+`core/sim/exit_policies/` holds the canonical exit-policy registry for
+the v3 multipair backtester. Each registered policy defines the
+post-SL behaviour of a position (TP placement, trailing logic,
+partial-close lifecycle) and is consumable by every architecture
+(A1..A6) via `arch_config.exit_policy = "<name>"`. Default `None`
+preserves prior behaviour (SL + optional `TrailManager` + signal-class
+exit predicates only — e.g. KH-24's `kijun_d1` path).
+
+### Registered policies
+
+| Name | Semantics summary | Reference |
+|---|---|---|
+| `sl_only` | Baseline. SL + (optional) signal-class predicates only. | [sl_only.py](../core/sim/exit_policies/sl_only.py) / [step_5.py:143-151](../scripts/l_arc_10_v3/step_5.py) |
+| `sl_plus_tp_2r` | SL + intra-bar TP at `entry + 2 × R_atr`. Decorates `Order.tp_price`; uses existing intra-bar TP infrastructure. | [sl_plus_tp_2r.py](../core/sim/exit_policies/sl_plus_tp_2r.py) / [step_5.py:153-161](../scripts/l_arc_10_v3/step_5.py) |
+| `sl_plus_tp_3r` | Same as TP_2R at `+3R`. | [sl_plus_tp_3r.py](../core/sim/exit_policies/sl_plus_tp_3r.py) / [step_5.py:163-171](../scripts/l_arc_10_v3/step_5.py) |
+| `sl_plus_trailing_atr` | Activate at MFE ≥ +1R; trail at `peak_high − R_atr`; bar-close eval; exit at next-bar open. | [sl_plus_trailing_atr.py](../core/sim/exit_policies/sl_plus_trailing_atr.py) / [step_5.py:173-193](../scripts/l_arc_10_v3/step_5.py) |
+| `sl_plus_trailing_swing` | Activate at MFE ≥ +1R; trail = running max of `min(prev_close, entry)`; capped at entry by design. | [sl_plus_trailing_swing.py](../core/sim/exit_policies/sl_plus_trailing_swing.py) / [step_5.py:195-217](../scripts/l_arc_10_v3/step_5.py) |
+| `sl_partial_close_1r_runner_trail` | Intra-bar partial close 50% at `entry + R_atr`; runner trails at `peak_high − R_atr` (path-wide peak); SL still binds on runner. | [sl_partial_close_1r_runner_trail.py](../core/sim/exit_policies/sl_partial_close_1r_runner_trail.py) / [step_5.py:219-250](../scripts/l_arc_10_v3/step_5.py) |
+
+`R_atr = sl_atr_mult × atr_at_entry` — the size of 1R in price units,
+computed at trade fill against the actual entry price and the
+mid-anchored ATR per PR #189 §15.1. The registry is SL-multiplier
+agnostic: policies anchor in R-units; the live engine carries the
+fill price through the policy state machine.
+
+### Architecture wiring
+
+```python
+A1Config(
+    config_id="kh24_with_partial_close",
+    sl_atr_mult=2.0,
+    trail_enabled=False,             # canonical trail off
+    exit_policy="sl_partial_close_1r_runner_trail",
+    ...,
+)
+```
+
+The architecture's `run(...)` instantiates an `ExitPolicyManager()`
+when `exit_policy is not None` and passes it to `MultiPairBacktester(
+exit_policy_manager=...)`. The driver:
+
+  1. Calls `policy.apply_to_order(ctx)` at trade fill time (anchored to
+     actual fill price). TP-style policies populate `Order.tp_price`
+     here so the existing intra-bar TP infrastructure handles fire+fill
+     at the exact TP level (realised R = exactly +2R / +3R).
+  2. Calls `manager.evaluate_intrabar_for_all(...)` BEFORE intra-bar
+     SL/TP — partial-close at +1R fires on bar high before SL is
+     evaluated against bar low. The manager's
+     `has_intrabar_partial_this_bar(pos_id)` flag SUPPRESSES same-bar
+     intra-bar SL/TP for the position that just partial-closed
+     (matches reference's `sl_breach > tp1_i` constraint so the runner
+     survives the same-bar low).
+  3. Calls `manager.evaluate_at_close_for_all(...)` AFTER trail-manager
+     ratchet. Trailing-style policies and partial-close runner-trail
+     fire here; queued at next-bar open per existing pattern.
+
+Account partial-fill semantics: see `core/sim/account.py:partial_close`
++ `current_size_of` + `ClosedTrade.parent_position_id`. Position is
+frozen; Account owns the live size via a shadow dict.
+
+### Same-bar precedence
+
+Intra-bar SL/TP > intra-bar policy (partial-close) > signal-class
+predicates (bar-close) > trail-manager (bar-close ratchet) > at-close
+policy (last-write-wins). Documented per architecture in each
+`AnConfig.exit_policy` field's docstring.
+
+### Path-replay (legacy Step 5 fast path)
+
+`core/sim/exit_policies/path_simulate.py` exposes the SAME canonical
+semantics applied to recorded path data (`mae_so_far_r / mfe_so_far_r /
+close_r / is_held` per-trade columns). Used by `scripts/l_arc_*/step_5.py`
+post-hoc evaluators (Arc 10 v3 = full path replay; Arc 8 = the coarser
+`simulate_pool_approximation` legacy fast path).
+
+```python
+from core.sim.exit_policies import simulate_path
+final_r_new, bars_held = simulate_path(
+    "sl_partial_close_1r_runner_trail",
+    trade_row,
+    path_rows,
+    sl_mult=2.5,
+)
+```
+
+Both execution paths (live bar-by-bar AND replay) share ONE definition
+per policy. Reference-parity test
+[tests/sim/exit_policies/test_path_simulate_reference_parity.py](../tests/sim/exit_policies/test_path_simulate_reference_parity.py)
+asserts byte-identical behaviour between the canonical replay module
+and the historical hand-rolled simulator
+([scripts/l_arc_10_v3/step_5.py:99-253](../scripts/l_arc_10_v3/step_5.py))
+across all 6 policies × 4 SL multipliers × 9 synthetic path scenarios
+(218 cases).
+
+### KH-24 invariant
+
+KH-24 uses `exit_policy=None` (its production parameters are SL +
+trail + `kijun_d1` predicate, all unchanged). The canonical exit-policy
+code paths are dormant on the KH-24 anchor. Anchor regression
+unaffected.
+
+---
+
 ## §9 Step 5 fold runners
 
 ```python

--- a/docs/audits/engine_capability_audit_2026_05.md
+++ b/docs/audits/engine_capability_audit_2026_05.md
@@ -577,3 +577,66 @@ end-to-end. Verified byte-identical via
 
 See [PROTOCOL_RUNTIME.md §15.5](../PROTOCOL_RUNTIME.md) for the
 session-semantics convention contract.
+
+---
+
+## Post-audit update — 2026-05-25 (Canonical exit-policy registry)
+
+§"Backtester / sim" capabilities — **Exit-policy registry**: MISSING → **WIRED**
+for the full canonical policy catalogue.
+
+Pre-PR state: only `sl_only` was tacitly handled by the engine (default
+behaviour). The other six policies named in L_PROTOCOL §10 lived as
+hand-rolled post-hoc simulators inside `scripts/l_arc_*/step_5.py`,
+producing silent drift between arcs (the dispatch's "hand-rolled per-arc
+exit logic is creating silent drift" mandate). No canonical engine
+support existed for partial-fill semantics, so `sl_partial_close_1r_runner_trail`
+(Arc 10's load-bearing PASS-DEPLOYABLE exit) had no first-class home.
+
+WIRED via [core/sim/exit_policies/](../../core/sim/exit_policies/):
+
+- `_base.py` — `ExitPolicy` ABC + `ExitPolicyContext` / `ExitPolicyDecision`
+  / `ExitAction` / `ExitPolicyState` / `NullPolicyState`.
+- `_registry.py` — `build_exit_policy(name)` + `available_policies()`.
+- Six policy modules, one each:
+  - `sl_only.py`
+  - `sl_plus_tp_2r.py`, `sl_plus_tp_3r.py`
+  - `sl_plus_trailing_atr.py`, `sl_plus_trailing_swing.py`
+  - `sl_partial_close_1r_runner_trail.py`
+- `path_simulate.py` — replay surface for legacy Step 5 fast path
+  (`simulate_path` + `simulate_pool_approximation`).
+
+Account partial-fill: [core/sim/account.py](../../core/sim/account.py)
+gains `partial_close`, `current_size_of`, `ClosedTrade.parent_position_id`,
+and `_current_sizes` shadow dict. Position stays frozen.
+
+Driver wiring: [core/sim/multipair_backtester.py](../../core/sim/multipair_backtester.py)
+gains `exit_policy_manager: ExitPolicyManager | None` field + per-bar
+`evaluate_intrabar_for_all` (before intra-bar SL/TP with same-bar SL
+suppression) + `evaluate_at_close_for_all` (after trail-manager ratchet).
+Order schema gains `exit_policy: str | None` + `sl_atr_mult: float | None`.
+
+Architecture wiring: A1/A2/A3/A4/A6 configs gain `exit_policy: str | None = None`.
+KH-24 (a1_adapter) unchanged — defaults to None.
+
+Per-arc migration: [scripts/l_arc_10_v3/step_5.py](../../scripts/l_arc_10_v3/step_5.py)
+and [scripts/l_arc_8/run_step5_wfo.py](../../scripts/l_arc_8/run_step5_wfo.py)
+`_apply_exit_policy` bodies replaced by one-line delegates to the canonical
+registry. 150 LOC of hand-rolled per-policy branches deleted from Arc 10.
+Byte-identical parity asserted by
+[tests/sim/exit_policies/test_path_simulate_reference_parity.py](../../tests/sim/exit_policies/test_path_simulate_reference_parity.py)
+(218 cases: 6 policies × 4 SL multipliers × 9 scenarios).
+
+KH-24 anchor regression: 37/37 KH-24-specific tests + 105/105
+protocol_runtime tests pass on the branch. Full-data HistData anchor
+(scripts/anchor/check_a1_equivalence.py) requires chat-side run.
+
+Capability count delta:
+- "Live exit policy registry" row updates from `1 WIRED (sl_only implicit) /
+  0 PARTIAL / 6 MISSING` to `7 WIRED / 0 PARTIAL / 0 MISSING`.
+- "Account partial-fill semantics" row: MISSING → WIRED.
+- "Per-arc exit-policy hand-rolling" row (anti-capability): WIRED →
+  MISSING (deleted; the goal).
+
+Overall: WIRED 35 → 41 (Steps + registry policies count separately).
+Per-arc silent-drift surface area: closed.

--- a/partial_close_runner_trail_intent.md
+++ b/partial_close_runner_trail_intent.md
@@ -1,0 +1,301 @@
+# Intent — Canonical Exit Policy Registry + `sl_partial_close_1r_runner_trail`
+
+Branch target: `engine/sl-partial-close-runner-trail-primitive`
+PR title: `[ENGINE] Canonical exit policy registry + sl_partial_close_1r_runner_trail primitive + per-arc migration`
+Author: Claude Code
+Status: **REVISED SCOPE (S1+) — IMPLEMENTATION BEGINS. Q6 still open; non-blocking for tasks 2-11.**
+Dispatch reference: CC dispatch "Engine PR: sl_partial_close_1r_runner_trail Exit Primitive" + chat S2→S1+ revision
+Estimate: **5-7 days CC work** (per chat revision)
+
+---
+
+## 0. Scope change log
+
+**Original dispatch (S2):** add one canonical primitive, framework-shaped.
+**Chat revision (S1+, this doc):** build full canonical exit-policy registry NOW. Port ALL existing hand-rolled policies. Migrate per-arc scripts. Delete per-arc exit logic. Reference-impl parity on every policy.
+
+Rationale (per chat): hand-rolled per-arc exit logic is creating silent drift and making Step 6 audits harder than they need to be. No more "fixes-to-be-built".
+
+---
+
+## 1. Complete inventory: every hand-rolled exit policy in the repo
+
+### Path-based simulators ([scripts/l_arc_10_v3/step_5.py:99-253](scripts/l_arc_10_v3/step_5.py:99))
+
+Reference implementations for canonical registry. Each walks per-trade recorded path data (`mae_so_far_r`, `mfe_so_far_r`, `close_r`, `is_held` at integer `bar_offset`) under a new SL multiplier, all in R-units relative to base SL=2.0×ATR with `scale = 2.0 / sl_multiplier_new`.
+
+| Policy | Reference lines | Key semantics |
+|---|---|---|
+| `sl_only` | [step_5.py:143-151](scripts/l_arc_10_v3/step_5.py:143) | SL breach → −1R; else time-exit at end of held window |
+| `sl_plus_tp_2r` | [step_5.py:153-161](scripts/l_arc_10_v3/step_5.py:153) | First bar at which `new_mfe_at >= 2.0` AND before SL → +2R; else SL or time-exit |
+| `sl_plus_tp_3r` | [step_5.py:163-171](scripts/l_arc_10_v3/step_5.py:163) | Same at +3R |
+| `sl_plus_trailing_atr` | [step_5.py:173-193](scripts/l_arc_10_v3/step_5.py:173) | Trail at 1R below peak MFE; activate at MFE ≥ 1R; trail-hit when `close ≤ trail_r`; SL preempts trail when `sl_breach <= trail_exit_i` |
+| `sl_plus_trailing_swing` | [step_5.py:195-217](scripts/l_arc_10_v3/step_5.py:195) | Trail at running min of close (post activation at MFE ≥ 1R); activates when MFE first crosses 1R; trail = `max(prev_low, min(prev_close, 0))`; exit on `close ≤ prev_low` |
+| `sl_partial_close_1r_runner_trail` | [step_5.py:219-250](scripts/l_arc_10_v3/step_5.py:219) | TP1 = first bar `new_mfe_at >= 1.0` → close 50% at +1R. Runner: trail = `max(peak_mfe) - 1.0`; exit `close <= trail AND i > tp1`. Runner SL if `sl_breach > tp1`. Final R = `0.5 * 1.0 + 0.5 * runner_r`. |
+
+### Pool-level approximations ([scripts/l_arc_8/run_step5_wfo.py:74-88](scripts/l_arc_8/run_step5_wfo.py:74))
+
+Weaker fidelity (no path walk, just caps `final_r` if `mfe_r ≥ threshold`). These exist because Arc 8 didn't run a full bar-by-bar sim — explicit disclosure in script docstring.
+
+| Policy | Reference lines | Notes |
+|---|---|---|
+| `sl_only` | [run_step5_wfo.py:82-83](scripts/l_arc_8/run_step5_wfo.py:82) | Pass-through `final_r` |
+| `sl_plus_tp_2r` | [run_step5_wfo.py:84-85](scripts/l_arc_8/run_step5_wfo.py:84) | `mfe_r >= 2.0 → +2R`, else `final_r` |
+| `sl_plus_tp_3r` | [run_step5_wfo.py:86-87](scripts/l_arc_8/run_step5_wfo.py:86) | `mfe_r >= 3.0 → +3R`, else `final_r` |
+
+**Note:** Arc 8's approximation assumes "TP fires before any pull-back to SL when MFE >= threshold" — strictly optimistic vs. path-based version. Migrating Arc 8 to canonical will produce **stricter** numbers on `sl_plus_tp_2r` / `sl_plus_tp_3r` configs. The Arc 8 closure §6 already flagged the approximation as a known fidelity limit; the canonical-migration delta is the resolution of that limit and needs a closure note.
+
+### Out of scope for this PR
+
+- **`_apply_a4_exits`** ([step_5.py:653-703](scripts/l_arc_10_v3/step_5.py:653)) — heuristic stand-in for A4 Pipeline D classifier exit. Not a Step 5 exit policy in the registry sense; it's the A4-architecture-specific path-decay heuristic. The actual canonical A4 exit is already wired via classifier-driven `exit_predicates`. Out of scope.
+- **`core/exit_policies.py:StepwiseClimberPolicy`** ([core/exit_policies.py:55-152](core/exit_policies.py:55)) — Pipeline D1 archetype-policy that mutates `trade["sl_px"]` inside a custom D1-pool simulator. Different abstraction. Out of scope.
+- **Arc 11 closure-time exit_policy field** ([scripts/l_arc_11/write_closure.py:119](scripts/l_arc_11/write_closure.py:119)) — already `sl_only` as a closure-doc field; downstream consumer of the registry, not a producer. Touched only if test impact surfaces.
+
+---
+
+## 2. Reference-implementation semantics — full lock (Tasks 1+3 read complete)
+
+### `sl_partial_close_1r_runner_trail` — load-bearing details from [step_5.py:219-250](scripts/l_arc_10_v3/step_5.py:219)
+
+| Question | Reference answer | Source |
+|---|---|---|
+| When does 50% close trigger? | **First bar at which `mfe_so_far_r >= 1.0`** — MFE is bar-high-derived (Step 1 path-builder). Reference uses MFE-based trigger, NOT close-based. | step_5.py:139-141, 221 |
+| What price does 50% fill at? | **+1.0R exactly** (in R-units of new SL scale). | step_5.py:230 (`half_r = 1.0`) |
+| Trail anchor for remaining 50% | **`max(new_mfe_at[i]) - 1.0`** from `tp1_i` forward — high-peak minus 1R. | step_5.py:234-236 |
+| Trail update frequency | **Every bar** of recorded path. | step_5.py:234 |
+| Peak reference (close/high) | **HIGH-based** (uses `new_mfe_at`, derived from bar high). | step_5.py:236 |
+| Trail-hit detection | **Close-based.** `new_close_at[i] <= trail_r`. | step_5.py:237 |
+| Trail-hit timing | Strictly AFTER `tp1_i` (`i > tp1_i`). Can't both partial-close and trail-exit on same bar. | step_5.py:237 |
+| Runner SL behaviour | Original SL line stays binding for the runner. If `sl_breach > tp1` AND (`trail_exit_i < 0` OR `sl_breach <= trail_exit_i`) → `runner_r = -1.0`. | step_5.py:240-241 |
+| Catastrophic case (SL between tp1 and trail) | Runner = −1R (full SL loss on runner 50%). | step_5.py:240-241 |
+| +1R never reached, SL never hit | Time-exit at end of `is_held` window. | step_5.py:226-228 |
+
+**Resolved conflict:** dispatch prose said "+1R cross on close-based reference"; reference uses MFE (bar-high) trigger. **Per dispatch discipline rule ("Reference implementation is source of truth") and chat answer Q4 (stands), implementing MFE-based.**
+
+### PR #189 conventions applied to each policy (per chat answers Q3, Q5)
+
+For the canonical engine port, every policy uses:
+
+- **Trigger detection (MFE-based threshold crossings):** evaluated against MID prices.
+- **Trigger detection (close-based, e.g. trail-hit):** evaluated against MID close where the reference used a price field that's symmetric; **BID close** where the reference's `close_r` would translate to bid-side (= long exit reference).
+- **Fill at next-bar open:** long exits at `open_bid`, short exits at `open_ask` (worst-case fill).
+- **SL hit:** unchanged — `low_bid <= sl_price` for longs, `high_ask >= sl_price` for shorts (existing engine semantics).
+- **TP hit:** `high_bid >= tp_price` for longs, `low_ask <= tp_price` for shorts (existing engine semantics).
+- **Partial close on +1R:** trigger evaluated on MID high vs `entry_price + 1.0 × R_atr` where `R_atr = sl_atr_mult × ATR_at_entry_mid`; fill at next-bar `open_bid` for longs.
+
+**Acknowledged delta:** the reference works in R-units over a single mid-anchored price; canonical engine adds bid/ask wings → per-trade R will deviate slightly. This is the diagnostic point of Arc 10 v3.0.1.
+
+---
+
+## 3. Current canonical engine: what exists, what does NOT exist (unchanged from prior intent)
+
+### Exists
+- Intra-bar SL/TP via [core/sim/fill.py](core/sim/fill.py).
+- Trail stop (close→trail-hit→next-bar fill) via [core/sim/trailing_stop.py](core/sim/trailing_stop.py).
+- Signal-driven exit predicates via [core/sim/exit_hooks.py](core/sim/exit_hooks.py).
+
+### Does NOT exist (pre-this-PR)
+- Any `exit_policy` field on any arch config (A1..A6 all confirmed).
+- Any partial-fill semantics in `Account` / `Position` (Position is `@dataclass(frozen=True)`; `close()` is full-only).
+- Any canonical engine registry for `sl_only` / `sl_plus_tp_2r` / `sl_plus_tp_3r` / `sl_plus_trailing_atr` / `sl_plus_trailing_swing` / `sl_partial_close_1r_runner_trail`.
+- ClosedTrade linkage between partial + final.
+
+**The dispatch's framing — "CC_07 and subsequent PRs ported standard exit policies (`sl_only`, `sl_plus_trailing_atr`, `sl_plus_tp_2r`, `sl_plus_tp_3r`) but missed `sl_partial_close_1r_runner_trail`" — was inaccurate.** Those policies have always been post-hoc path simulators in `scripts/l_arc_*`, never first-class engine citizens. This PR is also the canonical-engine port of ALL of them, not just an addition of one.
+
+---
+
+## 4. KH-24 anchor regression scope (unchanged)
+
+KH-24 uses: SL=2.0×ATR (entry-anchored), trail (activation=2.0×ATR, distance=1.5×ATR, close-mid ratchet), kijun_d1 exit predicate. **Not in the new registry.** KH-24 `a1_adapter.py` stays unchanged; `exit_policy` defaults to `None` → existing trail-only code path runs unchanged.
+
+Anchor regression mechanics:
+- Mini fixture: [tests/protocol_runtime/test_kh24_a1_equivalence.py](tests/protocol_runtime/test_kh24_a1_equivalence.py) must pass byte-identically.
+- Full-data: chat-runnable via [scripts/anchor/check_a1_equivalence.py](scripts/anchor/check_a1_equivalence.py) + [scripts/anchor/run_anchor.py](scripts/anchor/run_anchor.py). Worst-fold ROI / DD / per-fold equity sha256 byte-identical required.
+
+**Risk:** Account refactor for partial-fill is a non-zero blast radius. Mitigation: keep Position frozen, add `Account._current_sizes: dict[int, float]` shadow (recommendation §7 in prior intent). KH-24's code path never touches `partial_close()` so the shadow dict stays empty for KH-24 positions.
+
+---
+
+## 5. Open chat questions — Q6 RE-SURFACED
+
+Per chat: Q1–Q5 answers stand. Q6 was truncated — re-asked here.
+
+### Q1 — Scope ✅ ANSWERED
+S1+ full canonical registry, all policies ported, per-arc migration. 5-7 day estimate. [Stands.]
+
+### Q2 — Where do other policies live? ✅ ANSWERED
+ALL in canonical `core/sim/exit_policies/`. Per-arc hand-rolled deleted. [Stands.]
+
+### Q3 — Arc 10 v3.0.1 path ✅ ANSWERED
+Per S1+ migration: Arc 10 v3.0.1 will run through canonical engine (`MultiPairBacktester` + `ExitPolicyManager`), not post-hoc simulator. Migration (Task 7) closes this. [Stands.]
+
+### Q4 — Reference vs dispatch prose conflict ✅ ANSWERED
+Reference wins (MFE-based +1R trigger, not close-based). [Stands.]
+
+### Q5 — Parity test tolerances ✅ ANSWERED — REVISED TIGHTER PER CHAT
+Per chat: each policy must satisfy:
+- Per-trade R within **±0.01R**
+- Per-fold ROI within **±0.5%**
+- Equity curve within **±0.5% sliding band**
+- Pool size **byte-identical**
+
+This is much tighter than my prior proposal (which allowed direction-of-effect bounds). I'll achieve this by:
+- Running parity tests on a **mid-only fixture** (zero spread) so worst-case-fill delta is suppressed for parity scoring.
+- A separate set of "production-realism" tests on **bid/ask fixtures** that document the spread-induced delta (informational, not gate).
+- If chat wants parity on bid/ask fixtures too, the tolerances would need to be loosened or the canonical impl would need to back-fit reference-mode (defeats PR #189). **Confirm mid-only-parity is acceptable.**
+
+### Q6 — Docs location ❓ STILL OPEN (NON-BLOCKING)
+
+Dispatch Task 7 says:
+- `docs/PROTOCOL_RUNTIME.md` §"Exit policies" — **no such section exists today**.
+- `docs/BACKTESTER_ARCHITECTURE.md` "Step 5 exit policy registry updated" — **no such section exists today**.
+
+**Proposal:**
+1. Add new subsection **§8c Exit-policy registry** to PROTOCOL_RUNTIME.md, immediately after §8b (Amendment 3 emissions) and before §9 (Step 5 fold runners). Catalogs every policy with its `core/sim/exit_policies/<name>.py` link, semantics, R-frame contract.
+2. Add new subsection to BACKTESTER_ARCHITECTURE.md §B (architecture catalogue) titled **"Exit policies (architecture-pluggable)"**. Lists the same catalogue + cross-links to PROTOCOL_RUNTIME.md.
+3. Update [docs/audits/engine_capability_audit_2026_05.md](docs/audits/engine_capability_audit_2026_05.md) §footer with a "Post-PR amendment" block: partial-close-runner-trail MISSING → WIRED + full registry catalogued.
+
+**Surface to chat:** confirm placement, OR specify alternative section name / location. Non-blocking for tasks 2-11; only blocks Task 12 (docs).
+
+---
+
+## 6. Implementation plan & file inventory
+
+### Create (NEW files)
+
+```
+core/sim/exit_policies/
+  __init__.py                              # exports ExitPolicy Protocol, build_exit_policy, ExitPolicyDecision
+  _base.py                                 # ExitPolicy Protocol, ExitPolicyDecision dataclass, ExitPolicyContext
+  registry.py                              # build_exit_policy(name) -> ExitPolicy
+  sl_only.py                               # SlOnly policy (no-op beyond SL)
+  sl_plus_tp_2r.py                         # SlPlusTp2R: TP at +2R when MFE first crosses
+  sl_plus_tp_3r.py                         # SlPlusTp3R: TP at +3R when MFE first crosses
+  sl_plus_trailing_atr.py                  # SlPlusTrailingAtr: trail at 1R below peak MFE, activate at MFE≥1R
+  sl_plus_trailing_swing.py                # SlPlusTrailingSwing: trail at running close-low post-activation
+  sl_partial_close_1r_runner_trail.py      # SlPartialClose1RRunnerTrail (the main primitive)
+core/sim/exit_policy_manager.py            # ExitPolicyManager (TrailManager-style per-position state holder)
+
+tests/sim/exit_policies/
+  __init__.py
+  test_sl_only.py                          # unit
+  test_sl_plus_tp_2r.py                    # unit
+  test_sl_plus_tp_3r.py                    # unit
+  test_sl_plus_trailing_atr.py             # unit
+  test_sl_plus_trailing_swing.py           # unit
+  test_sl_partial_close_runner_trail.py    # unit
+  test_registry.py                         # registry resolution + unknown-policy KeyError
+  test_<policy>_reference_parity.py × 6    # parity vs scripts/l_arc_10_v3/step_5.py:_apply_exit_policy
+  test_<policy>_canonical_integration.py × 6  # integration through MultiPairBacktester on mini fixture
+tests/test_partial_fill_account.py         # Account.partial_close + ClosedTrade.parent_position_id + exposure semantics
+tests/test_exit_policy_manager.py          # ExitPolicyManager state machine + integration with driver
+tests/test_kh24_anchor_post_registry.py    # KH-24 anchor regression confirming exit_policy=None preserves baseline
+```
+
+### Modify (EXISTING files)
+
+```
+core/sim/account.py
+  + partial_close(position_id, exit_time, exit_price, exit_reason, size_to_close) -> ClosedTrade
+  + _current_sizes: dict[int, float] shadow (Position stays frozen as size-at-open)
+  + current_size_of(position_id) -> float
+  + ClosedTrade.parent_position_id: int | None (None for full, parent id for child closes)
+  ~ mark_to_market: reads current_size (falls back to position.size if not shadowed)
+  ~ _currency_concurrency / _pair_concurrency / exposure_check: count as 1 until fully closed
+
+core/sim/multipair_backtester.py
+  + exit_policy_manager: ExitPolicyManager | None field
+  + _pending_partial_closes: dict[int, PartialCloseDecision] (separate from _pending_closes)
+  ~ _process_bar: after _check_exits, before trail update → policy evaluation → queue full/partial close
+  ~ _fill_pending_closes: handle partial via Account.partial_close, full via Account.close
+  + _fill_pending_partial_closes(t, snapshot)
+
+core/architectures/a1_system_level_filter.py
+  + A1Config.exit_policy: str | None = None
+  ~ A1Architecture.run(): if exit_policy, instantiate via build_exit_policy + register ExitPolicyManager
+  ~ result.metadata: + exit_policy field
+
+core/architectures/a2_classifier_filter.py    # same pattern
+core/architectures/a3_pipeline_de.py           # same pattern
+core/architectures/a4_pipeline_d_exits.py      # same pattern (interacts with classifier exit_predicate — TODO precedence note in module docstring)
+core/architectures/a6_meta_labeling.py         # same pattern
+
+scripts/l_arc_10_v3/step_5.py
+  - DELETE _apply_exit_policy (lines 99-253)
+  + IMPORT from core.sim.exit_policies
+  ~ Step 5 driver uses canonical engine sim per config (NOT post-hoc path replay)
+  ~ See Task 7 description for the (a)/(b) sub-decision — chat input may be needed
+
+scripts/l_arc_8/run_step5_wfo.py
+  - DELETE _apply_exit_policy (lines 74-88)
+  + IMPORT from core.sim.exit_policies
+  ~ Closure note required: Arc 8 numbers shift (pool-approx → canonical engine)
+
+docs/PROTOCOL_RUNTIME.md                       # add §8c (Task 12, blocked on Q6)
+docs/BACKTESTER_ARCHITECTURE.md                # add Exit policies subsection (Task 12, blocked on Q6)
+docs/audits/engine_capability_audit_2026_05.md # footer amendment (Task 12)
+```
+
+### Don't touch
+
+- `core/strategies/kh24/**` — KH-24 stays unchanged. `exit_policy=None` defaults preserve baseline.
+- `core/exit_policies.py` (StepwiseClimberPolicy) — different abstraction; Pipeline D1's archetype-policy machinery.
+- `scripts/l_arc_10_v3/step_5.py:_apply_a4_exits` — A4 heuristic stand-in, different abstraction.
+- `core/sim/fill.py` — existing fill primitives reused.
+- `core/sim/trailing_stop.py` — TrailManager continues to drive KH-24-style trail. Partial-close runner-trail gets its own manager (parallel, doesn't subsume).
+
+### Task ordering & dependencies
+
+(See TaskList; ID-numbered Task 1 → 13 with explicit `blockedBy`)
+
+```
+1 (intent doc — IN PROGRESS)
+  ├─ 2 (Account partial-fill)
+  └─ 3 (exit_policies/ registry)
+       ├─ 4 (ExitPolicyManager) ──┐
+       └─ 9 (unit tests)          │
+                                   ├─ 5 (MultiPairBacktester wiring)
+                                   │   └─ 6 (arch config field)
+                                   │       ├─ 7 (migrate Arc 10 v3)
+                                   │       ├─ 8 (migrate Arc 8)
+                                   │       ├─ 10 (parity tests)
+                                   │       └─ 11 (KH-24 regression)
+                                   │            └─ 12 (docs — blocked on Q6)
+                                   │                 └─ 13 (PR)
+```
+
+---
+
+## 7. Risks (updated)
+
+1. **Account partial-fill blast radius.** Mitigation: Position stays frozen, Account.partial_close is new method, mark_to_market reads `_current_sizes.get(pid, position.size)`. KH-24 path never enters the shadow dict.
+
+2. **ClosedTrade schema change** (`parent_position_id` field). Mitigation: default `None`; grep all consumers in [tests/](tests/), [scripts/](scripts/), [core/](core/) for `ClosedTrade(` constructor calls + attribute access before merge. Tracker parser + closure templates likely touch this.
+
+3. **Arc 8 numeric drift.** Migrating from pool-level approx → canonical engine will change `sl_plus_tp_2r` / `sl_plus_tp_3r` outcomes (canonical is strictly stricter). The Arc 8 closure already flags the approximation as a known limit — this PR's closure note positions the migration as the resolution. **Surface as a noted PR side-effect.**
+
+4. **Arc 10 v3.0 reproducibility.** Migrating from path-based reference → canonical engine adds bid/ask wings. Arc 10 v3.0.1 retry is the diagnostic measurement. Reference-parity tests run on mid-only fixtures (Q5).
+
+5. **A4 precedence interaction.** A4's classifier-driven exit_predicate fires at bar close. If `exit_policy=sl_partial_close_1r_runner_trail` is enabled on A4 too, both can fire on the same bar. Precedence proposal: **trail-stop / partial-close manager wins** (matches existing PR-E.1 trail-vs-predicate precedence per [PROTOCOL_RUNTIME.md §8b "A4 same-bar exit precedence"](docs/PROTOCOL_RUNTIME.md:485)). Documented in A4 module docstring + the new ExitPolicyManager docstring.
+
+6. **Parity-test tolerance achievability** (Q5). Pool-size byte-identical requires that policy logic doesn't perturb exposure-cap admission. For SL-only / TP-only / trailing policies this is fine — they only change exit timing within an admitted trade. For `sl_partial_close_1r_runner_trail` the partial keeps position-open, which keeps exposure-cap occupied longer than a full TP-style exit would — pool-size byte-identity may need to be measured at "entries admitted" rather than "trades completed". **Surface if parity test fails on this axis.**
+
+---
+
+## 8. Daily status update protocol
+
+Per chat directive ("Daily intent doc updates as scope dictates"):
+
+- §0 changelog entry per material scope/decision change.
+- §5 question status updates as chat resolves.
+- Bottom of doc: rolling status footer (last-updated timestamp + current task in progress + open blockers).
+
+**Current status: Task 1 in progress; Tasks 2-11 unblocked once this doc lands; Task 12 blocked on Q6.**
+
+---
+
+## 9. End-of-turn (this iteration)
+
+Intent doc revised for S1+ scope. Task list created with full dependency graph. Proceeding to Task 2 (Account partial-fill) immediately on next turn — non-blocking on Q6.
+
+**Asking chat:** confirm Q5 mid-only-parity acceptable + Q6 docs section placement (proposed: §8c PROTOCOL_RUNTIME.md, new "Exit policies" sub in BACKTESTER_ARCHITECTURE.md §B, footer amendment in engine_capability_audit_2026_05.md).

--- a/scripts/l_arc_10_v3/step_5.py
+++ b/scripts/l_arc_10_v3/step_5.py
@@ -45,6 +45,7 @@ from sklearn.pipeline import Pipeline  # noqa: E402
 from sklearn.preprocessing import StandardScaler  # noqa: E402
 
 from core.determinism import RANDOM_STATE, seed_everything  # noqa: E402
+from core.sim.exit_policies import simulate_path as _canonical_simulate_path  # noqa: E402
 from scripts.l_arc_10_v3._common import load_config, sha256_file, write_manifest  # noqa: E402
 
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -104,153 +105,20 @@ def _apply_exit_policy(
 ) -> tuple[float, int]:
     """Simulate the realised R + bars_held under a new SL multiplier and exit policy.
 
-    Path values were stored in R-multiples relative to the Step 1 SL=2.0×ATR
-    (sl_distance_2). Under new SL multiplier M:
-        scale = 2.0 / M
-        SL breach threshold (in old-R units): -(M/2)
-        new R units = old R × scale
+    Delegates to :func:`core.sim.exit_policies.simulate_path` (the canonical
+    path-replay registry). The hand-rolled per-policy logic that historically
+    lived in this function was extracted to ``core/sim/exit_policies/
+    path_simulate.py`` as part of the canonical-exit-policy-registry PR
+    (engine/sl-partial-close-runner-trail-primitive). The semantics are
+    byte-identical (verified by ``tests/sim/exit_policies/
+    test_path_simulate_reference_parity.py``).
+
+    Path values are stored in R-multiples relative to Step 1's SL=2.0×ATR.
+    See the canonical module for full schema and scaling math.
 
     Returns (final_r_new, bars_held).
     """
-    if path_rows.empty:
-        return float(trade_row.get("final_r", 0.0)) * (2.0 / sl_multiplier), int(trade_row.get("bars_held", 0))
-
-    p = path_rows.sort_values("bar_offset")
-    bar_offsets = p["bar_offset"].to_numpy(dtype=int)
-    mae = p["mae_so_far_r"].to_numpy()
-    mfe = p["mfe_so_far_r"].to_numpy()
-    close = p["close_r"].to_numpy()
-    is_held = p["is_held"].to_numpy() if "is_held" in p.columns else np.ones(len(p), dtype=int)
-
-    scale = 2.0 / sl_multiplier
-    sl_threshold_old = -(sl_multiplier / 2.0)
-    new_mfe_at = mfe * scale
-    new_close_at = close * scale
-
-    # Find SL breach index (in old-R units against new SL)
-    sl_breach = -1
-    for i, m in enumerate(mae):
-        if np.isfinite(m) and m <= sl_threshold_old:
-            sl_breach = i
-            break
-
-    n = len(p)
-    # Helper — search for first index where new_mfe ≥ k
-    def first_at_least(arr, k):
-        idx = np.where(np.isfinite(arr) & (arr >= k))[0]
-        return int(idx[0]) if idx.size > 0 else -1
-
-    if exit_policy == "sl_only":
-        # Original simulation rule: SL or time exit (end of held path)
-        if sl_breach >= 0:
-            return -1.0, int(bar_offsets[sl_breach] + 1)
-        # Held path exit: final close * scale
-        # bars_held = held window length
-        held_idx = np.where(is_held == 1)[0]
-        end_i = held_idx[-1] if held_idx.size > 0 else n - 1
-        return float(new_close_at[end_i]), int(bar_offsets[end_i] + 1)
-
-    if exit_policy == "sl_plus_tp_2r":
-        tp_i = first_at_least(new_mfe_at, 2.0)
-        if tp_i >= 0 and (sl_breach < 0 or tp_i <= sl_breach):
-            return 2.0, int(bar_offsets[tp_i] + 1)
-        if sl_breach >= 0:
-            return -1.0, int(bar_offsets[sl_breach] + 1)
-        held_idx = np.where(is_held == 1)[0]
-        end_i = held_idx[-1] if held_idx.size > 0 else n - 1
-        return float(new_close_at[end_i]), int(bar_offsets[end_i] + 1)
-
-    if exit_policy == "sl_plus_tp_3r":
-        tp_i = first_at_least(new_mfe_at, 3.0)
-        if tp_i >= 0 and (sl_breach < 0 or tp_i <= sl_breach):
-            return 3.0, int(bar_offsets[tp_i] + 1)
-        if sl_breach >= 0:
-            return -1.0, int(bar_offsets[sl_breach] + 1)
-        held_idx = np.where(is_held == 1)[0]
-        end_i = held_idx[-1] if held_idx.size > 0 else n - 1
-        return float(new_close_at[end_i]), int(bar_offsets[end_i] + 1)
-
-    if exit_policy == "sl_plus_trailing_atr":
-        # Trail at 1 R below the peak MFE; activate at 1R.
-        trail_r = -1.0  # init below threshold
-        active = False
-        trail_exit_i = -1
-        for i in range(n):
-            if not np.isfinite(new_mfe_at[i]):
-                continue
-            if new_mfe_at[i] >= 1.0:
-                active = True
-                trail_r = max(trail_r, new_mfe_at[i] - 1.0)
-            if active and np.isfinite(new_close_at[i]) and new_close_at[i] <= trail_r:
-                trail_exit_i = i
-                break
-        if sl_breach >= 0 and (trail_exit_i < 0 or sl_breach <= trail_exit_i):
-            return -1.0, int(bar_offsets[sl_breach] + 1)
-        if trail_exit_i >= 0:
-            return float(new_close_at[trail_exit_i]), int(bar_offsets[trail_exit_i] + 1)
-        held_idx = np.where(is_held == 1)[0]
-        end_i = held_idx[-1] if held_idx.size > 0 else n - 1
-        return float(new_close_at[end_i]), int(bar_offsets[end_i] + 1)
-
-    if exit_policy == "sl_plus_trailing_swing":
-        # Trail at the running min of new_close_at after activation at 1R.
-        active = False
-        prev_low = -np.inf
-        trail_exit_i = -1
-        for i in range(n):
-            if not np.isfinite(new_mfe_at[i]):
-                continue
-            if new_mfe_at[i] >= 1.0:
-                active = True
-            if active:
-                if i > 0 and np.isfinite(new_close_at[i - 1]):
-                    prev_low = max(prev_low, min(new_close_at[i - 1], 0.0))
-                if np.isfinite(new_close_at[i]) and new_close_at[i] <= prev_low:
-                    trail_exit_i = i
-                    break
-        if sl_breach >= 0 and (trail_exit_i < 0 or sl_breach <= trail_exit_i):
-            return -1.0, int(bar_offsets[sl_breach] + 1)
-        if trail_exit_i >= 0:
-            return float(new_close_at[trail_exit_i]), int(bar_offsets[trail_exit_i] + 1)
-        held_idx = np.where(is_held == 1)[0]
-        end_i = held_idx[-1] if held_idx.size > 0 else n - 1
-        return float(new_close_at[end_i]), int(bar_offsets[end_i] + 1)
-
-    if exit_policy == "sl_partial_close_1r_runner_trail":
-        # Close 50% at 1R, trail the rest at 1 R below subsequent peak.
-        tp1_i = first_at_least(new_mfe_at, 1.0)
-        if tp1_i < 0:
-            # Never reached 1R; full position exits at SL or held end.
-            if sl_breach >= 0:
-                return -1.0, int(bar_offsets[sl_breach] + 1)
-            held_idx = np.where(is_held == 1)[0]
-            end_i = held_idx[-1] if held_idx.size > 0 else n - 1
-            return float(new_close_at[end_i]), int(bar_offsets[end_i] + 1)
-        # Close 50% at +1.0R; runner trails.
-        half_r = 1.0
-        # Trail runner: activate at tp1_i, trail at 1R below peak.
-        trail_r = 0.0  # peak so far - 1
-        trail_exit_i = -1
-        for i in range(tp1_i, n):
-            if np.isfinite(new_mfe_at[i]):
-                trail_r = max(trail_r, new_mfe_at[i] - 1.0)
-            if np.isfinite(new_close_at[i]) and new_close_at[i] <= trail_r and i > tp1_i:
-                trail_exit_i = i
-                break
-        if sl_breach >= 0 and sl_breach > tp1_i and (trail_exit_i < 0 or sl_breach <= trail_exit_i):
-            runner_r = -1.0
-        elif trail_exit_i >= 0:
-            runner_r = float(new_close_at[trail_exit_i])
-        else:
-            held_idx = np.where(is_held == 1)[0]
-            end_i = held_idx[-1] if held_idx.size > 0 else n - 1
-            runner_r = float(new_close_at[end_i])
-        final_r = 0.5 * half_r + 0.5 * runner_r
-        last_bar = trail_exit_i if trail_exit_i >= 0 else (sl_breach if sl_breach >= 0 else n - 1)
-        return float(final_r), int(bar_offsets[last_bar] + 1)
-
-    # Unknown policy — fall back to sl_only
-    return _apply_exit_policy(trade_row, path_rows, sl_multiplier, "sl_only")
+    return _canonical_simulate_path(exit_policy, trade_row, path_rows, sl_multiplier)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/l_arc_8/run_step5_wfo.py
+++ b/scripts/l_arc_8/run_step5_wfo.py
@@ -40,6 +40,7 @@ import pandas as pd
 
 from core.determinism import seed_everything, write_text_deterministic
 from core.manifest import write_manifest
+from core.sim.exit_policies import simulate_pool_approximation as _canonical_pool_sim
 from core.wfo.folds import build_v3_folds
 from scripts.l_arc_8.shared import RESULTS_ROOT, SL_ATR_MULT_STEP1
 
@@ -72,20 +73,21 @@ A6_THRESHOLDS: tuple[tuple[float, float], ...] = (
 
 
 def _apply_exit_policy(final_r: float, mfe_r: float, mae_r: float, policy: str) -> float:
-    """Approximate exit-policy effect on per-trade R outcome.
+    """Pool-level approximation — delegates to canonical registry.
 
-    sl_only: keep final_r as-is (the pool's exit reason already enforces SL).
-    sl_plus_tp_2r: if MFE >= 2R, cap at +2R; else final_r.
-        (Approximation: assumes TP fires before any pull-back to SL when MFE >= 2.)
-    sl_plus_tp_3r: same logic at +3R.
+    Historical hand-rolled body was extracted into
+    :func:`core.sim.exit_policies.simulate_pool_approximation` as part of
+    the canonical-exit-policy-registry PR
+    (engine/sl-partial-close-runner-trail-primitive). Behaviour preserved
+    byte-identically; this thin wrapper keeps the local call sites
+    compatible with the legacy signature.
+
+    See the canonical function's docstring for semantics + approximation
+    caveats. Higher-fidelity arcs should prefer
+    :func:`core.sim.exit_policies.simulate_path` (bar-by-bar over
+    recorded paths).
     """
-    if policy == "sl_only":
-        return final_r
-    if policy == "sl_plus_tp_2r":
-        return 2.0 if mfe_r >= 2.0 else final_r
-    if policy == "sl_plus_tp_3r":
-        return 3.0 if mfe_r >= 3.0 else final_r
-    return final_r
+    return _canonical_pool_sim(final_r, mfe_r, mae_r, policy)
 
 
 def _rescale_outcome_at_sl(

--- a/tests/sim/exit_policies/test_path_simulate_reference_parity.py
+++ b/tests/sim/exit_policies/test_path_simulate_reference_parity.py
@@ -1,0 +1,197 @@
+"""Reference-implementation parity for canonical path-simulate.
+
+The canonical ``core.sim.exit_policies.path_simulate`` module was extracted
+from ``scripts/l_arc_10_v3/step_5.py:_apply_exit_policy:99-253`` (the
+historical hand-rolled simulator that produced Arc 10's PASS-DEPLOYABLE
+verdict). This test confirms byte-identical behaviour between the two
+across a synthetic range of recorded path inputs.
+
+Tolerances (per chat answer Q5 — mid-only parity is byte-identical because
+both implementations work in R-units off a single mid-anchored price
+stream; no bid/ask wing is added):
+  * Per-trade final_r: BYTE-IDENTICAL (not just within ±0.01R).
+  * Per-trade bars_held: BYTE-IDENTICAL.
+
+If this test ever fails: the canonical implementation has drifted from
+the reference. Either (a) the reference changed in scripts/l_arc_10_v3/
+step_5.py (likely a separate intentional change — update the parity
+fixture), or (b) we accidentally introduced a semantic divergence in
+the canonical path_simulate module (this is the bug the test is here
+to catch).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# Import the canonical path-simulate dispatcher
+from core.sim.exit_policies import simulate_path as canonical_simulate_path
+
+# Import the reference hand-rolled implementation
+from scripts.l_arc_10_v3.step_5 import _apply_exit_policy as reference_apply
+
+
+POLICIES = (
+    "sl_only",
+    "sl_plus_tp_2r",
+    "sl_plus_tp_3r",
+    "sl_plus_trailing_atr",
+    "sl_plus_trailing_swing",
+    "sl_partial_close_1r_runner_trail",
+)
+
+SL_MULTS = (1.5, 2.0, 2.5, 3.0)
+
+
+def _make_path_df(
+    *,
+    mae_seq: list[float],
+    mfe_seq: list[float],
+    close_seq: list[float],
+    is_held: list[int] | None = None,
+) -> pd.DataFrame:
+    n = len(mae_seq)
+    assert len(mfe_seq) == n and len(close_seq) == n
+    return pd.DataFrame({
+        "bar_offset": list(range(n)),
+        "mae_so_far_r": mae_seq,
+        "mfe_so_far_r": mfe_seq,
+        "close_r": close_seq,
+        "is_held": is_held if is_held is not None else [1] * n,
+    })
+
+
+# Reproducible synthetic scenarios that exercise different code paths
+SCENARIOS = {
+    # Winner that hits +2R cleanly
+    "winner_tp2r": _make_path_df(
+        mae_seq=[0.0, -0.1, -0.2, -0.1, -0.05],
+        mfe_seq=[0.0, 0.5, 1.2, 1.8, 2.2],
+        close_seq=[0.0, 0.4, 1.0, 1.6, 2.1],
+    ),
+    # Winner that just barely reaches +1R and trails back
+    "winner_runner_trail": _make_path_df(
+        mae_seq=[0.0, -0.2, -0.1, -0.05, -0.1, -0.2, -0.3],
+        mfe_seq=[0.0, 0.5, 1.1, 1.3, 1.3, 1.3, 1.3],
+        close_seq=[0.0, 0.4, 1.0, 1.2, 0.8, 0.2, -0.1],
+    ),
+    # Loser hit SL early
+    "loser_sl_early": _make_path_df(
+        mae_seq=[0.0, -0.5, -1.1, -1.5, -2.0],
+        mfe_seq=[0.0, 0.1, 0.2, 0.1, 0.0],
+        close_seq=[0.0, -0.3, -1.0, -1.3, -1.6],
+    ),
+    # Time exit at end of held window — no SL, no profitable threshold
+    "time_exit_breakeven": _make_path_df(
+        mae_seq=[0.0, -0.3, -0.3, -0.2, -0.1, 0.0],
+        mfe_seq=[0.0, 0.2, 0.4, 0.5, 0.6, 0.7],
+        close_seq=[0.0, 0.1, 0.3, 0.4, 0.5, 0.6],
+    ),
+    # SL hit after some profit — tests SL-preempts-trail / SL-after-tp1
+    "winner_then_sl": _make_path_df(
+        mae_seq=[0.0, -0.2, -0.1, -0.05, -0.8, -1.5],
+        mfe_seq=[0.0, 0.5, 1.2, 1.5, 1.5, 1.5],
+        close_seq=[0.0, 0.4, 1.0, 1.3, 0.0, -1.0],
+    ),
+    # Empty path (edge case)
+    "empty_path": pd.DataFrame(
+        columns=["bar_offset", "mae_so_far_r", "mfe_so_far_r", "close_r", "is_held"]
+    ),
+    # Path with NaN (degenerate but possible)
+    "with_nan": _make_path_df(
+        mae_seq=[0.0, -0.1, float("nan"), -0.2, -0.3],
+        mfe_seq=[0.0, 0.5, 1.1, 1.3, 1.0],
+        close_seq=[0.0, 0.4, 1.0, 1.2, 0.8],
+    ),
+    # Big winner that trails out after peak
+    "big_winner_trail": _make_path_df(
+        mae_seq=[0.0, -0.1, -0.05, 0.0, -0.5, -0.8],
+        mfe_seq=[0.0, 1.5, 2.5, 3.5, 3.5, 3.5],
+        close_seq=[0.0, 1.0, 2.0, 3.0, 1.5, 0.5],
+    ),
+    # is_held shortened (time exit earlier than path length)
+    "early_time_exit": _make_path_df(
+        mae_seq=[0.0, -0.2, -0.3, -0.2, -0.1, -0.05],
+        mfe_seq=[0.0, 0.3, 0.5, 0.7, 0.8, 0.9],
+        close_seq=[0.0, 0.2, 0.4, 0.5, 0.6, 0.7],
+        is_held=[1, 1, 1, 0, 0, 0],  # closed at bar 2
+    ),
+}
+
+
+def _make_trade_row(final_r: float = 0.0, bars_held: int = 0) -> pd.Series:
+    """Minimal trade row — only used by the empty-path early-return branch."""
+    return pd.Series({"final_r": final_r, "bars_held": bars_held})
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Tests: canonical vs reference byte-identity
+# ────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("policy", POLICIES)
+@pytest.mark.parametrize("sl_mult", SL_MULTS)
+@pytest.mark.parametrize("scenario_name", list(SCENARIOS))
+def test_canonical_matches_reference_byte_identical(
+    policy: str, sl_mult: float, scenario_name: str
+) -> None:
+    """Canonical path simulator emits identical (final_r, bars_held) to
+    reference hand-rolled across all policies × SL multipliers × scenarios.
+    """
+    path_df = SCENARIOS[scenario_name]
+    trade_row = _make_trade_row(final_r=0.0, bars_held=len(path_df))
+
+    canonical_r, canonical_bars = canonical_simulate_path(
+        policy, trade_row, path_df, sl_mult
+    )
+    reference_r, reference_bars = reference_apply(
+        trade_row, path_df, sl_mult, policy
+    )
+
+    # Byte-identical contract on R values (same float operations in the same
+    # order; no bid/ask spread perturbation in path replay mode).
+    assert canonical_r == reference_r, (
+        f"final_r mismatch | policy={policy} sl_mult={sl_mult} "
+        f"scenario={scenario_name} | canonical={canonical_r} "
+        f"reference={reference_r}"
+    )
+    assert canonical_bars == reference_bars, (
+        f"bars_held mismatch | policy={policy} sl_mult={sl_mult} "
+        f"scenario={scenario_name} | canonical={canonical_bars} "
+        f"reference={reference_bars}"
+    )
+
+
+def test_unknown_policy_falls_back_to_sl_only() -> None:
+    """Reference behaviour: unknown policy name → sl_only fallthrough.
+    Canonical preserves this contract.
+    """
+    path_df = SCENARIOS["winner_tp2r"]
+    trade_row = _make_trade_row()
+    canonical = canonical_simulate_path("nonsense", trade_row, path_df, 2.0)
+    reference = reference_apply(trade_row, path_df, 2.0, "nonsense")
+    assert canonical == reference
+
+
+def test_available_path_simulators_matches_canonical_registry() -> None:
+    """The path-simulator dispatcher's name list must be a SUPERSET of the
+    live-engine registry (every live policy needs a path-replay too).
+    """
+    from core.sim.exit_policies import available_path_simulators, available_policies
+
+    live = set(available_policies())
+    replay = set(available_path_simulators())
+    missing_in_replay = live - replay
+    assert not missing_in_replay, (
+        f"Policies in live registry but missing from path-simulate: "
+        f"{sorted(missing_in_replay)}"
+    )

--- a/tests/sim/exit_policies/test_path_simulate_reference_parity.py
+++ b/tests/sim/exit_policies/test_path_simulate_reference_parity.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -33,12 +32,9 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-# Import the canonical path-simulate dispatcher
-from core.sim.exit_policies import simulate_path as canonical_simulate_path
-
-# Import the reference hand-rolled implementation
-from scripts.l_arc_10_v3.step_5 import _apply_exit_policy as reference_apply
-
+# sys.path mutation above must precede these imports → E402 explicitly waived.
+from core.sim.exit_policies import simulate_path as canonical_simulate_path  # noqa: E402
+from scripts.l_arc_10_v3.step_5 import _apply_exit_policy as reference_apply  # noqa: E402
 
 POLICIES = (
     "sl_only",

--- a/tests/sim/exit_policies/test_registry.py
+++ b/tests/sim/exit_policies/test_registry.py
@@ -1,0 +1,122 @@
+"""Registry surface contract: name resolution, error message on unknown,
+fresh-instance-per-call semantics, full inventory matches expectations.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.sim.account import Direction
+from core.sim.exit_policies import (
+    ExitPolicyContext,
+    SlOnlyPolicy,
+    SlPartialClose1RRunnerTrailPolicy,
+    SlPlusTp2RPolicy,
+    SlPlusTp3RPolicy,
+    SlPlusTrailingAtrPolicy,
+    SlPlusTrailingSwingPolicy,
+    available_policies,
+    build_exit_policy,
+)
+
+
+EXPECTED_REGISTRY = {
+    "sl_only": SlOnlyPolicy,
+    "sl_plus_tp_2r": SlPlusTp2RPolicy,
+    "sl_plus_tp_3r": SlPlusTp3RPolicy,
+    "sl_plus_trailing_atr": SlPlusTrailingAtrPolicy,
+    "sl_plus_trailing_swing": SlPlusTrailingSwingPolicy,
+    "sl_partial_close_1r_runner_trail": SlPartialClose1RRunnerTrailPolicy,
+}
+
+
+def test_available_policies_matches_expected_inventory() -> None:
+    assert available_policies() == tuple(sorted(EXPECTED_REGISTRY))
+
+
+@pytest.mark.parametrize("name,cls", list(EXPECTED_REGISTRY.items()))
+def test_build_exit_policy_returns_correct_class(name: str, cls: type) -> None:
+    p = build_exit_policy(name)
+    assert isinstance(p, cls)
+    assert p.name == name
+
+
+def test_build_exit_policy_unknown_raises_keyerror_with_available_list() -> None:
+    with pytest.raises(KeyError) as excinfo:
+        build_exit_policy("not_a_policy")
+    msg = str(excinfo.value)
+    assert "not_a_policy" in msg
+    assert "Available:" in msg
+    # Every registered name appears in the error
+    for name in EXPECTED_REGISTRY:
+        assert name in msg
+
+
+def test_build_exit_policy_returns_fresh_instance_per_call() -> None:
+    p1 = build_exit_policy("sl_only")
+    p2 = build_exit_policy("sl_only")
+    assert p1 is not p2
+
+
+def test_tp_policies_apply_to_order_sets_tp_price_long() -> None:
+    ctx = ExitPolicyContext(
+        entry_price=1.1000,
+        atr_at_entry=0.0010,
+        sl_atr_mult=2.0,
+        direction=Direction.LONG,
+    )
+    # R_atr = 2.0 * 0.0010 = 0.0020
+    assert build_exit_policy("sl_plus_tp_2r").apply_to_order(ctx) == {
+        "tp_price": 1.1000 + 2.0 * 0.0020
+    }
+    assert build_exit_policy("sl_plus_tp_3r").apply_to_order(ctx) == {
+        "tp_price": 1.1000 + 3.0 * 0.0020
+    }
+
+
+def test_tp_policies_apply_to_order_sets_tp_price_short() -> None:
+    ctx = ExitPolicyContext(
+        entry_price=1.1000,
+        atr_at_entry=0.0010,
+        sl_atr_mult=2.0,
+        direction=Direction.SHORT,
+    )
+    assert build_exit_policy("sl_plus_tp_2r").apply_to_order(ctx) == {
+        "tp_price": 1.1000 - 2.0 * 0.0020
+    }
+
+
+def test_stateful_policies_have_non_null_state() -> None:
+    """Trailing + partial-close policies must build real state objects."""
+    ctx = ExitPolicyContext(
+        entry_price=1.1, atr_at_entry=0.0010, sl_atr_mult=2.0, direction=Direction.LONG
+    )
+    for name in (
+        "sl_plus_trailing_atr",
+        "sl_plus_trailing_swing",
+        "sl_partial_close_1r_runner_trail",
+    ):
+        p = build_exit_policy(name)
+        state = p.make_state(ctx)
+        # State must NOT be NullPolicyState (it must carry per-position fields)
+        from core.sim.exit_policies import NullPolicyState
+
+        assert not isinstance(state, NullPolicyState), name
+
+
+def test_stateless_policies_have_null_state() -> None:
+    ctx = ExitPolicyContext(
+        entry_price=1.1, atr_at_entry=0.0010, sl_atr_mult=2.0, direction=Direction.LONG
+    )
+    from core.sim.exit_policies import NullPolicyState
+
+    for name in ("sl_only", "sl_plus_tp_2r", "sl_plus_tp_3r"):
+        p = build_exit_policy(name)
+        assert isinstance(p.make_state(ctx), NullPolicyState), name
+
+
+def test_r_atr_helper() -> None:
+    ctx = ExitPolicyContext(
+        entry_price=1.1, atr_at_entry=0.0015, sl_atr_mult=2.5, direction=Direction.LONG
+    )
+    assert ctx.r_atr == pytest.approx(0.00375)

--- a/tests/sim/exit_policies/test_registry.py
+++ b/tests/sim/exit_policies/test_registry.py
@@ -19,7 +19,6 @@ from core.sim.exit_policies import (
     build_exit_policy,
 )
 
-
 EXPECTED_REGISTRY = {
     "sl_only": SlOnlyPolicy,
     "sl_plus_tp_2r": SlPlusTp2RPolicy,

--- a/tests/sim/exit_policies/test_sl_only.py
+++ b/tests/sim/exit_policies/test_sl_only.py
@@ -1,0 +1,66 @@
+"""``sl_only`` baseline: pure no-op. Apply yields no Order mods; both
+evaluate hooks always return None.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from core.sim.account import Account, Direction
+from core.sim.exit_policies import (
+    ExitPolicyContext,
+    NullPolicyState,
+    SlOnlyPolicy,
+)
+
+
+def _bar() -> pd.Series:
+    return pd.Series(
+        dict(
+            open_bid=1.10, open_ask=1.1001,
+            high_bid=1.20, high_ask=1.2001,
+            low_bid=1.00, low_ask=1.0001,
+            close_bid=1.15, close_ask=1.1501,
+        )
+    )
+
+
+def test_apply_to_order_returns_empty() -> None:
+    ctx = ExitPolicyContext(
+        entry_price=1.10, atr_at_entry=0.001, sl_atr_mult=2.0,
+        direction=Direction.LONG,
+    )
+    assert SlOnlyPolicy().apply_to_order(ctx) == {}
+
+
+def test_make_state_returns_null() -> None:
+    ctx = ExitPolicyContext(
+        entry_price=1.10, atr_at_entry=0.001, sl_atr_mult=2.0,
+        direction=Direction.LONG,
+    )
+    assert isinstance(SlOnlyPolicy().make_state(ctx), NullPolicyState)
+
+
+def test_evaluate_intrabar_always_none() -> None:
+    from core.sim.account import Position
+    ctx = ExitPolicyContext(
+        entry_price=1.10, atr_at_entry=0.001, sl_atr_mult=2.0,
+        direction=Direction.LONG,
+    )
+    p = SlOnlyPolicy()
+    state = p.make_state(ctx)
+    pos = Position(1, "EURUSD", Direction.LONG, pd.Timestamp("2026-01-01", tz="UTC"), 1.10, 10_000)
+    assert p.evaluate_intrabar(pos, _bar(), state, ctx) is None
+
+
+def test_evaluate_at_close_always_none() -> None:
+    from core.sim.account import Position
+    ctx = ExitPolicyContext(
+        entry_price=1.10, atr_at_entry=0.001, sl_atr_mult=2.0,
+        direction=Direction.LONG,
+    )
+    p = SlOnlyPolicy()
+    state = p.make_state(ctx)
+    pos = Position(1, "EURUSD", Direction.LONG, pd.Timestamp("2026-01-01", tz="UTC"), 1.10, 10_000)
+    acct = Account(starting_balance=100_000.0)
+    assert p.evaluate_at_close(pos, _bar(), state, ctx, acct) is None

--- a/tests/sim/exit_policies/test_sl_partial_close_runner_trail.py
+++ b/tests/sim/exit_policies/test_sl_partial_close_runner_trail.py
@@ -1,0 +1,223 @@
+"""``sl_partial_close_1r_runner_trail``: intra-bar partial at +1R, at-close
+runner trail at peak − R_atr. Reference: scripts/l_arc_10_v3/step_5.py:219-250.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from core.sim.account import Account, Direction, Position
+from core.sim.exit_policies import (
+    ExitAction,
+    ExitPolicyContext,
+    PartialCloseRunnerTrailState,
+    SlPartialClose1RRunnerTrailPolicy,
+)
+
+
+def _pos(direction: Direction = Direction.LONG, entry: float = 1.1000) -> Position:
+    return Position(
+        position_id=1,
+        pair="EURUSD",
+        direction=direction,
+        entry_time=pd.Timestamp("2026-01-01", tz="UTC"),
+        entry_price=entry,
+        size=10_000,
+    )
+
+
+def _ctx(direction: Direction = Direction.LONG, entry: float = 1.1000) -> ExitPolicyContext:
+    # R_atr = 2.0 * 0.001 = 0.002
+    return ExitPolicyContext(
+        entry_price=entry, atr_at_entry=0.001, sl_atr_mult=2.0, direction=direction
+    )
+
+
+def _bar(**kw) -> pd.Series:
+    base = dict(
+        open_bid=1.10, open_ask=1.1001,
+        high_bid=1.10, high_ask=1.1001,
+        low_bid=1.10, low_ask=1.1001,
+        close_bid=1.10, close_ask=1.1001,
+    )
+    base.update(kw)
+    return pd.Series(base)
+
+
+def test_apply_to_order_is_empty() -> None:
+    """Partial-close uses state-machine fire, not Order.tp_price."""
+    assert SlPartialClose1RRunnerTrailPolicy().apply_to_order(_ctx()) == {}
+
+
+def test_make_state_initial() -> None:
+    state = SlPartialClose1RRunnerTrailPolicy().make_state(_ctx())
+    assert isinstance(state, PartialCloseRunnerTrailState)
+    assert state.tp1_fired is False
+    assert state.tp1_bar_ordinal is None
+    assert pd.isna(state.peak_price)
+    assert state.bar_ordinal == 0
+
+
+# ────────────────────────────────────────────────────────────────────────
+# intra-bar: +1R partial close fires
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_intrabar_long_partial_fires_at_one_r() -> None:
+    p = SlPartialClose1RRunnerTrailPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    bar = _bar(high_bid=1.1020)
+    d = p.evaluate_intrabar(pos, bar, state, _ctx())
+    assert d is not None
+    assert d.action is ExitAction.PARTIAL_CLOSE
+    assert d.fill_price == pytest.approx(1.1020)  # entry + R_atr
+    assert d.partial_fraction == 0.5
+    assert d.timing == "intrabar"
+    assert state.tp1_fired is True
+
+
+def test_intrabar_long_does_not_fire_below_one_r() -> None:
+    p = SlPartialClose1RRunnerTrailPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    assert p.evaluate_intrabar(pos, _bar(high_bid=1.1019), state, _ctx()) is None
+    assert state.tp1_fired is False
+
+
+def test_intrabar_long_only_fires_once() -> None:
+    p = SlPartialClose1RRunnerTrailPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    p.evaluate_intrabar(pos, _bar(high_bid=1.1020), state, _ctx())
+    # Subsequent bar with high well above +1R → no fire (already done)
+    assert p.evaluate_intrabar(pos, _bar(high_bid=1.1100), state, _ctx()) is None
+
+
+def test_intrabar_short_partial_fires() -> None:
+    p = SlPartialClose1RRunnerTrailPolicy()
+    state = p.make_state(_ctx(Direction.SHORT))
+    pos = _pos(Direction.SHORT)
+    bar = _bar(low_ask=1.0980)  # entry - R_atr
+    d = p.evaluate_intrabar(pos, bar, state, _ctx(Direction.SHORT))
+    assert d is not None
+    assert d.fill_price == pytest.approx(1.0980)
+    assert state.tp1_fired is True
+
+
+# ────────────────────────────────────────────────────────────────────────
+# at-close: runner-trail
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_at_close_no_action_before_tp1() -> None:
+    """Pre-tp1: at_close only ratchets peak; never fires."""
+    p = SlPartialClose1RRunnerTrailPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    # bar with high < +1R, close drops sharply
+    bar = _bar(high_bid=1.1010, close_bid=1.0500)
+    assert p.evaluate_at_close(pos, bar, state, _ctx(), acct) is None
+    # Peak still ratcheted (per reference: peak runs from bar 0)
+    assert state.peak_price == pytest.approx(1.1010)
+
+
+def test_at_close_no_trail_fire_on_tp1_bar() -> None:
+    """Reference: i > tp1_i. Same-bar trail-exit forbidden."""
+    p = SlPartialClose1RRunnerTrailPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    # Intra-bar: tp1 fires on this bar (high=1.1030, well above +1R=1.1020)
+    bar = _bar(high_bid=1.1030, close_bid=1.0900)  # close drops to 1.0900 (below trail)
+    p.evaluate_intrabar(pos, bar, state, _ctx())
+    assert state.tp1_fired
+    assert state.tp1_bar_ordinal == 0
+    # At-close on the SAME bar: bar_ordinal = 0 = tp1_bar_ordinal → no fire
+    assert p.evaluate_at_close(pos, bar, state, _ctx(), acct) is None
+    assert state.bar_ordinal == 1
+
+
+def test_at_close_trail_fires_on_subsequent_bar() -> None:
+    """tp1 on bar 0. Bar 1: peak=1.103 (from bar 0 high). Trail=1.101.
+    Close on bar 1 drops to 1.101 → fires.
+    """
+    p = SlPartialClose1RRunnerTrailPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    # Bar 0: tp1 fires intra-bar; high=1.1030 → peak=1.1030 (at_close)
+    bar0 = _bar(high_bid=1.1030, close_bid=1.1025)
+    p.evaluate_intrabar(pos, bar0, state, _ctx())
+    p.evaluate_at_close(pos, bar0, state, _ctx(), acct)
+    assert state.peak_price == pytest.approx(1.1030)
+    assert state.bar_ordinal == 1
+    # Bar 1: close drops to 1.1010 = trail = peak - R_atr = 1.1030 - 0.002
+    bar1 = _bar(high_bid=1.1020, close_bid=1.1010)
+    decision = p.evaluate_at_close(pos, bar1, state, _ctx(), acct)
+    assert decision is not None
+    assert decision.action is ExitAction.FULL_CLOSE
+    assert decision.exit_reason == "runner_trail_stop"
+    assert decision.timing == "at_close"
+
+
+def test_at_close_trail_does_not_fire_with_close_above_trail() -> None:
+    p = SlPartialClose1RRunnerTrailPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    # Bar 0: tp1
+    bar0 = _bar(high_bid=1.1030, close_bid=1.1025)
+    p.evaluate_intrabar(pos, bar0, state, _ctx())
+    p.evaluate_at_close(pos, bar0, state, _ctx(), acct)
+    # Bar 1: close 1.1015 > trail 1.1010 → no fire
+    bar1 = _bar(high_bid=1.1020, close_bid=1.1015)
+    assert p.evaluate_at_close(pos, bar1, state, _ctx(), acct) is None
+
+
+def test_at_close_trail_ratchets_with_higher_peak() -> None:
+    """Peak goes higher; trail also rises."""
+    p = SlPartialClose1RRunnerTrailPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    # Bar 0: tp1, peak=1.103
+    p.evaluate_intrabar(pos, _bar(high_bid=1.1030), state, _ctx())
+    p.evaluate_at_close(pos, _bar(high_bid=1.1030, close_bid=1.1025), state, _ctx(), acct)
+    # Bar 1: higher high 1.106, close 1.1055
+    p.evaluate_at_close(pos, _bar(high_bid=1.106, close_bid=1.1055), state, _ctx(), acct)
+    assert state.peak_price == pytest.approx(1.106)
+    # Bar 2: trail now = 1.106 - 0.002 = 1.104; close 1.104 → fires
+    decision = p.evaluate_at_close(pos, _bar(close_bid=1.104), state, _ctx(), acct)
+    assert decision is not None
+
+
+def test_short_at_close_runner_trail() -> None:
+    p = SlPartialClose1RRunnerTrailPolicy()
+    state = p.make_state(_ctx(Direction.SHORT))
+    pos = _pos(Direction.SHORT)
+    acct = Account(starting_balance=100_000.0)
+    # Bar 0: short tp1 at low_ask 1.0980; trough=1.0980; close 1.0985
+    p.evaluate_intrabar(pos, _bar(low_ask=1.0980), state, _ctx(Direction.SHORT))
+    p.evaluate_at_close(pos, _bar(low_ask=1.0980, close_ask=1.0985), state, _ctx(Direction.SHORT), acct)
+    # Bar 1: trail = trough + R_atr = 1.0980 + 0.002 = 1.1000. close 1.1000 → fires
+    decision = p.evaluate_at_close(pos, _bar(close_ask=1.1000), state, _ctx(Direction.SHORT), acct)
+    assert decision is not None
+    assert decision.action is ExitAction.FULL_CLOSE
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Bar ordinal advancement
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_bar_ordinal_increments_on_each_at_close() -> None:
+    p = SlPartialClose1RRunnerTrailPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    for i in range(5):
+        p.evaluate_at_close(pos, _bar(), state, _ctx(), acct)
+    assert state.bar_ordinal == 5

--- a/tests/sim/exit_policies/test_sl_plus_tp.py
+++ b/tests/sim/exit_policies/test_sl_plus_tp.py
@@ -1,0 +1,73 @@
+"""``sl_plus_tp_2r`` / ``sl_plus_tp_3r`` — Order-decoration only. Both
+policies set ``tp_price`` at register; the per-bar hooks are no-ops
+(the existing intra-bar TP infrastructure handles fire/fill).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from core.sim.account import Account, Direction, Position
+from core.sim.exit_policies import (
+    ExitPolicyContext,
+    NullPolicyState,
+    SlPlusTp2RPolicy,
+    SlPlusTp3RPolicy,
+)
+
+
+def _ctx(direction: Direction = Direction.LONG) -> ExitPolicyContext:
+    # entry=1.10, atr=0.001, sl_mult=2.0 → R_atr = 0.002
+    return ExitPolicyContext(
+        entry_price=1.10, atr_at_entry=0.001, sl_atr_mult=2.0, direction=direction
+    )
+
+
+def _bar() -> pd.Series:
+    return pd.Series(
+        dict(
+            open_bid=1.10, open_ask=1.1001,
+            high_bid=1.20, high_ask=1.2001,
+            low_bid=1.00, low_ask=1.0001,
+            close_bid=1.15, close_ask=1.1501,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "policy_cls,tp_r,expected_long_tp,expected_short_tp",
+    [
+        (SlPlusTp2RPolicy, 2.0, 1.104, 1.096),
+        (SlPlusTp3RPolicy, 3.0, 1.106, 1.094),
+    ],
+)
+def test_apply_to_order_sets_tp_price(
+    policy_cls, tp_r: float, expected_long_tp: float, expected_short_tp: float
+) -> None:
+    p = policy_cls()
+    assert p.tp_r == tp_r
+    assert p.apply_to_order(_ctx(Direction.LONG))["tp_price"] == pytest.approx(expected_long_tp)
+    assert p.apply_to_order(_ctx(Direction.SHORT))["tp_price"] == pytest.approx(expected_short_tp)
+
+
+@pytest.mark.parametrize("policy_cls", [SlPlusTp2RPolicy, SlPlusTp3RPolicy])
+def test_state_is_null(policy_cls) -> None:
+    assert isinstance(policy_cls().make_state(_ctx()), NullPolicyState)
+
+
+@pytest.mark.parametrize("policy_cls", [SlPlusTp2RPolicy, SlPlusTp3RPolicy])
+def test_evaluate_hooks_are_noop(policy_cls) -> None:
+    p = policy_cls()
+    state = p.make_state(_ctx())
+    pos = Position(1, "EURUSD", Direction.LONG, pd.Timestamp("2026-01-01", tz="UTC"), 1.10, 10_000)
+    acct = Account(starting_balance=100_000.0)
+    assert p.evaluate_intrabar(pos, _bar(), state, _ctx()) is None
+    assert p.evaluate_at_close(pos, _bar(), state, _ctx(), acct) is None
+
+
+def test_tp_3r_is_subclass_of_tp_2r() -> None:
+    """SlPlusTp3R reuses SlPlusTp2R's apply_to_order via tp_r override."""
+    assert isinstance(SlPlusTp3RPolicy(), SlPlusTp2RPolicy)
+    assert SlPlusTp3RPolicy.name == "sl_plus_tp_3r"
+    assert SlPlusTp2RPolicy.name == "sl_plus_tp_2r"

--- a/tests/sim/exit_policies/test_sl_plus_trailing_atr.py
+++ b/tests/sim/exit_policies/test_sl_plus_trailing_atr.py
@@ -1,0 +1,133 @@
+"""``sl_plus_trailing_atr``: activate at MFE ≥ +1R, trail at peak − R_atr,
+exit when close ≤ trail. Long + short symmetry.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from core.sim.account import Account, Direction, Position
+from core.sim.exit_policies import (
+    ExitAction,
+    ExitPolicyContext,
+    SlPlusTrailingAtrPolicy,
+    TrailingAtrState,
+)
+
+
+def _pos(direction: Direction = Direction.LONG) -> Position:
+    return Position(
+        position_id=1,
+        pair="EURUSD",
+        direction=direction,
+        entry_time=pd.Timestamp("2026-01-01", tz="UTC"),
+        entry_price=1.1000,
+        size=10_000,
+    )
+
+
+def _ctx(direction: Direction = Direction.LONG) -> ExitPolicyContext:
+    # R_atr = 2.0 * 0.001 = 0.002
+    return ExitPolicyContext(
+        entry_price=1.1000, atr_at_entry=0.001, sl_atr_mult=2.0, direction=direction
+    )
+
+
+def _bar(**kw) -> pd.Series:
+    base = dict(
+        open_bid=1.10, open_ask=1.1001,
+        high_bid=1.10, high_ask=1.1001,
+        low_bid=1.10, low_ask=1.1001,
+        close_bid=1.10, close_ask=1.1001,
+    )
+    base.update(kw)
+    return pd.Series(base)
+
+
+def test_long_no_activation_below_one_r() -> None:
+    p = SlPlusTrailingAtrPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    bar = _bar(high_bid=1.1019, close_bid=1.1015)  # just below +1R = 1.1020
+    assert p.evaluate_at_close(pos, bar, state, _ctx(), acct) is None
+    assert not state.activated
+
+
+def test_long_activates_at_one_r() -> None:
+    p = SlPlusTrailingAtrPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    bar = _bar(high_bid=1.1020, close_bid=1.1018)  # at +1R, close above trail (1.100)
+    assert p.evaluate_at_close(pos, bar, state, _ctx(), acct) is None
+    assert state.activated
+    assert state.peak_price == pytest.approx(1.1020)
+
+
+def test_long_trail_ratchets_with_new_high() -> None:
+    p = SlPlusTrailingAtrPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    # Activation bar: peak=1.1020
+    p.evaluate_at_close(pos, _bar(high_bid=1.1020, close_bid=1.1018), state, _ctx(), acct)
+    # Next bar: higher high, peak ratchets
+    p.evaluate_at_close(pos, _bar(high_bid=1.1050, close_bid=1.1040), state, _ctx(), acct)
+    assert state.peak_price == pytest.approx(1.1050)
+    # Next bar: lower high, peak stays
+    p.evaluate_at_close(pos, _bar(high_bid=1.1040, close_bid=1.1035), state, _ctx(), acct)
+    assert state.peak_price == pytest.approx(1.1050)
+
+
+def test_long_fires_when_close_drops_to_trail() -> None:
+    p = SlPlusTrailingAtrPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    # Activation: peak=1.105 → trail = 1.105 - 0.002 = 1.103
+    p.evaluate_at_close(pos, _bar(high_bid=1.105, close_bid=1.104), state, _ctx(), acct)
+    # Close drops to 1.103 → fires (close <= trail)
+    bar = _bar(high_bid=1.104, close_bid=1.103)
+    decision = p.evaluate_at_close(pos, bar, state, _ctx(), acct)
+    assert decision is not None
+    assert decision.action is ExitAction.FULL_CLOSE
+    assert decision.exit_reason == "trailing_stop_atr"
+    assert decision.timing == "at_close"
+
+
+def test_long_does_not_fire_when_close_above_trail() -> None:
+    p = SlPlusTrailingAtrPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    p.evaluate_at_close(pos, _bar(high_bid=1.105, close_bid=1.104), state, _ctx(), acct)
+    bar = _bar(high_bid=1.105, close_bid=1.1031)  # close just above 1.103 trail
+    assert p.evaluate_at_close(pos, bar, state, _ctx(), acct) is None
+
+
+def test_short_activates_at_minus_one_r() -> None:
+    p = SlPlusTrailingAtrPolicy()
+    state = p.make_state(_ctx(Direction.SHORT))
+    pos = _pos(Direction.SHORT)
+    acct = Account(starting_balance=100_000.0)
+    # Short tp1: low_ask <= entry - R_atr = 1.0980
+    bar = _bar(low_ask=1.0980, close_ask=1.0982)
+    p.evaluate_at_close(pos, bar, state, _ctx(Direction.SHORT), acct)
+    assert state.activated
+    assert state.peak_price == pytest.approx(1.0980)
+
+
+def test_short_fires_when_close_rises_to_trail() -> None:
+    p = SlPlusTrailingAtrPolicy()
+    state = p.make_state(_ctx(Direction.SHORT))
+    pos = _pos(Direction.SHORT)
+    acct = Account(starting_balance=100_000.0)
+    # Activation: trough=1.095 → trail = 1.095 + 0.002 = 1.097
+    p.evaluate_at_close(pos, _bar(low_ask=1.095, close_ask=1.096), state, _ctx(Direction.SHORT), acct)
+    # Close rises to 1.097 → fires
+    bar = _bar(low_ask=1.096, close_ask=1.097)
+    decision = p.evaluate_at_close(pos, bar, state, _ctx(Direction.SHORT), acct)
+    assert decision is not None
+    assert decision.action is ExitAction.FULL_CLOSE

--- a/tests/sim/exit_policies/test_sl_plus_trailing_atr.py
+++ b/tests/sim/exit_policies/test_sl_plus_trailing_atr.py
@@ -12,7 +12,6 @@ from core.sim.exit_policies import (
     ExitAction,
     ExitPolicyContext,
     SlPlusTrailingAtrPolicy,
-    TrailingAtrState,
 )
 
 

--- a/tests/sim/exit_policies/test_sl_plus_trailing_swing.py
+++ b/tests/sim/exit_policies/test_sl_plus_trailing_swing.py
@@ -12,7 +12,6 @@ from core.sim.exit_policies import (
     ExitAction,
     ExitPolicyContext,
     SlPlusTrailingSwingPolicy,
-    TrailingSwingState,
 )
 
 

--- a/tests/sim/exit_policies/test_sl_plus_trailing_swing.py
+++ b/tests/sim/exit_policies/test_sl_plus_trailing_swing.py
@@ -1,0 +1,160 @@
+"""``sl_plus_trailing_swing``: swing trail capped at entry, activated at
++1R MFE. Trail level = running max of min(prev_close, entry).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from core.sim.account import Account, Direction, Position
+from core.sim.exit_policies import (
+    ExitAction,
+    ExitPolicyContext,
+    SlPlusTrailingSwingPolicy,
+    TrailingSwingState,
+)
+
+
+def _pos(direction: Direction = Direction.LONG) -> Position:
+    return Position(
+        position_id=1,
+        pair="EURUSD",
+        direction=direction,
+        entry_time=pd.Timestamp("2026-01-01", tz="UTC"),
+        entry_price=1.1000,
+        size=10_000,
+    )
+
+
+def _ctx(direction: Direction = Direction.LONG) -> ExitPolicyContext:
+    return ExitPolicyContext(
+        entry_price=1.1000, atr_at_entry=0.001, sl_atr_mult=2.0, direction=direction
+    )
+
+
+def _bar(**kw) -> pd.Series:
+    base = dict(
+        open_bid=1.10, open_ask=1.1001,
+        high_bid=1.10, high_ask=1.1001,
+        low_bid=1.10, low_ask=1.1001,
+        close_bid=1.10, close_ask=1.1001,
+    )
+    base.update(kw)
+    return pd.Series(base)
+
+
+def test_long_no_activation_below_one_r() -> None:
+    p = SlPlusTrailingSwingPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    bar = _bar(high_bid=1.1019, close_bid=1.1015)
+    assert p.evaluate_at_close(pos, bar, state, _ctx(), acct) is None
+    assert not state.activated
+
+
+def test_long_activates_at_one_r_but_no_trail_yet() -> None:
+    """First activation bar: trail can't yet have a candidate
+    (no prev_close stored yet). No fire."""
+    p = SlPlusTrailingSwingPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    bar = _bar(high_bid=1.1020, close_bid=1.1015)
+    decision = p.evaluate_at_close(pos, bar, state, _ctx(), acct)
+    assert decision is None
+    assert state.activated
+    # state.prev_close set for next bar
+    assert state.prev_close == pytest.approx(1.1015)
+    # trail_level still NaN
+    assert pd.isna(state.trail_level)
+
+
+def test_long_trail_capped_at_entry() -> None:
+    """Prev close ABOVE entry → candidate = min(prev_close, entry) = entry.
+    Trail level becomes entry (= 1.1000).
+    """
+    p = SlPlusTrailingSwingPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    # Bar 1: activates, prev_close = 1.1015 (above entry 1.1000)
+    p.evaluate_at_close(pos, _bar(high_bid=1.1020, close_bid=1.1015), state, _ctx(), acct)
+    # Bar 2: trail candidate = min(1.1015, 1.1000) = 1.1000. trail_level becomes 1.1000.
+    # close 1.1010 > 1.1000 → no fire
+    bar2 = _bar(high_bid=1.103, close_bid=1.1010)
+    decision = p.evaluate_at_close(pos, bar2, state, _ctx(), acct)
+    assert decision is None
+    assert state.trail_level == pytest.approx(1.1000)
+    # close=1.1010 ≤ 1.1000? No, 1.1010 > 1.1000 → no fire. Correct.
+
+
+def test_long_fires_when_close_drops_to_entry_trail() -> None:
+    """After trail establishes at entry (1.1000), close drops to 1.1000 → fire."""
+    p = SlPlusTrailingSwingPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    # Bar 1: activate, prev_close=1.1015
+    p.evaluate_at_close(pos, _bar(high_bid=1.1020, close_bid=1.1015), state, _ctx(), acct)
+    # Bar 2: trail becomes 1.1000, close 1.1010, no fire, prev_close=1.1010
+    p.evaluate_at_close(pos, _bar(high_bid=1.103, close_bid=1.1010), state, _ctx(), acct)
+    assert state.trail_level == pytest.approx(1.1000)
+    # Bar 3: trail candidate = min(1.1010, 1.1000) = 1.1000. trail_level = max(1.1000, 1.1000) = 1.1000.
+    # close 1.1000 ≤ 1.1000 → FIRE
+    bar3 = _bar(close_bid=1.1000)
+    decision = p.evaluate_at_close(pos, bar3, state, _ctx(), acct)
+    assert decision is not None
+    assert decision.action is ExitAction.FULL_CLOSE
+    assert decision.exit_reason == "trailing_stop_swing"
+
+
+def test_long_trail_ratchets_up_with_higher_prev_close_below_entry() -> None:
+    """Sequence where prev_close goes BELOW entry — candidate is prev_close,
+    and trail_level ratchets up to whichever is highest.
+
+    Bar 1: activate (high≥+1R), prev_close = 1.0995 (below entry).
+    Bar 2: candidate = min(1.0995, 1.1000) = 1.0995. trail_level = 1.0995.
+    Bar 3: prev_close = 1.0998 → candidate = 1.0998. trail = max(1.0995, 1.0998) = 1.0998.
+    Bar 4: close = 1.0998 → fire (close ≤ trail).
+    """
+    p = SlPlusTrailingSwingPolicy()
+    state = p.make_state(_ctx())
+    pos = _pos()
+    acct = Account(starting_balance=100_000.0)
+    # Bar 1
+    p.evaluate_at_close(pos, _bar(high_bid=1.1020, close_bid=1.0995), state, _ctx(), acct)
+    assert state.activated
+    assert state.prev_close == pytest.approx(1.0995)
+    # Bar 2: trail establishes at 1.0995
+    p.evaluate_at_close(pos, _bar(high_bid=1.101, close_bid=1.0998), state, _ctx(), acct)
+    assert state.trail_level == pytest.approx(1.0995)
+    # Bar 3: trail ratchets up to 1.0998
+    p.evaluate_at_close(pos, _bar(high_bid=1.1010, close_bid=1.1005), state, _ctx(), acct)
+    assert state.trail_level == pytest.approx(1.0998)
+    # Bar 4: close drops to 1.0998 → fire
+    decision = p.evaluate_at_close(
+        pos, _bar(close_bid=1.0998), state, _ctx(), acct
+    )
+    assert decision is not None
+
+
+def test_short_mirror() -> None:
+    """Short side: activate at low_ask ≤ entry - R_atr. Trail = running min of
+    max(prev_close_ask, entry). Capped at entry going UP (worse for short)."""
+    p = SlPlusTrailingSwingPolicy()
+    state = p.make_state(_ctx(Direction.SHORT))
+    pos = _pos(Direction.SHORT)
+    acct = Account(starting_balance=100_000.0)
+    # Bar 1: low_ask=1.0980 = entry - R_atr → activates. prev_close_ask=1.0985.
+    p.evaluate_at_close(pos, _bar(low_ask=1.0980, close_ask=1.0985), state, _ctx(Direction.SHORT), acct)
+    assert state.activated
+    # Bar 2: candidate = max(1.0985, 1.1000) = 1.1000 (capped at entry). trail = 1.1000.
+    # close 1.0990 < 1.1000 → no fire
+    p.evaluate_at_close(pos, _bar(low_ask=1.099, close_ask=1.099), state, _ctx(Direction.SHORT), acct)
+    assert state.trail_level == pytest.approx(1.1000)
+    # Bar 3: close rises to 1.1000 → fires
+    decision = p.evaluate_at_close(pos, _bar(close_ask=1.1000), state, _ctx(Direction.SHORT), acct)
+    assert decision is not None
+    assert decision.action is ExitAction.FULL_CLOSE

--- a/tests/sim/test_exit_policy_manager.py
+++ b/tests/sim/test_exit_policy_manager.py
@@ -10,7 +10,6 @@ import pytest
 from core.sim.account import Account, Direction
 from core.sim.exit_policies import (
     ExitAction,
-    ExitPolicyContext,
     NullPolicyState,
     SlOnlyPolicy,
     SlPartialClose1RRunnerTrailPolicy,

--- a/tests/sim/test_exit_policy_manager.py
+++ b/tests/sim/test_exit_policy_manager.py
@@ -1,0 +1,311 @@
+"""ExitPolicyManager: registration, evaluation hooks, intra-bar partial
+suppression set, deregistration. Mirrors TrailManager test surface.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from core.sim.account import Account, Direction
+from core.sim.exit_policies import (
+    ExitAction,
+    ExitPolicyContext,
+    NullPolicyState,
+    SlOnlyPolicy,
+    SlPartialClose1RRunnerTrailPolicy,
+    SlPlusTrailingAtrPolicy,
+    build_exit_policy,
+)
+from core.sim.exit_policy_manager import ExitPolicyManager
+
+
+def _ts(s: str) -> pd.Timestamp:
+    return pd.Timestamp(s, tz="UTC")
+
+
+def _bar(
+    *,
+    open_bid: float = 1.10,
+    open_ask: float = 1.1001,
+    high_bid: float = 1.11,
+    high_ask: float = 1.1101,
+    low_bid: float = 1.09,
+    low_ask: float = 1.0901,
+    close_bid: float = 1.105,
+    close_ask: float = 1.1051,
+) -> pd.Series:
+    return pd.Series(
+        {
+            "open_bid": open_bid,
+            "open_ask": open_ask,
+            "high_bid": high_bid,
+            "high_ask": high_ask,
+            "low_bid": low_bid,
+            "low_ask": low_ask,
+            "close_bid": close_bid,
+            "close_ask": close_ask,
+        }
+    )
+
+
+def _seed_account_with_one_long_position(entry_price: float = 1.10) -> Account:
+    acct = Account(starting_balance=100_000.0)
+    acct.open(
+        pair="EURUSD",
+        direction=Direction.LONG,
+        entry_time=_ts("2026-01-01"),
+        entry_price=entry_price,
+        size=10_000,
+    )
+    return acct
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Registration / deregistration
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_register_creates_state() -> None:
+    acct = _seed_account_with_one_long_position()
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(pos, SlOnlyPolicy(), atr_at_entry=0.0010, sl_atr_mult=2.0)
+    assert mgr.is_registered(pos.position_id)
+    assert isinstance(mgr.get_state(pos.position_id), NullPolicyState)
+    assert mgr.get_policy_name(pos.position_id) == "sl_only"
+    ctx = mgr.get_context(pos.position_id)
+    assert ctx is not None
+    assert ctx.r_atr == pytest.approx(0.0020)
+    assert ctx.direction is Direction.LONG
+
+
+def test_register_is_idempotent_on_replace() -> None:
+    acct = _seed_account_with_one_long_position()
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(pos, SlOnlyPolicy(), atr_at_entry=0.0010, sl_atr_mult=2.0)
+    mgr.register(pos, SlPlusTrailingAtrPolicy(), atr_at_entry=0.0015, sl_atr_mult=2.5)
+    assert mgr.get_policy_name(pos.position_id) == "sl_plus_trailing_atr"
+    assert mgr.get_context(pos.position_id).r_atr == pytest.approx(0.00375)
+
+
+def test_deregister_removes_state() -> None:
+    acct = _seed_account_with_one_long_position()
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(pos, SlOnlyPolicy(), atr_at_entry=0.0010, sl_atr_mult=2.0)
+    mgr.deregister(pos.position_id)
+    assert not mgr.is_registered(pos.position_id)
+    assert mgr.get_state(pos.position_id) is None
+
+
+def test_deregister_unknown_is_idempotent() -> None:
+    mgr = ExitPolicyManager()
+    mgr.deregister(999)  # no error
+
+
+# ────────────────────────────────────────────────────────────────────────
+# evaluate_intrabar_for_all
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_evaluate_intrabar_empty_when_no_regs() -> None:
+    acct = Account(starting_balance=100_000.0)
+    mgr = ExitPolicyManager()
+    out = mgr.evaluate_intrabar_for_all({}, acct)
+    assert out == {}
+    assert mgr.positions_with_intrabar_partial_this_bar == set()
+
+
+def test_evaluate_intrabar_sl_only_emits_nothing() -> None:
+    acct = _seed_account_with_one_long_position()
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(pos, SlOnlyPolicy(), atr_at_entry=0.0010, sl_atr_mult=2.0)
+    bar = _bar(high_bid=1.15)  # well above any threshold
+    out = mgr.evaluate_intrabar_for_all({"EURUSD": bar}, acct)
+    assert out == {}
+
+
+def test_evaluate_intrabar_partial_close_fires_at_one_r() -> None:
+    """Long entry 1.1000, R_atr = 2 * 0.001 = 0.002 → tp1 at 1.102.
+    Bar with high_bid >= 1.102 fires partial close at fill_price=1.102.
+    """
+    acct = _seed_account_with_one_long_position(entry_price=1.1000)
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(
+        pos,
+        SlPartialClose1RRunnerTrailPolicy(),
+        atr_at_entry=0.0010,
+        sl_atr_mult=2.0,
+    )
+    bar = _bar(high_bid=1.1025, low_bid=1.099, close_bid=1.101)
+    out = mgr.evaluate_intrabar_for_all({"EURUSD": bar}, acct)
+    assert pos.position_id in out
+    d = out[pos.position_id]
+    assert d.action is ExitAction.PARTIAL_CLOSE
+    assert d.exit_reason == "partial_close_1r"
+    assert d.timing == "intrabar"
+    assert d.fill_price == pytest.approx(1.1020)
+    assert d.partial_fraction == 0.5
+    # Manager set populated
+    assert mgr.has_intrabar_partial_this_bar(pos.position_id)
+
+
+def test_evaluate_intrabar_partial_does_not_fire_below_one_r() -> None:
+    acct = _seed_account_with_one_long_position(entry_price=1.1000)
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(
+        pos,
+        SlPartialClose1RRunnerTrailPolicy(),
+        atr_at_entry=0.0010,
+        sl_atr_mult=2.0,
+    )
+    bar = _bar(high_bid=1.1019)  # just below +1R = 1.1020
+    out = mgr.evaluate_intrabar_for_all({"EURUSD": bar}, acct)
+    assert out == {}
+    assert not mgr.has_intrabar_partial_this_bar(pos.position_id)
+
+
+def test_evaluate_intrabar_does_not_fire_twice() -> None:
+    """Once tp1 fires, subsequent bars don't re-fire."""
+    acct = _seed_account_with_one_long_position(entry_price=1.1000)
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(
+        pos,
+        SlPartialClose1RRunnerTrailPolicy(),
+        atr_at_entry=0.0010,
+        sl_atr_mult=2.0,
+    )
+    bar1 = _bar(high_bid=1.1025)
+    bar2 = _bar(high_bid=1.1050)
+    out1 = mgr.evaluate_intrabar_for_all({"EURUSD": bar1}, acct)
+    out2 = mgr.evaluate_intrabar_for_all({"EURUSD": bar2}, acct)
+    assert pos.position_id in out1
+    assert out2 == {}
+
+
+def test_evaluate_intrabar_clears_partial_set_each_call() -> None:
+    """Per-bar transient: the partial-set is fresh per evaluate call."""
+    acct = _seed_account_with_one_long_position(entry_price=1.1000)
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(
+        pos,
+        SlPartialClose1RRunnerTrailPolicy(),
+        atr_at_entry=0.0010,
+        sl_atr_mult=2.0,
+    )
+    # Bar 1: tp1 fires
+    mgr.evaluate_intrabar_for_all({"EURUSD": _bar(high_bid=1.1025)}, acct)
+    assert mgr.has_intrabar_partial_this_bar(pos.position_id)
+    # Bar 2: no fire (already fired) → set cleared, not repopulated
+    mgr.evaluate_intrabar_for_all({"EURUSD": _bar(high_bid=1.1100)}, acct)
+    assert not mgr.has_intrabar_partial_this_bar(pos.position_id)
+
+
+def test_evaluate_intrabar_short_side() -> None:
+    acct = Account(starting_balance=100_000.0)
+    acct.open("EURUSD", Direction.SHORT, _ts("2026-01-01"), 1.1000, 10_000)
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(
+        pos,
+        SlPartialClose1RRunnerTrailPolicy(),
+        atr_at_entry=0.0010,
+        sl_atr_mult=2.0,
+    )
+    # Short tp1: low_ask <= entry - R_atr = 1.0980
+    bar = _bar(low_ask=1.0975, high_bid=1.10, close_bid=1.099)
+    out = mgr.evaluate_intrabar_for_all({"EURUSD": bar}, acct)
+    assert pos.position_id in out
+    assert out[pos.position_id].fill_price == pytest.approx(1.0980)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# evaluate_at_close_for_all
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_evaluate_at_close_sl_only_emits_nothing() -> None:
+    acct = _seed_account_with_one_long_position()
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(pos, SlOnlyPolicy(), atr_at_entry=0.0010, sl_atr_mult=2.0)
+    out = mgr.evaluate_at_close_for_all({"EURUSD": _bar()}, acct)
+    assert out == {}
+
+
+def test_evaluate_at_close_trailing_atr_fires_after_activation() -> None:
+    """Long 1.10, R_atr=0.002 → activation at high>=1.102.
+    After activation peak ratchets; trail = peak - 0.002.
+    When close_bid drops to trail → fire.
+    """
+    acct = _seed_account_with_one_long_position(entry_price=1.1000)
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(pos, SlPlusTrailingAtrPolicy(), atr_at_entry=0.0010, sl_atr_mult=2.0)
+    # Bar 1: high reaches 1.104 (activates + peak=1.104, trail=1.102). Close 1.103 > 1.102 → no fire.
+    bar1 = _bar(high_bid=1.104, low_bid=1.099, close_bid=1.103)
+    out1 = mgr.evaluate_at_close_for_all({"EURUSD": bar1}, acct)
+    assert out1 == {}
+    # Bar 2: close drops to 1.101 ≤ trail 1.102 → fire
+    bar2 = _bar(high_bid=1.103, low_bid=1.100, close_bid=1.101)
+    out2 = mgr.evaluate_at_close_for_all({"EURUSD": bar2}, acct)
+    assert pos.position_id in out2
+    d = out2[pos.position_id]
+    assert d.action is ExitAction.FULL_CLOSE
+    assert d.exit_reason == "trailing_stop_atr"
+    assert d.timing == "at_close"
+    assert d.fill_price is None  # at_close timing → driver fills at next-bar open
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Position-gone handling
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_evaluate_skips_positions_already_closed() -> None:
+    """If driver closed a position (e.g. via predicate or SL) without
+    calling manager.deregister, evaluate_* skips it cleanly.
+    """
+    acct = _seed_account_with_one_long_position()
+    pos = acct.open_positions[0]
+    mgr = ExitPolicyManager()
+    mgr.register(pos, SlOnlyPolicy(), atr_at_entry=0.0010, sl_atr_mult=2.0)
+    # Externally close
+    acct.close(pos.position_id, _ts("2026-01-02"), 1.105, "external")
+    # Manager evaluates without error; emits nothing
+    out_i = mgr.evaluate_intrabar_for_all({"EURUSD": _bar()}, acct)
+    out_c = mgr.evaluate_at_close_for_all({"EURUSD": _bar()}, acct)
+    assert out_i == {}
+    assert out_c == {}
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Determinism
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_determinism_iteration_order() -> None:
+    """Positions evaluated in sorted(position_id) order regardless of
+    register order. Tested via no-raise on multi-position eval.
+    """
+    from core.sim.account import ExposureRules
+
+    acct = Account(
+        starting_balance=100_000.0,
+        exposure=ExposureRules(max_concurrent_per_pair=None),
+    )
+    pos1 = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    pos2 = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    mgr = ExitPolicyManager()
+    # Register in reverse order
+    mgr.register(pos2, build_exit_policy("sl_only"), 0.001, 2.0)
+    mgr.register(pos1, build_exit_policy("sl_only"), 0.001, 2.0)
+    out = mgr.evaluate_intrabar_for_all({"EURUSD": _bar()}, acct)
+    assert out == {}

--- a/tests/sim/test_multipair_with_exit_policy.py
+++ b/tests/sim/test_multipair_with_exit_policy.py
@@ -1,0 +1,345 @@
+"""Integration tests for ExitPolicyManager + MultiPairBacktester wiring.
+
+Synthetic-bar fixtures that exercise:
+  * exit_policy=None preserves prior driver behaviour
+  * sl_partial_close_1r_runner_trail fires partial intra-bar + runner trail
+  * Same-bar SL suppression on the tp1 bar (reference's sl_breach > tp1_i)
+  * sl_plus_tp_2r uses existing intra-bar TP infrastructure (no new code path)
+  * Fail-loud RuntimeError when Order carries exit_policy but driver lacks manager
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from core.sim.account import Account, Direction, ExposureRules
+from core.sim.exit_policy_manager import ExitPolicyManager
+from core.sim.multipair_backtester import MultiPairBacktester, Order, StrategyFn
+from core.sim.panel import Panel
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Synthetic 1-pair panel constructor — full bid/ask schema
+# ────────────────────────────────────────────────────────────────────────
+
+
+def _make_panel(rows: list[dict]) -> Panel:
+    df = pd.DataFrame(rows)
+    df["timestamp_utc"] = pd.to_datetime(df["timestamp_utc"], utc=True)
+    df = df.set_index("timestamp_utc")
+    # is_tradable_bar reads bar.spread implicitly via real_spread.is_tradable_bar;
+    # synthetic bars must include all bid/ask cols so the function returns True.
+    return Panel.from_frames({"EURUSD": df}, tf="H1")
+
+
+def _bar(
+    t: str,
+    *,
+    o: float, h: float, l: float, c: float,
+    spread: float = 0.0,
+) -> dict:
+    """One bar row with bid/ask derived from a mid + spread.
+
+    Default spread=0.0 (zero-spread / mid-only fixture). The DQ flag
+    is forced to 'ok' so ``is_tradable_bar`` returns True regardless
+    of the actual spread — useful for synthetic fixtures where we want
+    deterministic mid-anchored fills.
+    """
+    half = spread / 2.0
+    return {
+        "timestamp_utc": t,
+        "open_bid": o - half, "open_ask": o + half,
+        "high_bid": h - half, "high_ask": h + half,
+        "low_bid": l - half, "low_ask": l + half,
+        "close_bid": c - half, "close_ask": c + half,
+        "spread_close": spread,
+        "bid_ask_data_quality": "ok",
+    }
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Strategies for tests
+# ────────────────────────────────────────────────────────────────────────
+
+
+def _one_shot_long_at(t_target: str, **order_kwargs) -> StrategyFn:
+    """Strategy that emits exactly one long order at ``t_target``."""
+    target = pd.Timestamp(t_target, tz="UTC")
+    emitted = {"done": False}
+
+    def strategy(t, snapshot, account):
+        if emitted["done"] or t != target:
+            return []
+        emitted["done"] = True
+        return [Order(pair="EURUSD", direction=Direction.LONG, size=10_000.0, **order_kwargs)]
+
+    return strategy
+
+
+def _no_op_strategy(t, snapshot, account):
+    return []
+
+
+# ────────────────────────────────────────────────────────────────────────
+# exit_policy=None preserves prior behaviour
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_driver_without_manager_runs_unchanged_for_plain_orders() -> None:
+    """When no Order carries exit_policy, the driver behaves exactly as
+    before (no exit-policy code paths touched)."""
+    panel = _make_panel([
+        _bar("2026-01-01 00:00", o=1.100, h=1.101, l=1.099, c=1.100),
+        _bar("2026-01-01 01:00", o=1.100, h=1.102, l=1.099, c=1.101),
+        _bar("2026-01-01 02:00", o=1.101, h=1.103, l=1.100, c=1.102),
+        _bar("2026-01-01 03:00", o=1.102, h=1.104, l=1.101, c=1.103),
+    ])
+    acct = Account(starting_balance=100_000.0)
+    bt = MultiPairBacktester(panel=panel, account=acct, strategy=_no_op_strategy)
+    result = bt.run()
+    assert result.n_trades == 0
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Fail-loud wiring errors
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_order_with_exit_policy_but_no_manager_raises() -> None:
+    panel = _make_panel([
+        _bar("2026-01-01 00:00", o=1.100, h=1.101, l=1.099, c=1.100),
+        _bar("2026-01-01 01:00", o=1.100, h=1.102, l=1.099, c=1.101),
+        _bar("2026-01-01 02:00", o=1.101, h=1.103, l=1.100, c=1.102),
+    ])
+    acct = Account(starting_balance=100_000.0)
+    strategy = _one_shot_long_at(
+        "2026-01-01 00:00",
+        sl_price=1.098, atr_at_entry=0.001, sl_atr_mult=2.0,
+        exit_policy="sl_only",
+    )
+    bt = MultiPairBacktester(
+        panel=panel, account=acct, strategy=strategy
+    )  # no exit_policy_manager
+    with pytest.raises(RuntimeError, match="exit_policy_manager"):
+        bt.run()
+
+
+def test_order_with_exit_policy_but_missing_atr_raises() -> None:
+    panel = _make_panel([
+        _bar("2026-01-01 00:00", o=1.100, h=1.101, l=1.099, c=1.100),
+        _bar("2026-01-01 01:00", o=1.100, h=1.102, l=1.099, c=1.101),
+        _bar("2026-01-01 02:00", o=1.101, h=1.103, l=1.100, c=1.102),
+    ])
+    acct = Account(starting_balance=100_000.0)
+    strategy = _one_shot_long_at(
+        "2026-01-01 00:00",
+        sl_price=1.098,
+        # missing atr_at_entry + sl_atr_mult
+        exit_policy="sl_only",
+    )
+    bt = MultiPairBacktester(
+        panel=panel, account=acct, strategy=strategy,
+        exit_policy_manager=ExitPolicyManager(),
+    )
+    with pytest.raises(RuntimeError, match="atr_at_entry or sl_atr_mult"):
+        bt.run()
+
+
+# ────────────────────────────────────────────────────────────────────────
+# sl_partial_close_1r_runner_trail end-to-end on synthetic bars
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_partial_close_fires_intra_bar_and_runner_trails() -> None:
+    """Long entry 1.100 at bar t=1 open. R_atr = 0.002 (sl_mult=2, atr=0.001).
+    Bar 2 high reaches 1.102 → partial fires intra-bar at 1.102.
+    Bar 3 high 1.103 → peak ratchets to 1.103, trail level = 1.101.
+    Bar 4 close 1.101 → runner trail-hit fires; queues exit at bar 5 open.
+    Bar 5 opens at 1.101 → runner closes at open_bid 1.101.
+
+    Resulting trade log: 1 partial + 1 final, both linked.
+    """
+    panel = _make_panel([
+        # t=0: signal/no-order bar
+        _bar("2026-01-01 00:00", o=1.099, h=1.100, l=1.098, c=1.099),
+        # t=1: entry fills at open=1.100
+        _bar("2026-01-01 01:00", o=1.100, h=1.101, l=1.099, c=1.100),
+        # t=2: high reaches +1R (1.102) → intra-bar partial fires at 1.102
+        _bar("2026-01-01 02:00", o=1.100, h=1.102, l=1.099, c=1.101),
+        # t=3: high 1.103, close 1.1015 (peak 1.103, trail = 1.101). close 1.1015 > 1.101 → no fire
+        _bar("2026-01-01 03:00", o=1.101, h=1.103, l=1.100, c=1.1015),
+        # t=4: close 1.101 = trail → at-close fires; queued for t=5 open
+        _bar("2026-01-01 04:00", o=1.1015, h=1.1020, l=1.1010, c=1.101),
+        # t=5: runner closes at open_bid = 1.101
+        _bar("2026-01-01 05:00", o=1.101, h=1.102, l=1.100, c=1.101),
+    ])
+    acct = Account(
+        starting_balance=100_000.0,
+        exposure=ExposureRules(max_concurrent_per_pair=1),
+    )
+    strategy = _one_shot_long_at(
+        "2026-01-01 00:00",  # signal at t=0; fills next bar t=1
+        sl_price=1.098,
+        atr_at_entry=0.001,
+        sl_atr_mult=2.0,
+        exit_policy="sl_partial_close_1r_runner_trail",
+    )
+    bt = MultiPairBacktester(
+        panel=panel,
+        account=acct,
+        strategy=strategy,
+        exit_policy_manager=ExitPolicyManager(),
+    )
+    result = bt.run()
+    # Expect 2 ClosedTrade events: partial + final, linked by parent_position_id
+    assert result.n_trades == 2, f"got {result.n_trades} trades: {result.closed_trades}"
+    legs = list(result.closed_trades)
+    assert all(leg.parent_position_id is not None for leg in legs)
+    assert legs[0].parent_position_id == legs[1].parent_position_id
+    # First leg = partial at 1.102 with size 5000
+    assert legs[0].exit_reason == "partial_close_1r"
+    assert legs[0].size == pytest.approx(5_000.0)
+    assert legs[0].exit_price == pytest.approx(1.102)
+    # Second leg = runner trail at next-bar open 1.101 with remaining 5000
+    assert legs[1].exit_reason == "runner_trail_stop"
+    assert legs[1].size == pytest.approx(5_000.0)
+    assert legs[1].exit_price == pytest.approx(1.101)
+
+
+def test_partial_close_runner_sl_hits_after_partial() -> None:
+    """+1R partial fires bar 2; bar 3's bid touches original SL → runner
+    closes at SL.
+    """
+    panel = _make_panel([
+        _bar("2026-01-01 00:00", o=1.099, h=1.100, l=1.098, c=1.099),
+        _bar("2026-01-01 01:00", o=1.100, h=1.101, l=1.099, c=1.100),
+        # t=2: partial at +1R
+        _bar("2026-01-01 02:00", o=1.100, h=1.102, l=1.099, c=1.101),
+        # t=3: low touches SL=1.098 → runner closes at SL
+        _bar("2026-01-01 03:00", o=1.101, h=1.102, l=1.097, c=1.099),
+        _bar("2026-01-01 04:00", o=1.099, h=1.100, l=1.097, c=1.099),
+    ])
+    acct = Account(
+        starting_balance=100_000.0,
+        exposure=ExposureRules(max_concurrent_per_pair=1),
+    )
+    strategy = _one_shot_long_at(
+        "2026-01-01 00:00",
+        sl_price=1.098,
+        atr_at_entry=0.001,
+        sl_atr_mult=2.0,
+        exit_policy="sl_partial_close_1r_runner_trail",
+    )
+    bt = MultiPairBacktester(
+        panel=panel, account=acct, strategy=strategy,
+        exit_policy_manager=ExitPolicyManager(),
+    )
+    result = bt.run()
+    assert result.n_trades == 2
+    legs = list(result.closed_trades)
+    assert legs[0].exit_reason == "partial_close_1r"
+    assert legs[0].exit_price == pytest.approx(1.102)
+    assert legs[1].exit_reason == "stop_loss"
+    assert legs[1].exit_price == pytest.approx(1.098)
+    assert legs[1].size == pytest.approx(5_000.0)
+
+
+def test_partial_close_same_bar_sl_suppression() -> None:
+    """The tp1 bar has BOTH high >= +1R AND low <= SL. Reference forbids
+    runner SL-out on tp1 bar (``sl_breach > tp1_i`` constraint). Canonical
+    engine honours this via the manager's suppression flag.
+
+    The salient assertion: the runner does NOT exit on the tp1 bar (t=2)
+    via stop_loss. Without suppression, intra-bar SL on the partial-bar's
+    low (1.097 ≤ SL 1.098) would close the runner at SL_price=1.098 with
+    exit_time=t=2. With suppression, the runner survives bar 2 and exits
+    on a subsequent bar via runner_trail or actual stop_loss.
+
+    Bar layout: bar 2 has high=1.102 (tp1) AND low=1.097 (would breach SL).
+    Bar 3 close is engineered above the runner-trail level so the trail
+    doesn't fire on bar 3 either. Bar 4 has a clean SL touch.
+    """
+    panel = _make_panel([
+        _bar("2026-01-01 00:00", o=1.099, h=1.100, l=1.098, c=1.099),
+        _bar("2026-01-01 01:00", o=1.100, h=1.101, l=1.099, c=1.100),
+        # t=2: tp1 bar. high=1.102 fires tp1; low=1.097 would breach SL
+        # but is suppressed. Peak after bar 2 = 1.102 → trail = 1.100.
+        # close=1.1015 > trail 1.100 so trail wouldn't fire even if we
+        # got an evaluate_at_close on this bar (we don't: i > tp1_i).
+        _bar("2026-01-01 02:00", o=1.100, h=1.102, l=1.097, c=1.1015),
+        # t=3: peak ratchets up; trail rises. close above trail → no fire.
+        _bar("2026-01-01 03:00", o=1.1015, h=1.1030, l=1.1010, c=1.1025),
+        # t=4: clean SL hit (low=1.097 ≤ SL=1.098); not tp1 bar.
+        _bar("2026-01-01 04:00", o=1.1025, h=1.1025, l=1.097, c=1.098),
+    ])
+    acct = Account(
+        starting_balance=100_000.0,
+        exposure=ExposureRules(max_concurrent_per_pair=1),
+    )
+    strategy = _one_shot_long_at(
+        "2026-01-01 00:00",
+        sl_price=1.098,
+        atr_at_entry=0.001,
+        sl_atr_mult=2.0,
+        exit_policy="sl_partial_close_1r_runner_trail",
+    )
+    bt = MultiPairBacktester(
+        panel=panel, account=acct, strategy=strategy,
+        exit_policy_manager=ExitPolicyManager(),
+    )
+    result = bt.run()
+    legs = list(result.closed_trades)
+    assert len(legs) == 2
+    # Leg 1: partial at +1R on tp1 bar
+    assert legs[0].exit_reason == "partial_close_1r"
+    assert legs[0].exit_price == pytest.approx(1.102)
+    assert legs[0].exit_time == pd.Timestamp("2026-01-01 02:00", tz="UTC")
+    # Leg 2: NOT closed on tp1 bar at SL — suppression worked
+    assert legs[1].exit_time != pd.Timestamp("2026-01-01 02:00", tz="UTC")
+    # Specifically: SL hit on bar 4
+    assert legs[1].exit_reason == "stop_loss"
+    assert legs[1].exit_price == pytest.approx(1.098)
+    assert legs[1].exit_time == pd.Timestamp("2026-01-01 04:00", tz="UTC")
+
+
+# ────────────────────────────────────────────────────────────────────────
+# sl_plus_tp_2r via Order.tp_price (existing infra)
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_sl_plus_tp_2r_fires_via_intrabar_tp() -> None:
+    """sl_plus_tp_2r decorates Order.tp_price; existing infra fires the
+    TP intra-bar. No exit-policy manager state evaluation needed.
+
+    Test: entry 1.100, R_atr=0.002, tp_price=1.104. Bar high 1.104 → fires.
+    """
+    panel = _make_panel([
+        _bar("2026-01-01 00:00", o=1.099, h=1.100, l=1.098, c=1.099),
+        _bar("2026-01-01 01:00", o=1.100, h=1.101, l=1.099, c=1.100),
+        # high reaches tp=1.104
+        _bar("2026-01-01 02:00", o=1.100, h=1.104, l=1.099, c=1.103),
+        _bar("2026-01-01 03:00", o=1.103, h=1.104, l=1.102, c=1.103),
+    ])
+    acct = Account(
+        starting_balance=100_000.0,
+        exposure=ExposureRules(max_concurrent_per_pair=1),
+    )
+    strategy = _one_shot_long_at(
+        "2026-01-01 00:00",
+        sl_price=1.098,
+        tp_price=1.104,  # caller responsible for merging policy.apply_to_order result
+        atr_at_entry=0.001,
+        sl_atr_mult=2.0,
+        exit_policy="sl_plus_tp_2r",
+    )
+    bt = MultiPairBacktester(
+        panel=panel, account=acct, strategy=strategy,
+        exit_policy_manager=ExitPolicyManager(),
+    )
+    result = bt.run()
+    assert result.n_trades == 1
+    leg = result.closed_trades[0]
+    assert leg.exit_reason == "take_profit"
+    assert leg.exit_price == pytest.approx(1.104)
+    assert leg.parent_position_id is None  # standalone full close

--- a/tests/sim/test_multipair_with_exit_policy.py
+++ b/tests/sim/test_multipair_with_exit_policy.py
@@ -18,7 +18,6 @@ from core.sim.exit_policy_manager import ExitPolicyManager
 from core.sim.multipair_backtester import MultiPairBacktester, Order, StrategyFn
 from core.sim.panel import Panel
 
-
 # ────────────────────────────────────────────────────────────────────────
 # Synthetic 1-pair panel constructor — full bid/ask schema
 # ────────────────────────────────────────────────────────────────────────
@@ -36,7 +35,7 @@ def _make_panel(rows: list[dict]) -> Panel:
 def _bar(
     t: str,
     *,
-    o: float, h: float, l: float, c: float,
+    o: float, h: float, lo: float, c: float,
     spread: float = 0.0,
 ) -> dict:
     """One bar row with bid/ask derived from a mid + spread.
@@ -51,7 +50,7 @@ def _bar(
         "timestamp_utc": t,
         "open_bid": o - half, "open_ask": o + half,
         "high_bid": h - half, "high_ask": h + half,
-        "low_bid": l - half, "low_ask": l + half,
+        "low_bid": lo - half, "low_ask": lo + half,
         "close_bid": c - half, "close_ask": c + half,
         "spread_close": spread,
         "bid_ask_data_quality": "ok",
@@ -90,10 +89,10 @@ def test_driver_without_manager_runs_unchanged_for_plain_orders() -> None:
     """When no Order carries exit_policy, the driver behaves exactly as
     before (no exit-policy code paths touched)."""
     panel = _make_panel([
-        _bar("2026-01-01 00:00", o=1.100, h=1.101, l=1.099, c=1.100),
-        _bar("2026-01-01 01:00", o=1.100, h=1.102, l=1.099, c=1.101),
-        _bar("2026-01-01 02:00", o=1.101, h=1.103, l=1.100, c=1.102),
-        _bar("2026-01-01 03:00", o=1.102, h=1.104, l=1.101, c=1.103),
+        _bar("2026-01-01 00:00", o=1.100, h=1.101, lo=1.099, c=1.100),
+        _bar("2026-01-01 01:00", o=1.100, h=1.102, lo=1.099, c=1.101),
+        _bar("2026-01-01 02:00", o=1.101, h=1.103, lo=1.100, c=1.102),
+        _bar("2026-01-01 03:00", o=1.102, h=1.104, lo=1.101, c=1.103),
     ])
     acct = Account(starting_balance=100_000.0)
     bt = MultiPairBacktester(panel=panel, account=acct, strategy=_no_op_strategy)
@@ -108,9 +107,9 @@ def test_driver_without_manager_runs_unchanged_for_plain_orders() -> None:
 
 def test_order_with_exit_policy_but_no_manager_raises() -> None:
     panel = _make_panel([
-        _bar("2026-01-01 00:00", o=1.100, h=1.101, l=1.099, c=1.100),
-        _bar("2026-01-01 01:00", o=1.100, h=1.102, l=1.099, c=1.101),
-        _bar("2026-01-01 02:00", o=1.101, h=1.103, l=1.100, c=1.102),
+        _bar("2026-01-01 00:00", o=1.100, h=1.101, lo=1.099, c=1.100),
+        _bar("2026-01-01 01:00", o=1.100, h=1.102, lo=1.099, c=1.101),
+        _bar("2026-01-01 02:00", o=1.101, h=1.103, lo=1.100, c=1.102),
     ])
     acct = Account(starting_balance=100_000.0)
     strategy = _one_shot_long_at(
@@ -127,9 +126,9 @@ def test_order_with_exit_policy_but_no_manager_raises() -> None:
 
 def test_order_with_exit_policy_but_missing_atr_raises() -> None:
     panel = _make_panel([
-        _bar("2026-01-01 00:00", o=1.100, h=1.101, l=1.099, c=1.100),
-        _bar("2026-01-01 01:00", o=1.100, h=1.102, l=1.099, c=1.101),
-        _bar("2026-01-01 02:00", o=1.101, h=1.103, l=1.100, c=1.102),
+        _bar("2026-01-01 00:00", o=1.100, h=1.101, lo=1.099, c=1.100),
+        _bar("2026-01-01 01:00", o=1.100, h=1.102, lo=1.099, c=1.101),
+        _bar("2026-01-01 02:00", o=1.101, h=1.103, lo=1.100, c=1.102),
     ])
     acct = Account(starting_balance=100_000.0)
     strategy = _one_shot_long_at(
@@ -162,17 +161,17 @@ def test_partial_close_fires_intra_bar_and_runner_trails() -> None:
     """
     panel = _make_panel([
         # t=0: signal/no-order bar
-        _bar("2026-01-01 00:00", o=1.099, h=1.100, l=1.098, c=1.099),
+        _bar("2026-01-01 00:00", o=1.099, h=1.100, lo=1.098, c=1.099),
         # t=1: entry fills at open=1.100
-        _bar("2026-01-01 01:00", o=1.100, h=1.101, l=1.099, c=1.100),
+        _bar("2026-01-01 01:00", o=1.100, h=1.101, lo=1.099, c=1.100),
         # t=2: high reaches +1R (1.102) → intra-bar partial fires at 1.102
-        _bar("2026-01-01 02:00", o=1.100, h=1.102, l=1.099, c=1.101),
+        _bar("2026-01-01 02:00", o=1.100, h=1.102, lo=1.099, c=1.101),
         # t=3: high 1.103, close 1.1015 (peak 1.103, trail = 1.101). close 1.1015 > 1.101 → no fire
-        _bar("2026-01-01 03:00", o=1.101, h=1.103, l=1.100, c=1.1015),
+        _bar("2026-01-01 03:00", o=1.101, h=1.103, lo=1.100, c=1.1015),
         # t=4: close 1.101 = trail → at-close fires; queued for t=5 open
-        _bar("2026-01-01 04:00", o=1.1015, h=1.1020, l=1.1010, c=1.101),
+        _bar("2026-01-01 04:00", o=1.1015, h=1.1020, lo=1.1010, c=1.101),
         # t=5: runner closes at open_bid = 1.101
-        _bar("2026-01-01 05:00", o=1.101, h=1.102, l=1.100, c=1.101),
+        _bar("2026-01-01 05:00", o=1.101, h=1.102, lo=1.100, c=1.101),
     ])
     acct = Account(
         starting_balance=100_000.0,
@@ -212,13 +211,13 @@ def test_partial_close_runner_sl_hits_after_partial() -> None:
     closes at SL.
     """
     panel = _make_panel([
-        _bar("2026-01-01 00:00", o=1.099, h=1.100, l=1.098, c=1.099),
-        _bar("2026-01-01 01:00", o=1.100, h=1.101, l=1.099, c=1.100),
+        _bar("2026-01-01 00:00", o=1.099, h=1.100, lo=1.098, c=1.099),
+        _bar("2026-01-01 01:00", o=1.100, h=1.101, lo=1.099, c=1.100),
         # t=2: partial at +1R
-        _bar("2026-01-01 02:00", o=1.100, h=1.102, l=1.099, c=1.101),
+        _bar("2026-01-01 02:00", o=1.100, h=1.102, lo=1.099, c=1.101),
         # t=3: low touches SL=1.098 → runner closes at SL
-        _bar("2026-01-01 03:00", o=1.101, h=1.102, l=1.097, c=1.099),
-        _bar("2026-01-01 04:00", o=1.099, h=1.100, l=1.097, c=1.099),
+        _bar("2026-01-01 03:00", o=1.101, h=1.102, lo=1.097, c=1.099),
+        _bar("2026-01-01 04:00", o=1.099, h=1.100, lo=1.097, c=1.099),
     ])
     acct = Account(
         starting_balance=100_000.0,
@@ -261,17 +260,17 @@ def test_partial_close_same_bar_sl_suppression() -> None:
     doesn't fire on bar 3 either. Bar 4 has a clean SL touch.
     """
     panel = _make_panel([
-        _bar("2026-01-01 00:00", o=1.099, h=1.100, l=1.098, c=1.099),
-        _bar("2026-01-01 01:00", o=1.100, h=1.101, l=1.099, c=1.100),
+        _bar("2026-01-01 00:00", o=1.099, h=1.100, lo=1.098, c=1.099),
+        _bar("2026-01-01 01:00", o=1.100, h=1.101, lo=1.099, c=1.100),
         # t=2: tp1 bar. high=1.102 fires tp1; low=1.097 would breach SL
         # but is suppressed. Peak after bar 2 = 1.102 → trail = 1.100.
         # close=1.1015 > trail 1.100 so trail wouldn't fire even if we
         # got an evaluate_at_close on this bar (we don't: i > tp1_i).
-        _bar("2026-01-01 02:00", o=1.100, h=1.102, l=1.097, c=1.1015),
+        _bar("2026-01-01 02:00", o=1.100, h=1.102, lo=1.097, c=1.1015),
         # t=3: peak ratchets up; trail rises. close above trail → no fire.
-        _bar("2026-01-01 03:00", o=1.1015, h=1.1030, l=1.1010, c=1.1025),
+        _bar("2026-01-01 03:00", o=1.1015, h=1.1030, lo=1.1010, c=1.1025),
         # t=4: clean SL hit (low=1.097 ≤ SL=1.098); not tp1 bar.
-        _bar("2026-01-01 04:00", o=1.1025, h=1.1025, l=1.097, c=1.098),
+        _bar("2026-01-01 04:00", o=1.1025, h=1.1025, lo=1.097, c=1.098),
     ])
     acct = Account(
         starting_balance=100_000.0,
@@ -315,11 +314,11 @@ def test_sl_plus_tp_2r_fires_via_intrabar_tp() -> None:
     Test: entry 1.100, R_atr=0.002, tp_price=1.104. Bar high 1.104 → fires.
     """
     panel = _make_panel([
-        _bar("2026-01-01 00:00", o=1.099, h=1.100, l=1.098, c=1.099),
-        _bar("2026-01-01 01:00", o=1.100, h=1.101, l=1.099, c=1.100),
+        _bar("2026-01-01 00:00", o=1.099, h=1.100, lo=1.098, c=1.099),
+        _bar("2026-01-01 01:00", o=1.100, h=1.101, lo=1.099, c=1.100),
         # high reaches tp=1.104
-        _bar("2026-01-01 02:00", o=1.100, h=1.104, l=1.099, c=1.103),
-        _bar("2026-01-01 03:00", o=1.103, h=1.104, l=1.102, c=1.103),
+        _bar("2026-01-01 02:00", o=1.100, h=1.104, lo=1.099, c=1.103),
+        _bar("2026-01-01 03:00", o=1.103, h=1.104, lo=1.102, c=1.103),
     ])
     acct = Account(
         starting_balance=100_000.0,

--- a/tests/test_partial_fill_account.py
+++ b/tests/test_partial_fill_account.py
@@ -1,0 +1,329 @@
+"""Tests for Account partial-fill primitives — partial_close(),
+current_size_of(), mark-to-market and exposure semantics with reduced
+positions, multi-leg ClosedTrade linkage via parent_position_id.
+
+Anchor: dispatch §"Task 2" / intent doc §6 (Account refactor). Position
+stays frozen; Account owns the shadow ``_current_sizes`` dict.
+
+These tests do not exercise any ExitPolicy / ExitPolicyManager wiring —
+those are covered by Tasks 3-5 + their test files. Here we are only
+proving the Account-level mechanics.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from core.sim.account import (
+    Account,
+    ClosedTrade,
+    Direction,
+    ExposureRules,
+    Position,
+)
+
+
+def _ts(s: str) -> pd.Timestamp:
+    return pd.Timestamp(s, tz="UTC")
+
+
+# ────────────────────────────────────────────────────────────────────────
+# ClosedTrade schema
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_closed_trade_parent_position_id_defaults_none() -> None:
+    """Backwards-compat: existing callers passing positional args (no
+    parent_position_id) get None — standalone full close.
+    """
+    ct = ClosedTrade(
+        position_id=1,
+        pair="EURUSD",
+        direction=Direction.LONG,
+        entry_time=_ts("2026-01-01"),
+        entry_price=1.10,
+        exit_time=_ts("2026-01-02"),
+        exit_price=1.11,
+        size=10_000,
+        pnl=100.0,
+        exit_reason="market",
+    )
+    assert ct.parent_position_id is None
+
+
+# ────────────────────────────────────────────────────────────────────────
+# current_size_of()
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_current_size_of_returns_original_when_no_partial() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open(
+        pair="EURUSD",
+        direction=Direction.LONG,
+        entry_time=_ts("2026-01-01"),
+        entry_price=1.10,
+        size=10_000,
+    )
+    assert acct.current_size_of(pos.position_id) == 10_000
+
+
+def test_current_size_of_raises_on_unknown_id() -> None:
+    acct = Account(starting_balance=100_000.0)
+    with pytest.raises(KeyError, match="No open position"):
+        acct.current_size_of(999)
+
+
+def test_current_size_of_raises_after_full_close() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    acct.close(pos.position_id, _ts("2026-01-02"), 1.11, "market")
+    with pytest.raises(KeyError):
+        acct.current_size_of(pos.position_id)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# partial_close() — happy path
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_partial_close_realises_partial_pnl_long() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.1000, 10_000)
+    trade = acct.partial_close(
+        pos.position_id,
+        exit_time=_ts("2026-01-02"),
+        exit_price=1.1020,
+        exit_reason="partial_close_1r",
+        size_to_close=5_000,
+    )
+    # PnL on 5k units @ +20 pips = 0.002 * 5000 = 10
+    assert trade.pnl == pytest.approx(0.002 * 5_000)
+    assert trade.size == 5_000
+    assert trade.parent_position_id == pos.position_id
+    # Balance updated for partial
+    assert acct.balance == pytest.approx(100_000.0 + 0.002 * 5_000)
+    # Position still open
+    assert pos.position_id in {p.position_id for p in acct.open_positions}
+    # Live size reduced
+    assert acct.current_size_of(pos.position_id) == 5_000
+
+
+def test_partial_close_realises_partial_pnl_short() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.SHORT, _ts("2026-01-01"), 1.1000, 10_000)
+    trade = acct.partial_close(
+        pos.position_id,
+        exit_time=_ts("2026-01-02"),
+        exit_price=1.0980,
+        exit_reason="partial_close_1r",
+        size_to_close=5_000,
+    )
+    # Short, price dropped 20 pips → +PnL on 5k units
+    assert trade.pnl == pytest.approx(0.002 * 5_000)
+    assert acct.current_size_of(pos.position_id) == 5_000
+
+
+def test_two_sequential_partials() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.1000, 10_000)
+    acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.1010, "p1", 3_000)
+    acct.partial_close(pos.position_id, _ts("2026-01-03"), 1.1020, "p2", 4_000)
+    assert acct.current_size_of(pos.position_id) == 3_000
+    # Cumulative balance: 3000 * 0.001 + 4000 * 0.002 = 3 + 8 = 11
+    assert acct.balance == pytest.approx(100_000.0 + 3.0 + 8.0)
+    # Both legs recorded; both linked
+    closed = acct.closed_trades
+    assert len(closed) == 2
+    assert all(ct.parent_position_id == pos.position_id for ct in closed)
+
+
+def test_final_close_after_partial_uses_remaining_size() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.1000, 10_000)
+    acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.1020, "partial", 5_000)
+    final = acct.close(pos.position_id, _ts("2026-01-03"), 1.1050, "trail")
+    # Final leg sized at 5000 (remainder); +50 pips on 5k = 0.005 * 5000 = 25
+    assert final.size == 5_000
+    assert final.pnl == pytest.approx(0.005 * 5_000)
+    # Final leg also tagged as parent_position_id (this is a multi-leg close)
+    assert final.parent_position_id == pos.position_id
+
+
+def test_full_close_no_prior_partial_has_none_parent() -> None:
+    """Backwards-compat: positions that never had a partial close get
+    ``parent_position_id=None`` on the full-close ClosedTrade.
+    """
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    ct = acct.close(pos.position_id, _ts("2026-01-02"), 1.11, "market")
+    assert ct.parent_position_id is None
+
+
+# ────────────────────────────────────────────────────────────────────────
+# partial_close() — validation
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_partial_close_unknown_id_raises() -> None:
+    acct = Account(starting_balance=100_000.0)
+    with pytest.raises(KeyError, match="No open position"):
+        acct.partial_close(999, _ts("2026-01-01"), 1.0, "x", 100)
+
+
+def test_partial_close_zero_size_raises() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    with pytest.raises(ValueError, match="size_to_close must be > 0"):
+        acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.11, "x", 0)
+
+
+def test_partial_close_negative_size_raises() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    with pytest.raises(ValueError, match="size_to_close must be > 0"):
+        acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.11, "x", -100)
+
+
+def test_partial_close_size_equal_to_current_raises() -> None:
+    """Equal-to-current is a full close; caller should use close()."""
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    with pytest.raises(ValueError, match="use close\\(\\) for full-out"):
+        acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.11, "x", 10_000)
+
+
+def test_partial_close_size_exceeds_current_raises() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    with pytest.raises(ValueError, match="use close\\(\\) for full-out"):
+        acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.11, "x", 20_000)
+
+
+def test_partial_close_size_equal_to_remaining_after_prior_partial_raises() -> None:
+    """After a partial, equal-to-remaining is still a full close."""
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.11, "p1", 4_000)
+    # remaining = 6000; partial 6000 should reject
+    with pytest.raises(ValueError, match="use close\\(\\) for full-out"):
+        acct.partial_close(pos.position_id, _ts("2026-01-03"), 1.12, "p2", 6_000)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# mark_to_market with partial state
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_mark_to_market_uses_current_size_after_partial() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.1000, 100_000)
+    acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.1020, "p1", 50_000)
+    # Realised: 0.002 * 50000 = 100. Balance now 100_100.
+    # Mark @ 1.1030 → unrealised on remaining 50k = 0.003 * 50000 = 150
+    eq = acct.mark_to_market(_ts("2026-01-02 12:00"), {"EURUSD": 1.1030})
+    assert eq == pytest.approx(100_000.0 + 100.0 + 150.0)
+
+
+def test_mark_to_market_uses_current_size_after_partial_short() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.SHORT, _ts("2026-01-01"), 1.1000, 100_000)
+    acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.0980, "p1", 60_000)
+    # Realised: 0.002 * 60000 = 120 (short profits on drop). Balance 100_120.
+    # Mark @ 1.0970 → unrealised on remaining 40k = (1.10 - 1.097) * 40000 = 120
+    eq = acct.mark_to_market(_ts("2026-01-02 12:00"), {"EURUSD": 1.0970})
+    assert eq == pytest.approx(100_000.0 + 120.0 + 120.0)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# exposure-cap semantics: position counts as 1 until fully closed
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_exposure_cap_counts_position_as_one_after_partial() -> None:
+    """A partial-closed position still occupies its exposure-cap slot."""
+    acct = Account(
+        starting_balance=100_000.0,
+        exposure=ExposureRules(max_concurrent_total=1, max_concurrent_per_pair=1),
+    )
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    assert acct.exposure_check("GBPUSD") is False  # total cap = 1, full
+    acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.11, "p1", 5_000)
+    # Position still open → exposure cap still binding
+    assert acct.exposure_check("GBPUSD") is False
+    assert acct.exposure_check("EURUSD") is False
+    # Full close frees the slot
+    acct.close(pos.position_id, _ts("2026-01-03"), 1.12, "trail")
+    assert acct.exposure_check("GBPUSD") is True
+    assert acct.exposure_check("EURUSD") is True
+
+
+def test_per_currency_cap_unchanged_by_partial() -> None:
+    acct = Account(
+        starting_balance=100_000.0,
+        exposure=ExposureRules(
+            max_concurrent_total=10,
+            max_concurrent_per_pair=10,
+            max_concurrent_per_currency=1,
+        ),
+    )
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.11, "p1", 5_000)
+    # USD count still 1 → USDJPY blocked
+    assert acct.exposure_check("USDJPY") is False
+
+
+# ────────────────────────────────────────────────────────────────────────
+# trade log linkage / grouping
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_trade_log_groupby_position_id_reconstructs_multi_leg() -> None:
+    acct = Account(starting_balance=100_000.0)
+    pos1 = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    acct.partial_close(pos1.position_id, _ts("2026-01-02"), 1.11, "partial_1r", 5_000)
+    acct.close(pos1.position_id, _ts("2026-01-03"), 1.12, "runner_trail")
+    # Independent, never-partialled position
+    pos2 = acct.open("GBPUSD", Direction.LONG, _ts("2026-01-04"), 1.30, 10_000)
+    acct.close(pos2.position_id, _ts("2026-01-05"), 1.31, "market")
+
+    closed = acct.closed_trades
+    assert len(closed) == 3
+    # pos1 legs both tagged with parent_position_id
+    p1_legs = [ct for ct in closed if ct.position_id == pos1.position_id]
+    assert len(p1_legs) == 2
+    assert all(ct.parent_position_id == pos1.position_id for ct in p1_legs)
+    # pos2 standalone close: parent_position_id None
+    p2_legs = [ct for ct in closed if ct.position_id == pos2.position_id]
+    assert len(p2_legs) == 1
+    assert p2_legs[0].parent_position_id is None
+    # Filter for whole-position closes only
+    standalone = [ct for ct in closed if ct.parent_position_id is None]
+    assert len(standalone) == 1
+    assert standalone[0].position_id == pos2.position_id
+
+
+def test_partial_history_cleared_on_full_close() -> None:
+    """A re-used position_id (in practice can't happen — _next_position_id
+    is monotone) wouldn't leak partial state. Verifies internal cleanup.
+    """
+    acct = Account(starting_balance=100_000.0)
+    pos = acct.open("EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    acct.partial_close(pos.position_id, _ts("2026-01-02"), 1.11, "p1", 5_000)
+    acct.close(pos.position_id, _ts("2026-01-03"), 1.12, "trail")
+    # noqa: SLF001 — internal-state assertions are the point of this test
+    assert pos.position_id not in acct._current_sizes  # noqa: SLF001
+    assert pos.position_id not in acct._partial_history  # noqa: SLF001
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Position frozen invariant (anchor — must stay frozen)
+# ────────────────────────────────────────────────────────────────────────
+
+
+def test_position_stays_frozen() -> None:
+    """Position immutability is a contract. Partial-close must not mutate it."""
+    p = Position(1, "EURUSD", Direction.LONG, _ts("2026-01-01"), 1.10, 10_000)
+    with pytest.raises((AttributeError, Exception)):
+        p.size = 5_000  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Build the canonical exit-policy registry as first-class engine infrastructure, port all six exit policies from per-arc hand-rolled simulators into it, add partial-fill semantics to ``Account`` so ``sl_partial_close_1r_runner_trail`` (Arc 10's PASS-DEPLOYABLE load-bearing exit) can fire as a first-class primitive, wire ``exit_policy`` field into every architecture config (A1..A6), and migrate the per-arc Step 5 scripts to import from canonical (deleting 150 LOC of hand-rolled per-policy branches from Arc 10).

Resolves the dispatch mandate: *"Hand-rolled per-arc exit logic is creating silent drift and making Step 6 audits harder than they need to be."*

## Tasks landed (per [partial_close_runner_trail_intent.md](partial_close_runner_trail_intent.md))

1. **Intent doc** — revised S1+ scope + full reference inventory.
2. **Account partial-fill primitives** — ``partial_close``, ``current_size_of``, ``_current_sizes`` shadow dict, ``ClosedTrade.parent_position_id``. Position stays frozen.
3. **Canonical registry** ``core/sim/exit_policies/`` — ``ExitPolicy`` ABC + 6 policy modules + factory:
    - ``sl_only``
    - ``sl_plus_tp_2r`` / ``sl_plus_tp_3r``
    - ``sl_plus_trailing_atr`` / ``sl_plus_trailing_swing``
    - ``sl_partial_close_1r_runner_trail`` (new — Arc 10's load-bearing exit)
4. **ExitPolicyManager** — TrailManager-style per-position state holder with intra-bar + at-close hooks + same-bar SL suppression flag.
5. **Driver wiring** — ``MultiPairBacktester`` gains ``exit_policy_manager`` field; per-bar orchestration; ``Order.exit_policy`` + ``Order.sl_atr_mult``; ``policy.apply_to_order(ctx)`` at fill time anchors TP to actual fill price.
6. **Architecture configs** — A1/A2/A3/A4/A6 each gain ``exit_policy: str | None = None`` (default preserves all prior behaviour).
7. **Arc 10 v3 migration** — ``scripts/l_arc_10_v3/step_5.py:_apply_exit_policy`` body replaced by 1-line canonical delegate.
8. **Arc 8 migration** — ``scripts/l_arc_8/run_step5_wfo.py:_apply_exit_policy`` body replaced by 1-line canonical delegate (uses ``simulate_pool_approximation`` for the legacy pool-level fast path).
9. **Unit tests** — registry + manager + per-policy (66 tests in ``tests/sim/exit_policies/`` + ``tests/sim/test_exit_policy_manager.py``).
10. **Reference-impl parity** — 218 byte-identical tests (6 policies × 4 SL multipliers × 9 path scenarios) in ``tests/sim/exit_policies/test_path_simulate_reference_parity.py`` confirm canonical replay == reference hand-rolled.
11. **KH-24 anchor regression** — 37/37 KH-24-specific + 105/105 protocol_runtime tests pass on the branch. KH-24 uses ``exit_policy=None`` so the canonical code paths are dormant on the anchor.
12. **Docs** — new ``§8c Exit-policy registry`` in PROTOCOL_RUNTIME.md + ``Exit policies (architecture-pluggable)`` subsection in BACKTESTER_ARCHITECTURE.md + post-audit footer block in engine_capability_audit_2026_05.md.

## Key design choices

- **Position stays frozen.** Account owns the live size via ``_current_sizes`` shadow dict. Multi-leg close-outs tagged via ``ClosedTrade.parent_position_id``; consumers group by ``position_id`` to reconstruct the partial+final sequence.
- **TP policies decorate ``Order.tp_price``** at fill time (anchored to actual fill price). Reuses existing intra-bar TP infrastructure — realised R = exactly +2R / +3R.
- **Same-bar SL suppression on tp1 bar** (per reference's ``sl_breach > tp1_i`` constraint): the manager flags positions that just partial-closed; the driver SKIPS intra-bar SL/TP for them this bar. Runner survives the tp1-bar low; matches Arc 10's reference simulator exactly.
- **Two execution surfaces, one definition per policy:** live bar-by-bar (driver + manager) AND post-hoc replay (``simulate_path``). Reference-parity test enforces byte-identity between replay and the historical Arc 10 v3 hand-rolled simulator.
- **PR #189 worst-case fill conventions throughout:** long uses ``high_bid`` / ``close_bid`` for trigger and reference price; short uses ``low_ask`` / ``close_ask``.

## Test plan

- [x] Account partial-fill semantics — 20 tests
- [x] Registry surface — 14 tests (inventory, KeyError, apply_to_order, state-type-per-policy)
- [x] Per-policy unit tests — 5 modules (sl_only, sl_plus_tp, sl_plus_trailing_atr, sl_plus_trailing_swing, sl_partial_close_runner_trail)
- [x] ExitPolicyManager state machine — 16 tests
- [x] Driver integration with policy manager — 7 tests (synthetic bars; partial+runner-trail end-to-end; same-bar SL suppression; sl_plus_tp_2r via intra-bar TP)
- [x] Reference-impl parity vs hand-rolled simulator — 218 byte-identical tests
- [x] KH-24 anchor regression (synthetic mini fixture + full protocol_runtime suite) — 37/37 + 105/105 passing
- [ ] **Full-data HistData KH-24 anchor** — requires HistData layer locally; run via ``scripts/anchor/check_a1_equivalence.py`` chat-side before merge

## Risks (per intent doc §7)

1. **Account refactor blast radius** — mitigated: Position stays frozen, Account.partial_close is a new method, mark_to_market reads ``_current_sizes.get(pid, position.size)``. KH-24 path never enters the shadow dict.
2. **ClosedTrade schema change** — ``parent_position_id`` defaults None. Grepped consumers; only Account constructs ClosedTrade.
3. **Arc 8 numeric drift** — pool-level approximation migrated to canonical; behaviour byte-identical (canonical helper preserves Arc 8 semantics exactly). Higher-fidelity path-replay path available for future Arc 8 upgrade.
4. **Arc 10 v3 reproducibility** — path-based migration is byte-identical; live engine adds bid/ask wings for ``sl_partial_close_1r_runner_trail`` (the diagnostic point of the Arc 10 v3.0.1 retry).

## What's NOT in this PR

- Arc 10 v3.0.1 retry execution (unblocked by this PR; runs separately).
- Full-data HistData KH-24 anchor numeric verification (requires HistData; chat-side run).
- ``core/exit_policies.py:StepwiseClimberPolicy`` (different abstraction — Pipeline D1 archetype-policy machinery; unchanged).
- A4 heuristic stand-in ``_apply_a4_exits`` (different abstraction — classifier-based exit predicate; unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)