### PR TITLE
[INFRA] heavy_ml_probe PR-E: integration + Step 5 adapters (gate PR)

### DIFF
--- a/configs/heavy_ml_probe/default.yaml
+++ b/configs/heavy_ml_probe/default.yaml
@@ -1,0 +1,127 @@
+# configs/heavy_ml_probe/default.yaml
+# heavy_ml_probe sub-protocol — default invocation parameters (PR-A).
+# Sub-protocol spec: docs/sub_protocols/heavy_ml_probe.md (locked v1.0)
+# Overseer: L_PROTOCOL.md v3.0 (Amendments 1-3).
+# Build dispatch: docs/dispatches/heavy_ml_probe_build_intent.md
+#
+# This file is the canonical schema for any arc invoking heavy_ml_probe.
+# Per-arc YAMLs may shadow individual values but MUST NOT add unknown keys
+# without a spec amendment.
+#
+# Chat resolutions baked in:
+#   Q1 — survival target: time_to_reach_1r_censored_at_sl_or_time_exit
+#   Q2 — FLAML budget: max_iter counts as 1-trial-per-evaluation
+#   Q5b — A4 consumer: adapter (B1) — survival models wrap to predict_admit shape
+#
+# Schema version stamped into manifest.json so downstream tooling can
+# detect breaking changes. Bump on any incompatible key change.
+
+schema_version: "1.0"
+
+sub_protocol:
+  name: heavy_ml_probe
+  spec_path: docs/sub_protocols/heavy_ml_probe.md
+  spec_version: "1.0"
+
+# ── Compute budget (dispatch §6 #6) ──────────────────────────────────
+# Hard cap. Sum across folds = max_iter_per_fold × n_folds = 1000 × 11 =
+# 11000 evaluations per cluster per arc. The automl.py wrapper refuses
+# to exceed; if FLAML's internal accounting prevents enforcement, PR-B
+# HALTs per WORKFLOW §6.
+automl:
+  framework: flaml                # locked per dispatch §5
+  max_iter_per_fold: 1000         # one evaluation == one FLAML trial (Q2)
+  n_folds: 11                     # 11-fold TimeSeriesSplit on IS (spec §"AutoML inside CV")
+  metric: roc_auc                 # target = binary; AUC-ROC matches vanilla Step 4
+  ensemble: true                  # FLAML decides ensembling/stacking internally
+  estimator_list:                 # search space per spec §"What overrides the overseer"
+    - rf
+    - lgbm
+    - xgboost
+    - catboost
+    - extra_tree
+    - lrl1                        # logistic regression (L1)
+  time_budget_seconds: null       # null = let max_iter be the binding cap; set non-null for compute ceilings
+  early_stop: true                # FLAML's internal early stop; does not relax max_iter
+
+# ── Meta-labeling target (dispatch §6 + spec §"Meta-labeling target") ─
+# Binary target: did the trade reach +1R MFE before hitting SL?
+# Constructed from pool's per-trade MFE / MAE columns at Step 1.
+meta_labeling:
+  enabled: true
+  target_kind: reach_1r_before_sl
+  mfe_r_threshold: 1.0            # +1R MFE
+  # Threshold sweep at PR-C: report precision / recall at each.
+  threshold_sweep: [0.30, 0.40, 0.50, 0.60, 0.70]
+
+# ── Survival models (dispatch §6 + spec §"Survival model variant") ───
+# Q1 resolution: target = time-to-+1R-MFE censored at SL or time-exit.
+# Adapter (Q5b option B1) maps survival predictions to A4's predict_admit shape.
+survival:
+  enabled: true
+  target_kind: time_to_reach_1r_censored_at_sl_or_time_exit
+  # Horizon used by the A4 adapter when translating S(t | features) to
+  # an exit decision. "Probability of reaching +1R within the next K
+  # bars" at each post-entry bar. Tested at PR-D's defaults; arc-side
+  # configs may override.
+  adapter_horizon_bars: 5
+  adapter_exit_thresholds: [0.30, 0.40, 0.50]
+  min_n_warn: 200                 # warn if cluster has fewer trades (dispatch §6 #10)
+  cox_ph:
+    penalizer: 0.0                # ridge penalty; 0.0 = unpenalised
+    fit_intercept: true
+  rsf:
+    n_estimators: 200             # mirrors vanilla Step 4 RF default
+    min_samples_leaf: 50          # matches L_PROTOCOL Appendix A RF default
+    max_depth: 6                  # matches L_PROTOCOL Appendix A RF default
+
+# ── Holdout discipline (dispatch §6 #3 + L_PROTOCOL §1) ──────────────
+# Holdout 2021-01-01 → present is OFF-LIMITS during training. The
+# pipeline filters the input pool to entry_time < train_end before
+# AutoML / meta-label / survival see any data. Mirrors vanilla Step 4's
+# train_end argument (see core/steps/step_4_extraction.py).
+training_window:
+  is_start: "2010-01-01"
+  train_end: "2021-01-01"         # exclusive cutoff; trades with entry_time >= this are excluded
+
+# ── Causal lineage gate (dispatch §6 #2 + Q3 resolution) ─────────────
+# Pre-evaluation filter on feature columns. Features without a clean
+# tag are dropped from the training set BEFORE AutoML sees them. Uses
+# the registry-backed core.features.pipeline.feature_lineage_dataframe()
+# as source-of-truth (same pattern as core/discovery/causal_filter.py).
+causal_filter:
+  accepted_lineage: ["clean"]
+  rejected_lineage: ["suspect", "unverified"]
+  exclude_classes: []             # optional: exclude e.g. "spread_regime" if known leaky
+
+# ── Determinism (dispatch §6 #4, #5, #7) ─────────────────────────────
+determinism:
+  random_state: 42
+  n_jobs: 1                       # single-threaded for reproducibility
+  text_line_terminator: "\n"
+
+# ── Output layout (dispatch §7) ──────────────────────────────────────
+# Per-arc invocation supplies the arc root; outputs land under it.
+output:
+  step4_subdir: step_4/heavy_ml
+  step5_subdir: step_5/heavy_ml_augmented
+  classifiers_subdir: classifiers
+  survival_subdir: survival
+  artefacts:
+    automl_leaderboard: automl_leaderboard.csv
+    automl_feature_importance: automl_feature_importance.csv
+    survival_model_results: survival_model_results.csv
+    meta_label_results: meta_label_results.csv
+    compute_budget_used: compute_budget_used.md
+    step4_manifest: manifest.json
+    classifiers_manifest: manifest.json     # under classifiers_subdir
+    survival_manifest: manifest.json        # under survival_subdir
+    step5_manifest: manifest.json           # under step5_subdir
+
+# ── Library versions (informational; recorded into manifest at runtime) ─
+# Pinning is the operator's responsibility (managed via
+# requirements-dev.txt). Recording the runtime-resolved versions into
+# the manifest gives downstream tooling cross-env audit signal — same
+# pattern as core/steps/step_4_extraction.py:_LGBM_VERSION.
+library_versions:
+  record_at_runtime: true

--- a/configs/heavy_ml_probe/default.yaml
+++ b/configs/heavy_ml_probe/default.yaml
@@ -50,9 +50,11 @@ automl:
 meta_labeling:
   enabled: true
   target_kind: reach_1r_before_sl
-  mfe_r_threshold: 1.0            # +1R MFE
-  # Threshold sweep at PR-C: report precision / recall at each.
-  threshold_sweep: [0.30, 0.40, 0.50, 0.60, 0.70]
+  mfe_r_threshold: 1.0            # +1R MFE (dispatch §1 locked)
+  # Threshold sweep — dispatch §3 locked grid. Reports precision,
+  # recall, f1, n_kept, n_dropped, mean_R_kept_set, mean_R_dropped_set,
+  # edge_lift_r per threshold.
+  threshold_sweep: [0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80]
 
 # ── Survival models (dispatch §6 + spec §"Survival model variant") ───
 # Q1 resolution: target = time-to-+1R-MFE censored at SL or time-exit.

--- a/core/heavy_ml_probe/__init__.py
+++ b/core/heavy_ml_probe/__init__.py
@@ -1,0 +1,29 @@
+"""heavy_ml_probe — Sub-protocol layered on L_PROTOCOL v3.0 overseer.
+
+Implements ``docs/sub_protocols/heavy_ml_probe.md`` v1.0. Replaces
+vanilla Step 4 with AutoML (FLAML) inside CV, adds a meta-labeling
+target ("reach +1R MFE before SL"), and trains Cox PH + Random Survival
+Forest variants for A4 Pipeline D consumption. Step 5 augmentation hook
+allows A2 / A4 / A6 to consume heavy-ML-trained components.
+
+This package is invoked when an arc's ``ARC_OPEN.md`` declares
+``sub_protocol: heavy_ml_probe``. Vanilla Step 1 / 2 / 3 / 6 + the §3
+deployment gates remain unchanged — heavy_ml_probe only overrides Step
+4 and augments Step 5 per the sub-protocol spec.
+
+PR-A scope (this commit): scaffolding + causal-lineage pre-evaluation
+gate + deterministic IO + sha256 manifest writer + metric stubs +
+orchestration skeleton + CLI stub. AutoML / meta-label / survival
+modules land in PR-B / PR-C / PR-D respectively.
+
+See:
+  - L_PROTOCOL.md §0 (project goal) + §2 Step 4-5 + §3 gates + §5 (sub-protocol mechanism)
+  - docs/sub_protocols/heavy_ml_probe.md (v1.0 spec)
+  - docs/sub_protocols/signal_discovery_probe.md (sibling reference)
+  - docs/dispatches/heavy_ml_probe_build_intent.md (build plan)
+  - configs/heavy_ml_probe/default.yaml (locked invocation parameters)
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"  # PR-A scaffolding; bumps per PR per build plan

--- a/core/heavy_ml_probe/adapters.py
+++ b/core/heavy_ml_probe/adapters.py
@@ -1,0 +1,721 @@
+"""Step 5 adapter contracts for heavy_ml_probe (PR-E).
+
+This module is the contract surface between heavy_ml_probe's Step 4
+artefacts (AutoML / meta-label / survival classifiers) and the
+existing L_PROTOCOL Step 5 architectures (A2 / A4 / A6) defined under
+``core/architectures/``. PR-E is **narrow scope** per dispatch §6:
+emits the adapters + ``heavy_ml_manifest.json``; downstream Step 5
+loop is responsible for invoking the architectures themselves.
+
+Three public builders:
+
+  * :func:`build_a2_from_heavy_ml` — wraps PR-B's FLAML best classifier
+    into an :class:`core.architectures.a2_classifier_filter.A2Config`.
+    FLAML's inner sklearn-compatible estimator (e.g. ``LGBMClassifier``,
+    ``XGBClassifier``) exposes ``predict_proba`` directly — drop-in.
+  * :func:`build_a4_from_heavy_ml` — wraps PR-D's Cox PH coefficients +
+    baseline cumulative hazard into a :class:`PathClassifierFit`-shaped
+    fit consumable by :func:`core.architectures._path_classifier.predict_admit`.
+    Per Q5b option B1 (chat resolution): A4's runtime treats this fit
+    identically to a vanilla per-fold RandomForest fit. The wrapper's
+    ``predict_proba`` reads ``bars_survived`` from a named column and
+    computes ``P(reach +1R in next K bars | survived to N)`` from Cox
+    PH.
+  * :func:`build_a6_from_heavy_ml` — wraps PR-C's meta-label classifier
+    into an :class:`core.architectures.a6_meta_labeling.A6Config`.
+    Same drop-in pattern as A2 (FLAML inner estimator).
+
+All three builders consume ``step_5/heavy_ml_augmented/heavy_ml_manifest.json``
+written by :mod:`core.heavy_ml_probe.pipeline` at the end of a successful
+``run_pipeline`` call. The manifest carries per-stage status + paths +
+adapter-buildability flags so adapters fail loudly with a clear
+message when an upstream stage skipped or failed.
+
+Fold selection (per dispatch §3):
+
+  * ``"last_fold"`` — use fold N (most recent training window). Default
+    for production deployment.
+  * ``"ensemble_mean"`` — average predictions across all valid folds.
+    Useful for sensitivity checks; less principled but smoke-testable.
+  * ``"full_refit"`` — NOT IMPLEMENTED in PR-E (raises
+    ``NotImplementedError``). Reserved for a future enhancement that
+    refits on the entire IS slice rather than using a fold artefact.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import joblib
+import numpy as np
+
+# ── Public manifest schema ───────────────────────────────────────────
+
+
+HEAVY_ML_MANIFEST_NAME: str = "heavy_ml_manifest.json"
+
+# Locked schema version stamped into the Step 5 manifest. Bumps when
+# the consumer-visible contract changes — adapters check the version
+# at load time and refuse to consume an unknown schema.
+STEP5_MANIFEST_SCHEMA_VERSION: str = "1.0"
+
+# Per-stage status taxonomy persisted into the manifest.
+STAGE_STATUS_OK: str = "ok"
+STAGE_STATUS_SKIPPED: str = "skipped"
+STAGE_STATUS_FAILED: str = "failed"
+
+# Conventional column name carrying "bars survived since entry" in the
+# feature row passed to the A4 adapter's predict_proba. A4's runtime
+# is responsible for populating this column when it calls predict_admit.
+BARS_SURVIVED_FEATURE: str = "_bars_survived"
+
+
+# ── Fold selection ───────────────────────────────────────────────────
+
+
+class FoldSelectionStrategy(str, enum.Enum):
+    """How to pick the per-fold artefact for deployment."""
+
+    LAST_FOLD = "last_fold"
+    ENSEMBLE_MEAN = "ensemble_mean"
+    FULL_REFIT = "full_refit"  # not implemented in PR-E
+
+
+# ── Adapter exceptions ───────────────────────────────────────────────
+
+
+class HeavyMLManifestError(RuntimeError):
+    """Raised when the manifest is missing, malformed, or schema-mismatched."""
+
+
+class StageUnavailableError(RuntimeError):
+    """Raised when an adapter is asked to build from a stage that
+    upstream-skipped or upstream-failed.
+
+    Example: ``build_a4_from_heavy_ml`` called against a manifest whose
+    ``stages.survival.status != "ok"``. The error message tells the
+    caller which stage is unavailable and why.
+    """
+
+
+# ── A4 Cox PH adapter wrapper ────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _CoxPHFoldPayload:
+    """Snapshot of one fold's persisted Cox PH content.
+
+    Mirrors the dict written by
+    :func:`core.heavy_ml_probe.survival.persist_fold_models`. Pulled
+    into a frozen dataclass so the adapter's internal state is
+    immutable + introspectable in tests.
+    """
+
+    coefficients: tuple[float, ...]
+    used_features: tuple[str, ...]
+    baseline_times: tuple[float, ...]
+    baseline_cumulative_hazard: tuple[float, ...]
+    baseline_survival: tuple[float, ...]
+
+
+def _coxph_payload_from_pickle(payload: dict) -> _CoxPHFoldPayload:
+    """Lift the joblib-pickled dict from
+    :func:`core.heavy_ml_probe.survival.persist_fold_models` into a
+    :class:`_CoxPHFoldPayload`. Tolerates the documented dict shape;
+    raises ``ValueError`` on any deviation."""
+    required = {"coefficients", "used_features", "baseline_hazard"}
+    missing = required - set(payload.keys())
+    if missing:
+        raise ValueError(
+            f"Cox PH pickle missing keys {sorted(missing)}; "
+            f"present: {sorted(payload.keys())}"
+        )
+    bh = payload["baseline_hazard"]
+    bh_required = {"times", "cumulative_hazard", "survival_function"}
+    bh_missing = bh_required - set(bh.keys())
+    if bh_missing:
+        raise ValueError(
+            f"Cox PH baseline_hazard missing keys {sorted(bh_missing)}"
+        )
+    return _CoxPHFoldPayload(
+        coefficients=tuple(float(c) for c in payload["coefficients"]),
+        used_features=tuple(str(f) for f in payload["used_features"]),
+        baseline_times=tuple(float(t) for t in bh["times"]),
+        baseline_cumulative_hazard=tuple(float(h) for h in bh["cumulative_hazard"]),
+        baseline_survival=tuple(float(s) for s in bh["survival_function"]),
+    )
+
+
+def _interp_cumulative_hazard(
+    payload: _CoxPHFoldPayload,
+    t_query: float,
+) -> float:
+    """Step-function lookup for the baseline cumulative hazard at ``t_query``.
+
+    Cox PH's baseline cumulative hazard is a right-continuous step
+    function defined at the unique observed event times. Standard
+    convention: for ``t`` between event times, the cumulative hazard
+    equals the value at the largest observed event time ≤ ``t``. Before
+    the first event time, H_0(t) = 0. After the last event time, the
+    Breslow estimator does not extrapolate — we clamp to the last
+    observed value.
+
+    Choice: step function (not linear interpolation) preserves Cox PH's
+    non-parametric semantics. Linear interpolation between event times
+    would introduce a fake assumption that hazard accrues smoothly
+    between events.
+    """
+    if not payload.baseline_times:
+        return 0.0
+    times = np.asarray(payload.baseline_times, dtype=float)
+    cumhaz = np.asarray(payload.baseline_cumulative_hazard, dtype=float)
+    if t_query < times[0]:
+        return 0.0
+    if t_query >= times[-1]:
+        return float(cumhaz[-1])
+    # searchsorted right gives the insertion point; idx-1 is the largest
+    # observed time ≤ t_query.
+    idx = int(np.searchsorted(times, t_query, side="right")) - 1
+    return float(cumhaz[max(0, idx)])
+
+
+@dataclass
+class CoxPHAdapter:
+    """Cox PH wrapper exposing both the dispatch's ``hazard_predict``
+    contract AND a sklearn-compatible ``predict_proba`` shim for A4's
+    :class:`PathClassifierFit` consumer.
+
+    Adapter math (per PR-D prompt §8 + dispatch §2.2):
+
+      .. code-block::
+
+         H_0(N)         = baseline_cumulative_hazard at time N
+         H_0(N+K)       = baseline_cumulative_hazard at time N+K
+         relative_risk  = exp(features_at_N @ cox_coefficients)
+         integrated_h   = (H_0(N+K) - H_0(N)) * relative_risk
+         P(reach 1R in
+           next K bars
+           | survived N) = 1 - exp(-integrated_h)
+
+    The ``predict_proba(X)`` shim reads ``bars_survived`` from a named
+    column (:data:`BARS_SURVIVED_FEATURE`) in ``X`` so that A4's
+    runtime — which only knows about ``predict_proba`` — can dispatch
+    to the Cox PH machinery without modification. The remaining feature
+    columns are the ones the Cox PH was fitted on (per
+    ``payload.used_features``).
+
+    When the strategy is :attr:`FoldSelectionStrategy.ENSEMBLE_MEAN`,
+    :class:`CoxPHAdapter` averages coefficients + baseline hazards
+    across all provided folds before any prediction (mean-coefficient
+    semantics; less principled than per-fold-mean-prediction but
+    cheaper and well-defined).
+    """
+
+    payloads: tuple[_CoxPHFoldPayload, ...]
+    strategy: FoldSelectionStrategy
+    k_horizon: int
+
+    def __post_init__(self) -> None:
+        if not self.payloads:
+            raise ValueError("CoxPHAdapter requires at least one fold payload")
+        if self.k_horizon <= 0:
+            raise ValueError(f"k_horizon must be > 0; got {self.k_horizon}")
+        # Effective payload after fold-strategy reduction
+        if self.strategy is FoldSelectionStrategy.LAST_FOLD:
+            object.__setattr__(self, "_effective", self.payloads[-1])
+        elif self.strategy is FoldSelectionStrategy.ENSEMBLE_MEAN:
+            object.__setattr__(self, "_effective", _ensemble_mean_payload(self.payloads))
+        elif self.strategy is FoldSelectionStrategy.FULL_REFIT:
+            raise NotImplementedError(
+                "FoldSelectionStrategy.FULL_REFIT is reserved for a future PR. "
+                "Use LAST_FOLD (default) or ENSEMBLE_MEAN."
+            )
+        else:  # pragma: no cover
+            raise ValueError(f"unknown fold strategy: {self.strategy!r}")
+
+    # ── Primary dispatch §2.2 contract ───────────────────────────────
+
+    def hazard_predict(
+        self,
+        features_at_N: Mapping[str, float],
+        bars_survived_at_N: int,
+    ) -> float:
+        """``P(reach +1R MFE in next K bars | survived to bar N)``.
+
+        Per dispatch §2.2 + PR-D log §7.2. Returns NaN if any of the
+        used features is missing or non-finite in ``features_at_N`` —
+        the A4 predicate treats NaN as a non-decision.
+        """
+        eff: _CoxPHFoldPayload = getattr(self, "_effective")
+        try:
+            x = np.array(
+                [float(features_at_N[k]) for k in eff.used_features],
+                dtype=np.float64,
+            )
+        except (KeyError, TypeError, ValueError):
+            return float("nan")
+        if not np.all(np.isfinite(x)):
+            return float("nan")
+        lp = float(x @ np.asarray(eff.coefficients, dtype=np.float64))
+        # Numerical guard: clamp exp argument to avoid overflow.
+        relative_risk = math.exp(min(max(lp, -50.0), 50.0))
+        h0_n = _interp_cumulative_hazard(eff, float(bars_survived_at_N))
+        h0_n_k = _interp_cumulative_hazard(
+            eff, float(bars_survived_at_N + self.k_horizon)
+        )
+        integrated = (h0_n_k - h0_n) * relative_risk
+        if integrated < 0:
+            # Shouldn't happen (cumhaz is non-decreasing) but defensive.
+            return 0.0
+        return float(1.0 - math.exp(-integrated))
+
+    # ── sklearn-compatible predict_proba shim ────────────────────────
+    #
+    # A4's runtime consumes via ``predict_admit(fit, feature_row)``
+    # (see ``core/architectures/_path_classifier.py``), which calls
+    # ``fit.model.predict_proba(X)`` where X is a (1, n_features)
+    # ndarray. This shim:
+    #
+    #   1. Reads ``bars_survived`` from a named feature column.
+    #   2. Delegates the rest of the columns to ``hazard_predict``.
+    #
+    # Returns the standard sklearn binary-classifier shape
+    # ``(n_samples, 2)`` where ``[:, 1]`` is P(event) and ``[:, 0]``
+    # is its complement.
+
+    @property
+    def feature_order(self) -> tuple[str, ...]:
+        """Feature column order expected by :meth:`predict_proba`.
+
+        Always: ``(*used_features, BARS_SURVIVED_FEATURE)``. The
+        bars-survived column is appended at the end so A4's existing
+        feature-assembly code can splice it in without re-shaping the
+        Cox PH coefficient vector.
+        """
+        eff: _CoxPHFoldPayload = getattr(self, "_effective")
+        return tuple(eff.used_features) + (BARS_SURVIVED_FEATURE,)
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        """sklearn-shape wrapper around :meth:`hazard_predict`.
+
+        Expects ``X.shape == (n_samples, len(self.feature_order))``.
+        Last column is interpreted as bars-survived per
+        :data:`BARS_SURVIVED_FEATURE`.
+        """
+        X = np.asarray(X, dtype=np.float64)
+        if X.ndim == 1:
+            X = X.reshape(1, -1)
+        eff: _CoxPHFoldPayload = getattr(self, "_effective")
+        n_features = len(eff.used_features)
+        if X.shape[1] != n_features + 1:
+            raise ValueError(
+                f"predict_proba expects shape (n, {n_features + 1}) "
+                f"(features + bars_survived); got {X.shape}"
+            )
+        out = np.zeros((X.shape[0], 2), dtype=np.float64)
+        for i in range(X.shape[0]):
+            feats = {
+                eff.used_features[j]: float(X[i, j]) for j in range(n_features)
+            }
+            bars = int(X[i, n_features])
+            p = self.hazard_predict(feats, bars)
+            if not np.isfinite(p):
+                # NaN P → default to 0.0 so A4's predicate treats as
+                # "no admit" rather than crashing on NaN comparison.
+                out[i, 1] = 0.0
+            else:
+                out[i, 1] = p
+            out[i, 0] = 1.0 - out[i, 1]
+        return out
+
+
+def _ensemble_mean_payload(
+    payloads: tuple[_CoxPHFoldPayload, ...],
+) -> _CoxPHFoldPayload:
+    """Average coefficients + baseline hazard across folds.
+
+    Coefficients: simple arithmetic mean across folds (folds with
+    different feature counts are rejected at load time, so all
+    payloads share ``used_features``).
+
+    Baseline hazard: interpolate each fold's H_0 to a common time grid
+    (the union of all observed event times across folds) and average.
+    Returns a new payload with the merged grid.
+    """
+    base = payloads[0]
+    for p in payloads[1:]:
+        if p.used_features != base.used_features:
+            raise ValueError(
+                "ensemble_mean: fold payloads have mismatched used_features; "
+                f"first={base.used_features}, other={p.used_features}"
+            )
+    # Mean coefficients
+    coefs = np.mean(
+        np.stack([np.asarray(p.coefficients, dtype=float) for p in payloads], axis=0),
+        axis=0,
+    )
+    # Common time grid = sorted union of all fold time grids
+    all_times = sorted({float(t) for p in payloads for t in p.baseline_times})
+    times_arr = np.asarray(all_times, dtype=float)
+    if times_arr.size == 0:
+        return _CoxPHFoldPayload(
+            coefficients=tuple(float(c) for c in coefs),
+            used_features=base.used_features,
+            baseline_times=(),
+            baseline_cumulative_hazard=(),
+            baseline_survival=(),
+        )
+    # Interpolate each fold's H_0 to the common grid using the same
+    # step-function semantics as _interp_cumulative_hazard.
+    cumhaz_per_fold = []
+    for p in payloads:
+        cumhaz_per_fold.append(
+            np.array([_interp_cumulative_hazard(p, t) for t in times_arr])
+        )
+    mean_cumhaz = np.mean(np.stack(cumhaz_per_fold, axis=0), axis=0)
+    # Survival function from mean cumulative hazard: S(t) = exp(-H(t))
+    mean_surv = np.exp(-mean_cumhaz)
+    return _CoxPHFoldPayload(
+        coefficients=tuple(float(c) for c in coefs),
+        used_features=base.used_features,
+        baseline_times=tuple(float(t) for t in times_arr),
+        baseline_cumulative_hazard=tuple(float(h) for h in mean_cumhaz),
+        baseline_survival=tuple(float(s) for s in mean_surv),
+    )
+
+
+# ── A2 / A6 sklearn-classifier wrapper (ensemble path) ──────────────
+
+
+@dataclass
+class EnsembleMeanProbaClassifier:
+    """sklearn-shaped wrapper that averages ``predict_proba`` across
+    multiple per-fold classifiers.
+
+    Used by :func:`build_a2_from_heavy_ml` and
+    :func:`build_a6_from_heavy_ml` when the caller requests
+    :attr:`FoldSelectionStrategy.ENSEMBLE_MEAN`. For
+    :attr:`FoldSelectionStrategy.LAST_FOLD` the underlying classifier
+    is returned directly (no wrapper needed).
+    """
+
+    members: tuple[Any, ...]  # each member exposes predict_proba(X)
+
+    def predict_proba(self, X) -> np.ndarray:
+        if not self.members:
+            raise RuntimeError(
+                "EnsembleMeanProbaClassifier has no members; cannot predict"
+            )
+        proba_stack = np.stack(
+            [np.asarray(m.predict_proba(X), dtype=float) for m in self.members],
+            axis=0,
+        )
+        return np.mean(proba_stack, axis=0)
+
+
+# ── Manifest IO ──────────────────────────────────────────────────────
+
+
+def _read_manifest(manifest_path: Path) -> dict:
+    p = Path(manifest_path)
+    if not p.exists():
+        raise HeavyMLManifestError(f"heavy_ml manifest not found: {p}")
+    payload = json.loads(p.read_text(encoding="utf-8"))
+    expected_schema = STEP5_MANIFEST_SCHEMA_VERSION
+    schema = payload.get("schema_version")
+    if schema != expected_schema:
+        raise HeavyMLManifestError(
+            f"heavy_ml manifest schema mismatch: expected "
+            f"{expected_schema!r}, got {schema!r}"
+        )
+    sub_protocol = payload.get("sub_protocol")
+    if sub_protocol != "heavy_ml_probe":
+        raise HeavyMLManifestError(
+            f"manifest sub_protocol must be 'heavy_ml_probe'; got {sub_protocol!r}"
+        )
+    return payload
+
+
+def _resolve_path(manifest_path: Path, rel: str) -> Path:
+    """Manifest paths are recorded relative to the manifest's parent."""
+    return (Path(manifest_path).parent / rel).resolve()
+
+
+def _assert_stage_ok(manifest: dict, stage: str) -> dict:
+    """Look up ``stages.<stage>`` and assert ``status == "ok"``;
+    return the stage dict so the caller can use its paths."""
+    stages = manifest.get("stages") or {}
+    info = stages.get(stage)
+    if info is None:
+        raise HeavyMLManifestError(
+            f"manifest has no `stages.{stage}` entry; cannot build adapter"
+        )
+    status = info.get("status")
+    if status != STAGE_STATUS_OK:
+        raise StageUnavailableError(
+            f"cannot build adapter from heavy_ml manifest: stage "
+            f"{stage!r} status={status!r} (skip_reason="
+            f"{info.get('skip_reason', '<unknown>')!r}). The upstream "
+            f"pipeline must report `ok` for this stage before adapters "
+            f"can consume it."
+        )
+    return info
+
+
+def _load_classifier_manifest(
+    heavy_ml_manifest: dict,
+    stage: str,
+    manifest_dir: Path,
+) -> tuple[Path, dict]:
+    """Locate + read the per-stage classifier manifest emitted by PR-C
+    (meta_label) or PR-D (survival). Returns (classifier_dir, parsed_json)."""
+    info = _assert_stage_ok(heavy_ml_manifest, stage)
+    rel = info.get("classifier_manifest_path")
+    if not rel:
+        raise HeavyMLManifestError(
+            f"manifest stages.{stage}.classifier_manifest_path is empty"
+        )
+    abs_path = _resolve_path(manifest_dir / "heavy_ml_manifest.json", rel)
+    if not abs_path.exists():
+        raise HeavyMLManifestError(
+            f"classifier manifest for stage {stage!r} not found at {abs_path}"
+        )
+    return abs_path.parent, json.loads(abs_path.read_text(encoding="utf-8"))
+
+
+# ── Builders ─────────────────────────────────────────────────────────
+
+
+def _pick_classifier_folds(
+    classifier_dir: Path,
+    fold_list: list[dict],
+    strategy: FoldSelectionStrategy,
+) -> tuple[list[Any], list[dict]]:
+    """Load + return ``(classifier_objects, fold_entries)`` per the
+    strategy. Returns a list because ENSEMBLE_MEAN needs all valid
+    folds; LAST_FOLD returns exactly one element."""
+    valid = [
+        f for f in fold_list
+        if f.get("path") and f.get("sha256")
+    ]
+    if not valid:
+        raise StageUnavailableError(
+            "no valid classifier folds in manifest (every fold has "
+            "path=null — upstream stage produced no fitted model)"
+        )
+    if strategy is FoldSelectionStrategy.LAST_FOLD:
+        chosen = [valid[-1]]
+    elif strategy is FoldSelectionStrategy.ENSEMBLE_MEAN:
+        chosen = list(valid)
+    elif strategy is FoldSelectionStrategy.FULL_REFIT:
+        raise NotImplementedError(
+            "FoldSelectionStrategy.FULL_REFIT is reserved for a future PR."
+        )
+    else:  # pragma: no cover
+        raise ValueError(f"unknown fold strategy: {strategy!r}")
+
+    loaded: list[Any] = []
+    for f in chosen:
+        path = classifier_dir / str(f["path"])
+        loaded.append(joblib.load(path))
+    return loaded, chosen
+
+
+def _pick_classifier_object(
+    objects: list[Any],
+    strategy: FoldSelectionStrategy,
+) -> Any:
+    """Reduce a multi-fold load to a single predict_proba-shaped
+    object. For LAST_FOLD: the single member. For ENSEMBLE_MEAN: an
+    :class:`EnsembleMeanProbaClassifier` wrapping all members."""
+    if not objects:
+        raise StageUnavailableError("empty classifier load")
+    if strategy is FoldSelectionStrategy.LAST_FOLD:
+        return objects[0]
+    if strategy is FoldSelectionStrategy.ENSEMBLE_MEAN:
+        return EnsembleMeanProbaClassifier(members=tuple(objects))
+    raise NotImplementedError(strategy)
+
+
+def build_a2_from_heavy_ml(
+    heavy_ml_manifest_path: Path,
+    *,
+    fold_selection_strategy: FoldSelectionStrategy = FoldSelectionStrategy.LAST_FOLD,
+    threshold: float | None = None,
+    config_id: str | None = None,
+    **a2_kwargs: Any,
+):
+    """Build an :class:`A2Config` from the heavy_ml manifest's AutoML
+    classifier.
+
+    AutoML stage's per-fold classifiers are persisted by PR-B
+    (``step_4/heavy_ml/classifiers/automl_*``) — at PR-E time PR-B
+    actually persists only the fold-wise leaderboard and the inner
+    estimator wrapper isn't yet on disk. This adapter therefore
+    consumes the meta-label classifier manifest INSTEAD when AutoML
+    classifiers aren't separately persisted, since the meta-label
+    classifier IS the FLAML AutoML output (PR-C runs the same FLAML
+    machine with the meta-label target).
+
+    Implementation note for PR-E narrow scope: per dispatch §2.1 + Q5a,
+    A2 consumes a ``predict_proba``-shaped classifier. PR-C's
+    meta-label classifiers are FLAML inner estimators (e.g.
+    ``LGBMClassifier`` from PR-C log §2.1). When chat wants A2 to
+    consume the vanilla-target AutoML output instead, PR-B will need
+    a separate persistence path (currently not implemented; this
+    adapter intentionally points at the PR-C artefact set).
+    """
+    from core.architectures.a2_classifier_filter import A2Config
+
+    mp = Path(heavy_ml_manifest_path)
+    manifest = _read_manifest(mp)
+    classifier_dir, clf_manifest = _load_classifier_manifest(
+        manifest, "meta_label", mp.parent,
+    )
+    objects, _ = _pick_classifier_folds(
+        classifier_dir, clf_manifest["folds"], fold_selection_strategy,
+    )
+    classifier = _pick_classifier_object(objects, fold_selection_strategy)
+
+    # Threshold: prefer explicit override; otherwise default to 0.5
+    # per L_PROTOCOL Amendment 2 §"A2" (AUC-best threshold default for
+    # vanilla A2; heavy_ml_probe doesn't compute per-cluster AUC-best
+    # thresholds at PR-E scope — surface as a future enhancement).
+    thr = float(threshold) if threshold is not None else 0.5
+    cid = config_id or f"a2_heavy_ml_t{thr:.4f}"
+
+    # Feature order is the classifier's training feature set. For
+    # FLAML inner estimators, this is the same column order passed to
+    # AutoML.fit(); PR-E stores it in the meta_label manifest extras
+    # (n_features_used) but not the column names themselves — the
+    # heavy_ml_manifest's top-level `used_features` carries the names.
+    used_features = tuple(manifest.get("used_features") or ())
+    return A2Config(
+        config_id=cid,
+        classifier=classifier,
+        threshold=thr,
+        classifier_feature_order=used_features,
+        **a2_kwargs,
+    )
+
+
+def build_a6_from_heavy_ml(
+    heavy_ml_manifest_path: Path,
+    *,
+    fold_selection_strategy: FoldSelectionStrategy = FoldSelectionStrategy.LAST_FOLD,
+    lower_threshold: float = 0.4,
+    upper_threshold: float = 0.6,
+    config_id: str | None = None,
+    **a6_kwargs: Any,
+):
+    """Build an :class:`A6Config` from PR-C's meta-label classifier."""
+    from core.architectures.a6_meta_labeling import A6Config
+
+    mp = Path(heavy_ml_manifest_path)
+    manifest = _read_manifest(mp)
+    classifier_dir, clf_manifest = _load_classifier_manifest(
+        manifest, "meta_label", mp.parent,
+    )
+    objects, _ = _pick_classifier_folds(
+        classifier_dir, clf_manifest["folds"], fold_selection_strategy,
+    )
+    classifier = _pick_classifier_object(objects, fold_selection_strategy)
+
+    used_features = tuple(manifest.get("used_features") or ())
+    cid = config_id or f"a6_heavy_ml_{lower_threshold:.2f}_{upper_threshold:.2f}"
+    return A6Config(
+        config_id=cid,
+        classifier=classifier,
+        lower_threshold=float(lower_threshold),
+        upper_threshold=float(upper_threshold),
+        classifier_feature_order=used_features,
+        **a6_kwargs,
+    )
+
+
+def build_a4_from_heavy_ml(
+    heavy_ml_manifest_path: Path,
+    *,
+    fold_selection_strategy: FoldSelectionStrategy = FoldSelectionStrategy.LAST_FOLD,
+    k_horizon: int = 5,
+    exit_threshold: float = 0.4,
+    config_id: str | None = None,
+    **a4_kwargs: Any,
+):
+    """Build an :class:`A4Config` from PR-D's Cox PH survival folds.
+
+    Returns a tuple ``(a4_config, cox_adapter)``:
+
+      * ``a4_config`` is the :class:`A4Config` with ``classifier_fit``
+        populated by a :class:`PathClassifierFit`-shaped wrapper around
+        :class:`CoxPHAdapter`. A4's runtime consumes this via
+        ``predict_admit`` per :mod:`core.architectures._path_classifier`.
+      * ``cox_adapter`` is the bare :class:`CoxPHAdapter` for direct
+        callers (chat-side analysis, tests). It exposes
+        ``hazard_predict(features, bars_survived) → P(reach +1R in
+        next K bars)`` per dispatch §2.2.
+
+    The bundle pattern (not a single object) is the cleanest
+    interpretation of dispatch §2.2's "A4Config object exposing a
+    callable hazard_predict" within the narrow scope of PR-E (no
+    changes to ``core/architectures/A4.py``). The A4Config stays
+    schema-pure; chat-side code that wants to introspect the adapter's
+    raw hazard math uses ``cox_adapter`` directly.
+    """
+    from core.architectures._path_classifier import PathClassifierFit
+    from core.architectures.a4_pipeline_d_exits import A4Config
+
+    mp = Path(heavy_ml_manifest_path)
+    manifest = _read_manifest(mp)
+    classifier_dir, clf_manifest = _load_classifier_manifest(
+        manifest, "survival", mp.parent,
+    )
+    # Load survival per-fold pickles + lift into _CoxPHFoldPayload
+    objects, _ = _pick_classifier_folds(
+        classifier_dir, clf_manifest["folds"], fold_selection_strategy,
+    )
+    payloads = tuple(_coxph_payload_from_pickle(o) for o in objects)
+    cox_adapter = CoxPHAdapter(
+        payloads=payloads,
+        strategy=fold_selection_strategy,
+        k_horizon=int(k_horizon),
+    )
+
+    fit = PathClassifierFit(
+        model=cox_adapter,
+        threshold=float(exit_threshold),
+        fit_auc=float("nan"),  # not available — Cox PH evaluated by concordance
+        feature_order=cox_adapter.feature_order,
+    )
+    cid = config_id or f"a4_heavy_ml_k{int(k_horizon)}_t{exit_threshold:.2f}"
+    config = A4Config(
+        config_id=cid,
+        classifier_fit=fit,
+        exit_threshold=float(exit_threshold),
+        per_trade_entry_features=None,
+        **a4_kwargs,
+    )
+    return config, cox_adapter
+
+
+__all__ = (
+    "BARS_SURVIVED_FEATURE",
+    "HEAVY_ML_MANIFEST_NAME",
+    "STAGE_STATUS_FAILED",
+    "STAGE_STATUS_OK",
+    "STAGE_STATUS_SKIPPED",
+    "STEP5_MANIFEST_SCHEMA_VERSION",
+    "CoxPHAdapter",
+    "EnsembleMeanProbaClassifier",
+    "FoldSelectionStrategy",
+    "HeavyMLManifestError",
+    "StageUnavailableError",
+    "build_a2_from_heavy_ml",
+    "build_a4_from_heavy_ml",
+    "build_a6_from_heavy_ml",
+)

--- a/core/heavy_ml_probe/automl.py
+++ b/core/heavy_ml_probe/automl.py
@@ -52,7 +52,7 @@ any AutoML call.
 from __future__ import annotations
 
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Mapping, Sequence
 
 import numpy as np
@@ -109,7 +109,12 @@ class AllFeaturesRejected(RuntimeError):
 
 @dataclass(frozen=True)
 class FoldResult:
-    """One fold of the AutoML CV evaluation."""
+    """One fold of the AutoML CV evaluation.
+
+    ``fitted_estimator`` is populated only when ``run_automl`` is called
+    with ``keep_classifiers=True`` (PR-C meta-labeling path); it stays
+    ``None`` for PR-B's default invocation.
+    """
 
     fold: int                       # 1..n_folds
     train_start: pd.Timestamp
@@ -127,11 +132,17 @@ class FoldResult:
     max_iter: int                   # the cap we passed in
     estimator_list: tuple[str, ...] # FLAML's estimator_list for this fold
     fit_wall_seconds: float
+    fitted_estimator: Any | None = None  # inner sklearn-compatible classifier (PR-C opt-in)
 
 
 @dataclass(frozen=True)
 class AutoMLResult:
-    """Aggregated AutoML output across all folds."""
+    """Aggregated AutoML output across all folds.
+
+    PR-B fields populated unconditionally; PR-C added ``oof_predictions``
+    (empty unless ``collect_oof_predictions=True`` was passed to
+    :func:`run_automl`).
+    """
 
     fold_results: tuple[FoldResult, ...]
     leaderboard: pd.DataFrame       # one row per (fold, estimator) — long-form
@@ -145,6 +156,10 @@ class AutoMLResult:
     total_fit_wall_seconds: float
     flaml_version: str
     metric: str
+    # PR-C: out-of-fold predictions per validation trade, aggregated
+    # across all folds. Columns: ``trade_id, fold, y_true, y_pred_proba``.
+    # Empty DataFrame when ``collect_oof_predictions=False`` (default).
+    oof_predictions: pd.DataFrame = field(default_factory=pd.DataFrame)
 
 
 # ── Internal helpers ─────────────────────────────────────────────────
@@ -274,9 +289,19 @@ def _run_one_fold(
     metric: str,
     n_jobs: int,
     permutation_repeats: int,
-) -> tuple[FoldResult, pd.DataFrame, pd.DataFrame]:
+    keep_classifier: bool = False,
+    collect_oof: bool = False,
+    trade_id_col: str = "trade_id",
+) -> tuple[FoldResult, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Train + evaluate one fold. Returns (fold_result, leaderboard_rows,
-    importance_rows)."""
+    importance_rows, oof_rows).
+
+    PR-C extensions (default-off, backwards-compatible with PR-B):
+      * ``keep_classifier=True`` → the fold's inner sklearn-compatible
+        estimator is stored on ``FoldResult.fitted_estimator``.
+      * ``collect_oof=True`` → returns a non-empty ``oof_rows`` DataFrame
+        with columns ``(trade_id, fold, y_true, y_pred_proba)``.
+    """
     import time
 
     from flaml import AutoML  # local import — heavy library, lazy load
@@ -311,8 +336,9 @@ def _run_one_fold(
             modelcount=0, max_iter=int(max_iter),
             estimator_list=(),
             fit_wall_seconds=0.0,
+            fitted_estimator=None,
         )
-        return fr, pd.DataFrame(), pd.DataFrame()
+        return fr, pd.DataFrame(), pd.DataFrame(), pd.DataFrame()
 
     t0 = time.perf_counter()
     automl = AutoML()
@@ -423,6 +449,17 @@ def _run_one_fold(
                 stacklevel=2,
             )
 
+    # PR-C: collect OOF predictions for the threshold sweep.
+    oof_rows = pd.DataFrame()
+    if collect_oof and trade_id_col in pool_sorted.columns:
+        val_trade_ids = pool_sorted[trade_id_col].values[val_s:val_e]
+        oof_rows = pd.DataFrame({
+            trade_id_col: val_trade_ids,
+            "fold": fold_idx,
+            "y_true": y_val,
+            "y_pred_proba": proba_val,
+        })
+
     fr = FoldResult(
         fold=fold_idx,
         train_start=times.iloc[train_s], train_end=times.iloc[train_e - 1],
@@ -437,8 +474,11 @@ def _run_one_fold(
         max_iter=int(max_iter),
         estimator_list=tuple(automl.estimator_list or ()),
         fit_wall_seconds=float(fit_wall),
+        # PR-C: optionally keep the inner sklearn-compatible estimator
+        # for downstream persistence (meta-labeling → A6 consumer).
+        fitted_estimator=(inner_estimator if keep_classifier else None),
     )
-    return fr, leaderboard_rows, importance_rows
+    return fr, leaderboard_rows, importance_rows, oof_rows
 
 
 # ── Public surface ───────────────────────────────────────────────────
@@ -457,6 +497,9 @@ def run_automl(
     permutation_repeats: int = DEFAULT_PERMUTATION_REPEATS,
     entry_time_col: str = "entry_time",
     target_col: str = "y",
+    trade_id_col: str = "trade_id",
+    keep_classifiers: bool = False,
+    collect_oof_predictions: bool = False,
 ) -> AutoMLResult:
     """Run heavy_ml_probe AutoML across an 11-fold TimeSeriesSplit.
 
@@ -466,6 +509,8 @@ def run_automl(
         Step-1 trade pool. Must contain ``entry_time`` (or
         ``entry_time_col``), the binary target ``y`` (or
         ``target_col``), and every column listed in ``used_features``.
+        Must additionally contain ``trade_id_col`` (default ``trade_id``)
+        when ``collect_oof_predictions=True``.
     used_features
         Column order to pass to FLAML. Caller is responsible for
         applying the lineage gate first (see
@@ -478,12 +523,29 @@ def run_automl(
         TimeSeriesSplit fold count. Default 11 per spec.
     max_iter_per_fold
         FLAML budget per fold. Default 1000 per spec.
+    target_col
+        Pool column holding the binary target. Default ``"y"``.
+        Meta-labeling (PR-C) passes ``"y_meta_label"`` for the
+        reach-1R-before-SL target; vanilla PR-B path uses ``"y"``.
+    trade_id_col
+        Pool column identifying each trade. Only consulted when
+        ``collect_oof_predictions=True``. Default ``"trade_id"``.
+    keep_classifiers
+        PR-C opt-in. When True, each ``FoldResult.fitted_estimator``
+        carries the fold's inner sklearn-compatible classifier
+        (``automl.model.estimator``) for downstream persistence. PR-B
+        callers leave this False to keep memory bounded.
+    collect_oof_predictions
+        PR-C opt-in. When True, the returned ``AutoMLResult.oof_predictions``
+        DataFrame is non-empty with columns
+        ``(trade_id_col, fold, y_true, y_pred_proba)``. Used by
+        meta-labeling's threshold sweep.
 
     Returns
     -------
     :class:`AutoMLResult` with per-fold ``FoldResult`` snapshots, a
-    long-form leaderboard DataFrame, an importance DataFrame, and
-    aggregate AUC + budget stats.
+    long-form leaderboard DataFrame, an importance DataFrame, OOF
+    predictions (when requested), and aggregate AUC + budget stats.
 
     Raises
     ------
@@ -520,12 +582,20 @@ def run_automl(
             f"a pool of size {len(pool_sorted)}; pool too small"
         )
 
+    # PR-C: validate trade_id presence when OOF predictions are requested.
+    if collect_oof_predictions and trade_id_col not in pool_sorted.columns:
+        raise ValueError(
+            f"collect_oof_predictions=True requires pool to contain "
+            f"{trade_id_col!r} column; present: {sorted(pool_sorted.columns)[:10]}..."
+        )
+
     fold_results: list[FoldResult] = []
     leaderboard_frames: list[pd.DataFrame] = []
     importance_frames: list[pd.DataFrame] = []
+    oof_frames: list[pd.DataFrame] = []
 
     for fold_idx, (train_s, train_e, val_s, val_e) in enumerate(folds, start=1):
-        fr, lb, imp = _run_one_fold(
+        fr, lb, imp, oof = _run_one_fold(
             fold_idx=fold_idx,
             pool_sorted=pool_sorted,
             used_features=used_features,
@@ -538,12 +608,17 @@ def run_automl(
             metric=metric,
             n_jobs=n_jobs,
             permutation_repeats=permutation_repeats,
+            keep_classifier=keep_classifiers,
+            collect_oof=collect_oof_predictions,
+            trade_id_col=trade_id_col,
         )
         fold_results.append(fr)
         if not lb.empty:
             leaderboard_frames.append(lb)
         if not imp.empty:
             importance_frames.append(imp)
+        if not oof.empty:
+            oof_frames.append(oof)
 
     leaderboard = (
         pd.concat(leaderboard_frames, ignore_index=True)
@@ -566,6 +641,15 @@ def run_automl(
         auc_mean = float(np.nanmean(auc_vals)) if n_valid > 0 else float("nan")
         auc_std = float(np.nanstd(auc_vals, ddof=0)) if n_valid > 0 else float("nan")
 
+    # PR-C: assemble OOF predictions deterministically by (fold, trade_id).
+    oof_predictions = (
+        pd.concat(oof_frames, ignore_index=True)
+        .sort_values(["fold", trade_id_col], kind="mergesort")
+        .reset_index(drop=True)
+        if oof_frames
+        else pd.DataFrame(columns=[trade_id_col, "fold", "y_true", "y_pred_proba"])
+    )
+
     return AutoMLResult(
         fold_results=tuple(fold_results),
         leaderboard=leaderboard,
@@ -579,6 +663,7 @@ def run_automl(
         total_fit_wall_seconds=float(sum(fr.fit_wall_seconds for fr in fold_results)),
         flaml_version=_flaml_version(),
         metric=metric,
+        oof_predictions=oof_predictions,
     )
 
 

--- a/core/heavy_ml_probe/automl.py
+++ b/core/heavy_ml_probe/automl.py
@@ -1,0 +1,754 @@
+"""FLAML AutoML wrapper for heavy_ml_probe Step 4 (PR-B).
+
+Per ``docs/sub_protocols/heavy_ml_probe.md`` v1.0 §"What overrides the
+overseer" + dispatch §1:
+
+  * CV: 11-fold ``TimeSeriesSplit`` on the IS slice (2010-01-01 →
+    2020-12-31). No random k-fold. Holdout (2021-01-01 → present)
+    untouched.
+  * Per-fold training: each fold runs its own ``flaml.AutoML.fit()``.
+    No "train once globally, evaluate per fold" — guarantees feature
+    selection + hyperparameter search happen inside the fold's
+    training window only.
+  * Budget cap: ``max_iter`` per fold per FLAML's native trial-
+    counting. PR-B empirical verification (see
+    ``docs/dispatches/heavy_ml_probe_pr_b_log.md`` §3a):
+    ``flaml.AutoML.modelcount`` == ``max_iter`` exactly when FLAML
+    runs to the cap. Ratio 1.0; locked.
+  * Determinism: ``seed=42`` propagated through FLAML + numpy +
+    pandas; ``n_jobs=1``; identical input pool → identical artefacts
+    across two runs.
+
+  * Estimator set: FLAML's default for binary classification on this
+    installation (FLAML 2.6.0):
+    ``['lgbm', 'rf', 'xgboost', 'extra_tree', 'xgb_limitdepth', 'sgd',
+    'catboost', 'lrl1']``. Captured at runtime into the leaderboard
+    artefact for cross-env audit.
+
+Single-class fold AUC handling (dispatch §3b): a fold whose validation
+slice contains only one class of the target yields an undefined ROC AUC.
+``sklearn.metrics.roc_auc_score`` returns NaN in that case in modern
+sklearn (verified at PR-B time); FLAML internally surfaces this as a
+sentinel loss but does not crash. This module's contract:
+
+  * Per-fold AUC is recorded as ``numpy.nan`` when the fold is
+    single-class. Confirmed by ``test_automl.py``.
+  * Aggregate AUC uses ``numpy.nanmean`` so a single bad fold does not
+    poison the whole estimate.
+  * ``n_folds_valid`` (folds with computable AUC) is reported
+    alongside the mean so downstream readers can tell whether the
+    aggregate spans all 11 folds or fewer.
+
+Holdout-guard (dispatch §5 #3): ``run_automl`` asserts the input
+pool's max ``entry_time`` is strictly less than the configured
+``train_end`` cutoff before calling FLAML. Violation raises
+:class:`HoldoutGuardViolation`.
+
+Lineage-rejects-all guard (dispatch §5 #2): if the lineage gate
+rejects every feature, :class:`AllFeaturesRejected` is raised before
+any AutoML call.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.inspection import permutation_importance
+from sklearn.model_selection import TimeSeriesSplit
+
+from core.heavy_ml_probe.metrics import auc_roc
+
+# Locked defaults — overridable via PipelineConfig/YAML but baked here
+# so internal callers (tests, integration) don't need to thread them
+# through every code path.
+DEFAULT_N_FOLDS: int = 11
+DEFAULT_MAX_ITER_PER_FOLD: int = 1000
+DEFAULT_PERMUTATION_REPEATS: int = 5
+DEFAULT_RANDOM_STATE: int = 42
+
+# FLAML's default binary-classification estimator list on this install
+# (FLAML 2.6.0). Recorded for cross-env audit; the actual list FLAML
+# uses at runtime is captured per-fold via ``automl.estimator_list`` so
+# we never log a stale value.
+DOCUMENTED_FLAML_2_6_0_ESTIMATORS: tuple[str, ...] = (
+    "lgbm",
+    "rf",
+    "xgboost",
+    "extra_tree",
+    "xgb_limitdepth",
+    "sgd",
+    "catboost",
+    "lrl1",
+)
+
+
+class HoldoutGuardViolation(RuntimeError):
+    """Raised when the input pool contains trades on/after ``train_end``.
+
+    Per L_PROTOCOL §1 (non-negotiable) + dispatch §5 #3: the 2021-01-01
+    → present holdout window is OFF-LIMITS during training. The guard
+    fires BEFORE any FLAML call so no holdout-tainted model ever lands
+    on disk.
+    """
+
+
+class AllFeaturesRejected(RuntimeError):
+    """Raised when the lineage gate rejects every column in the pool.
+
+    Per dispatch §5 #2: if no clean features remain, fail fast with a
+    clear error rather than calling AutoML with an empty design matrix.
+    """
+
+
+# ── Result types ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class FoldResult:
+    """One fold of the AutoML CV evaluation."""
+
+    fold: int                       # 1..n_folds
+    train_start: pd.Timestamp
+    train_end: pd.Timestamp
+    val_start: pd.Timestamp
+    val_end: pd.Timestamp
+    n_train: int
+    n_val: int
+    n_val_pos: int                  # positive-class count in val (for single-class diagnostic)
+    best_estimator: str             # FLAML's best_estimator name for this fold
+    best_loss: float                # FLAML's internal loss for the best config
+    auc_val: float                  # OOS AUC on the validation slice (NaN if single-class)
+    auc_train: float                # IS AUC on the training slice (NaN if single-class)
+    modelcount: int                 # FLAML's automl.modelcount (= actual trials run)
+    max_iter: int                   # the cap we passed in
+    estimator_list: tuple[str, ...] # FLAML's estimator_list for this fold
+    fit_wall_seconds: float
+
+
+@dataclass(frozen=True)
+class AutoMLResult:
+    """Aggregated AutoML output across all folds."""
+
+    fold_results: tuple[FoldResult, ...]
+    leaderboard: pd.DataFrame       # one row per (fold, estimator) — long-form
+    importance: pd.DataFrame        # mean + std permutation importance per feature
+    used_features: tuple[str, ...]  # post lineage-gate, in column-order passed to FLAML
+    n_folds_total: int
+    n_folds_valid: int              # folds with finite val AUC
+    auc_mean: float                 # nanmean of per-fold val AUCs
+    auc_std: float                  # nanstd of per-fold val AUCs
+    total_modelcount: int           # sum of per-fold modelcount values
+    total_fit_wall_seconds: float
+    flaml_version: str
+    metric: str
+
+
+# ── Internal helpers ─────────────────────────────────────────────────
+
+
+def _coerce_entry_time(pool: pd.DataFrame, column: str = "entry_time") -> pd.Series:
+    """Return ``pool[column]`` parsed as UTC pandas Timestamps.
+
+    Tests pass already-Timestamped columns; production pools come from
+    parquet with ISO strings or naive datetimes. Normalise both.
+    """
+    if column not in pool.columns:
+        raise ValueError(
+            f"pool must contain {column!r} column for TimeSeriesSplit ordering"
+        )
+    s = pool[column]
+    return pd.to_datetime(s, utc=True)
+
+
+def _assert_holdout_guard(
+    pool: pd.DataFrame,
+    train_end: pd.Timestamp,
+    *,
+    entry_time_col: str = "entry_time",
+) -> None:
+    """Per L_PROTOCOL §1: max ``entry_time`` in pool must be strictly
+    less than ``train_end``."""
+    ts = pd.Timestamp(train_end)
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    times = _coerce_entry_time(pool, entry_time_col)
+    if len(times) == 0:
+        return  # empty pool — nothing to guard
+    max_ts = times.max()
+    if max_ts >= ts:
+        raise HoldoutGuardViolation(
+            f"holdout-guard violated: pool max entry_time={max_ts.isoformat()} "
+            f"is >= train_end={ts.isoformat()}; filter the pool to IS-only "
+            f"before invoking AutoML"
+        )
+
+
+def _coerce_target(pool: pd.DataFrame, target_col: str = "y") -> np.ndarray:
+    """Return the target column as a binary int ndarray.
+
+    Tests and production pools both label the binary target ``y``. The
+    actual target-construction (cluster membership for PR-B; reach-1R
+    for PR-C) lives upstream — this module just consumes the array.
+    """
+    if target_col not in pool.columns:
+        raise ValueError(
+            f"pool must contain {target_col!r} column (binary target)"
+        )
+    y = pool[target_col].astype(int).values
+    uniq = set(int(v) for v in np.unique(y))
+    if not uniq.issubset({0, 1}):
+        raise ValueError(
+            f"target must be binary (0/1); found {sorted(uniq)}"
+        )
+    return y
+
+
+def _select_used_features(
+    pool: pd.DataFrame,
+    used_features: Sequence[str],
+) -> pd.DataFrame:
+    """Slice ``pool`` to the lineage-gate-cleared features in column order."""
+    if not used_features:
+        raise AllFeaturesRejected(
+            "lineage gate rejected every feature — cannot fit AutoML on an "
+            "empty design matrix. Inspect step_4/heavy_ml/manifest.json's "
+            "lineage_gate.rejection_reasons field for the per-feature reasons."
+        )
+    missing = [c for c in used_features if c not in pool.columns]
+    if missing:
+        raise ValueError(
+            f"pool missing lineage-gate-accepted columns: {missing[:10]}"
+            f"{'...' if len(missing) > 10 else ''}"
+        )
+    return pool[list(used_features)].copy()
+
+
+def _flaml_version() -> str:
+    try:
+        import flaml  # type: ignore
+
+        return str(flaml.__version__)
+    except ImportError:
+        return ""
+
+
+def _build_time_series_folds(
+    pool_sorted: pd.DataFrame,
+    n_folds: int,
+    entry_time_col: str = "entry_time",
+) -> list[tuple[int, int, int, int]]:
+    """Return ``[(train_start_idx, train_end_idx, val_start_idx, val_end_idx), ...]``.
+
+    Indices are half-open ranges into the time-sorted pool. Mirrors
+    ``sklearn.model_selection.TimeSeriesSplit`` exactly so the test
+    suite can assert behaviour without a second implementation.
+    """
+    cv = TimeSeriesSplit(n_splits=n_folds)
+    n = len(pool_sorted)
+    out: list[tuple[int, int, int, int]] = []
+    for train_idx, val_idx in cv.split(np.arange(n)):
+        if len(train_idx) == 0 or len(val_idx) == 0:
+            continue
+        out.append((int(train_idx[0]), int(train_idx[-1]) + 1,
+                    int(val_idx[0]), int(val_idx[-1]) + 1))
+    return out
+
+
+def _run_one_fold(
+    *,
+    fold_idx: int,
+    pool_sorted: pd.DataFrame,
+    used_features: Sequence[str],
+    y_all: np.ndarray,
+    train_s: int,
+    train_e: int,
+    val_s: int,
+    val_e: int,
+    times: pd.Series,
+    max_iter: int,
+    seed: int,
+    metric: str,
+    n_jobs: int,
+    permutation_repeats: int,
+) -> tuple[FoldResult, pd.DataFrame, pd.DataFrame]:
+    """Train + evaluate one fold. Returns (fold_result, leaderboard_rows,
+    importance_rows)."""
+    import time
+
+    from flaml import AutoML  # local import — heavy library, lazy load
+
+    X = pool_sorted[list(used_features)].values
+    X_train, X_val = X[train_s:train_e], X[val_s:val_e]
+    y_train, y_val = y_all[train_s:train_e], y_all[val_s:val_e]
+    n_val_pos = int((y_val == 1).sum())
+
+    # Per dispatch §3b: detect single-class fold up front so we can
+    # short-circuit the AutoML call. A single-class training fold breaks
+    # FLAML's internal CV; a single-class validation fold yields NaN
+    # AUC. Skip the fit when training is degenerate.
+    n_train_classes = len(np.unique(y_train))
+    if n_train_classes < 2:
+        warnings.warn(
+            f"fold {fold_idx} has single-class training slice "
+            f"(n_train={len(y_train)}, n_train_pos={int((y_train == 1).sum())}); "
+            f"skipping AutoML fit, AUC will be NaN",
+            UserWarning,
+            stacklevel=2,
+        )
+        fr = FoldResult(
+            fold=fold_idx,
+            train_start=times.iloc[train_s], train_end=times.iloc[train_e - 1],
+            val_start=times.iloc[val_s], val_end=times.iloc[val_e - 1],
+            n_train=int(train_e - train_s), n_val=int(val_e - val_s),
+            n_val_pos=n_val_pos,
+            best_estimator="<skipped:single_class_train>",
+            best_loss=float("nan"),
+            auc_val=float("nan"), auc_train=float("nan"),
+            modelcount=0, max_iter=int(max_iter),
+            estimator_list=(),
+            fit_wall_seconds=0.0,
+        )
+        return fr, pd.DataFrame(), pd.DataFrame()
+
+    t0 = time.perf_counter()
+    automl = AutoML()
+    # Per dispatch §1: FLAML's internal eval_method='cv' would do
+    # ANOTHER CV inside the training fold. That's expected — FLAML uses
+    # its own inner CV to pick hyperparameters; our outer 11-fold split
+    # is the OOS evaluation surface. n_splits=3 keeps inner-CV
+    # compute bounded.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        automl.fit(
+            X_train=X_train, y_train=y_train,
+            task="classification",
+            metric=metric,
+            max_iter=int(max_iter),
+            seed=int(seed),
+            n_jobs=int(n_jobs),
+            eval_method="cv",
+            n_splits=3,
+            verbose=0,
+        )
+    fit_wall = time.perf_counter() - t0
+
+    # Per dispatch §3a: automl.modelcount is the actual trial counter.
+    modelcount = int(getattr(automl, "modelcount", -1))
+    if modelcount < 0:
+        # Should not happen on FLAML 2.6.0; defensive fallback.
+        warnings.warn(
+            f"flaml.AutoML.modelcount unavailable; budget audit will be "
+            f"under-reported for fold {fold_idx}",
+            UserWarning,
+            stacklevel=2,
+        )
+        modelcount = 0
+    if modelcount > max_iter:
+        # PR-B HALT trigger per dispatch §3a if ratio ≥ 1.5×; we accept
+        # modelcount ≤ max_iter empirically (PR-B log §3a), but
+        # surface as a warning if it ever drifts.
+        warnings.warn(
+            f"fold {fold_idx} modelcount={modelcount} exceeds max_iter={max_iter}; "
+            f"FLAML budget accounting may have drifted — review PR-B log §3a",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    # OOS + IS AUCs
+    try:
+        proba_val = automl.predict_proba(X_val)[:, 1]
+    except Exception:
+        proba_val = np.full(len(y_val), np.nan)
+    try:
+        proba_train = automl.predict_proba(X_train)[:, 1]
+    except Exception:
+        proba_train = np.full(len(y_train), np.nan)
+    auc_val = auc_roc(y_val, proba_val) if np.all(np.isfinite(proba_val)) else float("nan")
+    auc_train = auc_roc(y_train, proba_train) if np.all(np.isfinite(proba_train)) else float("nan")
+
+    # Leaderboard rows: one per estimator FLAML evaluated. FLAML 2.6.0
+    # exposes ``best_loss_per_estimator``; use it as the leaderboard.
+    best_per_est: Mapping[str, Any] = dict(
+        getattr(automl, "best_loss_per_estimator", {}) or {}
+    )
+    leaderboard_rows = pd.DataFrame([
+        {
+            "fold": fold_idx,
+            "estimator": str(est),
+            "best_loss": float(loss) if loss is not None and np.isfinite(float(loss)) else float("nan"),
+            "is_overall_best": (str(est) == str(automl.best_estimator)),
+        }
+        for est, loss in sorted(best_per_est.items())
+    ])
+
+    # Permutation importance on the validation slice (dispatch §2).
+    # NaN-safe: if validation is single-class or sklearn raises,
+    # importance comes back NaN-filled.
+    #
+    # sklearn 1.5+'s permutation_importance refuses FLAML's outer
+    # AutoML wrapper because the wrapper does not advertise itself as
+    # a ClassifierMixin in a way sklearn's `_check_response_method`
+    # recognises. We pass the inner fitted estimator
+    # (``automl.model.estimator`` — e.g. ``LGBMClassifier``,
+    # ``XGBClassifier``, ``RandomForestClassifier``) instead, which IS
+    # a proper sklearn-compatible classifier. Predictions made through
+    # the inner estimator are byte-identical to the outer wrapper for
+    # standard pipelines per FLAML's docs.
+    importance_rows = pd.DataFrame()
+    inner_estimator = getattr(getattr(automl, "model", None), "estimator", None)
+    if len(np.unique(y_val)) >= 2 and inner_estimator is not None:
+        try:
+            pi = permutation_importance(
+                inner_estimator, X_val, y_val,
+                n_repeats=int(permutation_repeats),
+                random_state=int(seed),
+                n_jobs=int(n_jobs),
+                scoring="roc_auc",
+            )
+            importance_rows = pd.DataFrame({
+                "fold": fold_idx,
+                "feature": list(used_features),
+                "importance_mean": pi.importances_mean,
+                "importance_std": pi.importances_std,
+            })
+        except Exception as e:
+            warnings.warn(
+                f"fold {fold_idx}: permutation_importance raised "
+                f"{type(e).__name__}({e}); importance row will be empty",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    fr = FoldResult(
+        fold=fold_idx,
+        train_start=times.iloc[train_s], train_end=times.iloc[train_e - 1],
+        val_start=times.iloc[val_s], val_end=times.iloc[val_e - 1],
+        n_train=int(train_e - train_s), n_val=int(val_e - val_s),
+        n_val_pos=n_val_pos,
+        best_estimator=str(automl.best_estimator),
+        best_loss=float(automl.best_loss) if np.isfinite(automl.best_loss) else float("nan"),
+        auc_val=float(auc_val),
+        auc_train=float(auc_train),
+        modelcount=int(modelcount),
+        max_iter=int(max_iter),
+        estimator_list=tuple(automl.estimator_list or ()),
+        fit_wall_seconds=float(fit_wall),
+    )
+    return fr, leaderboard_rows, importance_rows
+
+
+# ── Public surface ───────────────────────────────────────────────────
+
+
+def run_automl(
+    pool: pd.DataFrame,
+    used_features: Sequence[str],
+    *,
+    train_end: pd.Timestamp,
+    n_folds: int = DEFAULT_N_FOLDS,
+    max_iter_per_fold: int = DEFAULT_MAX_ITER_PER_FOLD,
+    seed: int = DEFAULT_RANDOM_STATE,
+    metric: str = "roc_auc",
+    n_jobs: int = 1,
+    permutation_repeats: int = DEFAULT_PERMUTATION_REPEATS,
+    entry_time_col: str = "entry_time",
+    target_col: str = "y",
+) -> AutoMLResult:
+    """Run heavy_ml_probe AutoML across an 11-fold TimeSeriesSplit.
+
+    Parameters
+    ----------
+    pool
+        Step-1 trade pool. Must contain ``entry_time`` (or
+        ``entry_time_col``), the binary target ``y`` (or
+        ``target_col``), and every column listed in ``used_features``.
+    used_features
+        Column order to pass to FLAML. Caller is responsible for
+        applying the lineage gate first (see
+        :mod:`core.heavy_ml_probe.causal_lineage`).
+    train_end
+        Holdout-guard cutoff. Max ``entry_time`` in ``pool`` must be
+        strictly less than this timestamp; otherwise raises
+        :class:`HoldoutGuardViolation`.
+    n_folds
+        TimeSeriesSplit fold count. Default 11 per spec.
+    max_iter_per_fold
+        FLAML budget per fold. Default 1000 per spec.
+
+    Returns
+    -------
+    :class:`AutoMLResult` with per-fold ``FoldResult`` snapshots, a
+    long-form leaderboard DataFrame, an importance DataFrame, and
+    aggregate AUC + budget stats.
+
+    Raises
+    ------
+    HoldoutGuardViolation
+        If the input pool's max ``entry_time`` >= ``train_end``.
+    AllFeaturesRejected
+        If ``used_features`` is empty.
+    ValueError
+        If required columns are missing or the target is non-binary.
+    """
+    if not used_features:
+        raise AllFeaturesRejected(
+            "lineage gate rejected every feature — cannot fit AutoML on an "
+            "empty design matrix"
+        )
+    _assert_holdout_guard(pool, train_end, entry_time_col=entry_time_col)
+
+    # Sort by entry_time so TimeSeriesSplit indexing is causal.
+    times_all = _coerce_entry_time(pool, entry_time_col)
+    pool_sorted = pool.assign(_entry_ts=times_all).sort_values(
+        ["_entry_ts"], kind="mergesort"
+    ).drop(columns=["_entry_ts"]).reset_index(drop=True)
+    times = _coerce_entry_time(pool_sorted, entry_time_col).reset_index(drop=True)
+
+    y_all = _coerce_target(pool_sorted, target_col)
+    used_features = tuple(used_features)
+    # Validate column presence early — clearer error than FLAML's eventual KeyError.
+    _ = _select_used_features(pool_sorted, used_features)
+
+    folds = _build_time_series_folds(pool_sorted, n_folds, entry_time_col)
+    if not folds:
+        raise ValueError(
+            f"TimeSeriesSplit with n_folds={n_folds} produced no folds on "
+            f"a pool of size {len(pool_sorted)}; pool too small"
+        )
+
+    fold_results: list[FoldResult] = []
+    leaderboard_frames: list[pd.DataFrame] = []
+    importance_frames: list[pd.DataFrame] = []
+
+    for fold_idx, (train_s, train_e, val_s, val_e) in enumerate(folds, start=1):
+        fr, lb, imp = _run_one_fold(
+            fold_idx=fold_idx,
+            pool_sorted=pool_sorted,
+            used_features=used_features,
+            y_all=y_all,
+            train_s=train_s, train_e=train_e,
+            val_s=val_s, val_e=val_e,
+            times=times,
+            max_iter=max_iter_per_fold,
+            seed=seed,
+            metric=metric,
+            n_jobs=n_jobs,
+            permutation_repeats=permutation_repeats,
+        )
+        fold_results.append(fr)
+        if not lb.empty:
+            leaderboard_frames.append(lb)
+        if not imp.empty:
+            importance_frames.append(imp)
+
+    leaderboard = (
+        pd.concat(leaderboard_frames, ignore_index=True)
+        if leaderboard_frames
+        else pd.DataFrame(columns=["fold", "estimator", "best_loss", "is_overall_best"])
+    )
+    # Deterministic row order: (fold, estimator)
+    if not leaderboard.empty:
+        leaderboard = leaderboard.sort_values(
+            ["fold", "estimator"], kind="mergesort"
+        ).reset_index(drop=True)
+
+    importance = _aggregate_importance(importance_frames, used_features)
+
+    auc_vals = np.array([fr.auc_val for fr in fold_results], dtype=float)
+    finite_mask = np.isfinite(auc_vals)
+    n_valid = int(finite_mask.sum())
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # nanmean on all-NaN raises a RuntimeWarning
+        auc_mean = float(np.nanmean(auc_vals)) if n_valid > 0 else float("nan")
+        auc_std = float(np.nanstd(auc_vals, ddof=0)) if n_valid > 0 else float("nan")
+
+    return AutoMLResult(
+        fold_results=tuple(fold_results),
+        leaderboard=leaderboard,
+        importance=importance,
+        used_features=tuple(used_features),
+        n_folds_total=len(fold_results),
+        n_folds_valid=n_valid,
+        auc_mean=auc_mean,
+        auc_std=auc_std,
+        total_modelcount=int(sum(fr.modelcount for fr in fold_results)),
+        total_fit_wall_seconds=float(sum(fr.fit_wall_seconds for fr in fold_results)),
+        flaml_version=_flaml_version(),
+        metric=metric,
+    )
+
+
+def _aggregate_importance(
+    importance_frames: list[pd.DataFrame],
+    used_features: Sequence[str],
+) -> pd.DataFrame:
+    """Mean + std per feature across folds. ``n_folds_present`` records
+    how many folds contributed a finite importance for that feature."""
+    if not importance_frames:
+        return pd.DataFrame(columns=[
+            "feature", "importance_mean", "importance_std", "n_folds_present"
+        ])
+    cat = pd.concat(importance_frames, ignore_index=True)
+    agg = (
+        cat.groupby("feature")["importance_mean"]
+        .agg(["mean", "std", "count"])
+        .reset_index()
+        .rename(columns={
+            "mean": "importance_mean",
+            "std": "importance_std",
+            "count": "n_folds_present",
+        })
+    )
+    # Ensure every used feature appears (even if no fold had finite importance).
+    present = set(agg["feature"].tolist())
+    rows_to_add = [
+        {"feature": f, "importance_mean": float("nan"),
+         "importance_std": float("nan"), "n_folds_present": 0}
+        for f in used_features if f not in present
+    ]
+    if rows_to_add:
+        agg = pd.concat([agg, pd.DataFrame(rows_to_add)], ignore_index=True)
+    agg["n_folds_present"] = agg["n_folds_present"].astype(int)
+    # Sort by importance_mean desc, feature asc — deterministic.
+    agg = agg.sort_values(
+        ["importance_mean", "feature"],
+        ascending=[False, True], kind="mergesort", na_position="last",
+    ).reset_index(drop=True)
+    return agg
+
+
+# ── Artefact-shape helpers (consumed by io.py renderers) ─────────────
+
+
+def leaderboard_to_dataframe(result: AutoMLResult) -> pd.DataFrame:
+    """Long-form leaderboard CSV row layout. Columns:
+
+      fold, estimator, best_loss, is_overall_best, auc_val,
+      auc_train, modelcount, max_iter, best_estimator_for_fold
+
+    ``fit_wall_seconds`` is intentionally NOT included — wall-clock is
+    not deterministic across runs and would break the two-run
+    artefact-byte equality test. Wall-clock stays available on the
+    in-memory :class:`AutoMLResult` for log-doc / diagnostic use.
+    """
+    if not result.fold_results:
+        return pd.DataFrame(columns=[
+            "fold", "estimator", "best_loss", "is_overall_best",
+            "auc_val", "auc_train", "modelcount", "max_iter",
+            "best_estimator_for_fold",
+        ])
+    by_fold = {fr.fold: fr for fr in result.fold_results}
+    lb = result.leaderboard.copy()
+    if lb.empty:
+        # Build a synthetic leaderboard from fold results so callers
+        # always get a non-empty CSV when folds ran (even if FLAML did
+        # not produce best_loss_per_estimator on this install).
+        lb = pd.DataFrame([
+            {"fold": fr.fold, "estimator": fr.best_estimator,
+             "best_loss": fr.best_loss, "is_overall_best": True}
+            for fr in result.fold_results
+        ])
+    lb["auc_val"] = lb["fold"].map({k: v.auc_val for k, v in by_fold.items()})
+    lb["auc_train"] = lb["fold"].map({k: v.auc_train for k, v in by_fold.items()})
+    lb["modelcount"] = lb["fold"].map({k: v.modelcount for k, v in by_fold.items()})
+    lb["max_iter"] = lb["fold"].map({k: v.max_iter for k, v in by_fold.items()})
+    lb["best_estimator_for_fold"] = lb["fold"].map({k: v.best_estimator for k, v in by_fold.items()})
+    lb = lb[[
+        "fold", "estimator", "best_loss", "is_overall_best",
+        "auc_val", "auc_train", "modelcount", "max_iter",
+        "best_estimator_for_fold",
+    ]]
+    return lb.sort_values(["fold", "estimator"], kind="mergesort").reset_index(drop=True)
+
+
+def importance_to_dataframe(result: AutoMLResult) -> pd.DataFrame:
+    """Permutation importance CSV layout. Columns already set by
+    :func:`_aggregate_importance`."""
+    return result.importance.copy()
+
+
+def compute_budget_markdown(result: AutoMLResult, *, train_end: pd.Timestamp) -> str:
+    """Render the ``compute_budget_used.md`` artefact.
+
+    Stable formatting (no embedded timestamps, no wall-clock) so two-run
+    sha256 determinism holds. Wall-clock stays available on the
+    in-memory :class:`AutoMLResult` for log-doc / diagnostic use.
+    """
+    lines: list[str] = []
+    lines.append("# heavy_ml_probe — AutoML compute budget audit")
+    lines.append("")
+    lines.append(f"- FLAML version: `{result.flaml_version}`")
+    lines.append(f"- Metric: `{result.metric}`")
+    lines.append(f"- Folds total: **{result.n_folds_total}**")
+    lines.append(f"- Folds with valid OOS AUC: **{result.n_folds_valid}**")
+    if result.n_folds_total > 0:
+        max_iter = result.fold_results[0].max_iter
+        cap = max_iter * result.n_folds_total
+        ratio = (
+            float(result.total_modelcount) / float(cap)
+            if cap > 0 else float("nan")
+        )
+        lines.append(f"- `max_iter_per_fold`: **{max_iter}**")
+        lines.append(f"- Cap (max_iter × n_folds): **{cap}**")
+        lines.append(f"- Total modelcount across folds: **{result.total_modelcount}**")
+        lines.append(f"- Consumption ratio (actual/cap): **{ratio:.4f}**")
+    lines.append(
+        f"- Holdout cutoff (`train_end`): "
+        f"**{pd.Timestamp(train_end).strftime('%Y-%m-%dT%H:%M:%SZ')}**"
+    )
+    lines.append("")
+    lines.append(
+        "_Per dispatch §3a (PR-B empirical): `flaml.AutoML.modelcount` "
+        "equals `max_iter` exactly when FLAML runs to the cap; ratio 1.0. "
+        "Locked, proceed. Wall-clock measurements live on the in-memory "
+        "`AutoMLResult` (non-deterministic; excluded from artefacts)._"
+    )
+    lines.append("")
+    lines.append("## Per-fold trial counts")
+    lines.append("")
+    lines.append(
+        "| Fold | n_train | n_val | n_val_pos | best_estimator | modelcount | "
+        "max_iter | auc_val | auc_train |"
+    )
+    lines.append("|---:|---:|---:|---:|---|---:|---:|---:|---:|")
+    for fr in result.fold_results:
+        auc_v = "NaN" if not np.isfinite(fr.auc_val) else f"{fr.auc_val:.4f}"
+        auc_t = "NaN" if not np.isfinite(fr.auc_train) else f"{fr.auc_train:.4f}"
+        lines.append(
+            f"| {fr.fold} | {fr.n_train} | {fr.n_val} | {fr.n_val_pos} | "
+            f"{fr.best_estimator} | {fr.modelcount} | {fr.max_iter} | "
+            f"{auc_v} | {auc_t} |"
+        )
+    lines.append("")
+    lines.append("## Aggregate AUC (val, OOS)")
+    lines.append("")
+    auc_m = "NaN" if not np.isfinite(result.auc_mean) else f"{result.auc_mean:.4f}"
+    auc_s = "NaN" if not np.isfinite(result.auc_std) else f"{result.auc_std:.4f}"
+    lines.append(
+        f"- `nanmean` AUC: **{auc_m}** (across {result.n_folds_valid} "
+        f"valid folds; total {result.n_folds_total})"
+    )
+    lines.append(f"- `nanstd` AUC: **{auc_s}**")
+    lines.append("")
+    return "\n".join(lines)
+
+
+__all__ = (
+    "DEFAULT_N_FOLDS",
+    "DEFAULT_MAX_ITER_PER_FOLD",
+    "DEFAULT_PERMUTATION_REPEATS",
+    "DEFAULT_RANDOM_STATE",
+    "DOCUMENTED_FLAML_2_6_0_ESTIMATORS",
+    "HoldoutGuardViolation",
+    "AllFeaturesRejected",
+    "FoldResult",
+    "AutoMLResult",
+    "run_automl",
+    "leaderboard_to_dataframe",
+    "importance_to_dataframe",
+    "compute_budget_markdown",
+)

--- a/core/heavy_ml_probe/causal_lineage.py
+++ b/core/heavy_ml_probe/causal_lineage.py
@@ -1,0 +1,217 @@
+"""Pre-evaluation causal-lineage gate for heavy_ml_probe.
+
+Per ``docs/sub_protocols/heavy_ml_probe.md`` v1.0 §"Per-feature causal
+lineage" + dispatch §6 #2: every feature consumed by AutoML must carry
+a ``causal_lineage == "clean"`` tag from Step 1 (set at ``FeatureSpec``
+registration time, see ``core/features/lineage.py``). Features tagged
+``suspect`` or ``unverified`` are excluded from the training set
+*before* the AutoML run starts — not flagged after.
+
+This module mirrors ``core/discovery/causal_filter.py`` so the same
+filtering vocabulary appears across sub-protocols. The lineage source
+of truth is ``core.features.pipeline.feature_lineage_dataframe()``;
+this gate calls into it (or accepts the DataFrame directly for
+testability) and returns:
+
+  * the cleaned column list to pass to AutoML
+  * a rejection log (per-feature reason) for the manifest + audit trail
+
+Q3 resolution from build intent: lineage tags live on FeatureSpec, NOT
+embedded per-row in Step 1's pool parquet. Heavy ML's training matrix is
+columns × trades; the gate filters at column-level only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import pandas as pd
+
+# Lineage values that are accepted into training by default. Per spec
+# §"Per-feature causal lineage" only ``clean`` features pass. Tests may
+# override (e.g. to assert a hypothetical multi-tag policy) but
+# production callers should not.
+DEFAULT_ACCEPTED_LINEAGE: tuple[str, ...] = ("clean",)
+
+# Reason strings recorded in the rejection log. Stable + grep-able.
+REASON_NON_CLEAN_LINEAGE: str = "non_clean_lineage"
+REASON_EXCLUDED_CLASS: str = "excluded_feature_class"
+REASON_UNKNOWN_FEATURE: str = "unknown_feature"
+REASON_MISSING_FROM_MATRIX: str = "missing_from_training_matrix"
+
+
+@dataclass(frozen=True)
+class LineageGateResult:
+    """Outcome of running the pre-evaluation lineage gate.
+
+    Attributes
+    ----------
+    accepted_features
+        Sorted tuple of feature names cleared for training.
+    rejected
+        List of ``{"feature": <name>, "reason": <code>, "detail":
+        <str>}`` dicts in feature-name order. Empty when nothing was
+        rejected.
+    n_input_columns
+        Count of columns presented to the gate (post lineage_df join
+        but before filtering). Drives the rejection-fraction metric in
+        the manifest.
+    """
+
+    accepted_features: tuple[str, ...]
+    rejected: tuple[dict, ...]
+    n_input_columns: int
+
+    @property
+    def n_accepted(self) -> int:
+        return len(self.accepted_features)
+
+    @property
+    def n_rejected(self) -> int:
+        return len(self.rejected)
+
+
+def _normalise_lineage_df(lineage_df: pd.DataFrame) -> pd.DataFrame:
+    """Light shape-check on the lineage DataFrame.
+
+    Required columns: ``name``, ``causal_lineage``, ``feature_class``.
+    These match ``core.features.pipeline.feature_lineage_dataframe()``'s
+    output exactly. Other columns are ignored.
+
+    Raises ``ValueError`` with a precise diagnostic on missing columns;
+    callers passing a hand-built DataFrame in tests get a clear error
+    rather than a downstream KeyError.
+    """
+    required = {"name", "causal_lineage", "feature_class"}
+    missing = required - set(lineage_df.columns)
+    if missing:
+        raise ValueError(
+            f"lineage_df missing required columns: {sorted(missing)}; "
+            f"present: {sorted(lineage_df.columns)}"
+        )
+    return lineage_df
+
+
+def filter_training_columns(
+    training_columns: Iterable[str],
+    lineage_df: pd.DataFrame,
+    *,
+    accepted_lineage: Iterable[str] = DEFAULT_ACCEPTED_LINEAGE,
+    exclude_classes: Iterable[str] = (),
+) -> LineageGateResult:
+    """Pre-evaluation gate. Returns the column subset cleared for training.
+
+    Parameters
+    ----------
+    training_columns
+        Iterable of feature column names present in the training matrix.
+    lineage_df
+        Lineage table. Must have columns ``name``, ``causal_lineage``,
+        ``feature_class`` (see ``core.features.pipeline``).
+    accepted_lineage
+        Lineage values that pass the gate. Default ``("clean",)`` per
+        spec §"Per-feature causal lineage".
+    exclude_classes
+        Optional feature_class values to exclude regardless of lineage
+        (e.g. ``("spread_regime",)`` if a class is known leaky).
+    """
+    lineage_df = _normalise_lineage_df(lineage_df)
+    accepted_set = {s.lower() for s in accepted_lineage}
+    exclude_set = {s.lower() for s in exclude_classes}
+
+    cols = sorted(set(training_columns))
+    by_name = lineage_df.set_index("name", drop=False)
+    accepted: list[str] = []
+    rejected: list[dict] = []
+
+    for col in cols:
+        if col not in by_name.index:
+            rejected.append({
+                "feature": col,
+                "reason": REASON_UNKNOWN_FEATURE,
+                "detail": "no lineage row registered for this column",
+            })
+            continue
+        row = by_name.loc[col]
+        # by_name.loc returns a Series for unique index hits and a
+        # DataFrame for duplicates. The registry guarantees unique
+        # names, but for defensive parsing we always take the first row.
+        if isinstance(row, pd.DataFrame):
+            row = row.iloc[0]
+        lineage_val = str(row["causal_lineage"]).lower()
+        feat_class = str(row["feature_class"]).lower()
+        if feat_class in exclude_set:
+            rejected.append({
+                "feature": col,
+                "reason": REASON_EXCLUDED_CLASS,
+                "detail": f"feature_class={feat_class}",
+            })
+            continue
+        if lineage_val not in accepted_set:
+            rejected.append({
+                "feature": col,
+                "reason": REASON_NON_CLEAN_LINEAGE,
+                "detail": f"lineage={lineage_val}",
+            })
+            continue
+        accepted.append(col)
+
+    return LineageGateResult(
+        accepted_features=tuple(sorted(accepted)),
+        rejected=tuple(rejected),
+        n_input_columns=len(cols),
+    )
+
+
+def lineage_summary_markdown(result: LineageGateResult) -> str:
+    """Render a human-readable summary suitable for inclusion in the
+    Step 4 ``compute_budget_used.md`` or a dedicated lineage report.
+
+    Stable formatting for two-run sha256 determinism: feature lists
+    sorted, no timestamps embedded.
+    """
+    lines: list[str] = []
+    lines.append("# Causal lineage gate — heavy_ml_probe")
+    lines.append("")
+    lines.append(
+        f"- Input columns: **{result.n_input_columns}**"
+    )
+    lines.append(
+        f"- Accepted (clean): **{result.n_accepted}**"
+    )
+    lines.append(
+        f"- Rejected: **{result.n_rejected}**"
+    )
+    lines.append("")
+    if result.rejected:
+        # Aggregate by reason
+        from collections import Counter
+        reasons = Counter(r["reason"] for r in result.rejected)
+        lines.append("## Rejection breakdown")
+        lines.append("")
+        for reason, count in sorted(reasons.items()):
+            lines.append(f"- `{reason}`: {count}")
+        lines.append("")
+        lines.append("## Rejected features (sorted)")
+        lines.append("")
+        lines.append("| Feature | Reason | Detail |")
+        lines.append("|---|---|---|")
+        for r in sorted(result.rejected, key=lambda x: (x["reason"], x["feature"])):
+            lines.append(
+                f"| {r['feature']} | {r['reason']} | {r['detail']} |"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+__all__ = (
+    "DEFAULT_ACCEPTED_LINEAGE",
+    "REASON_NON_CLEAN_LINEAGE",
+    "REASON_EXCLUDED_CLASS",
+    "REASON_UNKNOWN_FEATURE",
+    "REASON_MISSING_FROM_MATRIX",
+    "LineageGateResult",
+    "filter_training_columns",
+    "lineage_summary_markdown",
+)

--- a/core/heavy_ml_probe/io.py
+++ b/core/heavy_ml_probe/io.py
@@ -1,0 +1,203 @@
+"""Deterministic IO for heavy_ml_probe artefacts + sha256 manifest.
+
+Mirrors ``core/discovery/io.py`` conventions exactly so the heavy_ml_probe
+artefact directory matches the sibling sub-protocol's manifest schema:
+
+  * sha256 sidecar manifest per output directory
+  * UTF-8 text writes always end in exactly one ``\\n``
+  * CSV writes use ``lineterminator='\\n'`` (cross-platform reproducibility,
+    per L_PROTOCOL §1)
+  * JSON writes use ``sort_keys=True`` + 2-space indent + trailing newline
+  * Parquet writes use ``compression='snappy'`` + sorted row order on a
+    declared key column
+
+The functions return the sha256 of every file written so the orchestrator
+can build the manifest payload without re-reading from disk.
+
+PR-A scope: manifest writer + text/CSV/parquet helpers + sha256 utility.
+The full per-artefact renderers (leaderboard, survival results, etc.)
+live in PR-B/C/D where the corresponding data exists.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import pandas as pd
+
+# Locked manifest schema version. Bump when a breaking key change ships.
+MANIFEST_SCHEMA_VERSION: str = "1.0"
+
+# Locked text encoding for every artefact this module writes.
+TEXT_ENCODING: str = "utf-8"
+TEXT_LINETERMINATOR: str = "\n"
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA256 hex digest of ``path``'s bytes."""
+    h = hashlib.sha256()
+    with Path(path).open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def write_text(path: Path, text: str) -> str:
+    """Write ``text`` to ``path`` as UTF-8 with exactly one trailing newline.
+
+    Returns the sha256 of the written file. Creates parent directories
+    as needed.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    if not text.endswith(TEXT_LINETERMINATOR):
+        text = text + TEXT_LINETERMINATOR
+    p.write_bytes(text.encode(TEXT_ENCODING))
+    return sha256_file(p)
+
+
+def write_csv(
+    path: Path,
+    df: pd.DataFrame,
+    *,
+    sort_by: Sequence[str] | None = None,
+    columns: Sequence[str] | None = None,
+) -> str:
+    """Write ``df`` to ``path`` as a deterministic CSV.
+
+    Optionally re-orders columns to ``columns`` (raises if a requested
+    column is missing) and sorts rows by ``sort_by`` (mergesort for
+    determinism). Uses ``lineterminator='\\n'`` per L_PROTOCOL §1.
+
+    Returns the sha256 of the written file.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    out = df.copy()
+    if columns is not None:
+        missing = [c for c in columns if c not in out.columns]
+        if missing:
+            raise ValueError(f"write_csv missing requested columns: {missing}")
+        out = out[list(columns)]
+    if sort_by:
+        out = out.sort_values(list(sort_by), kind="mergesort").reset_index(drop=True)
+    out.to_csv(p, index=False, lineterminator=TEXT_LINETERMINATOR)
+    return sha256_file(p)
+
+
+def write_parquet(
+    path: Path,
+    df: pd.DataFrame,
+    *,
+    sort_by: Sequence[str] | None = None,
+    columns: Sequence[str] | None = None,
+) -> str:
+    """Write ``df`` to ``path`` as a snappy-compressed parquet.
+
+    Row ordering determinism: callers should pass ``sort_by`` to lock
+    row order. Column ordering determinism: callers should pass
+    ``columns`` to lock column order; otherwise pandas' insertion order
+    is used.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    out = df.copy()
+    if columns is not None:
+        missing = [c for c in columns if c not in out.columns]
+        if missing:
+            raise ValueError(f"write_parquet missing requested columns: {missing}")
+        out = out[list(columns)]
+    if sort_by:
+        out = out.sort_values(list(sort_by), kind="mergesort").reset_index(drop=True)
+    out.to_parquet(p, compression="snappy", index=False)
+    return sha256_file(p)
+
+
+def write_manifest(
+    manifest_path: Path,
+    *,
+    arc_name: str,
+    step: str,
+    artefact_paths: Mapping[str, Path],
+    schema_version: str = MANIFEST_SCHEMA_VERSION,
+    extras: Mapping[str, object] | None = None,
+) -> str:
+    """Write the sha256 manifest sidecar and return its own sha256.
+
+    Manifest schema (matches ``core/discovery/io.py::write_manifest``
+    with a ``schema_version`` + ``sub_protocol`` field added so consumers
+    can detect breaking schema changes without diffing payloads):
+
+        {
+          "schema_version": "1.0",
+          "sub_protocol": "heavy_ml_probe",
+          "arc_name": "<arc>",
+          "step": "step_4/heavy_ml",
+          "created_at": "<UTC ISO>",
+          "artefacts": {
+            "<logical_name>": {
+              "path": "<relative-to-manifest-dir>",
+              "sha256": "<hex>"
+            }
+          },
+          ...extras
+        }
+
+    Paths in the manifest are recorded relative to the manifest's parent
+    directory (with forward-slash separators for cross-platform parity).
+    Callers pass absolute paths via ``artefact_paths``; the writer
+    handles the relativisation.
+    """
+    mp = Path(manifest_path)
+    artefacts: dict[str, dict] = {}
+    for logical_name, p in sorted(artefact_paths.items()):
+        abs_path = Path(p).resolve()
+        try:
+            rel = abs_path.relative_to(mp.parent.resolve())
+        except ValueError:
+            # Path is outside the manifest's parent — record as-is with
+            # forward slashes so downstream consumers don't break on
+            # Windows back-slashes. This is a fallback; typically all
+            # artefacts live alongside the manifest.
+            rel = abs_path
+        artefacts[logical_name] = {
+            "path": str(rel).replace("\\", "/"),
+            "sha256": sha256_file(abs_path),
+        }
+    payload: dict[str, object] = {
+        "schema_version": schema_version,
+        "sub_protocol": "heavy_ml_probe",
+        "arc_name": arc_name,
+        "step": step,
+        "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "artefacts": artefacts,
+    }
+    if extras:
+        for k, v in extras.items():
+            if k in payload:
+                raise ValueError(
+                    f"manifest extras key {k!r} collides with reserved field"
+                )
+            payload[k] = v
+    mp.parent.mkdir(parents=True, exist_ok=True)
+    blob = json.dumps(payload, sort_keys=True, indent=2)
+    if not blob.endswith(TEXT_LINETERMINATOR):
+        blob = blob + TEXT_LINETERMINATOR
+    mp.write_bytes(blob.encode(TEXT_ENCODING))
+    return sha256_file(mp)
+
+
+__all__ = (
+    "MANIFEST_SCHEMA_VERSION",
+    "TEXT_ENCODING",
+    "TEXT_LINETERMINATOR",
+    "sha256_file",
+    "write_text",
+    "write_csv",
+    "write_parquet",
+    "write_manifest",
+)

--- a/core/heavy_ml_probe/meta_labeling.py
+++ b/core/heavy_ml_probe/meta_labeling.py
@@ -1,0 +1,631 @@
+"""Meta-labeling target construction + classifier pipeline for heavy_ml_probe.
+
+Per ``docs/sub_protocols/heavy_ml_probe.md`` v1.0 §"What overrides the
+overseer" and dispatch §1: the meta-label target is binary —
+
+  1 = trade reached +1R MFE STRICTLY BEFORE SL hit OR time-exit
+  0 = otherwise
+
+Same-bar tie-break (dispatch §1): when +1R MFE and SL hit fall on the
+same bar within OHLC, treat as SL-hit-first (conservative). Equivalent
+formulation:
+
+  * ``bars_to_1r_mfe`` is NaN     → target = 0  (never reached 1R)
+  * ``bars_to_1r_mfe <  bars_held`` → target = 1 (reached strictly before close)
+  * ``bars_to_1r_mfe == bars_held``:
+        - ``exit_reason == "sl"``     → target = 0 (same-bar tie, SL wins)
+        - any other exit reason       → target = 1 (reached 1R same bar
+                                                    as a non-adverse close)
+  * ``bars_to_1r_mfe >  bars_held`` → target = 0 (defensive; shouldn't
+                                                  happen on consistent data)
+
+**Relationship to PR-D survival target (chat resolution Q1):** the
+survival framing (``time_to_reach_1r_censored_at_sl_or_time_exit``)
+models the same underlying event with time-to-event semantics +
+censoring. Meta-labeling here models the event-occurred as a binary
+classification problem. Both share the +1R MFE event definition AND
+the SL/time-exit competing-risk definition; they differ in what they
+model. Reference Q1 in PR-D's survival module when it lands.
+
+**No lookahead in features (still); target is hindsight by design.**
+Per dispatch §1: the target uses post-entry MFE / MAE / exit columns
+from the closed-trade pool, which is correct — the target is a
+hindsight label of what actually happened. The non-negotiable is that
+the features consumed by the classifier are ex-ante (enforced by the
+lineage gate in PR-A + the holdout cutoff in PR-B).
+
+This module:
+
+  1. ``build_meta_label_target`` — vectorised target construction over
+     a pool DataFrame with the required schema (see
+     :data:`REQUIRED_POOL_COLUMNS`).
+  2. ``run_meta_labeling`` — orchestrates target construction →
+     ``run_automl(target_col=..., keep_classifiers=True,
+     collect_oof_predictions=True)`` → threshold sweep → classifier
+     persistence → manifest emission.
+  3. Threshold sweep produces ``meta_label_results.csv`` rows with
+     ``precision, recall, f1, n_trades_kept, n_trades_dropped,
+     mean_R_kept_set, mean_R_dropped_set`` per threshold in
+     :data:`DEFAULT_THRESHOLD_SWEEP`.
+  4. Per-fold classifier persistence to
+     ``<classifiers_dir>/fold_{N}.joblib`` with sha256-bound manifest
+     so PR-E's A6 consumer (``build_a6_config_from_heavy_ml``) can load
+     them.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import joblib
+import numpy as np
+import pandas as pd
+
+from core.heavy_ml_probe.automl import (
+    DEFAULT_MAX_ITER_PER_FOLD,
+    DEFAULT_N_FOLDS,
+    DEFAULT_PERMUTATION_REPEATS,
+    DEFAULT_RANDOM_STATE,
+    AllFeaturesRejected,
+    AutoMLResult,
+    HoldoutGuardViolation,
+    run_automl,
+)
+from core.heavy_ml_probe.io import sha256_file
+
+# Locked target name + threshold sweep grid per dispatch §3.
+META_LABEL_TARGET_COL: str = "y_meta_label"
+DEFAULT_THRESHOLD_SWEEP: tuple[float, ...] = (0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80)
+DEFAULT_MFE_R_THRESHOLD: float = 1.0  # +1R per dispatch §1
+
+
+class PoolSchemaError(ValueError):
+    """Raised when the input pool is missing columns required for
+    meta-label target construction. Per dispatch §1 (last paragraph),
+    schema mismatches HALT loudly — they are NOT papered over.
+    """
+
+
+# Columns the meta-labeling stage requires on the input pool. The
+# classifier-pipeline stage adds ``entry_time`` + ``trade_id`` (already
+# required by PR-B's ``run_automl``) on top of these.
+REQUIRED_POOL_COLUMNS: tuple[str, ...] = (
+    "bars_to_1r_mfe",   # int, NaN if MFE never reached +1R
+    "bars_held",        # int, total bars trade was open (= bars_to_close)
+    "exit_reason",      # str, e.g. "sl" | "time_exit" | "tp" | ...
+    "final_r",          # float, realised R-multiple at close (for kept/dropped means)
+)
+
+# Exit-reason value that triggers the same-bar SL tie-break. Lowercased
+# during comparison so producer drift between ``SL`` / ``Sl`` / ``sl``
+# is absorbed.
+SL_EXIT_REASON: str = "sl"
+
+
+# ── Target construction ──────────────────────────────────────────────
+
+
+def _validate_pool_schema(pool: pd.DataFrame) -> None:
+    """Per dispatch §1 last paragraph: HALT loud on missing columns."""
+    missing = [c for c in REQUIRED_POOL_COLUMNS if c not in pool.columns]
+    if missing:
+        raise PoolSchemaError(
+            f"meta-label target requires pool columns {sorted(REQUIRED_POOL_COLUMNS)}; "
+            f"missing: {sorted(missing)} — pool has: {sorted(pool.columns)[:20]}"
+            + ("..." if len(pool.columns) > 20 else "")
+        )
+
+
+def build_meta_label_target(
+    pool: pd.DataFrame,
+    *,
+    mfe_r_threshold: float = DEFAULT_MFE_R_THRESHOLD,
+    sl_exit_reason: str = SL_EXIT_REASON,
+) -> np.ndarray:
+    """Construct the binary meta-label target over ``pool``.
+
+    Parameters
+    ----------
+    pool
+        Must contain :data:`REQUIRED_POOL_COLUMNS`.
+    mfe_r_threshold
+        Multiple of R that defines the favourable event. Default 1.0
+        per dispatch §1. Exposed for sensitivity probes.
+    sl_exit_reason
+        Exit-reason string that triggers the same-bar tie-break per
+        dispatch §1. Case-insensitive at comparison time.
+
+    Returns
+    -------
+    ``np.ndarray`` of shape ``(len(pool),)`` with values in ``{0, 1}``
+    in the same row order as ``pool``.
+
+    Raises
+    ------
+    PoolSchemaError
+        If any required column is missing.
+    ValueError
+        If a per-trade record has missing ``bars_held`` (defensive — the
+        pool should always have this).
+
+    Notes
+    -----
+    The ``mfe_r_threshold`` parameter is non-default *only* for
+    sensitivity analyses; production runs MUST use 1.0 per spec. The
+    threshold value is recorded in the meta-label manifest so audits
+    can detect non-spec overrides.
+    """
+    _validate_pool_schema(pool)
+    bars_to_1r = pool["bars_to_1r_mfe"]
+    bars_held = pool["bars_held"]
+    exit_reason = pool["exit_reason"].astype(str).str.lower()
+
+    if bars_held.isna().any():
+        raise ValueError(
+            "meta-label target: bars_held column has NaN values; this is "
+            "structurally inconsistent (every closed trade has a known "
+            "duration). Inspect pool integrity."
+        )
+
+    # The mfe_r_threshold parameter is recorded but the bars_to_1r_mfe
+    # column already reflects the +1R event in production pools. For
+    # non-1.0 sensitivity analyses, callers must pre-compute the
+    # equivalent ``bars_to_<threshold>r_mfe`` column. PR-C surfaces a
+    # ValueError in that case rather than silently using the wrong
+    # column.
+    if not np.isclose(mfe_r_threshold, 1.0):
+        raise ValueError(
+            f"mfe_r_threshold={mfe_r_threshold} != 1.0 not supported in "
+            f"PR-C; production pools carry `bars_to_1r_mfe` only. To run "
+            f"a sensitivity analysis with a different threshold, pre-compute "
+            f"the equivalent column upstream + pass via a future "
+            f"`bars_to_event_col` override (not yet implemented)."
+        )
+
+    n = len(pool)
+    y = np.zeros(n, dtype=int)
+
+    # Vectorised branches:
+    reached = bars_to_1r.notna().values
+    bars_1r_arr = bars_to_1r.values
+    bars_held_arr = bars_held.values
+    exit_arr = exit_reason.values
+    sl_lower = sl_exit_reason.lower()
+
+    for i in range(n):
+        if not reached[i]:
+            y[i] = 0
+            continue
+        b1r = float(bars_1r_arr[i])
+        bh = float(bars_held_arr[i])
+        if b1r < bh:
+            y[i] = 1
+        elif b1r == bh:
+            # Same-bar tie: SL wins (conservative).
+            y[i] = 0 if exit_arr[i] == sl_lower else 1
+        else:
+            # bars_to_1r_mfe > bars_held: defensive — shouldn't happen.
+            y[i] = 0
+    return y
+
+
+# ── Threshold sweep ──────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ThresholdRow:
+    """One row of the meta-label threshold sweep."""
+
+    threshold: float
+    precision: float
+    recall: float
+    f1: float
+    n_trades_kept: int
+    n_trades_dropped: int
+    mean_r_kept_set: float
+    mean_r_dropped_set: float
+    edge_lift_r: float  # mean_R_kept - mean_R_dropped
+
+
+def _safe_div(num: float, den: float) -> float:
+    return float(num / den) if den > 0 else float("nan")
+
+
+def _f1(precision: float, recall: float) -> float:
+    if not (np.isfinite(precision) and np.isfinite(recall)):
+        return float("nan")
+    if (precision + recall) <= 0:
+        return 0.0
+    return 2.0 * precision * recall / (precision + recall)
+
+
+def threshold_sweep(
+    oof: pd.DataFrame,
+    final_r_by_trade_id: pd.Series,
+    *,
+    thresholds: Sequence[float] = DEFAULT_THRESHOLD_SWEEP,
+    trade_id_col: str = "trade_id",
+) -> pd.DataFrame:
+    """Compute the threshold sweep over out-of-fold predictions.
+
+    Per dispatch §3:
+
+      * Aggregate all 11 folds' OOF predictions into one prediction
+        table (keyed by trade_id).
+      * For each threshold, compute precision / recall / f1 against the
+        binary target AND the mean realised R for both the kept set
+        (probability ≥ threshold) and the dropped set (probability <
+        threshold).
+      * ``edge_lift_r = mean_r_kept_set - mean_r_dropped_set`` is the
+        load-bearing diagnostic — a meta-label that doesn't shift mean
+        R isn't adding edge.
+
+    Parameters
+    ----------
+    oof
+        DataFrame with columns ``(trade_id, fold, y_true, y_pred_proba)``
+        from :class:`AutoMLResult.oof_predictions`.
+    final_r_by_trade_id
+        ``Series`` indexed by ``trade_id`` mapping to realised R.
+    thresholds
+        Iterable of probability thresholds to sweep. Default per dispatch
+        §3.
+
+    Returns
+    -------
+    DataFrame with one row per threshold, columns matching
+    :class:`ThresholdRow` field names.
+    """
+    required = {trade_id_col, "y_true", "y_pred_proba"}
+    missing = required - set(oof.columns)
+    if missing:
+        raise ValueError(
+            f"threshold_sweep requires OOF columns {sorted(required)}; "
+            f"missing: {sorted(missing)}"
+        )
+
+    # If a trade was scored in multiple folds (shouldn't happen with
+    # TimeSeriesSplit, but defensive), keep the LAST fold's prediction.
+    # Sort by fold ascending → groupby trade_id → tail(1) for stability.
+    oof_sorted = oof.sort_values(["fold", trade_id_col], kind="mergesort")
+    oof_dedup = (
+        oof_sorted
+        .groupby(trade_id_col, sort=True)
+        .tail(1)
+        .reset_index(drop=True)
+    )
+
+    # Align realised R to OOF rows. Missing trade_ids land as NaN; the
+    # kept/dropped mean R for those trades is excluded via nanmean.
+    realised_r = oof_dedup[trade_id_col].map(final_r_by_trade_id).astype(float).values
+    y_true = oof_dedup["y_true"].astype(int).values
+    y_pred_proba = oof_dedup["y_pred_proba"].astype(float).values
+    n_pos = int((y_true == 1).sum())
+
+    rows: list[ThresholdRow] = []
+    for t in thresholds:
+        kept_mask = y_pred_proba >= float(t)
+        dropped_mask = ~kept_mask
+        n_kept = int(kept_mask.sum())
+        n_dropped = int(dropped_mask.sum())
+        tp = int(((kept_mask) & (y_true == 1)).sum())
+        precision = _safe_div(tp, n_kept)
+        recall = _safe_div(tp, n_pos)
+        f1 = _f1(precision, recall)
+
+        # Realised R aggregates (silence the all-NaN nanmean warning)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            mean_r_kept = (
+                float(np.nanmean(realised_r[kept_mask])) if n_kept > 0 else float("nan")
+            )
+            mean_r_dropped = (
+                float(np.nanmean(realised_r[dropped_mask])) if n_dropped > 0 else float("nan")
+            )
+
+        edge_lift = (
+            mean_r_kept - mean_r_dropped
+            if np.isfinite(mean_r_kept) and np.isfinite(mean_r_dropped)
+            else float("nan")
+        )
+        rows.append(ThresholdRow(
+            threshold=float(t),
+            precision=precision,
+            recall=recall,
+            f1=f1,
+            n_trades_kept=n_kept,
+            n_trades_dropped=n_dropped,
+            mean_r_kept_set=mean_r_kept,
+            mean_r_dropped_set=mean_r_dropped,
+            edge_lift_r=edge_lift,
+        ))
+
+    df = pd.DataFrame([r.__dict__ for r in rows])
+    return df.sort_values("threshold", kind="mergesort").reset_index(drop=True)
+
+
+# ── Classifier persistence ───────────────────────────────────────────
+
+
+def persist_fold_classifiers(
+    automl_result: AutoMLResult,
+    classifiers_dir: Path,
+    *,
+    arc_name: str,
+    cluster_id: int,
+) -> Path:
+    """Persist each fold's inner sklearn-compatible classifier to disk.
+
+    Requires the upstream ``run_automl(..., keep_classifiers=True)``.
+    Writes per-fold joblib pickles + a sidecar manifest with sha256 +
+    provenance so PR-E's A6 consumer can load + verify without
+    retraining.
+
+    Manifest schema:
+
+        {
+          "arc_name": "<arc>",
+          "cluster_id": <int>,
+          "sub_protocol": "heavy_ml_probe",
+          "stage": "meta_label",
+          "generated_at": "<UTC ISO>",
+          "joblib_version": "<x.y.z>",
+          "n_folds_persisted": <int>,
+          "folds": [
+            {
+              "fold_id": <int>,
+              "path": "<relative_to_classifiers_dir>",
+              "sha256": "<hex>",
+              "classifier_type": "<sklearn class name>",
+              "n_train": <int>,
+              "n_valid": <int>,
+              "fold_auc": <float | null>,
+              "best_estimator_name": "<FLAML name>"
+            },
+            ...
+          ]
+        }
+
+    Returns the manifest path. Folds whose ``fitted_estimator`` is
+    ``None`` (single-class training or AutoML skip) are still recorded
+    in the manifest with ``path: null`` so the audit trail covers every
+    fold.
+    """
+    classifiers_dir = Path(classifiers_dir)
+    classifiers_dir.mkdir(parents=True, exist_ok=True)
+
+    folds: list[dict] = []
+    for fr in automl_result.fold_results:
+        entry: dict = {
+            "fold_id": int(fr.fold),
+            "n_train": int(fr.n_train),
+            "n_valid": int(fr.n_val),
+            "fold_auc": float(fr.auc_val) if np.isfinite(fr.auc_val) else None,
+            "best_estimator_name": str(fr.best_estimator),
+        }
+        if fr.fitted_estimator is None:
+            entry["path"] = None
+            entry["sha256"] = None
+            entry["classifier_type"] = None
+        else:
+            fname = f"fold_{int(fr.fold):02d}.joblib"
+            fpath = classifiers_dir / fname
+            joblib.dump(fr.fitted_estimator, fpath, compress=3)
+            entry["path"] = fname
+            entry["sha256"] = sha256_file(fpath)
+            entry["classifier_type"] = type(fr.fitted_estimator).__name__
+        folds.append(entry)
+
+    # No ``generated_at`` timestamp: the classifier manifest is a
+    # sidecar to the top-level step_4/heavy_ml/manifest.json, which
+    # already carries ``created_at``. Omitting the timestamp here keeps
+    # the classifier manifest's sha256 deterministic across two runs,
+    # which in turn keeps the top-level manifest's
+    # ``artefacts.meta_label_classifier_manifest.sha256`` deterministic.
+    # (If a future audit needs per-classifier-manifest write time,
+    # mtime on disk is the source of truth.)
+    manifest_payload = {
+        "arc_name": str(arc_name),
+        "cluster_id": int(cluster_id),
+        "sub_protocol": "heavy_ml_probe",
+        "stage": "meta_label",
+        "joblib_version": str(joblib.__version__),
+        "n_folds_persisted": int(sum(1 for f in folds if f["path"] is not None)),
+        "folds": folds,
+    }
+    manifest_path = classifiers_dir / "manifest.json"
+    import json
+    blob = json.dumps(manifest_payload, sort_keys=True, indent=2)
+    if not blob.endswith("\n"):
+        blob = blob + "\n"
+    manifest_path.write_bytes(blob.encode("utf-8"))
+    return manifest_path
+
+
+def stable_classifier_manifest_sha256(manifest_path: Path) -> str:
+    """SHA256 of the classifier manifest payload.
+
+    No timestamp field exists in the classifier manifest by design (the
+    top-level Step 4 manifest carries ``created_at``; the sidecar
+    doesn't duplicate it) — so this function is equivalent to
+    ``sha256_file(manifest_path)``. Kept on the public API surface for
+    symmetry with :func:`core.heavy_ml_probe.pipeline.stable_payload_sha256`
+    and so a future timestamp re-introduction has an obvious place to
+    strip it.
+    """
+    import hashlib
+    return hashlib.sha256(Path(manifest_path).read_bytes()).hexdigest()
+
+
+# ── Top-level orchestrator ──────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class MetaLabelResult:
+    """Aggregated outcome of one meta-labeling run."""
+
+    automl_result: AutoMLResult
+    threshold_sweep: pd.DataFrame
+    target_distribution: dict[int, int]  # {0: count, 1: count}
+    classifier_manifest_path: Path | None
+    skip_reason: str = "ok"
+
+    @property
+    def n_total(self) -> int:
+        return int(sum(self.target_distribution.values()))
+
+    @property
+    def positive_rate(self) -> float:
+        n = self.n_total
+        return float(self.target_distribution.get(1, 0) / n) if n > 0 else float("nan")
+
+
+def run_meta_labeling(
+    pool: pd.DataFrame,
+    used_features: Sequence[str],
+    *,
+    train_end: pd.Timestamp,
+    arc_name: str,
+    cluster_id: int,
+    classifiers_dir: Path,
+    n_folds: int = DEFAULT_N_FOLDS,
+    max_iter_per_fold: int = DEFAULT_MAX_ITER_PER_FOLD,
+    seed: int = DEFAULT_RANDOM_STATE,
+    n_jobs: int = 1,
+    permutation_repeats: int = DEFAULT_PERMUTATION_REPEATS,
+    thresholds: Sequence[float] = DEFAULT_THRESHOLD_SWEEP,
+    entry_time_col: str = "entry_time",
+    trade_id_col: str = "trade_id",
+    final_r_col: str = "final_r",
+    mfe_r_threshold: float = DEFAULT_MFE_R_THRESHOLD,
+) -> MetaLabelResult:
+    """Run the full meta-labeling stage end-to-end.
+
+    Sequence:
+
+      1. Validate pool schema (HALT loud on missing columns).
+      2. Construct the binary target via :func:`build_meta_label_target`.
+      3. Inject target into the pool under the locked column name
+         :data:`META_LABEL_TARGET_COL` (does NOT mutate caller's pool).
+      4. Call :func:`core.heavy_ml_probe.automl.run_automl` with
+         ``target_col=META_LABEL_TARGET_COL``, ``keep_classifiers=True``,
+         ``collect_oof_predictions=True``.
+      5. Run threshold sweep on the OOF predictions vs realised R.
+      6. Persist per-fold classifiers + sidecar manifest under
+         ``classifiers_dir``.
+
+    Raises
+    ------
+    PoolSchemaError
+        If the pool is missing any column in :data:`REQUIRED_POOL_COLUMNS`
+        (HALT-loud per dispatch §1 last paragraph).
+    HoldoutGuardViolation
+        If the pool has trades on/after ``train_end`` (propagated from
+        ``run_automl``).
+    AllFeaturesRejected
+        If ``used_features`` is empty (propagated).
+    """
+    # 1. Schema validation up-front
+    _validate_pool_schema(pool)
+    if final_r_col not in pool.columns:
+        raise PoolSchemaError(
+            f"meta-labeling threshold sweep requires {final_r_col!r} column "
+            f"(realised R per trade); pool has: {sorted(pool.columns)[:20]}"
+        )
+
+    # 2. Target construction (vectorised over the pool)
+    target = build_meta_label_target(
+        pool, mfe_r_threshold=mfe_r_threshold,
+        sl_exit_reason=SL_EXIT_REASON,
+    )
+    target_distribution = {
+        0: int((target == 0).sum()),
+        1: int((target == 1).sum()),
+    }
+
+    # 3. Inject target. Use .assign so the caller's DataFrame is not
+    # mutated; the resulting frame is row-aligned to the original.
+    pool_with_target = pool.assign(**{META_LABEL_TARGET_COL: target})
+
+    # 4. Classifier pipeline reusing PR-B's run_automl
+    automl_result = run_automl(
+        pool=pool_with_target,
+        used_features=used_features,
+        train_end=train_end,
+        n_folds=n_folds,
+        max_iter_per_fold=max_iter_per_fold,
+        seed=seed,
+        metric="roc_auc",
+        n_jobs=n_jobs,
+        permutation_repeats=permutation_repeats,
+        entry_time_col=entry_time_col,
+        target_col=META_LABEL_TARGET_COL,
+        trade_id_col=trade_id_col,
+        keep_classifiers=True,
+        collect_oof_predictions=True,
+    )
+
+    # 5. Threshold sweep on OOF predictions vs realised R
+    final_r_series = pool[[trade_id_col, final_r_col]].set_index(trade_id_col)[final_r_col]
+    sweep_df = threshold_sweep(
+        automl_result.oof_predictions,
+        final_r_series,
+        thresholds=thresholds,
+        trade_id_col=trade_id_col,
+    )
+
+    # 6. Persist per-fold classifiers
+    classifier_manifest_path = persist_fold_classifiers(
+        automl_result, Path(classifiers_dir),
+        arc_name=arc_name, cluster_id=cluster_id,
+    )
+
+    return MetaLabelResult(
+        automl_result=automl_result,
+        threshold_sweep=sweep_df,
+        target_distribution=target_distribution,
+        classifier_manifest_path=classifier_manifest_path,
+        skip_reason="ok",
+    )
+
+
+def meta_label_results_to_dataframe(result: MetaLabelResult) -> pd.DataFrame:
+    """Wrap the threshold sweep with diagnostic columns for the CSV.
+
+    Adds per-fold AUC context + the OOF-aggregated positive rate so a
+    single CSV reader gets the full meta-label picture without
+    cross-referencing other artefacts.
+    """
+    df = result.threshold_sweep.copy()
+    df["target_n_pos"] = result.target_distribution.get(1, 0)
+    df["target_n_neg"] = result.target_distribution.get(0, 0)
+    df["target_positive_rate"] = result.positive_rate
+    df["aggregate_oof_auc_mean"] = result.automl_result.auc_mean
+    df["aggregate_oof_auc_std"] = result.automl_result.auc_std
+    df["n_folds_valid"] = result.automl_result.n_folds_valid
+    df["n_folds_total"] = result.automl_result.n_folds_total
+    return df
+
+
+__all__ = (
+    "DEFAULT_MFE_R_THRESHOLD",
+    "DEFAULT_THRESHOLD_SWEEP",
+    "META_LABEL_TARGET_COL",
+    "REQUIRED_POOL_COLUMNS",
+    "SL_EXIT_REASON",
+    "MetaLabelResult",
+    "PoolSchemaError",
+    "ThresholdRow",
+    "build_meta_label_target",
+    "meta_label_results_to_dataframe",
+    "persist_fold_classifiers",
+    "run_meta_labeling",
+    "stable_classifier_manifest_sha256",
+    "threshold_sweep",
+    # re-exports for upstream callers that only need to import from one place
+    "AllFeaturesRejected",
+    "HoldoutGuardViolation",
+)

--- a/core/heavy_ml_probe/metrics.py
+++ b/core/heavy_ml_probe/metrics.py
@@ -1,0 +1,129 @@
+"""Metric wrappers for heavy_ml_probe.
+
+Thin wrappers around sklearn / lifelines / scikit-survival so the
+sub-protocol's per-model evaluation calls a single canonical surface.
+PR-A lands callable stubs that exercise the dependency imports
+defensively (so sklearn / lifelines / sksurv availability is detectable
+at module import without crashing scaffolding), with real bodies
+landing in PR-B/D where the data exists.
+
+Coverage:
+
+  * ``auc_roc(y_true, y_score)`` — wraps ``sklearn.metrics.roc_auc_score``.
+    Used by AutoML (PR-B) per-fold scoring and by meta-labeling (PR-C)
+    threshold sweeps.
+  * ``concordance(y_event, y_time, predicted_risk)`` — wraps lifelines'
+    concordance index. Used by Cox PH (PR-D).
+  * ``integrated_brier_score(...)`` — wraps scikit-survival's
+    ``integrated_brier_score``. Used by Random Survival Forest (PR-D).
+
+All metric functions return ``float`` and raise informatively on input
+shape mismatches; NaN / non-finite returns are propagated, not masked.
+
+Lifelines / scikit-survival are imported lazily so the rest of the
+sub-protocol can scaffold without them (matches the defensive
+``lightgbm`` import pattern in ``core/steps/_classifier_defaults.py``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from sklearn.metrics import roc_auc_score
+
+
+def auc_roc(y_true, y_score) -> float:
+    """Binary AUC-ROC. Identical semantics to ``sklearn.metrics.roc_auc_score``.
+
+    Returns ``float('nan')`` when the input set has < 2 classes
+    (sklearn raises in that case; we degrade to NaN since per-fold
+    AutoML can hit single-class folds for rare events).
+    """
+    y_true_arr = np.asarray(y_true)
+    y_score_arr = np.asarray(y_score)
+    if y_true_arr.shape != y_score_arr.shape:
+        raise ValueError(
+            f"auc_roc shape mismatch: y_true={y_true_arr.shape} y_score={y_score_arr.shape}"
+        )
+    if len(set(y_true_arr.tolist())) < 2:
+        return float("nan")
+    return float(roc_auc_score(y_true_arr, y_score_arr))
+
+
+def concordance(y_event, y_time, predicted_risk) -> float:
+    """C-index for survival models.
+
+    Wraps ``lifelines.utils.concordance_index``. Imports lifelines
+    lazily so PR-A scaffolding does not require the library to be
+    installed in environments that won't run the survival path.
+
+    Parameters
+    ----------
+    y_event : array-like of {0, 1}
+        Event indicator (1 = event observed, 0 = censored).
+    y_time : array-like of float
+        Observed time (event time if observed, censoring time otherwise).
+    predicted_risk : array-like of float
+        Higher = higher predicted risk.
+    """
+    try:
+        from lifelines.utils import concordance_index
+    except ImportError as e:  # pragma: no cover — environment-dependent
+        raise ImportError(
+            "lifelines is required for concordance(); install via "
+            "requirements-dev.txt"
+        ) from e
+
+    y_event_arr = np.asarray(y_event)
+    y_time_arr = np.asarray(y_time)
+    pred_arr = np.asarray(predicted_risk)
+    if not (y_event_arr.shape == y_time_arr.shape == pred_arr.shape):
+        raise ValueError(
+            f"concordance shape mismatch: y_event={y_event_arr.shape} "
+            f"y_time={y_time_arr.shape} predicted_risk={pred_arr.shape}"
+        )
+    # lifelines' concordance_index uses ``higher risk = lower expected
+    # survival time``. Pass risk directly; do NOT negate.
+    return float(concordance_index(y_time_arr, -pred_arr, y_event_arr))
+
+
+def integrated_brier_score(
+    survival_train,
+    survival_test,
+    survival_predictions,
+    times,
+) -> float:
+    """IBS for survival predictions.
+
+    Wraps ``sksurv.metrics.integrated_brier_score``. Imports sksurv
+    lazily for the same reason as :func:`concordance` above.
+
+    Parameters
+    ----------
+    survival_train : structured ndarray
+        Training survival data in sksurv's ``(event, time)`` structured
+        array shape (typically the output of
+        ``sksurv.util.Surv.from_arrays``).
+    survival_test : structured ndarray
+        Test survival data in the same shape.
+    survival_predictions : 2-D ndarray of shape (n_test, len(times))
+        Predicted survival probabilities at each evaluation time.
+    times : 1-D array of float
+        Time points at which IBS is evaluated.
+    """
+    try:
+        from sksurv.metrics import integrated_brier_score as _ibs
+    except ImportError as e:  # pragma: no cover — environment-dependent
+        raise ImportError(
+            "scikit-survival is required for integrated_brier_score(); "
+            "install via requirements-dev.txt"
+        ) from e
+    return float(
+        _ibs(survival_train, survival_test, survival_predictions, times)
+    )
+
+
+__all__ = (
+    "auc_roc",
+    "concordance",
+    "integrated_brier_score",
+)

--- a/core/heavy_ml_probe/metrics.py
+++ b/core/heavy_ml_probe/metrics.py
@@ -1,28 +1,19 @@
 """Metric wrappers for heavy_ml_probe.
 
-Thin wrappers around sklearn / lifelines / scikit-survival so the
-sub-protocol's per-model evaluation calls a single canonical surface.
-PR-A lands callable stubs that exercise the dependency imports
-defensively (so sklearn / lifelines / sksurv availability is detectable
-at module import without crashing scaffolding), with real bodies
-landing in PR-B/D where the data exists.
-
 Coverage:
 
   * ``auc_roc(y_true, y_score)`` — wraps ``sklearn.metrics.roc_auc_score``.
     Used by AutoML (PR-B) per-fold scoring and by meta-labeling (PR-C)
     threshold sweeps.
-  * ``concordance(y_event, y_time, predicted_risk)`` — wraps lifelines'
-    concordance index. Used by Cox PH (PR-D).
-  * ``integrated_brier_score(...)`` — wraps scikit-survival's
-    ``integrated_brier_score``. Used by Random Survival Forest (PR-D).
+  * ``concordance(y_event, y_time, predicted_risk)`` — Harrell's C-index,
+    implemented from scratch in PR-D. Used by Cox PH survival evaluation.
+  * ``integrated_brier_score(...)`` — deferred per PR-B/D library-block
+    decisions (sksurv is blocked on Python 3.14). Stub retained so the
+    public surface stays stable; raises ``NotImplementedError`` at call
+    time. Will be revisited if RSF is re-enabled.
 
 All metric functions return ``float`` and raise informatively on input
 shape mismatches; NaN / non-finite returns are propagated, not masked.
-
-Lifelines / scikit-survival are imported lazily so the rest of the
-sub-protocol can scaffold without them (matches the defensive
-``lightgbm`` import pattern in ``core/steps/_classifier_defaults.py``).
 """
 
 from __future__ import annotations
@@ -50,11 +41,26 @@ def auc_roc(y_true, y_score) -> float:
 
 
 def concordance(y_event, y_time, predicted_risk) -> float:
-    """C-index for survival models.
+    """Harrell's C-index — from-scratch implementation (PR-D).
 
-    Wraps ``lifelines.utils.concordance_index``. Imports lifelines
-    lazily so PR-A scaffolding does not require the library to be
-    installed in environments that won't run the survival path.
+    Per dispatch §4 fallback: lifelines + scikit-survival are blocked
+    on Python 3.14, so this implements the canonical pairwise-comparable
+    definition directly. Math reference: Harrell, F. E. Jr. (1982),
+    "Evaluating the yield of medical tests" (JAMA).
+
+    Definition. For all ordered pairs ``(i, j)`` where trade ``i`` had
+    ``event=1`` AND ``time_i < time_j`` (``j`` may be censored OR event):
+
+      * concordant if ``predicted_risk_i  >  predicted_risk_j``
+      * tied       if ``predicted_risk_i  ==  predicted_risk_j``
+      * discordant if ``predicted_risk_i  <  predicted_risk_j``
+
+    Returns ``(concordant + 0.5 * tied) / (concordant + discordant + tied)``.
+
+    Note: pairs where both trades have ``time_i == time_j`` are
+    skipped (no rank-order signal). Pairs where the earlier-time trade
+    is censored are also skipped (we cannot know it would have ranked
+    against ``j``).
 
     Parameters
     ----------
@@ -63,27 +69,69 @@ def concordance(y_event, y_time, predicted_risk) -> float:
     y_time : array-like of float
         Observed time (event time if observed, censoring time otherwise).
     predicted_risk : array-like of float
-        Higher = higher predicted risk.
-    """
-    try:
-        from lifelines.utils import concordance_index
-    except ImportError as e:  # pragma: no cover — environment-dependent
-        raise ImportError(
-            "lifelines is required for concordance(); install via "
-            "requirements-dev.txt"
-        ) from e
+        Higher = higher predicted risk → faster expected event. For Cox
+        PH this is ``exp(features @ coefficients)``.
 
-    y_event_arr = np.asarray(y_event)
-    y_time_arr = np.asarray(y_time)
-    pred_arr = np.asarray(predicted_risk)
+    Returns
+    -------
+    Concordance index in ``[0, 1]``. Returns ``float('nan')`` when no
+    comparable pairs exist (e.g. fold validation slice is all-censored
+    or all-same-time).
+    """
+    y_event_arr = np.asarray(y_event, dtype=int)
+    y_time_arr = np.asarray(y_time, dtype=float)
+    pred_arr = np.asarray(predicted_risk, dtype=float)
     if not (y_event_arr.shape == y_time_arr.shape == pred_arr.shape):
         raise ValueError(
             f"concordance shape mismatch: y_event={y_event_arr.shape} "
             f"y_time={y_time_arr.shape} predicted_risk={pred_arr.shape}"
         )
-    # lifelines' concordance_index uses ``higher risk = lower expected
-    # survival time``. Pass risk directly; do NOT negate.
-    return float(concordance_index(y_time_arr, -pred_arr, y_event_arr))
+    if y_event_arr.ndim != 1:
+        raise ValueError(
+            f"concordance expects 1-D arrays; got y_event.ndim={y_event_arr.ndim}"
+        )
+    n = len(y_event_arr)
+    if n < 2:
+        return float("nan")
+    # Drop rows with non-finite predictions/times — they cannot rank.
+    finite_mask = (
+        np.isfinite(y_time_arr) & np.isfinite(pred_arr)
+    )
+    if finite_mask.sum() < 2:
+        return float("nan")
+    e = y_event_arr[finite_mask]
+    t = y_time_arr[finite_mask]
+    r = pred_arr[finite_mask]
+    # Vectorised pair enumeration via broadcasting. O(n^2) memory; fine
+    # at synthetic-test scale (n ~ 400) and at validation-fold scale
+    # (n ~ a few hundred at typical L-arc pool sizes).
+    t_i = t.reshape(-1, 1)
+    t_j = t.reshape(1, -1)
+    r_i = r.reshape(-1, 1)
+    r_j = r.reshape(1, -1)
+    e_i = e.reshape(-1, 1)
+    # Comparable mask: i had event, t_i < t_j (strict — same-time pairs
+    # excluded since they carry no rank signal). j's event status is
+    # irrelevant — being censored at time > t_i still gives a valid
+    # ordering.
+    comparable = (e_i == 1) & (t_i < t_j)
+    n_comparable = int(comparable.sum())
+    if n_comparable == 0:
+        return float("nan")
+    # Higher risk → faster event → should rank with smaller time. So
+    # for comparable (i, j) with t_i < t_j, concordant means r_i > r_j.
+    concordant = int(((r_i > r_j) & comparable).sum())
+    tied = int(((r_i == r_j) & comparable).sum())
+    discordant = int(((r_i < r_j) & comparable).sum())
+    # Sanity: concordant + tied + discordant == n_comparable
+    if concordant + tied + discordant != n_comparable:
+        # Should not happen given the three branches partition the
+        # comparable set; defensive guard against future refactors.
+        raise RuntimeError(
+            f"concordance internal accounting drift: "
+            f"c={concordant}+t={tied}+d={discordant} != comparable={n_comparable}"
+        )
+    return float((concordant + 0.5 * tied) / n_comparable)
 
 
 def integrated_brier_score(
@@ -92,33 +140,20 @@ def integrated_brier_score(
     survival_predictions,
     times,
 ) -> float:
-    """IBS for survival predictions.
+    """IBS for survival predictions — DEFERRED per PR-B/D library-block.
 
-    Wraps ``sksurv.metrics.integrated_brier_score``. Imports sksurv
-    lazily for the same reason as :func:`concordance` above.
-
-    Parameters
-    ----------
-    survival_train : structured ndarray
-        Training survival data in sksurv's ``(event, time)`` structured
-        array shape (typically the output of
-        ``sksurv.util.Surv.from_arrays``).
-    survival_test : structured ndarray
-        Test survival data in the same shape.
-    survival_predictions : 2-D ndarray of shape (n_test, len(times))
-        Predicted survival probabilities at each evaluation time.
-    times : 1-D array of float
-        Time points at which IBS is evaluated.
+    scikit-survival's ``integrated_brier_score`` is the canonical
+    implementation but sksurv is blocked on Python 3.14 (transitive dep
+    ``ecos`` has no cp314 wheel). Per PR-B flag-1 disposition: RSF is
+    deferred; this function stays as a stable public-API stub. Raises
+    ``NotImplementedError`` at call time with a pointer to the deferral
+    rationale.
     """
-    try:
-        from sksurv.metrics import integrated_brier_score as _ibs
-    except ImportError as e:  # pragma: no cover — environment-dependent
-        raise ImportError(
-            "scikit-survival is required for integrated_brier_score(); "
-            "install via requirements-dev.txt"
-        ) from e
-    return float(
-        _ibs(survival_train, survival_test, survival_predictions, times)
+    raise NotImplementedError(
+        "integrated_brier_score is deferred per heavy_ml_probe PR-B "
+        "flag-1 disposition: scikit-survival is blocked on Python 3.14 "
+        "(ecos has no cp314 wheel). Will be reinstated when the wheel "
+        "ships AND chat re-enables RSF in the spec."
     )
 
 

--- a/core/heavy_ml_probe/pipeline.py
+++ b/core/heavy_ml_probe/pipeline.py
@@ -6,31 +6,43 @@ Owns the end-to-end flow:
   2. Load Step 1 pool
   3. Apply causal lineage gate (PR-A)
   4. Run AutoML across an 11-fold TimeSeriesSplit (PR-B)
-  5. [future] Meta-labeling (PR-C)
+  5. Meta-labeling (PR-C) — reach-1R-before-SL target + threshold sweep
   6. [future] Survival (PR-D)
   7. Write artefact set + sha256 manifest
 
-PR-B adds steps 4 — AutoML — and the three new artefacts
-(``automl_leaderboard.csv``, ``automl_feature_importance.csv``,
-``compute_budget_used.md``). The AutoML stage is auto-skipped when the
-input pool lacks the required ``entry_time`` / target columns; this
-keeps PR-A's lineage-gate-only tests untouched. Production invocations
-always have these columns and AutoML runs.
+PR-C adds step 5 — meta-labeling — and two new artefacts
+(``meta_label_results.csv``, ``classifiers/meta_label/manifest.json``).
+The meta-labeling stage is auto-skipped when the input pool lacks the
+columns required for target construction (see
+:data:`core.heavy_ml_probe.meta_labeling.REQUIRED_POOL_COLUMNS`); this
+keeps PR-B's classifier-membership smoke pools untouched.
 
-Skip-reason taxonomy (recorded in the manifest's ``automl`` extras
-block so downstream tooling can audit why a run shipped without the
-AutoML artefact set):
+Skip-reason taxonomy — AutoML stage (PR-B):
 
   * ``ok`` — AutoML ran; artefacts present
-  * ``missing_entry_time`` — pool has no ``entry_time`` column; PR-A
-    smoke / synthetic-pool path
-  * ``missing_target`` — pool has no ``y`` column; same
-  * ``no_clean_features`` — lineage gate rejected every column;
-    raised as ``AllFeaturesRejected`` from automl.run_automl, recorded
-    here as well for the manifest narrative
-  * ``holdout_guard_violation`` — pool max ``entry_time`` >= train_end;
-    raised as ``HoldoutGuardViolation``; surfaces in the manifest
-    before the exception propagates to the CLI
+  * ``missing_entry_time`` — pool has no ``entry_time`` column
+  * ``missing_y`` — pool has no ``y`` column
+  * ``no_clean_features`` — lineage gate rejected every column
+  * ``holdout_guard_violation`` — pool max ``entry_time`` >= train_end
+
+Skip-reason taxonomy — meta-labeling stage (PR-C):
+
+  Meta-labeling is INDEPENDENT of the vanilla AutoML stage — its target
+  is constructed from the pool's MFE/exit columns, not from the pool's
+  ``y`` column. Skip reasons:
+
+  * ``ok`` — meta-labeling ran; artefacts present
+  * ``no_clean_features`` — lineage gate rejected every column
+  * ``missing_entry_time`` — pool has no ``entry_time`` column
+    (required by TimeSeriesSplit ordering)
+  * ``missing_trade_id`` — pool has no ``trade_id`` column (required
+    by OOF-predictions keying)
+  * ``missing_meta_label_columns:<list>`` — pool lacks any of
+    :data:`REQUIRED_POOL_COLUMNS` (``bars_to_1r_mfe`` / ``bars_held`` /
+    ``exit_reason`` / ``final_r``). Logged with the specific missing
+    column names so downstream readers know what schema gap fired.
+  * ``holdout_guard_violation`` — pool max ``entry_time`` >= train_end
+    (propagated from ``run_automl`` inside ``run_meta_labeling``)
 
 Public surface stable from PR-A:
   - ``PipelineConfig`` (extended fields, additive only)
@@ -71,6 +83,14 @@ from core.heavy_ml_probe.io import (
     write_csv,
     write_manifest,
     write_text,
+)
+from core.heavy_ml_probe.meta_labeling import (
+    REQUIRED_POOL_COLUMNS as META_LABEL_REQUIRED_COLUMNS,
+)
+from core.heavy_ml_probe.meta_labeling import (
+    MetaLabelResult,
+    meta_label_results_to_dataframe,
+    run_meta_labeling,
 )
 
 
@@ -147,8 +167,12 @@ class PipelineResult:
     automl_leaderboard_path: Path | None = None
     automl_importance_path: Path | None = None
     compute_budget_path: Path | None = None
-    # Reserved for PR-C/D — empty in PR-B.
-    meta_label_artefacts: tuple[Path, ...] = field(default_factory=tuple)
+    # PR-C fields
+    meta_label_result: MetaLabelResult | None = None
+    meta_label_skip_reason: str = "ok"
+    meta_label_results_path: Path | None = None
+    meta_label_classifier_manifest_path: Path | None = None
+    # Reserved for PR-D — empty in PR-C.
     survival_artefacts: tuple[Path, ...] = field(default_factory=tuple)
     step5_manifest_path: Path | None = None
 
@@ -316,18 +340,102 @@ def _run_automl_stage(
     return result, "ok", paths
 
 
+# ── PR-C: Meta-labeling stage skip / run decision ───────────────────
+
+
+def _should_run_meta_labeling(
+    pool: pd.DataFrame,
+    gate: LineageGateResult,
+) -> tuple[bool, str]:
+    """Decide whether to run the meta-labeling stage.
+
+    Meta-labeling is INDEPENDENT of the vanilla AutoML stage — it
+    constructs its own target from the pool's MFE/exit columns and
+    invokes ``run_automl(target_col=META_LABEL_TARGET_COL)`` directly.
+    Vanilla AutoML's ``y`` column is not consulted.
+
+    Skip if:
+      * gate rejected every feature (``no_clean_features``)
+      * pool lacks ``entry_time`` (TimeSeriesSplit ordering required)
+      * pool lacks ``trade_id`` (OOF predictions keyed by trade_id)
+      * pool lacks any of :data:`META_LABEL_REQUIRED_COLUMNS`
+        (``bars_to_1r_mfe`` / ``bars_held`` / ``exit_reason`` /
+        ``final_r``); logged with specific missing column names per
+        the skip-reason taxonomy
+    """
+    if gate.n_accepted == 0:
+        return False, "no_clean_features"
+    if "entry_time" not in pool.columns:
+        return False, "missing_entry_time"
+    if "trade_id" not in pool.columns:
+        return False, "missing_trade_id"
+    missing = [c for c in META_LABEL_REQUIRED_COLUMNS if c not in pool.columns]
+    if missing:
+        return False, f"missing_meta_label_columns:{','.join(missing)}"
+    return True, "ok"
+
+
+def _run_meta_label_stage(
+    cfg: PipelineConfig,
+    pool: pd.DataFrame,
+    gate: LineageGateResult,
+    automl_result: AutoMLResult | None,  # noqa: ARG001 — kept for symmetry with _run_automl_stage; meta-labeling does NOT depend on vanilla AutoML
+) -> tuple[MetaLabelResult | None, str, dict[str, Path]]:
+    """Run meta-labeling + write the two new artefacts. Returns
+    (result_or_none, skip_reason, {logical_name: path})."""
+    should_run, reason = _should_run_meta_labeling(pool, gate)
+    if not should_run:
+        return None, reason, {}
+
+    ml_cfg = cfg.raw_config.get("meta_labeling", {})
+    thresholds = tuple(float(t) for t in ml_cfg.get(
+        "threshold_sweep", (0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80)
+    ))
+
+    art_cfg = cfg.raw_config["output"]["artefacts"]
+    results_path = cfg.step4_dir / str(art_cfg.get("meta_label_results", "meta_label_results.csv"))
+    classifiers_dir = cfg.step4_dir / "classifiers" / "meta_label"
+
+    result = run_meta_labeling(
+        pool=pool,
+        used_features=gate.accepted_features,
+        train_end=cfg.train_end,
+        arc_name=cfg.arc_name,
+        cluster_id=cfg.cluster_id,
+        classifiers_dir=classifiers_dir,
+        n_folds=cfg.automl_n_folds,
+        max_iter_per_fold=cfg.automl_max_iter_per_fold,
+        seed=cfg.random_state,
+        n_jobs=cfg.n_jobs,
+        thresholds=thresholds,
+    )
+
+    write_csv(
+        results_path,
+        meta_label_results_to_dataframe(result),
+        sort_by=["threshold"],
+    )
+
+    paths = {
+        "meta_label_results": results_path,
+        "meta_label_classifier_manifest": result.classifier_manifest_path,
+    }
+    return result, "ok", paths
+
+
 def _stub_summary_md(
     cfg: PipelineConfig,
     gate: LineageGateResult,
     pool_size: int,
     automl_result: AutoMLResult | None,
     automl_skip_reason: str,
+    meta_label_result: MetaLabelResult | None = None,
+    meta_label_skip_reason: str = "ok",
 ) -> str:
     """Render the Step 4 stub summary.
 
-    Stable formatting: no embedded timestamps. PR-A behaviour preserved
-    when AutoML is skipped; PR-B appends a stage-status block when
-    AutoML ran.
+    Stable formatting: no embedded timestamps. Each PR adds a section
+    for its stage; checklist at the bottom reflects current build state.
     """
     lines = [
         "# heavy_ml_probe — Step 4 summary",
@@ -369,12 +477,34 @@ def _stub_summary_md(
         ]
     lines += [
         "",
+        "## Meta-labeling stage",
+        "",
+        f"- Status: **{meta_label_skip_reason}**",
+    ]
+    if meta_label_result is not None:
+        mr = meta_label_result
+        mr_ar = mr.automl_result
+        lines += [
+            f"- Target positive rate: **{mr.positive_rate:.4f}** "
+            f"({mr.target_distribution.get(1, 0)} of {mr.n_total})",
+            f"- Meta-label folds total: **{mr_ar.n_folds_total}** "
+            f"(valid AUC: **{mr_ar.n_folds_valid}**)",
+            (
+                f"- Meta-label AUC (nanmean ± nanstd): "
+                f"**{mr_ar.auc_mean:.4f} ± {mr_ar.auc_std:.4f}**"
+                if pd.notna(mr_ar.auc_mean)
+                else "- Meta-label AUC: **NaN ± NaN** (no valid folds)"
+            ),
+            f"- Threshold sweep rows: **{len(mr.threshold_sweep)}**",
+        ]
+    lines += [
+        "",
         "## Pipeline stages",
         "",
         "- [x] PR-A: scaffolding + causal lineage gate + deterministic IO + sha256 manifest",
         f"- [{'x' if automl_result is not None else ' '}] PR-B: AutoML (FLAML, 11-fold TimeSeriesSplit, 1000 evals/fold cap)",
-        "- [ ] PR-C: Meta-labeling target (reach +1R MFE before SL)",
-        "- [ ] PR-D: Survival models (Cox PH + RSF; A4 adapter)",
+        f"- [{'x' if meta_label_result is not None else ' '}] PR-C: Meta-labeling target (reach +1R MFE before SL)",
+        "- [ ] PR-D: Survival models (Cox PH only; A4 adapter)",
         "- [ ] PR-E: Step 5 augmentation hook",
         "- [ ] PR-F: Docs + polish",
         "",
@@ -442,6 +572,48 @@ def _automl_extras_for_manifest(
     }
 
 
+def _meta_label_extras_for_manifest(
+    result: MetaLabelResult | None,
+    skip_reason: str,
+) -> dict:
+    """Serialise the meta-label stage result for the manifest.
+
+    NaN-safe (JSON has no NaN; coerce to ``None``).
+    """
+    def _f(x: float) -> float | None:
+        if x is None:
+            return None
+        try:
+            if not pd.notna(x):
+                return None
+        except TypeError:
+            return None
+        return float(x)
+
+    if result is None:
+        return {"meta_label": {"skip_reason": str(skip_reason)}}
+    ar = result.automl_result
+    return {
+        "meta_label": {
+            "skip_reason": str(skip_reason),
+            "target_distribution": {
+                str(k): int(v) for k, v in result.target_distribution.items()
+            },
+            "positive_rate": _f(result.positive_rate),
+            "n_folds_total": int(ar.n_folds_total),
+            "n_folds_valid": int(ar.n_folds_valid),
+            "auc_mean": _f(ar.auc_mean),
+            "auc_std": _f(ar.auc_std),
+            "total_modelcount": int(ar.total_modelcount),
+            "n_thresholds_swept": int(len(result.threshold_sweep)),
+            "classifier_manifest_path": (
+                result.classifier_manifest_path.name
+                if result.classifier_manifest_path is not None else None
+            ),
+        }
+    }
+
+
 def run_pipeline(
     cfg: PipelineConfig,
     *,
@@ -469,12 +641,18 @@ def run_pipeline(
     try:
         automl_result, automl_skip_reason, automl_paths = _run_automl_stage(cfg, pool, gate)
     except HoldoutGuardViolation:
-        # Record the skip reason in the manifest, then re-raise.
+        # Record the skip reason in the manifest, then re-raise. Meta-
+        # labeling would have hit the same guard had it been reached,
+        # so report the matching skip reason rather than masking it as
+        # "automl_skipped".
         automl_skip_reason = "holdout_guard_violation"
         _emit_partial_manifest(
             cfg, gate, pool_size=len(pool),
             automl_result=None, automl_skip_reason=automl_skip_reason,
             automl_paths={},
+            meta_label_result=None,
+            meta_label_skip_reason="holdout_guard_violation",
+            meta_label_paths={},
         )
         raise
     except AllFeaturesRejected:
@@ -483,10 +661,44 @@ def run_pipeline(
             cfg, gate, pool_size=len(pool),
             automl_result=None, automl_skip_reason=automl_skip_reason,
             automl_paths={},
+            meta_label_result=None,
+            meta_label_skip_reason="no_clean_features",
+            meta_label_paths={},
         )
         raise
 
-    # ── Stub summary (PR-A artefact, PR-B extended content) ──────────
+    # ── PR-C Meta-labeling stage ─────────────────────────────────────
+    meta_label_result: MetaLabelResult | None = None
+    meta_label_skip_reason: str = "ok"
+    meta_label_paths: dict[str, Path] = {}
+    try:
+        meta_label_result, meta_label_skip_reason, meta_label_paths = (
+            _run_meta_label_stage(cfg, pool, gate, automl_result)
+        )
+    except HoldoutGuardViolation:
+        # Inherited guard; AutoML already passed so this would be a
+        # downstream bug. Re-raise with partial manifest.
+        meta_label_skip_reason = "holdout_guard_violation"
+        _emit_partial_manifest(
+            cfg, gate, pool_size=len(pool),
+            automl_result=automl_result, automl_skip_reason=automl_skip_reason,
+            automl_paths=automl_paths,
+            meta_label_result=None, meta_label_skip_reason=meta_label_skip_reason,
+            meta_label_paths={},
+        )
+        raise
+    except AllFeaturesRejected:
+        meta_label_skip_reason = "no_clean_features"
+        _emit_partial_manifest(
+            cfg, gate, pool_size=len(pool),
+            automl_result=automl_result, automl_skip_reason=automl_skip_reason,
+            automl_paths=automl_paths,
+            meta_label_result=None, meta_label_skip_reason=meta_label_skip_reason,
+            meta_label_paths={},
+        )
+        raise
+
+    # ── Stub summary (PR-A artefact; PR-B/C extended content) ───────
     stub_summary_path = cfg.step4_dir / "stub_summary.md"
     write_text(
         stub_summary_path,
@@ -494,11 +706,17 @@ def run_pipeline(
             cfg, gate, pool_size=len(pool),
             automl_result=automl_result,
             automl_skip_reason=automl_skip_reason,
+            meta_label_result=meta_label_result,
+            meta_label_skip_reason=meta_label_skip_reason,
         ),
     )
 
     # ── Manifest ─────────────────────────────────────────────────────
-    artefact_paths: dict[str, Path] = {"stub_summary": stub_summary_path, **automl_paths}
+    artefact_paths: dict[str, Path] = {
+        "stub_summary": stub_summary_path,
+        **automl_paths,
+        **meta_label_paths,
+    }
     manifest_path = cfg.step4_dir / str(cfg.raw_config["output"]["artefacts"]["step4_manifest"])
     write_manifest(
         manifest_path,
@@ -512,6 +730,7 @@ def run_pipeline(
             "pool_size": int(len(pool)),
             **_gate_extras_for_manifest(gate),
             **_automl_extras_for_manifest(automl_result, automl_skip_reason),
+            **_meta_label_extras_for_manifest(meta_label_result, meta_label_skip_reason),
         },
     )
 
@@ -525,6 +744,10 @@ def run_pipeline(
         automl_leaderboard_path=automl_paths.get("automl_leaderboard"),
         automl_importance_path=automl_paths.get("automl_feature_importance"),
         compute_budget_path=automl_paths.get("compute_budget_used"),
+        meta_label_result=meta_label_result,
+        meta_label_skip_reason=meta_label_skip_reason,
+        meta_label_results_path=meta_label_paths.get("meta_label_results"),
+        meta_label_classifier_manifest_path=meta_label_paths.get("meta_label_classifier_manifest"),
     )
 
 
@@ -536,14 +759,19 @@ def _emit_partial_manifest(
     automl_result: AutoMLResult | None,
     automl_skip_reason: str,
     automl_paths: dict[str, Path],
+    meta_label_result: MetaLabelResult | None = None,
+    meta_label_skip_reason: str = "automl_skipped",
+    meta_label_paths: dict[str, Path] | None = None,
 ) -> None:
     """Write a manifest reflecting the partial run before re-raising.
 
-    Used when a guard fires after the lineage gate but before the
-    AutoML artefacts land — gives downstream tooling something to
-    inspect even on the failure path.
+    Used when a guard fires mid-pipeline — gives downstream tooling
+    something to inspect even on the failure path. Updated in PR-C to
+    record meta-label skip reason alongside AutoML skip reason.
     """
     cfg.step4_dir.mkdir(parents=True, exist_ok=True)
+    if meta_label_paths is None:
+        meta_label_paths = {}
     stub_summary_path = cfg.step4_dir / "stub_summary.md"
     write_text(
         stub_summary_path,
@@ -551,9 +779,15 @@ def _emit_partial_manifest(
             cfg, gate, pool_size=pool_size,
             automl_result=automl_result,
             automl_skip_reason=automl_skip_reason,
+            meta_label_result=meta_label_result,
+            meta_label_skip_reason=meta_label_skip_reason,
         ),
     )
-    artefact_paths: dict[str, Path] = {"stub_summary": stub_summary_path, **automl_paths}
+    artefact_paths: dict[str, Path] = {
+        "stub_summary": stub_summary_path,
+        **automl_paths,
+        **meta_label_paths,
+    }
     manifest_path = cfg.step4_dir / str(cfg.raw_config["output"]["artefacts"]["step4_manifest"])
     write_manifest(
         manifest_path,
@@ -567,6 +801,7 @@ def _emit_partial_manifest(
             "pool_size": int(pool_size),
             **_gate_extras_for_manifest(gate),
             **_automl_extras_for_manifest(automl_result, automl_skip_reason),
+            **_meta_label_extras_for_manifest(meta_label_result, meta_label_skip_reason),
         },
     )
 

--- a/core/heavy_ml_probe/pipeline.py
+++ b/core/heavy_ml_probe/pipeline.py
@@ -1,0 +1,324 @@
+"""Orchestration skeleton for the heavy_ml_probe sub-protocol.
+
+Owns the end-to-end flow: load pool → apply causal lineage gate →
+[future] AutoML → [future] meta-labeling → [future] survival → write
+artefact set + manifest. Steps not yet implemented HALT cleanly with
+``NotImplementedError`` carrying the PR they land in (per the build
+plan in ``docs/dispatches/heavy_ml_probe_build_intent.md`` §8).
+
+PR-A scope: load config + apply lineage gate + write skeleton manifest
++ summary. Returns enough context for the CLI to print actionable next
+steps.
+
+PR-B (automl), PR-C (meta_labeling), PR-D (survival) extend this
+module. The public ``run_pipeline`` surface is stable from PR-A; new PRs
+add fields to :class:`PipelineResult` and populate currently-empty
+artefact slots.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import pandas as pd
+import yaml
+
+from core.heavy_ml_probe import __version__ as HEAVY_ML_VERSION
+from core.heavy_ml_probe.causal_lineage import (
+    LineageGateResult,
+    filter_training_columns,
+    lineage_summary_markdown,
+)
+from core.heavy_ml_probe.io import (
+    MANIFEST_SCHEMA_VERSION,
+    write_manifest,
+    write_text,
+)
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """Resolved invocation parameters for one pipeline run.
+
+    Subset of ``configs/heavy_ml_probe/default.yaml``. Fields not used
+    by PR-A scaffolding are still parsed so the YAML schema stays
+    locked from this PR forward.
+    """
+
+    arc_name: str
+    cluster_id: int
+    pool_path: Path
+    output_root: Path
+    config_path: Path
+    raw_config: Mapping[str, Any]
+
+    @property
+    def step4_dir(self) -> Path:
+        sub = str(self.raw_config["output"]["step4_subdir"])
+        return self.output_root / sub
+
+    @property
+    def step5_dir(self) -> Path:
+        sub = str(self.raw_config["output"]["step5_subdir"])
+        return self.output_root / sub
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    """Aggregated outcome of one pipeline run.
+
+    PR-A populates ``lineage_gate``, ``step4_manifest_path``, and
+    ``stub_summary_path``. Later PRs fill the empty slots
+    (``automl_artefacts``, ``meta_label_artefacts``, ``survival_artefacts``,
+    ``step5_manifest_path``).
+    """
+
+    cfg: PipelineConfig
+    lineage_gate: LineageGateResult
+    step4_manifest_path: Path
+    stub_summary_path: Path
+    # Reserved for PR-B/C/D — empty in PR-A.
+    automl_artefacts: tuple[Path, ...] = field(default_factory=tuple)
+    meta_label_artefacts: tuple[Path, ...] = field(default_factory=tuple)
+    survival_artefacts: tuple[Path, ...] = field(default_factory=tuple)
+    step5_manifest_path: Path | None = None
+
+
+def load_config(
+    config_path: Path,
+    *,
+    arc_name: str,
+    cluster_id: int,
+    pool_path: Path,
+    output_root: Path,
+) -> PipelineConfig:
+    """Load + minimally-validate a heavy_ml_probe YAML config.
+
+    Validation is intentionally light at PR-A — full schema enforcement
+    lands when PR-B/C/D start consuming the AutoML / meta-labeling /
+    survival blocks.
+    """
+    cp = Path(config_path)
+    if not cp.exists():
+        raise FileNotFoundError(f"heavy_ml_probe config not found: {cp}")
+    with cp.open("r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"heavy_ml_probe config must be a YAML mapping; got {type(raw).__name__}"
+        )
+    required_top = {"schema_version", "sub_protocol", "automl",
+                    "meta_labeling", "survival", "training_window",
+                    "causal_filter", "determinism", "output"}
+    missing = required_top - set(raw.keys())
+    if missing:
+        raise ValueError(
+            f"heavy_ml_probe config missing top-level sections: {sorted(missing)}"
+        )
+    if str(raw["sub_protocol"]["name"]) != "heavy_ml_probe":
+        raise ValueError(
+            f"config sub_protocol.name must be 'heavy_ml_probe'; got "
+            f"{raw['sub_protocol']['name']!r}"
+        )
+    return PipelineConfig(
+        arc_name=arc_name,
+        cluster_id=int(cluster_id),
+        pool_path=Path(pool_path),
+        output_root=Path(output_root),
+        config_path=cp,
+        raw_config=raw,
+    )
+
+
+def load_pool(pool_path: Path) -> pd.DataFrame:
+    """Read the Step 1 pool parquet.
+
+    PR-A only reads the columns; the body of work happens in PR-B+.
+    Surfacing the load here gives PR-A's CLI a non-trivial smoke
+    capability — we can fail fast on a bad pool path before later PRs
+    add dependencies.
+    """
+    p = Path(pool_path)
+    if not p.exists():
+        raise FileNotFoundError(f"pool parquet not found: {p}")
+    return pd.read_parquet(p)
+
+
+def _build_lineage_dataframe() -> pd.DataFrame:
+    """Resolve the canonical lineage table.
+
+    Wraps ``core.features.pipeline.feature_lineage_dataframe`` so tests
+    can monkey-patch this thin shim without importing the full v3
+    features stack (which triggers panel + cache imports).
+    """
+    from core.features.pipeline import feature_lineage_dataframe
+    return feature_lineage_dataframe()
+
+
+def apply_lineage_gate(
+    pool_columns: list[str],
+    cfg: PipelineConfig,
+    *,
+    lineage_df: pd.DataFrame | None = None,
+) -> LineageGateResult:
+    """Run the pre-evaluation lineage gate over ``pool_columns``.
+
+    ``lineage_df`` defaults to the registry-backed table; pass in a
+    hand-built DataFrame for tests.
+    """
+    if lineage_df is None:
+        lineage_df = _build_lineage_dataframe()
+    cf_cfg = cfg.raw_config["causal_filter"]
+    return filter_training_columns(
+        pool_columns,
+        lineage_df,
+        accepted_lineage=tuple(cf_cfg.get("accepted_lineage", ["clean"])),
+        exclude_classes=tuple(cf_cfg.get("exclude_classes", []) or []),
+    )
+
+
+def _stub_summary_md(
+    cfg: PipelineConfig,
+    gate: LineageGateResult,
+    pool_size: int,
+) -> str:
+    """Render a deterministic stub summary for PR-A end-to-end runs.
+
+    No timestamps inside the artefact body (only in the manifest's
+    ``created_at`` field, which lives one indirection away) so the
+    summary stays byte-identical across two consecutive runs.
+    """
+    lines = [
+        "# heavy_ml_probe — Step 4 stub summary (PR-A)",
+        "",
+        f"- Arc: `{cfg.arc_name}`",
+        f"- Cluster ID: `{cfg.cluster_id}`",
+        f"- Pool path: `{cfg.pool_path.as_posix()}`",
+        f"- Config path: `{cfg.config_path.as_posix()}`",
+        f"- heavy_ml_probe version: `{HEAVY_ML_VERSION}`",
+        f"- Manifest schema version: `{MANIFEST_SCHEMA_VERSION}`",
+        "",
+        "## Pool",
+        "",
+        f"- Trade rows loaded: **{pool_size}**",
+        "",
+        "## Lineage gate",
+        "",
+        f"- Columns evaluated: **{gate.n_input_columns}**",
+        f"- Accepted (clean): **{gate.n_accepted}**",
+        f"- Rejected: **{gate.n_rejected}**",
+        "",
+        "## Pipeline stages",
+        "",
+        "- [x] PR-A: scaffolding + causal lineage gate + deterministic IO + sha256 manifest",
+        "- [ ] PR-B: AutoML (FLAML, 11-fold TimeSeriesSplit, 1000 evals/fold cap)",
+        "- [ ] PR-C: Meta-labeling target (reach +1R MFE before SL)",
+        "- [ ] PR-D: Survival models (Cox PH + RSF; A4 adapter)",
+        "- [ ] PR-E: Step 5 augmentation hook",
+        "- [ ] PR-F: Docs + polish",
+        "",
+        "_See `docs/dispatches/heavy_ml_probe_build_intent.md` for the full build plan._",
+        "",
+    ]
+    if gate.n_rejected > 0:
+        lines.append(lineage_summary_markdown(gate))
+    return "\n".join(lines)
+
+
+def _gate_extras_for_manifest(gate: LineageGateResult) -> dict:
+    """Serialise the gate result into the manifest extras block.
+
+    Sorted lists / dicts so the manifest stays byte-identical across
+    two runs. Reasons aggregated for quick scan; full per-feature
+    rejection list deferred to the stub summary artefact.
+    """
+    from collections import Counter
+    reasons = Counter(r["reason"] for r in gate.rejected)
+    return {
+        "lineage_gate": {
+            "n_input_columns": int(gate.n_input_columns),
+            "n_accepted": int(gate.n_accepted),
+            "n_rejected": int(gate.n_rejected),
+            "accepted_features": list(gate.accepted_features),
+            "rejection_reasons": dict(sorted(reasons.items())),
+        }
+    }
+
+
+def run_pipeline(
+    cfg: PipelineConfig,
+    *,
+    lineage_df: pd.DataFrame | None = None,
+) -> PipelineResult:
+    """Run the heavy_ml_probe pipeline end-to-end (PR-A: lineage gate
+    + skeleton manifest only).
+
+    Side effects:
+      * Writes ``<step4_dir>/stub_summary.md`` and
+        ``<step4_dir>/manifest.json`` to disk.
+      * Creates parent directories as needed.
+
+    The function is idempotent on identical inputs by construction
+    (deterministic writes via :mod:`core.heavy_ml_probe.io`). Two
+    consecutive invocations produce byte-identical artefacts (modulo
+    the manifest's ``created_at`` field, which the determinism tests
+    intentionally exclude from the sha256 comparison by hashing the
+    payload sans that field).
+    """
+    pool = load_pool(cfg.pool_path)
+    gate = apply_lineage_gate(list(pool.columns), cfg, lineage_df=lineage_df)
+
+    cfg.step4_dir.mkdir(parents=True, exist_ok=True)
+    stub_summary_path = cfg.step4_dir / "stub_summary.md"
+    write_text(stub_summary_path, _stub_summary_md(cfg, gate, pool_size=len(pool)))
+
+    manifest_path = cfg.step4_dir / str(cfg.raw_config["output"]["artefacts"]["step4_manifest"])
+    write_manifest(
+        manifest_path,
+        arc_name=cfg.arc_name,
+        step="step_4/heavy_ml",
+        artefact_paths={"stub_summary": stub_summary_path},
+        extras={
+            "heavy_ml_probe_version": HEAVY_ML_VERSION,
+            "cluster_id": int(cfg.cluster_id),
+            "pool_path": cfg.pool_path.as_posix(),
+            "pool_size": int(len(pool)),
+            **_gate_extras_for_manifest(gate),
+        },
+    )
+
+    return PipelineResult(
+        cfg=cfg,
+        lineage_gate=gate,
+        step4_manifest_path=manifest_path,
+        stub_summary_path=stub_summary_path,
+    )
+
+
+def stable_payload_sha256(manifest_path: Path) -> str:
+    """SHA256 of the manifest with the ``created_at`` field zeroed out.
+
+    Useful for two-run determinism tests where everything except the
+    timestamp must match byte-for-byte. Reads the manifest, replaces
+    ``created_at`` with a fixed sentinel, re-serialises, hashes.
+    """
+    payload = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    payload["created_at"] = "<determinism-test-sentinel>"
+    import hashlib
+
+    blob = json.dumps(payload, sort_keys=True, indent=2)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+__all__ = (
+    "PipelineConfig",
+    "PipelineResult",
+    "load_config",
+    "load_pool",
+    "apply_lineage_gate",
+    "run_pipeline",
+    "stable_payload_sha256",
+)

--- a/core/heavy_ml_probe/pipeline.py
+++ b/core/heavy_ml_probe/pipeline.py
@@ -7,15 +7,16 @@ Owns the end-to-end flow:
   3. Apply causal lineage gate (PR-A)
   4. Run AutoML across an 11-fold TimeSeriesSplit (PR-B)
   5. Meta-labeling (PR-C) — reach-1R-before-SL target + threshold sweep
-  6. [future] Survival (PR-D)
+  6. Cox PH survival (PR-D) — time-to-+1R censored at SL/time-exit
   7. Write artefact set + sha256 manifest
 
-PR-C adds step 5 — meta-labeling — and two new artefacts
-(``meta_label_results.csv``, ``classifiers/meta_label/manifest.json``).
-The meta-labeling stage is auto-skipped when the input pool lacks the
-columns required for target construction (see
-:data:`core.heavy_ml_probe.meta_labeling.REQUIRED_POOL_COLUMNS`); this
-keeps PR-B's classifier-membership smoke pools untouched.
+PR-D adds step 6 — Cox PH survival via ``statsmodels.PHReg`` (lifelines
++ scikit-survival both blocked on Py 3.14; RSF deferred per PR-B
+flag-1) — and two new artefacts (``survival_model_results.csv``,
+``classifiers/survival/manifest.json``). The survival stage is
+auto-skipped when the input pool lacks the columns required for target
+construction (see
+:data:`core.heavy_ml_probe.survival.SURVIVAL_REQUIRED_POOL_COLUMNS`).
 
 Skip-reason taxonomy — AutoML stage (PR-B):
 
@@ -44,6 +45,22 @@ Skip-reason taxonomy — meta-labeling stage (PR-C):
   * ``holdout_guard_violation`` — pool max ``entry_time`` >= train_end
     (propagated from ``run_automl`` inside ``run_meta_labeling``)
 
+Skip-reason taxonomy — survival stage (PR-D):
+
+  Survival is INDEPENDENT of vanilla AutoML AND meta-labeling — same
+  event definition as meta-labeling (+1R MFE before SL/time-exit) but
+  modelled as time-to-event with censoring. Does not require
+  ``final_r``. Skip reasons:
+
+  * ``ok`` — survival ran; artefacts present
+  * ``no_clean_features`` — lineage gate rejected every column
+  * ``missing_entry_time`` — pool has no ``entry_time`` column
+  * ``missing_trade_id`` — pool has no ``trade_id`` column
+  * ``missing_survival_columns:<list>`` — pool lacks any of
+    :data:`SURVIVAL_REQUIRED_POOL_COLUMNS` (``bars_to_1r_mfe`` /
+    ``bars_held`` / ``exit_reason``)
+  * ``holdout_guard_violation`` — pool max ``entry_time`` >= train_end
+
 Public surface stable from PR-A:
   - ``PipelineConfig`` (extended fields, additive only)
   - ``PipelineResult`` (extended fields, additive only)
@@ -56,7 +73,7 @@ Public surface stable from PR-A:
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -91,6 +108,12 @@ from core.heavy_ml_probe.meta_labeling import (
     MetaLabelResult,
     meta_label_results_to_dataframe,
     run_meta_labeling,
+)
+from core.heavy_ml_probe.survival import (
+    SURVIVAL_REQUIRED_POOL_COLUMNS,
+    SurvivalResult,
+    run_survival,
+    survival_results_to_dataframe,
 )
 
 
@@ -172,8 +195,12 @@ class PipelineResult:
     meta_label_skip_reason: str = "ok"
     meta_label_results_path: Path | None = None
     meta_label_classifier_manifest_path: Path | None = None
-    # Reserved for PR-D — empty in PR-C.
-    survival_artefacts: tuple[Path, ...] = field(default_factory=tuple)
+    # PR-D fields
+    survival_result: SurvivalResult | None = None
+    survival_skip_reason: str = "ok"
+    survival_results_path: Path | None = None
+    survival_classifier_manifest_path: Path | None = None
+    # Reserved for PR-E — empty in PR-D.
     step5_manifest_path: Path | None = None
 
 
@@ -423,6 +450,83 @@ def _run_meta_label_stage(
     return result, "ok", paths
 
 
+# ── PR-D: Survival stage skip / run decision ────────────────────────
+
+
+def _should_run_survival(
+    pool: pd.DataFrame,
+    gate: LineageGateResult,
+) -> tuple[bool, str]:
+    """Decide whether to run the survival stage.
+
+    Survival is INDEPENDENT of vanilla AutoML AND meta-labeling — its
+    target is constructed from the pool's MFE/exit columns (same as
+    meta-labeling, but modelled as time-to-event rather than binary).
+    A pool can carry the survival schema without carrying meta-label's
+    ``final_r`` (which only meta-labeling needs for kept/dropped means).
+
+    Skip if:
+      * gate rejected every feature (``no_clean_features``)
+      * pool lacks ``entry_time`` (TimeSeriesSplit ordering required)
+      * pool lacks ``trade_id`` (manifest persistence keying)
+      * pool lacks any of :data:`SURVIVAL_REQUIRED_POOL_COLUMNS`
+        (``bars_to_1r_mfe`` / ``bars_held`` / ``exit_reason``); logged
+        with the specific missing column names per the skip-reason
+        taxonomy
+    """
+    if gate.n_accepted == 0:
+        return False, "no_clean_features"
+    if "entry_time" not in pool.columns:
+        return False, "missing_entry_time"
+    if "trade_id" not in pool.columns:
+        return False, "missing_trade_id"
+    missing = [c for c in SURVIVAL_REQUIRED_POOL_COLUMNS if c not in pool.columns]
+    if missing:
+        return False, f"missing_survival_columns:{','.join(missing)}"
+    return True, "ok"
+
+
+def _run_survival_stage(
+    cfg: PipelineConfig,
+    pool: pd.DataFrame,
+    gate: LineageGateResult,
+) -> tuple[SurvivalResult | None, str, dict[str, Path]]:
+    """Run Cox PH survival + write the two new artefacts. Returns
+    (result_or_none, skip_reason, {logical_name: path})."""
+    should_run, reason = _should_run_survival(pool, gate)
+    if not should_run:
+        return None, reason, {}
+
+    art_cfg = cfg.raw_config["output"]["artefacts"]
+    results_path = cfg.step4_dir / str(art_cfg.get(
+        "survival_model_results", "survival_model_results.csv"
+    ))
+    classifiers_dir = cfg.step4_dir / "classifiers" / "survival"
+
+    result = run_survival(
+        pool=pool,
+        used_features=gate.accepted_features,
+        train_end=cfg.train_end,
+        arc_name=cfg.arc_name,
+        cluster_id=cfg.cluster_id,
+        classifiers_dir=classifiers_dir,
+        n_folds=cfg.automl_n_folds,
+        seed=cfg.random_state,
+    )
+
+    write_csv(
+        results_path,
+        survival_results_to_dataframe(result),
+        sort_by=["fold", "feature"],
+    )
+
+    paths = {
+        "survival_model_results": results_path,
+        "survival_classifier_manifest": result.classifier_manifest_path,
+    }
+    return result, "ok", paths
+
+
 def _stub_summary_md(
     cfg: PipelineConfig,
     gate: LineageGateResult,
@@ -431,6 +535,8 @@ def _stub_summary_md(
     automl_skip_reason: str,
     meta_label_result: MetaLabelResult | None = None,
     meta_label_skip_reason: str = "ok",
+    survival_result: SurvivalResult | None = None,
+    survival_skip_reason: str = "ok",
 ) -> str:
     """Render the Step 4 stub summary.
 
@@ -499,12 +605,32 @@ def _stub_summary_md(
         ]
     lines += [
         "",
+        "## Survival stage",
+        "",
+        f"- Status: **{survival_skip_reason}**",
+    ]
+    if survival_result is not None:
+        sr = survival_result
+        lines += [
+            f"- statsmodels version: `{sr.statsmodels_version}`",
+            f"- Folds total: **{sr.n_folds_total}** "
+            f"(valid concordance: **{sr.n_folds_valid}**)",
+            (
+                f"- Concordance (nanmean ± nanstd): "
+                f"**{sr.concordance_mean:.4f} ± {sr.concordance_std:.4f}**"
+                if pd.notna(sr.concordance_mean)
+                else "- Concordance: **NaN ± NaN** (no valid folds)"
+            ),
+            f"- Total events across training slices: **{sr.total_n_events}**",
+        ]
+    lines += [
+        "",
         "## Pipeline stages",
         "",
         "- [x] PR-A: scaffolding + causal lineage gate + deterministic IO + sha256 manifest",
         f"- [{'x' if automl_result is not None else ' '}] PR-B: AutoML (FLAML, 11-fold TimeSeriesSplit, 1000 evals/fold cap)",
         f"- [{'x' if meta_label_result is not None else ' '}] PR-C: Meta-labeling target (reach +1R MFE before SL)",
-        "- [ ] PR-D: Survival models (Cox PH only; A4 adapter)",
+        f"- [{'x' if survival_result is not None else ' '}] PR-D: Cox PH survival (statsmodels.PHReg; RSF deferred)",
         "- [ ] PR-E: Step 5 augmentation hook",
         "- [ ] PR-F: Docs + polish",
         "",
@@ -568,6 +694,44 @@ def _automl_extras_for_manifest(
             "total_modelcount": int(result.total_modelcount),
             # Wall-clock intentionally omitted — non-deterministic.
             "n_features_used": int(len(result.used_features)),
+        }
+    }
+
+
+def _survival_extras_for_manifest(
+    result: SurvivalResult | None,
+    skip_reason: str,
+) -> dict:
+    """Serialise the survival stage result for the manifest.
+
+    NaN-safe (JSON has no NaN; coerce to ``None``).
+    """
+    def _f(x):
+        if x is None:
+            return None
+        try:
+            if not pd.notna(x):
+                return None
+        except TypeError:
+            return None
+        return float(x)
+
+    if result is None:
+        return {"survival": {"skip_reason": str(skip_reason)}}
+    return {
+        "survival": {
+            "skip_reason": str(skip_reason),
+            "statsmodels_version": str(result.statsmodels_version),
+            "n_folds_total": int(result.n_folds_total),
+            "n_folds_valid": int(result.n_folds_valid),
+            "concordance_mean": _f(result.concordance_mean),
+            "concordance_std": _f(result.concordance_std),
+            "total_n_events": int(result.total_n_events),
+            "n_features_used": int(len(result.used_features)),
+            "classifier_manifest_path": (
+                result.classifier_manifest_path.name
+                if result.classifier_manifest_path is not None else None
+            ),
         }
     }
 
@@ -642,9 +806,9 @@ def run_pipeline(
         automl_result, automl_skip_reason, automl_paths = _run_automl_stage(cfg, pool, gate)
     except HoldoutGuardViolation:
         # Record the skip reason in the manifest, then re-raise. Meta-
-        # labeling would have hit the same guard had it been reached,
-        # so report the matching skip reason rather than masking it as
-        # "automl_skipped".
+        # labeling and survival would have hit the same guard had they
+        # been reached, so report the matching skip reason rather than
+        # masking as "automl_skipped".
         automl_skip_reason = "holdout_guard_violation"
         _emit_partial_manifest(
             cfg, gate, pool_size=len(pool),
@@ -653,6 +817,9 @@ def run_pipeline(
             meta_label_result=None,
             meta_label_skip_reason="holdout_guard_violation",
             meta_label_paths={},
+            survival_result=None,
+            survival_skip_reason="holdout_guard_violation",
+            survival_paths={},
         )
         raise
     except AllFeaturesRejected:
@@ -664,6 +831,9 @@ def run_pipeline(
             meta_label_result=None,
             meta_label_skip_reason="no_clean_features",
             meta_label_paths={},
+            survival_result=None,
+            survival_skip_reason="no_clean_features",
+            survival_paths={},
         )
         raise
 
@@ -685,6 +855,8 @@ def run_pipeline(
             automl_paths=automl_paths,
             meta_label_result=None, meta_label_skip_reason=meta_label_skip_reason,
             meta_label_paths={},
+            survival_result=None, survival_skip_reason="holdout_guard_violation",
+            survival_paths={},
         )
         raise
     except AllFeaturesRejected:
@@ -695,10 +867,47 @@ def run_pipeline(
             automl_paths=automl_paths,
             meta_label_result=None, meta_label_skip_reason=meta_label_skip_reason,
             meta_label_paths={},
+            survival_result=None, survival_skip_reason="no_clean_features",
+            survival_paths={},
         )
         raise
 
-    # ── Stub summary (PR-A artefact; PR-B/C extended content) ───────
+    # ── PR-D Survival stage (independent of AutoML + meta-labeling) ──
+    survival_result: SurvivalResult | None = None
+    survival_skip_reason: str = "ok"
+    survival_paths: dict[str, Path] = {}
+    try:
+        survival_result, survival_skip_reason, survival_paths = (
+            _run_survival_stage(cfg, pool, gate)
+        )
+    except HoldoutGuardViolation:
+        survival_skip_reason = "holdout_guard_violation"
+        _emit_partial_manifest(
+            cfg, gate, pool_size=len(pool),
+            automl_result=automl_result, automl_skip_reason=automl_skip_reason,
+            automl_paths=automl_paths,
+            meta_label_result=meta_label_result,
+            meta_label_skip_reason=meta_label_skip_reason,
+            meta_label_paths=meta_label_paths,
+            survival_result=None, survival_skip_reason=survival_skip_reason,
+            survival_paths={},
+        )
+        raise
+    except AllFeaturesRejected:
+        survival_skip_reason = "no_clean_features"
+        _emit_partial_manifest(
+            cfg, gate, pool_size=len(pool),
+            automl_result=automl_result, automl_skip_reason=automl_skip_reason,
+            automl_paths=automl_paths,
+            meta_label_result=meta_label_result,
+            meta_label_skip_reason=meta_label_skip_reason,
+            meta_label_paths=meta_label_paths,
+            survival_result=None, survival_skip_reason=survival_skip_reason,
+            survival_paths={},
+        )
+        raise
+
+    # ── Stub summary (PR-A artefact; PR-B/C/D extended content) ─────
     stub_summary_path = cfg.step4_dir / "stub_summary.md"
     write_text(
         stub_summary_path,
@@ -708,6 +917,8 @@ def run_pipeline(
             automl_skip_reason=automl_skip_reason,
             meta_label_result=meta_label_result,
             meta_label_skip_reason=meta_label_skip_reason,
+            survival_result=survival_result,
+            survival_skip_reason=survival_skip_reason,
         ),
     )
 
@@ -716,6 +927,7 @@ def run_pipeline(
         "stub_summary": stub_summary_path,
         **automl_paths,
         **meta_label_paths,
+        **survival_paths,
     }
     manifest_path = cfg.step4_dir / str(cfg.raw_config["output"]["artefacts"]["step4_manifest"])
     write_manifest(
@@ -731,6 +943,7 @@ def run_pipeline(
             **_gate_extras_for_manifest(gate),
             **_automl_extras_for_manifest(automl_result, automl_skip_reason),
             **_meta_label_extras_for_manifest(meta_label_result, meta_label_skip_reason),
+            **_survival_extras_for_manifest(survival_result, survival_skip_reason),
         },
     )
 
@@ -748,6 +961,10 @@ def run_pipeline(
         meta_label_skip_reason=meta_label_skip_reason,
         meta_label_results_path=meta_label_paths.get("meta_label_results"),
         meta_label_classifier_manifest_path=meta_label_paths.get("meta_label_classifier_manifest"),
+        survival_result=survival_result,
+        survival_skip_reason=survival_skip_reason,
+        survival_results_path=survival_paths.get("survival_model_results"),
+        survival_classifier_manifest_path=survival_paths.get("survival_classifier_manifest"),
     )
 
 
@@ -762,16 +979,21 @@ def _emit_partial_manifest(
     meta_label_result: MetaLabelResult | None = None,
     meta_label_skip_reason: str = "automl_skipped",
     meta_label_paths: dict[str, Path] | None = None,
+    survival_result: SurvivalResult | None = None,
+    survival_skip_reason: str = "automl_skipped",
+    survival_paths: dict[str, Path] | None = None,
 ) -> None:
     """Write a manifest reflecting the partial run before re-raising.
 
     Used when a guard fires mid-pipeline — gives downstream tooling
-    something to inspect even on the failure path. Updated in PR-C to
-    record meta-label skip reason alongside AutoML skip reason.
+    something to inspect even on the failure path. Extended in PR-D to
+    record survival skip reason alongside AutoML + meta-label.
     """
     cfg.step4_dir.mkdir(parents=True, exist_ok=True)
     if meta_label_paths is None:
         meta_label_paths = {}
+    if survival_paths is None:
+        survival_paths = {}
     stub_summary_path = cfg.step4_dir / "stub_summary.md"
     write_text(
         stub_summary_path,
@@ -781,12 +1003,15 @@ def _emit_partial_manifest(
             automl_skip_reason=automl_skip_reason,
             meta_label_result=meta_label_result,
             meta_label_skip_reason=meta_label_skip_reason,
+            survival_result=survival_result,
+            survival_skip_reason=survival_skip_reason,
         ),
     )
     artefact_paths: dict[str, Path] = {
         "stub_summary": stub_summary_path,
         **automl_paths,
         **meta_label_paths,
+        **survival_paths,
     }
     manifest_path = cfg.step4_dir / str(cfg.raw_config["output"]["artefacts"]["step4_manifest"])
     write_manifest(
@@ -802,6 +1027,7 @@ def _emit_partial_manifest(
             **_gate_extras_for_manifest(gate),
             **_automl_extras_for_manifest(automl_result, automl_skip_reason),
             **_meta_label_extras_for_manifest(meta_label_result, meta_label_skip_reason),
+            **_survival_extras_for_manifest(survival_result, survival_skip_reason),
         },
     )
 

--- a/core/heavy_ml_probe/pipeline.py
+++ b/core/heavy_ml_probe/pipeline.py
@@ -1,19 +1,44 @@
-"""Orchestration skeleton for the heavy_ml_probe sub-protocol.
+"""Orchestration for the heavy_ml_probe sub-protocol.
 
-Owns the end-to-end flow: load pool → apply causal lineage gate →
-[future] AutoML → [future] meta-labeling → [future] survival → write
-artefact set + manifest. Steps not yet implemented HALT cleanly with
-``NotImplementedError`` carrying the PR they land in (per the build
-plan in ``docs/dispatches/heavy_ml_probe_build_intent.md`` §8).
+Owns the end-to-end flow:
 
-PR-A scope: load config + apply lineage gate + write skeleton manifest
-+ summary. Returns enough context for the CLI to print actionable next
-steps.
+  1. Load + validate config
+  2. Load Step 1 pool
+  3. Apply causal lineage gate (PR-A)
+  4. Run AutoML across an 11-fold TimeSeriesSplit (PR-B)
+  5. [future] Meta-labeling (PR-C)
+  6. [future] Survival (PR-D)
+  7. Write artefact set + sha256 manifest
 
-PR-B (automl), PR-C (meta_labeling), PR-D (survival) extend this
-module. The public ``run_pipeline`` surface is stable from PR-A; new PRs
-add fields to :class:`PipelineResult` and populate currently-empty
-artefact slots.
+PR-B adds steps 4 — AutoML — and the three new artefacts
+(``automl_leaderboard.csv``, ``automl_feature_importance.csv``,
+``compute_budget_used.md``). The AutoML stage is auto-skipped when the
+input pool lacks the required ``entry_time`` / target columns; this
+keeps PR-A's lineage-gate-only tests untouched. Production invocations
+always have these columns and AutoML runs.
+
+Skip-reason taxonomy (recorded in the manifest's ``automl`` extras
+block so downstream tooling can audit why a run shipped without the
+AutoML artefact set):
+
+  * ``ok`` — AutoML ran; artefacts present
+  * ``missing_entry_time`` — pool has no ``entry_time`` column; PR-A
+    smoke / synthetic-pool path
+  * ``missing_target`` — pool has no ``y`` column; same
+  * ``no_clean_features`` — lineage gate rejected every column;
+    raised as ``AllFeaturesRejected`` from automl.run_automl, recorded
+    here as well for the manifest narrative
+  * ``holdout_guard_violation`` — pool max ``entry_time`` >= train_end;
+    raised as ``HoldoutGuardViolation``; surfaces in the manifest
+    before the exception propagates to the CLI
+
+Public surface stable from PR-A:
+  - ``PipelineConfig`` (extended fields, additive only)
+  - ``PipelineResult`` (extended fields, additive only)
+  - ``load_config`` / ``load_pool`` / ``apply_lineage_gate``
+  - ``run_pipeline``
+  - ``stable_payload_sha256``  — intentional public API for downstream
+    determinism verification per PR-A flag-3 disposition.
 """
 
 from __future__ import annotations
@@ -27,6 +52,15 @@ import pandas as pd
 import yaml
 
 from core.heavy_ml_probe import __version__ as HEAVY_ML_VERSION
+from core.heavy_ml_probe.automl import (
+    AllFeaturesRejected,
+    AutoMLResult,
+    HoldoutGuardViolation,
+    compute_budget_markdown,
+    importance_to_dataframe,
+    leaderboard_to_dataframe,
+    run_automl,
+)
 from core.heavy_ml_probe.causal_lineage import (
     LineageGateResult,
     filter_training_columns,
@@ -34,6 +68,7 @@ from core.heavy_ml_probe.causal_lineage import (
 )
 from core.heavy_ml_probe.io import (
     MANIFEST_SCHEMA_VERSION,
+    write_csv,
     write_manifest,
     write_text,
 )
@@ -43,9 +78,8 @@ from core.heavy_ml_probe.io import (
 class PipelineConfig:
     """Resolved invocation parameters for one pipeline run.
 
-    Subset of ``configs/heavy_ml_probe/default.yaml``. Fields not used
-    by PR-A scaffolding are still parsed so the YAML schema stays
-    locked from this PR forward.
+    Mirrors ``configs/heavy_ml_probe/default.yaml``. Fields not used at
+    this PR are still parsed so the YAML schema stays locked.
     """
 
     arc_name: str
@@ -65,23 +99,55 @@ class PipelineConfig:
         sub = str(self.raw_config["output"]["step5_subdir"])
         return self.output_root / sub
 
+    @property
+    def train_end(self) -> pd.Timestamp:
+        """Holdout cutoff per L_PROTOCOL §1 + dispatch §5 #3."""
+        return pd.Timestamp(
+            str(self.raw_config["training_window"]["train_end"])
+        ).tz_localize("UTC")
+
+    @property
+    def automl_max_iter_per_fold(self) -> int:
+        return int(self.raw_config["automl"]["max_iter_per_fold"])
+
+    @property
+    def automl_n_folds(self) -> int:
+        return int(self.raw_config["automl"]["n_folds"])
+
+    @property
+    def automl_metric(self) -> str:
+        return str(self.raw_config["automl"].get("metric", "roc_auc"))
+
+    @property
+    def random_state(self) -> int:
+        return int(self.raw_config["determinism"]["random_state"])
+
+    @property
+    def n_jobs(self) -> int:
+        return int(self.raw_config["determinism"]["n_jobs"])
+
 
 @dataclass(frozen=True)
 class PipelineResult:
     """Aggregated outcome of one pipeline run.
 
-    PR-A populates ``lineage_gate``, ``step4_manifest_path``, and
-    ``stub_summary_path``. Later PRs fill the empty slots
-    (``automl_artefacts``, ``meta_label_artefacts``, ``survival_artefacts``,
-    ``step5_manifest_path``).
+    PR-A: ``lineage_gate``, ``step4_manifest_path``, ``stub_summary_path``.
+    PR-B adds: ``automl_result``, ``automl_skip_reason``,
+    ``automl_leaderboard_path``, ``automl_importance_path``,
+    ``compute_budget_path``.
     """
 
     cfg: PipelineConfig
     lineage_gate: LineageGateResult
     step4_manifest_path: Path
     stub_summary_path: Path
-    # Reserved for PR-B/C/D — empty in PR-A.
-    automl_artefacts: tuple[Path, ...] = field(default_factory=tuple)
+    # PR-B fields (None when AutoML was skipped or upstream guards fired)
+    automl_result: AutoMLResult | None = None
+    automl_skip_reason: str = "ok"
+    automl_leaderboard_path: Path | None = None
+    automl_importance_path: Path | None = None
+    compute_budget_path: Path | None = None
+    # Reserved for PR-C/D — empty in PR-B.
     meta_label_artefacts: tuple[Path, ...] = field(default_factory=tuple)
     survival_artefacts: tuple[Path, ...] = field(default_factory=tuple)
     step5_manifest_path: Path | None = None
@@ -95,12 +161,7 @@ def load_config(
     pool_path: Path,
     output_root: Path,
 ) -> PipelineConfig:
-    """Load + minimally-validate a heavy_ml_probe YAML config.
-
-    Validation is intentionally light at PR-A — full schema enforcement
-    lands when PR-B/C/D start consuming the AutoML / meta-labeling /
-    survival blocks.
-    """
+    """Load + minimally-validate a heavy_ml_probe YAML config."""
     cp = Path(config_path)
     if not cp.exists():
         raise FileNotFoundError(f"heavy_ml_probe config not found: {cp}")
@@ -134,13 +195,7 @@ def load_config(
 
 
 def load_pool(pool_path: Path) -> pd.DataFrame:
-    """Read the Step 1 pool parquet.
-
-    PR-A only reads the columns; the body of work happens in PR-B+.
-    Surfacing the load here gives PR-A's CLI a non-trivial smoke
-    capability — we can fail fast on a bad pool path before later PRs
-    add dependencies.
-    """
+    """Read the Step 1 pool parquet."""
     p = Path(pool_path)
     if not p.exists():
         raise FileNotFoundError(f"pool parquet not found: {p}")
@@ -164,11 +219,7 @@ def apply_lineage_gate(
     *,
     lineage_df: pd.DataFrame | None = None,
 ) -> LineageGateResult:
-    """Run the pre-evaluation lineage gate over ``pool_columns``.
-
-    ``lineage_df`` defaults to the registry-backed table; pass in a
-    hand-built DataFrame for tests.
-    """
+    """Run the pre-evaluation lineage gate over ``pool_columns``."""
     if lineage_df is None:
         lineage_df = _build_lineage_dataframe()
     cf_cfg = cfg.raw_config["causal_filter"]
@@ -180,19 +231,106 @@ def apply_lineage_gate(
     )
 
 
+# ── PR-B: AutoML stage skip / run decision ───────────────────────────
+
+
+# Columns the AutoML stage requires. Skip cleanly if either is absent
+# rather than crashing — this lets PR-A's lineage-gate-only smoke pools
+# coexist with PR-B production pools in the same code path.
+AUTOML_REQUIRED_COLUMNS: tuple[str, str] = ("entry_time", "y")
+
+
+def _should_run_automl(
+    pool: pd.DataFrame,
+    gate: LineageGateResult,
+) -> tuple[bool, str]:
+    """Decide whether to run the AutoML stage. Returns (should_run, reason)."""
+    if gate.n_accepted == 0:
+        return False, "no_clean_features"
+    for col in AUTOML_REQUIRED_COLUMNS:
+        if col not in pool.columns:
+            return False, f"missing_{col}"
+    return True, "ok"
+
+
+def _run_automl_stage(
+    cfg: PipelineConfig,
+    pool: pd.DataFrame,
+    gate: LineageGateResult,
+) -> tuple[AutoMLResult | None, str, dict[str, Path]]:
+    """Run AutoML + write the three new artefacts. Returns
+    (result_or_none, skip_reason, {logical_name: path})."""
+    should_run, reason = _should_run_automl(pool, gate)
+    if not should_run:
+        return None, reason, {}
+
+    try:
+        result = run_automl(
+            pool=pool,
+            used_features=gate.accepted_features,
+            train_end=cfg.train_end,
+            n_folds=cfg.automl_n_folds,
+            max_iter_per_fold=cfg.automl_max_iter_per_fold,
+            seed=cfg.random_state,
+            metric=cfg.automl_metric,
+            n_jobs=cfg.n_jobs,
+        )
+    except HoldoutGuardViolation:
+        # Propagate after recording in the manifest narrative — but the
+        # current orchestrator can't write the manifest after raising.
+        # So we record the skip reason and re-raise; the CLI surfaces
+        # the error via stderr + exit code 1. The manifest's
+        # ``automl.skip_reason`` field will reflect ``holdout_guard_violation``
+        # only on a SUCCESSFUL guard-violation pre-check path; an
+        # actual violation kills the pipeline cleanly.
+        raise
+    except AllFeaturesRejected:
+        # Same: the caller (run_pipeline) catches this and folds it
+        # into the manifest. Re-raise here for the orchestrator to
+        # handle.
+        raise
+
+    paths: dict[str, Path] = {}
+    art_cfg = cfg.raw_config["output"]["artefacts"]
+    lb_path = cfg.step4_dir / str(art_cfg["automl_leaderboard"])
+    imp_path = cfg.step4_dir / str(art_cfg["automl_feature_importance"])
+    budget_path = cfg.step4_dir / str(art_cfg["compute_budget_used"])
+
+    write_csv(
+        lb_path,
+        leaderboard_to_dataframe(result),
+        sort_by=["fold", "estimator"],
+    )
+    write_csv(
+        imp_path,
+        importance_to_dataframe(result),
+        sort_by=["feature"],
+    )
+    write_text(
+        budget_path,
+        compute_budget_markdown(result, train_end=cfg.train_end),
+    )
+    paths["automl_leaderboard"] = lb_path
+    paths["automl_feature_importance"] = imp_path
+    paths["compute_budget_used"] = budget_path
+    return result, "ok", paths
+
+
 def _stub_summary_md(
     cfg: PipelineConfig,
     gate: LineageGateResult,
     pool_size: int,
+    automl_result: AutoMLResult | None,
+    automl_skip_reason: str,
 ) -> str:
-    """Render a deterministic stub summary for PR-A end-to-end runs.
+    """Render the Step 4 stub summary.
 
-    No timestamps inside the artefact body (only in the manifest's
-    ``created_at`` field, which lives one indirection away) so the
-    summary stays byte-identical across two consecutive runs.
+    Stable formatting: no embedded timestamps. PR-A behaviour preserved
+    when AutoML is skipped; PR-B appends a stage-status block when
+    AutoML ran.
     """
     lines = [
-        "# heavy_ml_probe — Step 4 stub summary (PR-A)",
+        "# heavy_ml_probe — Step 4 summary",
         "",
         f"- Arc: `{cfg.arc_name}`",
         f"- Cluster ID: `{cfg.cluster_id}`",
@@ -211,10 +349,30 @@ def _stub_summary_md(
         f"- Accepted (clean): **{gate.n_accepted}**",
         f"- Rejected: **{gate.n_rejected}**",
         "",
+        "## AutoML stage",
+        "",
+        f"- Status: **{automl_skip_reason}**",
+    ]
+    if automl_result is not None:
+        ar = automl_result
+        lines += [
+            f"- FLAML version: `{ar.flaml_version}`",
+            f"- Folds total: **{ar.n_folds_total}** (valid AUC: **{ar.n_folds_valid}**)",
+            (
+                f"- AUC (nanmean ± nanstd): **{ar.auc_mean:.4f} ± {ar.auc_std:.4f}**"
+                if pd.notna(ar.auc_mean)
+                else "- AUC (nanmean ± nanstd): **NaN ± NaN** (no valid folds)"
+            ),
+            f"- Total modelcount across folds: **{ar.total_modelcount}**",
+            # Wall-clock intentionally NOT logged here — non-deterministic;
+            # available on the in-memory AutoMLResult for log/diagnostic use.
+        ]
+    lines += [
+        "",
         "## Pipeline stages",
         "",
         "- [x] PR-A: scaffolding + causal lineage gate + deterministic IO + sha256 manifest",
-        "- [ ] PR-B: AutoML (FLAML, 11-fold TimeSeriesSplit, 1000 evals/fold cap)",
+        f"- [{'x' if automl_result is not None else ' '}] PR-B: AutoML (FLAML, 11-fold TimeSeriesSplit, 1000 evals/fold cap)",
         "- [ ] PR-C: Meta-labeling target (reach +1R MFE before SL)",
         "- [ ] PR-D: Survival models (Cox PH + RSF; A4 adapter)",
         "- [ ] PR-E: Step 5 augmentation hook",
@@ -232,8 +390,7 @@ def _gate_extras_for_manifest(gate: LineageGateResult) -> dict:
     """Serialise the gate result into the manifest extras block.
 
     Sorted lists / dicts so the manifest stays byte-identical across
-    two runs. Reasons aggregated for quick scan; full per-feature
-    rejection list deferred to the stub summary artefact.
+    two runs.
     """
     from collections import Counter
     reasons = Counter(r["reason"] for r in gate.rejected)
@@ -248,45 +405,113 @@ def _gate_extras_for_manifest(gate: LineageGateResult) -> dict:
     }
 
 
+def _automl_extras_for_manifest(
+    result: AutoMLResult | None,
+    skip_reason: str,
+) -> dict:
+    """Serialise the AutoML stage result for the manifest.
+
+    Floats are coerced to native Python; NaN serialised via ``None`` so
+    the JSON is strict-spec compliant (JSON does not have NaN).
+    """
+    def _f(x: float) -> float | None:
+        if x is None:
+            return None
+        try:
+            if not pd.notna(x):
+                return None
+        except TypeError:
+            return None
+        return float(x)
+
+    if result is None:
+        return {"automl": {"skip_reason": str(skip_reason)}}
+    return {
+        "automl": {
+            "skip_reason": str(skip_reason),
+            "flaml_version": str(result.flaml_version),
+            "metric": str(result.metric),
+            "n_folds_total": int(result.n_folds_total),
+            "n_folds_valid": int(result.n_folds_valid),
+            "auc_mean": _f(result.auc_mean),
+            "auc_std": _f(result.auc_std),
+            "total_modelcount": int(result.total_modelcount),
+            # Wall-clock intentionally omitted — non-deterministic.
+            "n_features_used": int(len(result.used_features)),
+        }
+    }
+
+
 def run_pipeline(
     cfg: PipelineConfig,
     *,
     lineage_df: pd.DataFrame | None = None,
 ) -> PipelineResult:
-    """Run the heavy_ml_probe pipeline end-to-end (PR-A: lineage gate
-    + skeleton manifest only).
+    """Run the heavy_ml_probe pipeline end-to-end.
 
-    Side effects:
-      * Writes ``<step4_dir>/stub_summary.md`` and
-        ``<step4_dir>/manifest.json`` to disk.
-      * Creates parent directories as needed.
+    PR-A stages: lineage gate + skeleton manifest + stub summary.
+    PR-B stages: AutoML across an 11-fold TimeSeriesSplit (when the
+    input pool supports it) + AutoML artefacts in the manifest.
 
-    The function is idempotent on identical inputs by construction
-    (deterministic writes via :mod:`core.heavy_ml_probe.io`). Two
-    consecutive invocations produce byte-identical artefacts (modulo
-    the manifest's ``created_at`` field, which the determinism tests
-    intentionally exclude from the sha256 comparison by hashing the
-    payload sans that field).
+    Determinism: identical config + identical pool → byte-identical
+    artefacts and (modulo ``created_at``) byte-identical manifest. The
+    determinism tests use :func:`stable_payload_sha256` to verify the
+    payload sans timestamp.
     """
     pool = load_pool(cfg.pool_path)
     gate = apply_lineage_gate(list(pool.columns), cfg, lineage_df=lineage_df)
-
     cfg.step4_dir.mkdir(parents=True, exist_ok=True)
-    stub_summary_path = cfg.step4_dir / "stub_summary.md"
-    write_text(stub_summary_path, _stub_summary_md(cfg, gate, pool_size=len(pool)))
 
+    # ── PR-B AutoML stage ────────────────────────────────────────────
+    automl_result: AutoMLResult | None = None
+    automl_skip_reason: str = "ok"
+    automl_paths: dict[str, Path] = {}
+    try:
+        automl_result, automl_skip_reason, automl_paths = _run_automl_stage(cfg, pool, gate)
+    except HoldoutGuardViolation:
+        # Record the skip reason in the manifest, then re-raise.
+        automl_skip_reason = "holdout_guard_violation"
+        _emit_partial_manifest(
+            cfg, gate, pool_size=len(pool),
+            automl_result=None, automl_skip_reason=automl_skip_reason,
+            automl_paths={},
+        )
+        raise
+    except AllFeaturesRejected:
+        automl_skip_reason = "no_clean_features"
+        _emit_partial_manifest(
+            cfg, gate, pool_size=len(pool),
+            automl_result=None, automl_skip_reason=automl_skip_reason,
+            automl_paths={},
+        )
+        raise
+
+    # ── Stub summary (PR-A artefact, PR-B extended content) ──────────
+    stub_summary_path = cfg.step4_dir / "stub_summary.md"
+    write_text(
+        stub_summary_path,
+        _stub_summary_md(
+            cfg, gate, pool_size=len(pool),
+            automl_result=automl_result,
+            automl_skip_reason=automl_skip_reason,
+        ),
+    )
+
+    # ── Manifest ─────────────────────────────────────────────────────
+    artefact_paths: dict[str, Path] = {"stub_summary": stub_summary_path, **automl_paths}
     manifest_path = cfg.step4_dir / str(cfg.raw_config["output"]["artefacts"]["step4_manifest"])
     write_manifest(
         manifest_path,
         arc_name=cfg.arc_name,
         step="step_4/heavy_ml",
-        artefact_paths={"stub_summary": stub_summary_path},
+        artefact_paths=artefact_paths,
         extras={
             "heavy_ml_probe_version": HEAVY_ML_VERSION,
             "cluster_id": int(cfg.cluster_id),
             "pool_path": cfg.pool_path.as_posix(),
             "pool_size": int(len(pool)),
             **_gate_extras_for_manifest(gate),
+            **_automl_extras_for_manifest(automl_result, automl_skip_reason),
         },
     )
 
@@ -295,15 +520,65 @@ def run_pipeline(
         lineage_gate=gate,
         step4_manifest_path=manifest_path,
         stub_summary_path=stub_summary_path,
+        automl_result=automl_result,
+        automl_skip_reason=automl_skip_reason,
+        automl_leaderboard_path=automl_paths.get("automl_leaderboard"),
+        automl_importance_path=automl_paths.get("automl_feature_importance"),
+        compute_budget_path=automl_paths.get("compute_budget_used"),
+    )
+
+
+def _emit_partial_manifest(
+    cfg: PipelineConfig,
+    gate: LineageGateResult,
+    *,
+    pool_size: int,
+    automl_result: AutoMLResult | None,
+    automl_skip_reason: str,
+    automl_paths: dict[str, Path],
+) -> None:
+    """Write a manifest reflecting the partial run before re-raising.
+
+    Used when a guard fires after the lineage gate but before the
+    AutoML artefacts land — gives downstream tooling something to
+    inspect even on the failure path.
+    """
+    cfg.step4_dir.mkdir(parents=True, exist_ok=True)
+    stub_summary_path = cfg.step4_dir / "stub_summary.md"
+    write_text(
+        stub_summary_path,
+        _stub_summary_md(
+            cfg, gate, pool_size=pool_size,
+            automl_result=automl_result,
+            automl_skip_reason=automl_skip_reason,
+        ),
+    )
+    artefact_paths: dict[str, Path] = {"stub_summary": stub_summary_path, **automl_paths}
+    manifest_path = cfg.step4_dir / str(cfg.raw_config["output"]["artefacts"]["step4_manifest"])
+    write_manifest(
+        manifest_path,
+        arc_name=cfg.arc_name,
+        step="step_4/heavy_ml",
+        artefact_paths=artefact_paths,
+        extras={
+            "heavy_ml_probe_version": HEAVY_ML_VERSION,
+            "cluster_id": int(cfg.cluster_id),
+            "pool_path": cfg.pool_path.as_posix(),
+            "pool_size": int(pool_size),
+            **_gate_extras_for_manifest(gate),
+            **_automl_extras_for_manifest(automl_result, automl_skip_reason),
+        },
     )
 
 
 def stable_payload_sha256(manifest_path: Path) -> str:
     """SHA256 of the manifest with the ``created_at`` field zeroed out.
 
-    Useful for two-run determinism tests where everything except the
-    timestamp must match byte-for-byte. Reads the manifest, replaces
-    ``created_at`` with a fixed sentinel, re-serialises, hashes.
+    Intentional public API for downstream determinism verification per
+    PR-A flag-3 disposition. Two consecutive ``run_pipeline`` calls on
+    identical inputs produce manifests whose ``stable_payload_sha256``
+    values match — the only varying field is ``created_at``, which is
+    excluded here.
     """
     payload = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
     payload["created_at"] = "<determinism-test-sentinel>"
@@ -314,6 +589,7 @@ def stable_payload_sha256(manifest_path: Path) -> str:
 
 
 __all__ = (
+    "AUTOML_REQUIRED_COLUMNS",
     "PipelineConfig",
     "PipelineResult",
     "load_config",

--- a/core/heavy_ml_probe/pipeline.py
+++ b/core/heavy_ml_probe/pipeline.py
@@ -77,6 +77,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
+import numpy as np
 import pandas as pd
 import yaml
 
@@ -85,7 +86,6 @@ from core.heavy_ml_probe.automl import (
     AllFeaturesRejected,
     AutoMLResult,
     HoldoutGuardViolation,
-    compute_budget_markdown,
     importance_to_dataframe,
     leaderboard_to_dataframe,
     run_automl,
@@ -200,8 +200,12 @@ class PipelineResult:
     survival_skip_reason: str = "ok"
     survival_results_path: Path | None = None
     survival_classifier_manifest_path: Path | None = None
-    # Reserved for PR-E — empty in PR-D.
+    # PR-E fields
     step5_manifest_path: Path | None = None
+    overall_status: str = "all_ok"  # "all_ok" | "all_skipped" | "partial"
+    # Note: `compute_budget_path` (PR-B field above) is now the aggregate
+    # compute_budget_used.md written at pipeline end covering all 3
+    # stages — PR-E moved the writer out of `_run_automl_stage`.
 
 
 def load_config(
@@ -345,7 +349,6 @@ def _run_automl_stage(
     art_cfg = cfg.raw_config["output"]["artefacts"]
     lb_path = cfg.step4_dir / str(art_cfg["automl_leaderboard"])
     imp_path = cfg.step4_dir / str(art_cfg["automl_feature_importance"])
-    budget_path = cfg.step4_dir / str(art_cfg["compute_budget_used"])
 
     write_csv(
         lb_path,
@@ -357,13 +360,10 @@ def _run_automl_stage(
         importance_to_dataframe(result),
         sort_by=["feature"],
     )
-    write_text(
-        budget_path,
-        compute_budget_markdown(result, train_end=cfg.train_end),
-    )
     paths["automl_leaderboard"] = lb_path
     paths["automl_feature_importance"] = imp_path
-    paths["compute_budget_used"] = budget_path
+    # ``compute_budget_used.md`` is now written at pipeline end (PR-E)
+    # to aggregate all three stages — see :func:`_write_aggregate_budget`.
     return result, "ok", paths
 
 
@@ -778,6 +778,286 @@ def _meta_label_extras_for_manifest(
     }
 
 
+# ── PR-E: aggregate compute-budget renderer ─────────────────────────
+
+
+def _compute_budget_aggregate_markdown(
+    cfg: PipelineConfig,
+    automl_result: AutoMLResult | None,
+    automl_skip_reason: str,
+    meta_label_result: MetaLabelResult | None,
+    meta_label_skip_reason: str,
+    survival_result: SurvivalResult | None,
+    survival_skip_reason: str,
+) -> str:
+    """Render the cross-stage compute-budget artefact.
+
+    Stable formatting (no timestamps, no wall-clock per
+    :func:`core.heavy_ml_probe.automl.compute_budget_markdown`'s
+    determinism convention).
+    """
+    lines: list[str] = []
+    lines.append("# heavy_ml_probe — compute budget used (all stages)")
+    lines.append("")
+    lines.append(f"- Arc: `{cfg.arc_name}`")
+    lines.append(f"- Cluster ID: `{cfg.cluster_id}`")
+    lines.append(
+        f"- Holdout cutoff (`train_end`): "
+        f"**{cfg.train_end.strftime('%Y-%m-%dT%H:%M:%SZ')}**"
+    )
+    lines.append("")
+
+    # ── AutoML ───────────────────────────────────────────────────────
+    lines.append("## AutoML stage (PR-B)")
+    lines.append("")
+    if automl_result is None:
+        lines.append(f"- Status: **{automl_skip_reason}** (skipped)")
+    else:
+        ar = automl_result
+        lines.append("- Status: **ok**")
+        lines.append(f"- FLAML version: `{ar.flaml_version}`")
+        lines.append(
+            f"- Folds total: **{ar.n_folds_total}** (valid AUC: **{ar.n_folds_valid}**)"
+        )
+        auc_m = "NaN" if not np.isfinite(ar.auc_mean) else f"{ar.auc_mean:.4f}"
+        auc_s = "NaN" if not np.isfinite(ar.auc_std) else f"{ar.auc_std:.4f}"
+        lines.append(f"- AUC (nanmean ± nanstd): **{auc_m} ± {auc_s}**")
+        if ar.n_folds_total > 0:
+            max_iter = ar.fold_results[0].max_iter
+            cap = max_iter * ar.n_folds_total
+            ratio = (
+                float(ar.total_modelcount) / float(cap) if cap > 0 else float("nan")
+            )
+            lines.append(f"- `max_iter_per_fold`: **{max_iter}**")
+            lines.append(f"- Cap (max_iter × n_folds): **{cap}**")
+            lines.append(f"- Total modelcount: **{ar.total_modelcount}**")
+            lines.append(f"- Consumption ratio (actual/cap): **{ratio:.4f}**")
+    lines.append("")
+
+    # ── Meta-labeling ────────────────────────────────────────────────
+    lines.append("## Meta-labeling stage (PR-C)")
+    lines.append("")
+    if meta_label_result is None:
+        lines.append(f"- Status: **{meta_label_skip_reason}** (skipped)")
+    else:
+        mr = meta_label_result
+        mr_ar = mr.automl_result
+        lines.append("- Status: **ok**")
+        lines.append(
+            f"- Target positive rate: **{mr.positive_rate:.4f}** "
+            f"({mr.target_distribution.get(1, 0)} of {mr.n_total})"
+        )
+        auc_m = "NaN" if not np.isfinite(mr_ar.auc_mean) else f"{mr_ar.auc_mean:.4f}"
+        auc_s = "NaN" if not np.isfinite(mr_ar.auc_std) else f"{mr_ar.auc_std:.4f}"
+        lines.append(
+            f"- Meta-label AUC (nanmean ± nanstd): **{auc_m} ± {auc_s}** "
+            f"(across {mr_ar.n_folds_valid}/{mr_ar.n_folds_total} folds)"
+        )
+        lines.append(f"- Total modelcount: **{mr_ar.total_modelcount}**")
+        lines.append(f"- Threshold sweep rows: **{len(mr.threshold_sweep)}**")
+    lines.append("")
+
+    # ── Survival ─────────────────────────────────────────────────────
+    lines.append("## Survival stage (PR-D — Cox PH via statsmodels.PHReg)")
+    lines.append("")
+    if survival_result is None:
+        lines.append(f"- Status: **{survival_skip_reason}** (skipped)")
+    else:
+        sr = survival_result
+        lines.append("- Status: **ok**")
+        lines.append(f"- statsmodels version: `{sr.statsmodels_version}`")
+        lines.append(
+            f"- Folds total: **{sr.n_folds_total}** "
+            f"(valid concordance: **{sr.n_folds_valid}**)"
+        )
+        c_m = "NaN" if not np.isfinite(sr.concordance_mean) else f"{sr.concordance_mean:.4f}"
+        c_s = "NaN" if not np.isfinite(sr.concordance_std) else f"{sr.concordance_std:.4f}"
+        lines.append(f"- Concordance (nanmean ± nanstd): **{c_m} ± {c_s}**")
+        lines.append(f"- Total events across training slices: **{sr.total_n_events}**")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ── PR-E: Step 5 augmentation manifest emission ─────────────────────
+
+
+def _stage_status(result, skip_reason: str) -> str:
+    """Map a per-stage (result, skip_reason) pair to the Step 5
+    manifest's `status` taxonomy.
+
+    Uses string literals (not the adapters module's enums) because
+    pipeline.py shouldn't import from adapters — circular dep risk
+    when PR-E adapters consume the manifest pipeline emits.
+    """
+    if result is not None:
+        return "ok"
+    if skip_reason in ("ok", ""):
+        return "ok"
+    # Treat all skip reasons as 'skipped' — they document why the stage
+    # didn't run but don't represent a runtime failure. Real failures
+    # would have raised before reaching this code path.
+    return "skipped"
+
+
+def _emit_step5_manifest(
+    cfg: PipelineConfig,
+    gate: LineageGateResult,
+    automl_result: AutoMLResult | None,
+    automl_skip_reason: str,
+    meta_label_result: MetaLabelResult | None,
+    meta_label_skip_reason: str,
+    survival_result: SurvivalResult | None,
+    survival_skip_reason: str,
+) -> Path:
+    """Write ``step_5/heavy_ml_augmented/heavy_ml_manifest.json``.
+
+    Locked schema:
+
+      .. code-block:: json
+
+        {
+          "schema_version": "1.0",
+          "sub_protocol": "heavy_ml_probe",
+          "arc_name": "...",
+          "cluster_id": 0,
+          "step4_dir": "<relative>",
+          "used_features": ["..."],
+          "stages": {
+            "automl": {"status": "ok|skipped", "skip_reason": "...",
+                       "classifier_manifest_path": null},
+            "meta_label": {"status": "...", "skip_reason": "...",
+                           "classifier_manifest_path": "classifiers/meta_label/manifest.json"},
+            "survival": {"status": "...", "skip_reason": "...",
+                         "classifier_manifest_path": "classifiers/survival/manifest.json"}
+          },
+          "adapters": {
+            "a2_buildable": bool,    # requires meta_label.status == ok
+            "a4_buildable": bool,    # requires survival.status == ok
+            "a6_buildable": bool     # requires meta_label.status == ok
+          },
+          "schema_doc": "<reference>"
+        }
+
+    Path stored in :attr:`PipelineResult.step5_manifest_path`. Read by
+    :func:`core.heavy_ml_probe.adapters.build_a2_from_heavy_ml` and
+    siblings.
+
+    Determinism: no ``generated_at`` timestamp (mirrors PR-C's
+    classifier-manifest convention — top-level Step 4 manifest carries
+    ``created_at``; sidecars don't duplicate).
+    """
+    import os
+
+    from core.heavy_ml_probe.adapters import STEP5_MANIFEST_SCHEMA_VERSION
+
+    step5_dir = cfg.step5_dir
+    step5_dir.mkdir(parents=True, exist_ok=True)
+    # step4_dir relative to output_root for display only — both dirs
+    # are guaranteed descendants of output_root.
+    step4_rel = os.path.relpath(
+        cfg.step4_dir.resolve(), start=cfg.output_root.resolve()
+    ).replace("\\", "/")
+
+    # Per-stage classifier manifest paths recorded RELATIVE to this
+    # Step 5 manifest's location. Step 4 and Step 5 dirs are siblings
+    # under output_root, so the relative path includes ``..`` segments;
+    # ``os.path.relpath`` handles that cleanly (``Path.relative_to``
+    # requires descendant-only).
+    def _rel_classifier_manifest(result, sub_subdir: str) -> str | None:
+        if result is None or getattr(result, "classifier_manifest_path", None) is None:
+            return None
+        abs_path = Path(result.classifier_manifest_path).resolve()
+        return os.path.relpath(abs_path, start=step5_dir.resolve()).replace("\\", "/")
+
+    meta_label_clf_rel = _rel_classifier_manifest(meta_label_result, "meta_label")
+    survival_clf_rel = _rel_classifier_manifest(survival_result, "survival")
+
+    automl_status = _stage_status(automl_result, automl_skip_reason)
+    meta_label_status = _stage_status(meta_label_result, meta_label_skip_reason)
+    survival_status = _stage_status(survival_result, survival_skip_reason)
+
+    payload = {
+        "schema_version": STEP5_MANIFEST_SCHEMA_VERSION,
+        "sub_protocol": "heavy_ml_probe",
+        "arc_name": str(cfg.arc_name),
+        "cluster_id": int(cfg.cluster_id),
+        "step4_dir": step4_rel,
+        "used_features": list(gate.accepted_features),
+        "stages": {
+            "automl": {
+                "status": automl_status,
+                "skip_reason": str(automl_skip_reason),
+                # AutoML doesn't persist a classifier directory yet (PR-B
+                # writes only leaderboard + importance + budget). The
+                # field stays in the schema so PR-E's adapters can grow
+                # an AutoML-direct path later; for now adapters source
+                # FLAML output via the meta_label classifier manifest.
+                "classifier_manifest_path": None,
+            },
+            "meta_label": {
+                "status": meta_label_status,
+                "skip_reason": str(meta_label_skip_reason),
+                "classifier_manifest_path": meta_label_clf_rel,
+            },
+            "survival": {
+                "status": survival_status,
+                "skip_reason": str(survival_skip_reason),
+                "classifier_manifest_path": survival_clf_rel,
+            },
+        },
+        "adapters": {
+            "a2_buildable": bool(meta_label_status == "ok"),
+            "a4_buildable": bool(survival_status == "ok"),
+            "a6_buildable": bool(meta_label_status == "ok"),
+        },
+        "schema_doc": (
+            "core.heavy_ml_probe.adapters.STEP5_MANIFEST_SCHEMA_VERSION; "
+            "consumed by build_a{2,4,6}_from_heavy_ml"
+        ),
+    }
+    manifest_path = step5_dir / "heavy_ml_manifest.json"
+    blob = json.dumps(payload, sort_keys=True, indent=2)
+    if not blob.endswith("\n"):
+        blob = blob + "\n"
+    manifest_path.write_bytes(blob.encode("utf-8"))
+    return manifest_path
+
+
+def _pipeline_overall_status(
+    automl_skip_reason: str,
+    meta_label_skip_reason: str,
+    survival_skip_reason: str,
+    automl_result: AutoMLResult | None,
+    meta_label_result: MetaLabelResult | None,
+    survival_result: SurvivalResult | None,
+) -> str:
+    """Map per-stage outcomes to the pipeline's overall status.
+
+    Returns one of:
+
+      * ``"all_ok"`` — every stage succeeded (result is not None).
+      * ``"all_skipped"`` — every stage cleanly skipped.
+      * ``"partial"`` — at least one stage succeeded AND at least one
+        stage was skipped or failed. Drives ``run_probe.py``'s exit
+        code 3 per dispatch §4.
+
+    Note: "failure" (uncaught exception) is handled at a higher level
+    by ``run_probe.py``'s ``try/except`` → exit code 1. This function
+    only sees the (result, skip_reason) tuples for stages that
+    completed without raising.
+    """
+    statuses = [
+        _stage_status(automl_result, automl_skip_reason),
+        _stage_status(meta_label_result, meta_label_skip_reason),
+        _stage_status(survival_result, survival_skip_reason),
+    ]
+    if all(s == "ok" for s in statuses):
+        return "all_ok"
+    if all(s == "skipped" for s in statuses):
+        return "all_skipped"
+    return "partial"
+
+
 def run_pipeline(
     cfg: PipelineConfig,
     *,
@@ -907,6 +1187,32 @@ def run_pipeline(
         )
         raise
 
+    # ── PR-E aggregate compute_budget_used.md (covers all 3 stages) ──
+    art_cfg = cfg.raw_config["output"]["artefacts"]
+    budget_path = cfg.step4_dir / str(art_cfg["compute_budget_used"])
+    write_text(
+        budget_path,
+        _compute_budget_aggregate_markdown(
+            cfg,
+            automl_result=automl_result,
+            automl_skip_reason=automl_skip_reason,
+            meta_label_result=meta_label_result,
+            meta_label_skip_reason=meta_label_skip_reason,
+            survival_result=survival_result,
+            survival_skip_reason=survival_skip_reason,
+        ),
+    )
+
+    # ── PR-E Step 5 manifest (downstream A2/A4/A6 adapter consumer) ─
+    step5_manifest_path = _emit_step5_manifest(
+        cfg, gate,
+        automl_result=automl_result, automl_skip_reason=automl_skip_reason,
+        meta_label_result=meta_label_result,
+        meta_label_skip_reason=meta_label_skip_reason,
+        survival_result=survival_result,
+        survival_skip_reason=survival_skip_reason,
+    )
+
     # ── Stub summary (PR-A artefact; PR-B/C/D extended content) ─────
     stub_summary_path = cfg.step4_dir / "stub_summary.md"
     write_text(
@@ -922,9 +1228,10 @@ def run_pipeline(
         ),
     )
 
-    # ── Manifest ─────────────────────────────────────────────────────
+    # ── Top-level Step 4 manifest ────────────────────────────────────
     artefact_paths: dict[str, Path] = {
         "stub_summary": stub_summary_path,
+        "compute_budget_used": budget_path,
         **automl_paths,
         **meta_label_paths,
         **survival_paths,
@@ -947,6 +1254,15 @@ def run_pipeline(
         },
     )
 
+    overall = _pipeline_overall_status(
+        automl_skip_reason=automl_skip_reason,
+        meta_label_skip_reason=meta_label_skip_reason,
+        survival_skip_reason=survival_skip_reason,
+        automl_result=automl_result,
+        meta_label_result=meta_label_result,
+        survival_result=survival_result,
+    )
+
     return PipelineResult(
         cfg=cfg,
         lineage_gate=gate,
@@ -956,7 +1272,7 @@ def run_pipeline(
         automl_skip_reason=automl_skip_reason,
         automl_leaderboard_path=automl_paths.get("automl_leaderboard"),
         automl_importance_path=automl_paths.get("automl_feature_importance"),
-        compute_budget_path=automl_paths.get("compute_budget_used"),
+        compute_budget_path=budget_path,
         meta_label_result=meta_label_result,
         meta_label_skip_reason=meta_label_skip_reason,
         meta_label_results_path=meta_label_paths.get("meta_label_results"),
@@ -965,6 +1281,8 @@ def run_pipeline(
         survival_skip_reason=survival_skip_reason,
         survival_results_path=survival_paths.get("survival_model_results"),
         survival_classifier_manifest_path=survival_paths.get("survival_classifier_manifest"),
+        step5_manifest_path=step5_manifest_path,
+        overall_status=overall,
     )
 
 

--- a/core/heavy_ml_probe/survival.py
+++ b/core/heavy_ml_probe/survival.py
@@ -1,0 +1,767 @@
+"""Cox PH survival modelling for heavy_ml_probe Step 4 (PR-D).
+
+Per ``docs/sub_protocols/heavy_ml_probe.md`` v1.0 §"Survival model
+variant for Pipeline D" (updated PR-D) + chat resolution Q1 + dispatch
+§3:
+
+  * **Target framing:** time-to-+1R-MFE censored at SL hit OR time-exit.
+  * **Event indicator:** ``1`` if trade reached +1R MFE before SL/time-exit;
+    ``0`` otherwise (censored).
+  * **Duration:** number of bars from entry to first of
+    ``{+1R MFE, SL hit, time-exit}``.
+  * **Same-bar tie-break:** if +1R MFE and SL hit fall on the same bar
+    (within OHLC), treat as SL-hit-first (event = 0, censored at that
+    bar). Identical tie-break to PR-C's ``build_meta_label_target`` —
+    same underlying event modelled differently.
+
+**Library swap from spec:** the original dispatch named `lifelines` for
+Cox PH; this module uses ``statsmodels.duration.hazard_regression.PHReg``
+instead because `lifelines` is blocked on Python 3.14 (transitive dep
+``ecos`` has no cp314 wheel). Modelling semantics are equivalent.
+
+**RSF (Random Survival Forest) deferred** per PR-B flag-1 disposition —
+scikit-survival is also blocked on Py 3.14. PR-D ships Cox PH only.
+
+**Concordance** is computed by :func:`core.heavy_ml_probe.metrics.concordance`
+(Harrell's C-index, from-scratch implementation per dispatch §4 fallback).
+
+**Pool schema** (PR-C compatible — meta-labeling and survival share the
+same +1R event + competing-risk definition):
+
+  * ``bars_to_1r_mfe`` (int, NaN if never reached)
+  * ``bars_held`` (int, total bars to close)
+  * ``exit_reason`` (str, ``"sl"`` triggers tie-break)
+  * ``entry_time`` (datetime, TimeSeriesSplit ordering)
+  * ``trade_id`` (int, OOF / persistence keying)
+
+Optional column ``final_r`` is NOT required by survival (unlike
+meta-labeling, which uses it for kept/dropped mean R).
+
+Module surface:
+
+  * ``build_survival_target(pool)`` → ``(duration, event)`` ndarrays
+    over the pool, vectorised.
+  * ``run_survival(pool, used_features, ...)`` → :class:`SurvivalResult`
+    with per-fold ``PHRegResults`` snapshots, concordance per fold,
+    aggregate, and persistence of all folds for PR-E's A4 adapter.
+  * ``persist_fold_models(...)`` writes
+    ``<classifiers_dir>/fold_NN.joblib`` plus a sidecar manifest with
+    sha256 + per-fold provenance (matches PR-C convention).
+
+Minimum-N discipline (dispatch §6): warn on n < 200, mark
+``convergence_warning=True`` in the per-fold output, never silently
+skip. Convergence failures (``ConvergenceWarning`` / ``LinAlgError``)
+are caught — fold concordance becomes ``NaN`` and the loop continues.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Sequence
+
+import joblib
+import numpy as np
+import pandas as pd
+
+from core.heavy_ml_probe.automl import (
+    DEFAULT_N_FOLDS,
+    DEFAULT_RANDOM_STATE,
+    AllFeaturesRejected,
+    _assert_holdout_guard,
+    _build_time_series_folds,
+    _coerce_entry_time,
+    _select_used_features,
+)
+from core.heavy_ml_probe.io import sha256_file
+from core.heavy_ml_probe.meta_labeling import (
+    SL_EXIT_REASON,
+    PoolSchemaError,
+)
+from core.heavy_ml_probe.metrics import concordance
+
+# Locked threshold per dispatch §3. Cox PH is unstable below this n.
+MIN_N_WARN: int = 200
+
+# Survival target consumes a subset of the meta-label schema (final_r
+# not required). Kept as a separate constant so future schema drift
+# can fork cleanly.
+SURVIVAL_REQUIRED_POOL_COLUMNS: tuple[str, ...] = (
+    "bars_to_1r_mfe",
+    "bars_held",
+    "exit_reason",
+)
+
+
+# ── Result types ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class SurvivalFoldResult:
+    """One fold of the Cox PH evaluation."""
+
+    fold: int                      # 1..n_folds
+    train_start: pd.Timestamp
+    train_end: pd.Timestamp
+    val_start: pd.Timestamp
+    val_end: pd.Timestamp
+    n_train: int
+    n_train_event: int             # event=1 count in training slice
+    n_train_censored: int          # event=0 count in training slice
+    n_val: int
+    n_val_event: int
+    n_val_censored: int
+    fit_succeeded: bool
+    convergence_warning: bool
+    concordance: float             # NaN if fit failed or no comparable pairs
+    coefficients: tuple[float, ...]  # one per used_feature; () if fit failed
+    log_likelihood: float          # NaN if fit failed
+    fit_message: str               # human-readable status / failure reason
+    fitted_results: Any | None = field(default=None, repr=False)  # PHRegResults; not pickled at result level
+
+
+@dataclass(frozen=True)
+class SurvivalResult:
+    """Aggregated Cox PH output across all folds."""
+
+    fold_results: tuple[SurvivalFoldResult, ...]
+    coefficients_long: pd.DataFrame   # (fold, feature, coef, p_value, std_err)
+    used_features: tuple[str, ...]
+    n_folds_total: int
+    n_folds_valid: int                # folds where concordance is finite
+    concordance_mean: float           # nanmean
+    concordance_std: float            # nanstd
+    total_n_events: int               # sum of event=1 across folds' training slices
+    statsmodels_version: str
+    skip_reason: str = "ok"
+    classifier_manifest_path: Path | None = None
+
+
+# ── Target construction ──────────────────────────────────────────────
+
+
+def _validate_pool_schema(pool: pd.DataFrame) -> None:
+    """HALT loud on missing columns. Mirrors PR-C convention."""
+    missing = [c for c in SURVIVAL_REQUIRED_POOL_COLUMNS if c not in pool.columns]
+    if missing:
+        raise PoolSchemaError(
+            f"survival target requires pool columns "
+            f"{sorted(SURVIVAL_REQUIRED_POOL_COLUMNS)}; "
+            f"missing: {sorted(missing)} — pool has: "
+            f"{sorted(pool.columns)[:20]}"
+            + ("..." if len(pool.columns) > 20 else "")
+        )
+
+
+def build_survival_target(
+    pool: pd.DataFrame,
+    *,
+    sl_exit_reason: str = SL_EXIT_REASON,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Construct ``(duration, event)`` for Cox PH.
+
+    Per dispatch §3:
+
+      * ``event[i] = 1`` if trade ``i`` reached +1R MFE strictly before
+        SL hit or time-exit (i.e. it's a real event).
+      * ``event[i] = 0`` otherwise (censored at the close bar).
+      * ``duration[i]`` = bars to first of ``{+1R MFE, SL hit, time-exit}``.
+
+    Same-bar tie-break (mirrors PR-C ``build_meta_label_target``):
+
+      * ``bars_to_1r_mfe is NaN`` → event=0, duration=bars_held
+      * ``bars_to_1r_mfe <  bars_held`` → event=1, duration=bars_to_1r_mfe
+      * ``bars_to_1r_mfe == bars_held``:
+            ``exit_reason == "sl"`` → event=0 (SL wins same-bar tie),
+                duration=bars_held
+            otherwise              → event=1 (reached +1R same bar as
+                non-adverse close), duration=bars_to_1r_mfe
+      * ``bars_to_1r_mfe >  bars_held`` → event=0 (defensive; shouldn't
+        happen on consistent data), duration=bars_held
+
+    Returns
+    -------
+    duration : np.ndarray[int] of shape (len(pool),)
+        Time-to-first-event in bars. Always positive.
+    event : np.ndarray[int] of shape (len(pool),)
+        Binary event indicator.
+
+    Raises
+    ------
+    PoolSchemaError
+        If any required column is missing.
+    ValueError
+        If ``bars_held`` has NaN values (data integrity guard).
+    """
+    _validate_pool_schema(pool)
+    bars_to_1r = pool["bars_to_1r_mfe"]
+    bars_held = pool["bars_held"]
+    exit_reason = pool["exit_reason"].astype(str).str.lower()
+
+    if bars_held.isna().any():
+        raise ValueError(
+            "survival target: bars_held column has NaN values; "
+            "every closed trade must have a known duration."
+        )
+
+    n = len(pool)
+    event = np.zeros(n, dtype=int)
+    duration = np.zeros(n, dtype=int)
+    sl_lower = sl_exit_reason.lower()
+
+    reached = bars_to_1r.notna().values
+    b1r = bars_to_1r.values
+    bh = bars_held.values
+    er = exit_reason.values
+
+    for i in range(n):
+        held_i = int(bh[i])
+        if not reached[i]:
+            event[i] = 0
+            duration[i] = held_i
+            continue
+        first_r = float(b1r[i])
+        if first_r < held_i:
+            event[i] = 1
+            duration[i] = int(first_r)
+        elif first_r == held_i:
+            if er[i] == sl_lower:
+                event[i] = 0      # SL-wins tie-break
+                duration[i] = held_i
+            else:
+                event[i] = 1      # +1R on same bar as non-adverse close
+                duration[i] = held_i
+        else:
+            # Defensive — shouldn't happen on consistent pool data.
+            event[i] = 0
+            duration[i] = held_i
+
+    # Cox PH requires duration > 0 — clip any 0-duration entries to 1
+    # (trades that closed on bar 0 are degenerate; clipping preserves
+    # them in the dataset without breaking the fit).
+    duration = np.maximum(duration, 1)
+    return duration, event
+
+
+# ── Internal: PHReg fit + concordance ─────────────────────────────────
+
+
+def _statsmodels_version() -> str:
+    try:
+        import statsmodels  # type: ignore
+
+        return str(statsmodels.__version__)
+    except ImportError:
+        return ""
+
+
+def _safe_phreg_fit(
+    *,
+    X: np.ndarray,
+    duration: np.ndarray,
+    event: np.ndarray,
+) -> tuple[Any | None, bool, str]:
+    """Fit PHReg with full error trapping.
+
+    Returns ``(results_or_none, convergence_warning, message)``.
+
+      * On success: ``(results, False, "ok")``.
+      * On ConvergenceWarning raised but fit returned: ``(results, True, "converged_with_warning")``.
+      * On exception: ``(None, True, f"{ExcType}: {msg}")``.
+    """
+    from statsmodels.duration.hazard_regression import PHReg
+    from statsmodels.tools.sm_exceptions import ConvergenceWarning
+
+    try:
+        model = PHReg(endog=duration, status=event, exog=X)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", ConvergenceWarning)
+            results = model.fit(disp=0)
+        warned = any(
+            issubclass(w.category, ConvergenceWarning) for w in caught
+        )
+        return results, bool(warned), ("converged_with_warning" if warned else "ok")
+    except Exception as exc:
+        return None, True, f"{type(exc).__name__}: {exc}"
+
+
+def _predicted_risk(results: Any, X: np.ndarray) -> np.ndarray:
+    """Per-trade hazard ratio ``exp(X @ params)``.
+
+    Used as the ranking score for concordance. Higher → faster expected
+    event → should rank with smaller duration. Computed manually (not
+    via ``results.predict(pred_type='hr')``) so we don't depend on
+    statsmodels' predict-bunch shape staying stable across versions —
+    and so we can return a plain ndarray regardless of how PHReg
+    structures its prediction return.
+    """
+    lp = X @ np.asarray(results.params, dtype=float)
+    return np.exp(lp)
+
+
+def _extract_baseline_cumulative_hazard(results: Any) -> dict[str, list[float]]:
+    """Extract the baseline cumulative hazard in a stable shape.
+
+    statsmodels' ``results.baseline_cumulative_hazard`` is a list of
+    strata, each stratum being ``[unique_times, cumhaz, survival]``.
+    For single-stratum models (default) we have one entry. Returned as
+    a plain Python dict for joblib portability (no ndarray dtype
+    surprises across runs):
+
+        {
+          "stratum": <int>,
+          "times": [...],
+          "cumulative_hazard": [...],
+          "survival_function": [...],
+        }
+
+    For multi-stratum models (rare in our use case) only the first
+    stratum is returned with a warning. PR-D's invocation does not
+    stratify, so this branch never fires in production.
+    """
+    bch = results.baseline_cumulative_hazard
+    if not isinstance(bch, list) or len(bch) == 0:
+        return {
+            "stratum": 0,
+            "times": [],
+            "cumulative_hazard": [],
+            "survival_function": [],
+        }
+    if len(bch) > 1:
+        warnings.warn(
+            f"PHReg returned {len(bch)} strata; persisting first only. "
+            "heavy_ml_probe does not stratify Cox PH by default.",
+            UserWarning,
+            stacklevel=3,
+        )
+    stratum = bch[0]
+    if not isinstance(stratum, (list, tuple)) or len(stratum) < 3:
+        return {
+            "stratum": 0,
+            "times": [],
+            "cumulative_hazard": [],
+            "survival_function": [],
+        }
+    times, cumhaz, surv = stratum[0], stratum[1], stratum[2]
+    return {
+        "stratum": 0,
+        "times": [float(t) for t in times],
+        "cumulative_hazard": [float(h) for h in cumhaz],
+        "survival_function": [float(s) for s in surv],
+    }
+
+
+# ── Per-fold runner ──────────────────────────────────────────────────
+
+
+def _run_one_fold(
+    *,
+    fold_idx: int,
+    pool_sorted: pd.DataFrame,
+    used_features: Sequence[str],
+    duration_all: np.ndarray,
+    event_all: np.ndarray,
+    train_s: int,
+    train_e: int,
+    val_s: int,
+    val_e: int,
+    times: pd.Series,
+    keep_model: bool,
+) -> SurvivalFoldResult:
+    X = pool_sorted[list(used_features)].values
+    X_train, X_val = X[train_s:train_e], X[val_s:val_e]
+    d_train, d_val = duration_all[train_s:train_e], duration_all[val_s:val_e]
+    e_train, e_val = event_all[train_s:train_e], event_all[val_s:val_e]
+
+    n_train = int(len(d_train))
+    n_train_event = int((e_train == 1).sum())
+    n_train_censored = int((e_train == 0).sum())
+    n_val = int(len(d_val))
+    n_val_event = int((e_val == 1).sum())
+    n_val_censored = int((e_val == 0).sum())
+
+    # Cox PH fit requires at least one event in the training slice.
+    if n_train_event == 0:
+        return SurvivalFoldResult(
+            fold=fold_idx,
+            train_start=times.iloc[train_s], train_end=times.iloc[train_e - 1],
+            val_start=times.iloc[val_s], val_end=times.iloc[val_e - 1],
+            n_train=n_train, n_train_event=n_train_event,
+            n_train_censored=n_train_censored,
+            n_val=n_val, n_val_event=n_val_event, n_val_censored=n_val_censored,
+            fit_succeeded=False, convergence_warning=True,
+            concordance=float("nan"),
+            coefficients=(),
+            log_likelihood=float("nan"),
+            fit_message="skipped:no_events_in_training_slice",
+            fitted_results=None,
+        )
+    if n_train < MIN_N_WARN:
+        warnings.warn(
+            f"survival fold {fold_idx}: n_train={n_train} < MIN_N_WARN="
+            f"{MIN_N_WARN}; Cox PH coefficients may be unstable. "
+            f"convergence_warning flagged on output row.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    results, conv_warning, msg = _safe_phreg_fit(
+        X=X_train, duration=d_train, event=e_train,
+    )
+    if results is None:
+        # Convergence failure → NaN concordance + propagate the loop.
+        return SurvivalFoldResult(
+            fold=fold_idx,
+            train_start=times.iloc[train_s], train_end=times.iloc[train_e - 1],
+            val_start=times.iloc[val_s], val_end=times.iloc[val_e - 1],
+            n_train=n_train, n_train_event=n_train_event,
+            n_train_censored=n_train_censored,
+            n_val=n_val, n_val_event=n_val_event, n_val_censored=n_val_censored,
+            fit_succeeded=False, convergence_warning=True,
+            concordance=float("nan"),
+            coefficients=(),
+            log_likelihood=float("nan"),
+            fit_message=msg,
+            fitted_results=None,
+        )
+
+    # Minimum-N flag is OR-ed with statsmodels' own convergence warning.
+    convergence_warning = bool(conv_warning or n_train < MIN_N_WARN)
+
+    # Concordance on the validation slice
+    val_risk = _predicted_risk(results, X_val)
+    try:
+        c_idx = concordance(e_val, d_val, val_risk)
+    except Exception as exc:  # defensive
+        warnings.warn(
+            f"survival fold {fold_idx}: concordance computation raised "
+            f"{type(exc).__name__}({exc}); concordance set to NaN",
+            UserWarning, stacklevel=2,
+        )
+        c_idx = float("nan")
+
+    coefs = tuple(float(c) for c in np.asarray(results.params, dtype=float).tolist())
+    try:
+        ll = float(results.llf)
+    except Exception:
+        ll = float("nan")
+
+    return SurvivalFoldResult(
+        fold=fold_idx,
+        train_start=times.iloc[train_s], train_end=times.iloc[train_e - 1],
+        val_start=times.iloc[val_s], val_end=times.iloc[val_e - 1],
+        n_train=n_train, n_train_event=n_train_event,
+        n_train_censored=n_train_censored,
+        n_val=n_val, n_val_event=n_val_event, n_val_censored=n_val_censored,
+        fit_succeeded=True, convergence_warning=convergence_warning,
+        concordance=float(c_idx),
+        coefficients=coefs,
+        log_likelihood=ll,
+        fit_message=msg,
+        fitted_results=(results if keep_model else None),
+    )
+
+
+# ── Persistence ──────────────────────────────────────────────────────
+
+
+def persist_fold_models(
+    result: SurvivalResult,
+    classifiers_dir: Path,
+    *,
+    arc_name: str,
+    cluster_id: int,
+) -> Path:
+    """Persist each fold's ``PHRegResults`` + extracted baseline-hazard
+    metadata, plus a sidecar manifest with sha256 + provenance.
+
+    Per dispatch §7: ``classifiers/survival/fold_{NN}.joblib``. Each
+    pickle is a dict ``{results, baseline_hazard, used_features,
+    coefficients}`` so PR-E's A4 adapter has everything it needs to
+    compute ``P(reach +1R in next K bars | survived to N)`` without
+    re-fitting.
+
+    No ``generated_at`` timestamp on the sidecar manifest — same
+    convention as PR-C ``meta_labeling.persist_fold_classifiers`` (the
+    top-level Step-4 manifest carries ``created_at``). Manifest:
+
+        {
+          "arc_name": "<arc>",
+          "cluster_id": <int>,
+          "sub_protocol": "heavy_ml_probe",
+          "stage": "survival",
+          "joblib_version": "<x.y.z>",
+          "statsmodels_version": "<x.y.z>",
+          "n_folds_persisted": <int>,
+          "folds": [
+            {
+              "fold_id": <int>,
+              "path": "<filename.joblib>" | null,
+              "sha256": "<hex>" | null,
+              "n_train": <int>,
+              "n_train_event": <int>,
+              "n_train_censored": <int>,
+              "concordance": <float | null>,
+              "convergence_warning": <bool>,
+              "fit_succeeded": <bool>,
+              "fit_message": "<str>"
+            },
+            ...
+          ]
+        }
+    """
+    classifiers_dir = Path(classifiers_dir)
+    classifiers_dir.mkdir(parents=True, exist_ok=True)
+
+    folds: list[dict] = []
+    for fr in result.fold_results:
+        entry: dict = {
+            "fold_id": int(fr.fold),
+            "n_train": int(fr.n_train),
+            "n_train_event": int(fr.n_train_event),
+            "n_train_censored": int(fr.n_train_censored),
+            "concordance": (
+                float(fr.concordance) if np.isfinite(fr.concordance) else None
+            ),
+            "convergence_warning": bool(fr.convergence_warning),
+            "fit_succeeded": bool(fr.fit_succeeded),
+            "fit_message": str(fr.fit_message),
+        }
+        if not fr.fit_succeeded or fr.fitted_results is None:
+            entry["path"] = None
+            entry["sha256"] = None
+        else:
+            fname = f"fold_{int(fr.fold):02d}.joblib"
+            fpath = classifiers_dir / fname
+            payload = {
+                "results": fr.fitted_results,
+                "baseline_hazard": _extract_baseline_cumulative_hazard(fr.fitted_results),
+                "used_features": list(result.used_features),
+                "coefficients": list(fr.coefficients),
+            }
+            joblib.dump(payload, fpath, compress=3)
+            entry["path"] = fname
+            entry["sha256"] = sha256_file(fpath)
+        folds.append(entry)
+
+    manifest_payload = {
+        "arc_name": str(arc_name),
+        "cluster_id": int(cluster_id),
+        "sub_protocol": "heavy_ml_probe",
+        "stage": "survival",
+        "joblib_version": str(joblib.__version__),
+        "statsmodels_version": _statsmodels_version(),
+        "n_folds_persisted": int(sum(1 for f in folds if f["path"] is not None)),
+        "folds": folds,
+    }
+    manifest_path = classifiers_dir / "manifest.json"
+    import json
+    blob = json.dumps(manifest_payload, sort_keys=True, indent=2)
+    if not blob.endswith("\n"):
+        blob = blob + "\n"
+    manifest_path.write_bytes(blob.encode("utf-8"))
+    return manifest_path
+
+
+# ── Top-level orchestrator ───────────────────────────────────────────
+
+
+def run_survival(
+    pool: pd.DataFrame,
+    used_features: Sequence[str],
+    *,
+    train_end: pd.Timestamp,
+    arc_name: str,
+    cluster_id: int,
+    classifiers_dir: Path,
+    n_folds: int = DEFAULT_N_FOLDS,
+    seed: int = DEFAULT_RANDOM_STATE,  # noqa: ARG001 — Cox PH is deterministic; seed kept for signature parity
+    entry_time_col: str = "entry_time",
+    trade_id_col: str = "trade_id",
+) -> SurvivalResult:
+    """Run heavy_ml_probe Cox PH survival across an 11-fold TimeSeriesSplit.
+
+    Sequence:
+
+      1. Validate pool schema (HALT loud on missing columns).
+      2. Apply holdout guard via :func:`core.heavy_ml_probe.automl._assert_holdout_guard`.
+      3. Sort pool by ``entry_time`` for causal TimeSeriesSplit indexing.
+      4. Construct ``(duration, event)`` via :func:`build_survival_target`.
+      5. Iterate folds via :func:`_run_one_fold`; trap ConvergenceWarning
+         + LinAlgError; never silently skip.
+      6. Persist all folds via :func:`persist_fold_models`.
+
+    Raises
+    ------
+    PoolSchemaError
+        If pool lacks any column in :data:`SURVIVAL_REQUIRED_POOL_COLUMNS`
+        (HALT-loud per dispatch §9 #7).
+    HoldoutGuardViolation
+        If pool's max ``entry_time`` >= ``train_end``.
+    AllFeaturesRejected
+        If ``used_features`` is empty.
+    ValueError
+        If required columns missing or fold construction degenerate.
+    """
+    if not used_features:
+        raise AllFeaturesRejected(
+            "lineage gate rejected every feature — cannot fit Cox PH on an "
+            "empty design matrix"
+        )
+    _validate_pool_schema(pool)
+    if trade_id_col not in pool.columns:
+        raise PoolSchemaError(
+            f"survival requires {trade_id_col!r} column for fold-result "
+            f"persistence keying"
+        )
+    _assert_holdout_guard(pool, train_end, entry_time_col=entry_time_col)
+
+    # Sort by entry_time for causal indexing
+    times_all = _coerce_entry_time(pool, entry_time_col)
+    pool_sorted = (
+        pool.assign(_entry_ts=times_all)
+        .sort_values(["_entry_ts"], kind="mergesort")
+        .drop(columns=["_entry_ts"])
+        .reset_index(drop=True)
+    )
+    times = _coerce_entry_time(pool_sorted, entry_time_col).reset_index(drop=True)
+
+    used_features = tuple(used_features)
+    _ = _select_used_features(pool_sorted, used_features)
+
+    duration, event = build_survival_target(pool_sorted)
+    folds = _build_time_series_folds(pool_sorted, n_folds, entry_time_col)
+    if not folds:
+        raise ValueError(
+            f"TimeSeriesSplit with n_folds={n_folds} produced no folds on "
+            f"pool of size {len(pool_sorted)}; pool too small"
+        )
+
+    fold_results: list[SurvivalFoldResult] = []
+    coef_rows: list[dict] = []
+    for fold_idx, (train_s, train_e, val_s, val_e) in enumerate(folds, start=1):
+        fr = _run_one_fold(
+            fold_idx=fold_idx,
+            pool_sorted=pool_sorted,
+            used_features=used_features,
+            duration_all=duration,
+            event_all=event,
+            train_s=train_s, train_e=train_e,
+            val_s=val_s, val_e=val_e,
+            times=times,
+            keep_model=True,
+        )
+        fold_results.append(fr)
+
+        # Long-form coefficients for the CSV. Per-feature columns: coef,
+        # p_value, std_err. Pull from results object directly when fit
+        # succeeded; emit NaN rows otherwise so every feature appears
+        # for every fold (sparse-row-less CSV).
+        if fr.fit_succeeded and fr.fitted_results is not None:
+            try:
+                pvals = np.asarray(fr.fitted_results.pvalues, dtype=float)
+            except Exception:
+                pvals = np.full(len(used_features), np.nan)
+            try:
+                bse = np.asarray(fr.fitted_results.bse, dtype=float)
+            except Exception:
+                bse = np.full(len(used_features), np.nan)
+            for j, feat in enumerate(used_features):
+                coef_rows.append({
+                    "fold": fr.fold,
+                    "feature": feat,
+                    "coefficient": float(fr.coefficients[j]),
+                    "p_value": float(pvals[j]) if np.isfinite(pvals[j]) else float("nan"),
+                    "std_err": float(bse[j]) if np.isfinite(bse[j]) else float("nan"),
+                    "concordance": float(fr.concordance) if np.isfinite(fr.concordance) else float("nan"),
+                    "n_train": int(fr.n_train),
+                    "n_train_event": int(fr.n_train_event),
+                    "convergence_warning": bool(fr.convergence_warning),
+                })
+        else:
+            for feat in used_features:
+                coef_rows.append({
+                    "fold": fr.fold,
+                    "feature": feat,
+                    "coefficient": float("nan"),
+                    "p_value": float("nan"),
+                    "std_err": float("nan"),
+                    "concordance": float("nan"),
+                    "n_train": int(fr.n_train),
+                    "n_train_event": int(fr.n_train_event),
+                    "convergence_warning": True,
+                })
+
+    coefficients_long = pd.DataFrame(coef_rows)
+    if not coefficients_long.empty:
+        coefficients_long = coefficients_long.sort_values(
+            ["fold", "feature"], kind="mergesort"
+        ).reset_index(drop=True)
+
+    c_vals = np.array([fr.concordance for fr in fold_results], dtype=float)
+    n_valid = int(np.isfinite(c_vals).sum())
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # nanmean-of-all-nan RuntimeWarning
+        c_mean = float(np.nanmean(c_vals)) if n_valid > 0 else float("nan")
+        c_std = float(np.nanstd(c_vals, ddof=0)) if n_valid > 0 else float("nan")
+
+    result = SurvivalResult(
+        fold_results=tuple(fold_results),
+        coefficients_long=coefficients_long,
+        used_features=tuple(used_features),
+        n_folds_total=len(fold_results),
+        n_folds_valid=n_valid,
+        concordance_mean=c_mean,
+        concordance_std=c_std,
+        total_n_events=int(sum(fr.n_train_event for fr in fold_results)),
+        statsmodels_version=_statsmodels_version(),
+        skip_reason="ok",
+    )
+
+    # Persist all folds + sidecar manifest
+    manifest_path = persist_fold_models(
+        result, Path(classifiers_dir),
+        arc_name=arc_name, cluster_id=cluster_id,
+    )
+    return SurvivalResult(
+        fold_results=result.fold_results,
+        coefficients_long=result.coefficients_long,
+        used_features=result.used_features,
+        n_folds_total=result.n_folds_total,
+        n_folds_valid=result.n_folds_valid,
+        concordance_mean=result.concordance_mean,
+        concordance_std=result.concordance_std,
+        total_n_events=result.total_n_events,
+        statsmodels_version=result.statsmodels_version,
+        skip_reason="ok",
+        classifier_manifest_path=manifest_path,
+    )
+
+
+def survival_results_to_dataframe(result: SurvivalResult) -> pd.DataFrame:
+    """Long-form survival results CSV per dispatch §7.
+
+    One row per (fold, feature). Columns:
+      ``fold, feature, coefficient, p_value, std_err, concordance,
+      n_train, n_train_event, convergence_warning``
+
+    Aggregate-AUC-style columns are NOT included per-row (they would be
+    redundant across rows within a fold). Aggregate concordance lives
+    on the in-memory :class:`SurvivalResult` and in the manifest
+    extras block — surfacing it as a CSV header would be more confusing
+    than helpful.
+    """
+    return result.coefficients_long.copy()
+
+
+__all__ = (
+    "MIN_N_WARN",
+    "SURVIVAL_REQUIRED_POOL_COLUMNS",
+    "SurvivalFoldResult",
+    "SurvivalResult",
+    "build_survival_target",
+    "persist_fold_models",
+    "run_survival",
+    "survival_results_to_dataframe",
+)

--- a/docs/dispatches/heavy_ml_probe_build_intent.md
+++ b/docs/dispatches/heavy_ml_probe_build_intent.md
@@ -1,0 +1,346 @@
+# heavy_ml_probe — Build Intent Doc
+
+> **Authoring CC session:** worktree `elegant-ride-ad9a57` on branch `claude/elegant-ride-ad9a57`.
+> **Status:** intent doc only; no code, config, or branch changes this turn. End-of-turn for chat review per WORKFLOW §2 + dispatch §11.
+> **Dispatch reference:** `CC Dispatch — Build heavy_ml_probe Sub-Protocol` (this conversation).
+> **Source of truth being implemented:** `docs/sub_protocols/heavy_ml_probe.md` v1.0 (locked).
+> **Sibling reference consumed:** `core/discovery/**`, `scripts/arc_discovery_01/**`, `configs/arc_discovery_01.yaml`, `docs/dispatches/arc_discovery_01_intent.md`, `tests/discovery/**`.
+> **Predecessor docs read in order per §11:** `L_PROTOCOL.md` (full, with focus on §1 / §2 Step 1 / §2 Step 4 / §2 Step 5 incl. Amendment 2 retraining policy + Amendment 3 risk-normalised gates / §3 / §5 sub-protocol mechanism); `docs/sub_protocols/heavy_ml_probe.md` v1.0; `docs/sub_protocols/signal_discovery_probe.md` v1.0; `WORKFLOW.md` §2 + §6; `ARC_TRACKER.md` (read-only — no row to touch).
+> **Engine-consumer modules surveyed:** `core/steps/step_4_extraction.py`, `core/steps/classifier_persistence.py`, `core/steps/path_classifier_per_fold.py`, `core/architectures/{a1,a2,a4,a6}*.py`, `core/architectures/_path_classifier.py`, `core/features/{lineage,pipeline,registry}.py`.
+
+---
+
+## §1 Goal restatement (one paragraph)
+
+Build the `heavy_ml_probe` sub-protocol so a future arc can declare `sub_protocol: heavy_ml_probe` in its `ARC_OPEN.md` and run the overseer's Step 4 + Step 5 with: (a) FLAML AutoML in 11-fold TimeSeriesSplit replacing the vanilla three-classifier Step 4, (b) a meta-labeling target (`reach +1R MFE before SL`) trained via the same AutoML path, (c) Cox PH + Random Survival Forest fed into A4 (Pipeline D exits), and (d) Step 5 augmentation hook so A2 / A4 / A6 consume heavy-ML-trained components. No arc dispatched against this; build-now-so-ready-when-needed. Overseer Step 1 / 2 / 3 / 6 + §3 gates untouched.
+
+---
+
+## §2 Prerequisites verified
+
+| Prerequisite | Status | Where |
+|---|---|---|
+| L_PROTOCOL v3.0 + Amendments 1-3 locked | ✅ | `L_PROTOCOL.md` header + §3 risk-normalised gates locked. heavy_ml_probe does NOT touch gates per spec §"Discipline rules". |
+| Sub-protocol v1.0 doc | ✅ | `docs/sub_protocols/heavy_ml_probe.md` (read; spec is the bind). |
+| Sibling sub-protocol implemented | ✅ | `core/discovery/**` (10 modules) + `scripts/arc_discovery_01/run_discovery.py` + `tests/discovery/**` (9 test modules). Conventions to mirror: IO layout, manifest schema, lineterminator='\n', sorted JSON, sha256, random_state=42, n_jobs=1, locked YAML config. |
+| Feature lineage source-of-truth | ✅ | `core/features/lineage.py::CausalLineage` (CLEAN/SUSPECT/UNVERIFIED) attached at `FeatureSpec` construction. `core/features/pipeline.py::feature_lineage_dataframe()` returns columns `name, feature_class, causal_lineage, needs_panel, description`. Already consumed by `core/discovery/causal_filter.py` — heavy_ml_probe reuses the same read pattern (see §4 Q3 resolution). |
+| Step 4 classifier persistence + manifest convention | ✅ | `core/steps/step_4_extraction.py::_persist_best_classifier` + `_write_manifest` (joblib.dump compress=3, sha256, classifier_type/feature_order/best_threshold/auc_oos_cv5 entries). `core/steps/classifier_persistence.py::load_classifier` with SHA256 verification + version-drift warning. A heavy-ML augmented artefact set can land in a parallel directory using the exact same manifest schema. |
+| A2 / A6 consumer wiring exists | ✅ | `build_a2_config_from_step4`, `build_a6_config_from_step4` already load a `predict_proba`-shaped classifier and wrap it in `A2Config` / `A6Config`. Heavy-ML AutoML output IS `predict_proba`-shaped (FLAML's best estimator exposes `predict_proba`) — drop-in compatible. |
+| A4 consumer wiring exists for binary classifier | ✅ partial — see §4 Q5b | `core/architectures/a4_pipeline_d_exits.py::_A4ExitPredicate` consults `PathClassifierFit` via `predict_admit(...)`. Cox PH / RSF do NOT emit a binary admit decision — they emit hazards / survival probabilities. Spec §"Survival model variant for Pipeline D" says "predicted hazard at each post-entry bar feeds Step 5 Pipeline D exit policy." Translation rule (hazard → exit decision) is not yet specified at the consumer interface. Surface as Q5b open question. |
+| WORKFLOW §2 intent → log → PR pattern | ✅ | Followed for sibling (`arc_discovery_01_intent.md` / `_log.md`). This doc is the heavy_ml_probe equivalent. |
+| `docs/dispatches/` write convention | ✅ | All prior dispatch artefacts follow `<work>_intent.md` / `<work>_log.md` / `<work>_diagnostic.md` naming. This doc lands at `docs/dispatches/heavy_ml_probe_build_intent.md`. |
+| Branch strategy | ✅ | Build branch `infra/heavy_ml_probe_build` cut from main; per-PR branches off it (`infra/heavy_ml_probe_pr_a` ... `_pr_f`). Final merge to main after PR-F. Per dispatch §12. |
+
+---
+
+## §3 Confirmed module structure (dispatch §4)
+
+Dispatch §4's proposed tree is adopted verbatim with no deviations. Mirrors `core/discovery/**` shape so reviewers can navigate by analogy:
+
+```
+core/heavy_ml_probe/
+  __init__.py                # version + public API surface
+  automl.py                  # FLAML wrapper, evaluation-count enforcement, 11-fold CV loop
+  meta_labeling.py           # reach-1R-before-SL target construction + AutoML training reuse
+  survival.py                # Cox PH (lifelines) + RSF (scikit-survival); n < 200 warning per dispatch §6.10
+  pipeline.py                # orchestration: Step 1 pool in → Step 4 heavy-ML artefacts out
+  metrics.py                 # AUC + concordance + IBS wrappers
+  io.py                      # manifest writer, deterministic CSV/parquet writers, sha256 utility
+  causal_lineage.py          # pre-evaluation gate per spec §"Per-feature causal lineage"
+
+scripts/heavy_ml_probe/
+  __init__.py
+  run_probe.py               # CLI: --arc <name> --pool <path> --config <yaml> --cluster-id <id>
+
+configs/heavy_ml_probe/
+  default.yaml               # AutoML budget, model search space, CV folds, thresholds, library versions
+
+tests/heavy_ml_probe/
+  __init__.py
+  test_automl.py
+  test_meta_labeling.py
+  test_survival.py
+  test_causal_lineage.py
+  test_io_manifest.py        # added: same coverage gap noticed in sibling, worth filling proactively
+  test_pipeline_integration.py   # renamed from dispatch's `test_integration.py` for clarity
+```
+
+**Two minor additions to dispatch §4** (flagged here for chat sign-off rather than silently changing):
+
+1. `tests/heavy_ml_probe/test_io_manifest.py` — sibling has determinism-artefact tests (`tests/discovery/test_determinism_artefacts.py`); same pattern fits here. Keeps PR-A test surface honest without inflating PR-A.
+2. `scripts/heavy_ml_probe/__init__.py` — matches `scripts/arc_discovery_01/__init__.py` (an empty marker so the script package imports cleanly). Trivial; included for parity.
+
+Nothing else changes from dispatch §4.
+
+---
+
+## §4 Open question resolutions (dispatch §9)
+
+Dispatch §11 asks me to answer each §9 question from the codebase where possible and explicitly list the rest for chat. Working through them in order:
+
+### Q1 — Survival model target (CHAT, unresolvable from code)
+
+Dispatch §9.1 lists three plausible framings:
+- (a) time-to-SL-or-time-exit (realised exit event)
+- (b) time-to-MFE-peak (time at which MFE was maximised)
+- (c) time-to-reach-1R-MFE (event = +1R hit, censored at SL/time-exit)
+
+The codebase doesn't choose. Each has different downstream A4 implications:
+
+| Framing | What A4 does at each bar | Failure mode |
+|---|---|---|
+| (a) time-to-exit | Predict survival probability past horizon h; exit if S(h) drops below threshold. Maximally generic. | Lumps profitable runners and SL-flushes into one hazard, blunts signal. |
+| (b) time-to-MFE-peak | Predict bars-until-MFE-peak; exit when t > predicted peak. | Requires MFE-peak in the training label (uses full path), which is fine for IS labels but A4 needs to behave at OOS bars where MFE-peak is unknown — only a prediction is used, but the target is path-dependent and noisy. |
+| (c) time-to-reach-1R-MFE censored at SL/time-exit | Predict probability of reaching +1R within remaining horizon; exit when probability drops below threshold. Aligns directly with the meta-labeling target (reach-1R-before-SL). | Cleanest semantically; same event definition as the meta-labeling target → fewer concept mismatches. |
+
+**CC recommendation: (c)** — it aligns the survival target with the meta-labeling target (both events = "reach +1R before SL"). One semantic story across heavy_ml_probe. (a) is the safe fallback; (b) is the most novel but most fragile. Chat to confirm before PR-D.
+
+### Q2 — FLAML evaluation-count granularity (PARTIAL — default reading, chat to confirm strict reading)
+
+FLAML's `max_iter` counts hyperparameter combinations evaluated, not "model evaluations" in the abstract. One `max_iter=1000` call typically spans multiple base learners with the budget divided across them by FLAML's bandit-style scheduler. **Default reading: 1 trial = 1 evaluation; `max_iter=1000` per fold = 1000 evaluations per fold = 11,000 per cluster.** This matches FLAML's `max_iter` semantics and is the cleanest mapping to dispatch §6 #6.
+
+Stricter reading (1 base-learner × 1 hyperparam config = 1 evaluation; multi-learner FLAML run with `max_iter=1000` counts as N × 1000 where N = number of base learners) is possible but would force `max_iter ≈ 167` per fold (1000 / 6 learners), which materially reduces FLAML's search depth.
+
+CC recommendation: default reading. Surface to chat; if stricter reading is required, set `max_iter = floor(1000 / n_estimators_searched)` in YAML and document.
+
+HALT trigger: if FLAML cannot enforce a hard upper bound under either reading (e.g. internal warm-start trials are uncounted), HALT per dispatch §5 and surface for library swap.
+
+### Q3 — Causal lineage tag schema (RESOLVED FROM CODEBASE — no chat needed)
+
+Resolved by reading `core/features/lineage.py`, `core/features/pipeline.py`, `core/discovery/causal_filter.py`:
+
+- Lineage tags are attached at `FeatureSpec` registration time via the `lineage: CausalLineage` field (`CLEAN` / `SUSPECT` / `UNVERIFIED`). Registry-resident; NOT embedded in Step 1's `pool.parquet` per-row.
+- `feature_lineage_dataframe()` returns a DataFrame with columns `name, feature_class, causal_lineage, needs_panel, description`. This is the canonical lineage table.
+- `core/discovery/causal_filter.py::clean_feature_pool(lineage_df, accepted=("clean",), exclude_classes=())` returns the filtered feature-name tuple.
+- `core/steps/step_4_extraction.py::_filter_lineage` does the same job inside vanilla Step 4 (also keying on `lineage["causal_lineage"] == "clean"`).
+
+**heavy_ml_probe convention (mirroring sibling):** `core/heavy_ml_probe/causal_lineage.py` consumes `feature_lineage_dataframe()`, filters the feature pool to `causal_lineage == "clean"`, and logs the rejection list with the same reason vocabulary as `core.discovery.causal_filter` (`non_clean_lineage`, `excluded_class`, `unknown_feature`). The CC layer enforces the pre-evaluation gate per dispatch §6 #2 by filtering training-set columns BEFORE the AutoML run starts. No new schema invented; no separate metadata file.
+
+### Q4 — Per-cluster invocation pattern (RESOLVED — CC recommends single-cluster CLI)
+
+Dispatch §9.4's default — `run_probe.py` takes a single cluster ID as input, orchestration over clusters is the caller's responsibility — is what CC will implement unless chat redirects. Reasons:
+
+1. Keeps `run_probe.py` unit-testable in isolation (`test_pipeline_integration.py` only needs one cluster's worth of synthetic data).
+2. Compute budget (8-24h per arc per spec §"Expected compute cost") is dominated by the per-cluster AutoML run — coarse-grained parallelism over clusters is best done at the caller layer (a shell loop or future orchestrator hook), not buried inside the script.
+3. Matches sibling pattern: `scripts/arc_discovery_01/run_discovery.py` runs one arc's worth of search, not multi-arc auto-iteration.
+
+If chat prefers auto-iteration over all candidate clusters from a Step 3 output, that's a one-flag change (`--all-candidate-clusters` reading `step_3/capturability_summary.md`). Mention in PR-A if chat redirects.
+
+### Q5 — Step 5 architecture-layer interface (PARTIAL — A2/A6 work today, A4 needs a small interface decision)
+
+**Q5a (A2 / A6 — RESOLVED FROM CODEBASE):** `core/steps/classifier_persistence.py` already exposes `build_a2_config_from_step4` / `build_a6_config_from_step4`. Both load a `predict_proba`-shaped fitted estimator from a directory layout `step_4/classifiers/<cluster_id>.pkl` + `step_4/classifiers/manifest.json`. FLAML's best estimator exposes `predict_proba`, so a heavy-ML artefact directory at `step_4/heavy_ml/classifiers/<cluster_id>.pkl` + sibling manifest is plug-and-play. PR-E will provide thin wrappers (`build_a2_config_from_heavy_ml`, `build_a6_config_from_heavy_ml`) that point at the heavy-ML directory instead of the vanilla one; same downstream `A2Config` / `A6Config` consumed.
+
+**Q5b (A4 / survival — NEEDS CHAT DECISION):** A4's consumer interface today expects a `PathClassifierFit` with `.model.predict_proba` and a binary "exit if prob < threshold" rule (`_A4ExitPredicate.__call__` in `core/architectures/a4_pipeline_d_exits.py:110-159`). Survival models (Cox PH, RSF) don't fit this shape — they predict a hazard rate or a survival probability over a horizon, not a single "should-exit" probability.
+
+Three options to bridge:
+
+| Option | What changes | Pros | Cons |
+|---|---|---|---|
+| **B1.** Wrap survival prediction in a `PathClassifierFit`-shaped adapter that maps `S(h | features) < threshold` to a binary exit at the calling bar. | New `SurvivalPathClassifierAdapter` class with `.predict_admit(features) -> (admit, proba)`. A4 unchanged. | Zero engine surface change. Fits the dispatch §3 "out-of-scope" boundary. | Hides the survival semantics — debuggers see "AUC 0.X" but the underlying object is computing a hazard. Threshold tuning is at one horizon only. |
+| **B2.** Extend A4 with an opt-in `SurvivalExitPredicate` alongside `_A4ExitPredicate`. Heavy_ml_probe builds the new predicate; vanilla A4 keeps `_A4ExitPredicate`. | Cleaner separation of survival vs. binary semantics. | Touches `core/architectures/a4_pipeline_d_exits.py` — dispatch §3 says that file is out-of-scope. Engine-team would have to approve. | Wider scope; needs a chat-decided "engine extension allowed?" sign-off. |
+| **B3.** Surface the survival model in the Step 4 manifest only; A4 augmentation deferred to a follow-up engine PR; heavy_ml_probe ships with AutoML + meta-labeling consuming A2/A6 only, and A4 closure on heavy-ML stays a TODO. | Cleanest scope-wise. Matches dispatch §3 boundary literally. | Spec §"A4 (Pipeline D) uses the survival-model-predicted exit timing" not honored by this build; A4 heavy-ML augmentation becomes a follow-up. |
+
+**CC recommendation: B1 (adapter pattern).** Keeps A4 untouched per dispatch §3, gives heavy_ml_probe a complete A4 path. The adapter's threshold is the hyperparam chat tunes at Step 5. If chat prefers B2 (cleaner) or B3 (most conservative scope), the impact is on PR-D's design — flag at PR-D intent.
+
+PR-E will flag this in the PR description regardless of which option is chosen, per dispatch §9.5: "if that consumer code doesn't exist yet, this build can't be end-to-end-verified against A2/A4/A6 — only against the Step 4 artefact set."
+
+---
+
+## §5 Library choices (dispatch §5)
+
+| Component | Library | Confirmed? | Notes |
+|---|---|---|---|
+| AutoML | **FLAML** | ✅ confirmed | Native `max_iter` budget enforcement maps to dispatch §6 #6 cleanly. HALT trigger reaffirmed: if `max_iter` cannot enforce the hard 1000-eval/fold cap under either reading from Q2, HALT and surface to chat for library swap. |
+| Cox Proportional Hazards | **lifelines** | ✅ confirmed | Canonical Python implementation. Returns concordance, log-likelihood. |
+| Random Survival Forest + IBS | **scikit-survival** (`sksurv`) | ✅ confirmed | Standard RSF + Integrated Brier Score. |
+| Base learners inside FLAML search | RF, LightGBM, XGBoost, CatBoost, ExtraTrees, LR | ⚠️ partial — see §6 dep bump | LightGBM already in vanilla Step 4 (via `core.steps._classifier_defaults`); XGBoost + CatBoost NOT installed. |
+| Determinism | stdlib + `random_state=42` | ✅ confirmed | n_jobs=1; lineterminator='\n'; sha256 sidecar manifests. Same convention as `core/discovery/io.py`. |
+
+**Dependency bump required in PR-A:**
+
+`requirements-dev.txt` currently lists: `numpy, pandas, pyarrow, pytest, ruff, pyyaml, pydantic, scipy, scikit-learn, joblib`. Missing for heavy_ml_probe: **`flaml`, `lifelines`, `scikit-survival`, `xgboost`, `catboost`, `lightgbm`** (lightgbm imports defensively in `core.steps._classifier_defaults` so it's optional today, but heavy_ml_probe relies on it more centrally and should make it a hard dep).
+
+PR-A will append these to `requirements-dev.txt` and pin them in `configs/heavy_ml_probe/default.yaml` under a `library_versions` block (same convention as `core/steps/step_4_extraction.py:_LGBM_VERSION` tracking) so the manifest can record env drift like vanilla Step 4 already does.
+
+No alternative libraries proposed — FLAML / lifelines / scikit-survival are the canonical choices per the spec doc and the dispatch. Hold the line.
+
+---
+
+## §6 Constraints baked in (dispatch §6)
+
+Each constraint is mapped to the module that enforces it:
+
+| Constraint | Module enforcing | Mechanism |
+|---|---|---|
+| 1. No lookahead | `causal_lineage.py` (pre-evaluation gate) + reuse of registry tags | feature pool filtered to `CLEAN` before AutoML sees any data |
+| 2. Causal lineage gate is pre-evaluation | `causal_lineage.py::filter_training_columns(X, lineage_df)` | column-drop BEFORE `automl.fit` is called |
+| 3. Holdout window OFF-LIMITS | `pipeline.py` accepts `train_end: pd.Timestamp` and filters trades to `entry_time < train_end` before passing into AutoML / meta-label / survival fit | mirrors `core/steps/step_4_extraction.py:362-382` |
+| 4. 11-fold TimeSeriesSplit on IS | `automl.py::run_per_fold_automl(X, y, n_folds=11)` | `sklearn.model_selection.TimeSeriesSplit(n_splits=11)` |
+| 5. Per-fold AutoML training | `automl.py` loops over `(train_idx, test_idx) in cv.split(X)` | NO "train once globally" shortcut path; verified by `test_automl.py` |
+| 6. Compute budget hard cap | `automl.py::FlamlBudget` wrapper | `max_iter=1000` per fold; recorded evaluations per fold logged to `compute_budget_used.md`; HALT if cap exceeded |
+| 7. Determinism | `core/heavy_ml_probe/io.py` + everywhere | `random_state=42`, `n_jobs=1`, `lineterminator='\n'`, sorted JSON, sha256 in manifest, two-run determinism in `test_pipeline_integration.py` |
+| 8. sha256 manifests | `io.py::write_manifest` | mirror of `core/discovery/io.py::write_manifest`; outputs `step_4/heavy_ml/manifest.json` + `step_5/heavy_ml_augmented/manifest.json` |
+| 9. r_min=0.15% / r_max=2.0% from Amendment 3 | NOT enforced by heavy_ml_probe | scalability gate lives in overseer Step 5 + §3; heavy_ml_probe emits artefacts, overseer reads them |
+| 10. Minimum-N (n < 200) warning | `survival.py::fit_cox_ph(...)` + `fit_rsf(...)` | `warnings.warn(...)` and proceed; per dispatch §6.10 do NOT skip silently |
+
+---
+
+## §7 Output artefact layout (dispatch §7 — unchanged)
+
+`step_4/heavy_ml/`:
+- `automl_leaderboard.csv` — per-fold FLAML model rankings + per-config AUC + budget consumed
+- `automl_feature_importance.csv` — per-feature permutation importance averaged across folds
+- `survival_model_results.csv` — Cox PH coefficients + concordance, RSF feature importance + IBS
+- `meta_label_results.csv` — per-fold AUC + threshold-sweep precision/recall for reach-1R-before-SL
+- `compute_budget_used.md` — evaluations consumed per fold vs cap (HALT-trigger evidence if breached)
+- `classifiers/<cluster_id>.pkl` — joblib-pickled best FLAML estimator (mirrors vanilla `step_4/classifiers/`)
+- `classifiers/manifest.json` — sha256 + provenance (joblib / sklearn / flaml / lightgbm / xgboost / catboost versions; `auc_in_sample`, `auc_oos_cv5`, `trained_on_pool_size`, `feature_order`)
+- `survival/<cluster_id>_cox.pkl` + `survival/<cluster_id>_rsf.pkl` (added — needed for PR-D's A4 adapter)
+- `survival/manifest.json` — sha256 + provenance (lifelines / sksurv versions, target framing per Q1, concordance / IBS)
+- `manifest.json` — top-level sha256 per file above
+
+`step_5/heavy_ml_augmented/`:
+- `heavy_ml_augmented_architectures.csv` — A2 / A4 / A6 results using heavy-ML-trained components (filled by the augmentation hook, not by this build per dispatch §3)
+- `manifest.json`
+
+PR-E emits an empty `step_5/heavy_ml_augmented/manifest.json` template + the hook contract documented for the engine team to consume.
+
+---
+
+## §8 Build order (dispatch §8 — confirmed verbatim)
+
+No reordering. Sized estimates per PR appear below in §10. Each PR is reviewable in isolation per dispatch + WORKFLOW §5.
+
+**PR-A — Scaffolding + causal lineage gate + IO + dep bump**
+- `core/heavy_ml_probe/{__init__.py, pipeline.py (skeleton), causal_lineage.py, io.py, metrics.py}`
+- `configs/heavy_ml_probe/default.yaml` (config skeleton)
+- `scripts/heavy_ml_probe/{__init__.py, run_probe.py (stub running scaffolding only)}`
+- `requirements-dev.txt` — append flaml, lifelines, scikit-survival, xgboost, catboost, lightgbm
+- Tests: `test_causal_lineage.py`, `test_io_manifest.py`
+- End turn for chat review.
+
+**PR-B — AutoML**
+- `core/heavy_ml_probe/automl.py` (FLAML wrapper, 11-fold TS-split, eval-count enforcement, leaderboard + importance)
+- `pipeline.py` wires AutoML into orchestration
+- Tests: `test_automl.py` (synthetic data; respects cap; deterministic)
+- End turn.
+
+**PR-C — Meta-labeling**
+- `core/heavy_ml_probe/meta_labeling.py` (target = reach-1R-before-SL from pool's MFE/MAE columns; reuse AutoML path for training with new target; threshold sweep)
+- `pipeline.py` orchestrates meta-labeling alongside AutoML
+- Tests: `test_meta_labeling.py` (target construction matches spec; no lookahead in target; end-to-end runs)
+- End turn.
+
+**PR-D — Survival**
+- `core/heavy_ml_probe/survival.py` (Cox PH via lifelines, RSF via sksurv; target per Q1 resolution; censoring at time-exit horizon)
+- `pipeline.py` orchestrates survival training
+- Adapter (Q5b option B1, unless chat overrides): `SurvivalPathClassifierAdapter` exposing `predict_admit(features) -> (admit, proba)` for A4 consumption
+- Tests: `test_survival.py` (n ≥ 200 synthetic pool, Cox + RSF run end-to-end; metrics within sane bounds; minimum-N warning fires under n < 200)
+- End turn.
+
+**PR-E — Integration + Step 5 augmentation hook (gate PR)**
+- `pipeline.py` full orchestration: causal-filter → AutoML → meta-label → survival → write artefact set + manifests
+- Step 5 hook: emit `step_5/heavy_ml_augmented/manifest.json` template + consumer documentation for chat to wire engine-side
+- `test_pipeline_integration.py` — small synthetic pool end-to-end; two-run determinism check (sha256-byte-identical)
+- `compute_budget_used.md` template + writer
+- End turn (gate PR).
+
+**PR-F — Documentation + polish**
+- README addition or operator notes for invocation
+- Docstring / inline doc cleanup surfaced during PR-A → PR-E
+- `docs/sub_protocols/heavy_ml_probe.md` itself NOT modified unless a spec gap was found and chat ratified (per dispatch §3)
+- End turn (final PR).
+
+---
+
+## §9 Open questions remaining for chat (consolidated)
+
+After §4 resolution, the following remain chat-side:
+
+1. **Q1 — Survival target framing.** CC recommends (c) `time-to-reach-1R-MFE censored at SL/time-exit`. Chat to confirm or pick (a) / (b).
+2. **Q2 — FLAML budget granularity.** CC defaults to 1 trial = 1 evaluation (max_iter=1000 per fold). Chat to confirm or impose stricter accounting.
+3. **Q5b — A4 survival consumer interface.** CC recommends B1 (adapter pattern, A4 untouched). Chat to confirm or pick B2 (A4 extension) / B3 (defer A4 augmentation).
+4. **Minor — module-structure deviations (§3 above).** Two added test files (`test_io_manifest.py`, `scripts/heavy_ml_probe/__init__.py`). Trivial; flag-only.
+
+Q3 (lineage schema) and Q4 (per-cluster invocation) are CC-resolved from codebase reading — no chat action needed unless chat disagrees with the resolution.
+
+---
+
+## §10 Pace estimate (dispatch §10)
+
+| PR | Estimate | Driver |
+|---|---|---|
+| PR-A | ≤ 1 day | Scaffolding is mostly file-creation + mirroring sibling conventions. Dep bump may surface install issues on Windows for sksurv (Cython-build) — flag if so. |
+| PR-B | 1-2 days | FLAML wrapper + CV discipline + eval-count enforcement + permutation importance + first determinism check. Largest single PR. |
+| PR-C | ≤ 1 day | Reuses PR-B's AutoML path with a different target. Target construction is mechanical from the pool's MFE/MAE columns. |
+| PR-D | ≤ 1 day | Cox PH + RSF are out-of-the-box library calls; the adapter (per Q5b) adds a small wrapper class. |
+| PR-E | ≤ 1 day | Mostly orchestration glue + integration test + manifest scaffolding. Step 5 hook is a markdown + JSON-template emission, not engine code. |
+| PR-F | ≤ 0.5 day | Doc polish. |
+| **Total** | **4-6 working days** | Matches dispatch §10. |
+
+No artificial deadline. HALT per WORKFLOW §6 if:
+- FLAML cannot enforce hard eval cap (PR-B)
+- sksurv install on Windows fails (PR-A)
+- Q1 / Q2 / Q5b are unanswered when their PR opens
+- Determinism check fails on PR-E
+- Any spec gap surfaces requiring `heavy_ml_probe.md` amendment
+
+---
+
+## §11 Files this dispatch will create / touch
+
+### New
+- `core/heavy_ml_probe/{__init__,automl,meta_labeling,survival,pipeline,metrics,io,causal_lineage}.py`
+- `scripts/heavy_ml_probe/{__init__,run_probe}.py`
+- `configs/heavy_ml_probe/default.yaml`
+- `tests/heavy_ml_probe/{__init__,test_automl,test_meta_labeling,test_survival,test_causal_lineage,test_io_manifest,test_pipeline_integration}.py`
+- `docs/dispatches/heavy_ml_probe_build_{intent,log}.md` (this doc + PR-F log)
+
+### Modified (existing files touched)
+- `requirements-dev.txt` — append heavy-ML deps (PR-A)
+
+### Read-only (consumed but not modified)
+- `core/features/{lineage,pipeline,registry}.py` — lineage source-of-truth
+- `core/steps/step_4_extraction.py`, `core/steps/classifier_persistence.py` — vanilla Step 4 patterns to mirror
+- `core/architectures/{a2,a4,a6}*.py`, `core/architectures/_path_classifier.py` — consumer interfaces for Q5a/Q5b reasoning
+- `core/discovery/**`, `scripts/arc_discovery_01/**` — sibling implementation conventions
+- `docs/sub_protocols/heavy_ml_probe.md` — the spec being implemented
+- `L_PROTOCOL.md`, `WORKFLOW.md` — methodology + operations
+- `ARC_TRACKER.md` — no row to touch (build dispatch, not arc)
+
+### Explicitly NOT touched (per dispatch §3)
+- `core/steps/**` — overseer Step 1-6 mechanics
+- `core/architectures/**` — A1-A6 base implementations (Q5b option B1 keeps this true; B2 would change it, flag at PR-D if chat picks B2)
+- `L_PROTOCOL.md`, `docs/sub_protocols/heavy_ml_probe.md` — the spec itself (HALT + surface if gap found)
+- Any arc invocation; no `results/<arc>/` lands from this build
+
+---
+
+## §12 Branch + PR mechanics (dispatch §12)
+
+- Build branch: `infra/heavy_ml_probe_build`, cut from `main` at the point this intent doc is approved
+- Per-PR branches: `infra/heavy_ml_probe_pr_{a,b,c,d,e,f}` off the build branch
+- Each PR merges into the build branch; final PR-F merge + build-branch merge to `main`
+- One `docs/dispatches/heavy_ml_probe_build_log.md` written at PR-F time consolidating verification across all 6 PRs (per WORKFLOW §2.4)
+- HALT pattern per WORKFLOW §6 produces `docs/dispatches/heavy_ml_probe_build_diagnostic.md`
+
+The current worktree (`elegant-ride-ad9a57` on `claude/elegant-ride-ad9a57`) hosts THIS intent doc only. The implementation branches will be cut fresh from main after chat ratification per dispatch §12.
+
+---
+
+## §13 What I'm waiting on
+
+Per dispatch §11 last line: **do not start PR-A until chat confirms intent.** This turn ends here.
+
+Chat actions needed before PR-A opens:
+1. Confirm or redirect §4 Q1 (survival target).
+2. Confirm or redirect §4 Q2 (FLAML evaluation granularity).
+3. Confirm or redirect §4 Q5b (A4 survival consumer interface).
+4. Note (or veto) the two minor module-structure additions in §3.
+5. Approve the `requirements-dev.txt` dep bump (PR-A surface).
+
+Once those land, PR-A opens on `infra/heavy_ml_probe_pr_a` cut from `infra/heavy_ml_probe_build` cut from `main`.
+
+---
+
+End of intent doc.

--- a/docs/dispatches/heavy_ml_probe_pr_a_log.md
+++ b/docs/dispatches/heavy_ml_probe_pr_a_log.md
@@ -1,0 +1,167 @@
+# heavy_ml_probe PR-A — Log Doc
+
+> **Branch:** `infra/heavy_ml_probe_pr_a` → `infra/heavy_ml_probe_build` (cut from `main` @ `7c238e8`).
+> **Dispatch:** chat reply confirming PR-A scope + Q1/Q2/Q5b resolutions (2026-05-24).
+> **Intent doc:** [`docs/dispatches/heavy_ml_probe_build_intent.md`](heavy_ml_probe_build_intent.md).
+> **Sub-protocol spec:** [`docs/sub_protocols/heavy_ml_probe.md`](../sub_protocols/heavy_ml_probe.md) v1.0.
+> **Authoring CC session:** worktree `elegant-ride-ad9a57`.
+
+---
+
+## §1 Scope landed (verbatim against dispatch §8 PR-A)
+
+| Path | Purpose | Lines |
+|---|---|---|
+| `requirements-dev.txt` | Append heavy-ML deps (flaml, lifelines, scikit-survival, xgboost, catboost, lightgbm) | +12 |
+| `configs/heavy_ml_probe/default.yaml` | Locked invocation parameters; PR-B/C/D YAML schema frozen from this PR | new |
+| `core/heavy_ml_probe/__init__.py` | Package marker + version | new |
+| `core/heavy_ml_probe/io.py` | Deterministic CSV / parquet / text + sha256 manifest writer | new |
+| `core/heavy_ml_probe/metrics.py` | AUC + concordance + IBS wrappers (lazy lifelines / sksurv imports) | new |
+| `core/heavy_ml_probe/causal_lineage.py` | Pre-evaluation lineage gate (Q3-resolved schema: `FeatureSpec`-backed) | new |
+| `core/heavy_ml_probe/pipeline.py` | Orchestration skeleton: config → pool → lineage gate → stub manifest | new |
+| `scripts/heavy_ml_probe/__init__.py` | Empty package marker for CLI parity with sibling | new |
+| `scripts/heavy_ml_probe/run_probe.py` | CLI: `--arc --pool --cluster-id --config --output-root` | new |
+| `tests/heavy_ml_probe/__init__.py` | Package marker | new |
+| `tests/heavy_ml_probe/test_causal_lineage.py` | 12 tests — gate behaviour + summary determinism + case-insensitivity + purity | new |
+| `tests/heavy_ml_probe/test_io_manifest.py` | 19 tests — IO determinism + manifest schema + two-run end-to-end | new |
+
+End-to-end stub semantics per dispatch: CLI runs, reads pool parquet, applies lineage gate via the registry-backed `feature_lineage_dataframe()`, writes `step_4/heavy_ml/stub_summary.md` + `step_4/heavy_ml/manifest.json` with sha256 of the summary. AutoML / meta-label / survival code paths are explicitly not implemented (PR-B/C/D).
+
+---
+
+## §2 Verification results
+
+### §2.1 Test suite
+
+```
+py -3 -m pytest tests/heavy_ml_probe -x -q
+...............................                                          [100%]
+31 passed in 0.64s
+```
+
+All 31 tests pass on the first run. Coverage breakdown:
+
+- `test_causal_lineage.py` — 12 tests: accepts clean; rejects suspect / unverified / unknown / excluded-class; mixed pool accounting; dedup; purity (no input mutation); summary determinism; case-insensitive lineage values; raises on missing required columns.
+- `test_io_manifest.py` — 19 tests: write_text appends single newline; LF (no CR) on Windows; CSV deterministic sort; CSV column-mismatch raises; parquet round-trip; sha256 matches hand-computed digest; manifest schema includes `schema_version` + `sub_protocol`; nested forward-slash paths; artefact sort determinism; extras collision raises; extras recorded; end-to-end stub writes both artefacts; lineage gate filters suspect; two-run byte-identical artefacts; two-run stable-payload manifest sha256; FileNotFoundError on missing pool; ValueError on bad sub_protocol name; ValueError on missing top-level config sections.
+
+### §2.2 Sibling regression
+
+```
+py -3 -m pytest tests/discovery -q
+..........................................                               [100%]
+42 passed in 49.91s
+```
+
+42/42 — sibling sub-protocol untouched.
+
+### §2.3 Lint
+
+```
+py -3 -m ruff check core/heavy_ml_probe scripts/heavy_ml_probe tests/heavy_ml_probe
+All checks passed!
+```
+
+One ruff warning surfaced during initial write (`dataclasses.field` unused import in `causal_lineage.py`) and was fixed before commit. Final pass clean.
+
+### §2.4 CLI smoke
+
+End-to-end smoke against the default config + a 10-row synthetic pool:
+
+```
+lineage gate: 2 / 2
+manifest written: True
+stub summary written: True
+```
+
+The CLI surface (`scripts/heavy_ml_probe/run_probe.py`) exits 0 on a clean run and exits 1 with a clear stderr message on `FileNotFoundError` / `ValueError`. Both branches exercised by the test suite.
+
+### §2.5 Determinism (dispatch §6 #7)
+
+Two-run sha256 equality verified two ways in `test_io_manifest.py`:
+
+1. **Artefact bytes** — `stub_summary.md` is timestamp-free, so its sha256 matches byte-identically across two pipeline runs against the same input pool.
+2. **Stable-payload manifest** — `pipeline.stable_payload_sha256` zeroes out the `created_at` field and hashes the canonicalised JSON. The remaining payload (schema version, arc, cluster, pool path, pool size, lineage gate counts, artefacts block) matches across runs.
+
+The manifest's `created_at` timestamp intentionally differs across runs (UTC ISO of write time). This matches the sibling discovery convention; the determinism test harness excludes it explicitly.
+
+### §2.6 sksurv Windows wheel (intent doc PR-A risk #1)
+
+`py -3 -m pip install --dry-run flaml lifelines scikit-survival xgboost catboost lightgbm` resolved cleanly on this Windows machine (Python 3.14, x64):
+
+```
+scikit_survival-0.27.0-cp314-cp314-win_amd64.whl (822 kB)
+```
+
+No Cython-from-source fallback required. The intent-doc-flagged risk did not materialise on this environment. Other contributors on different Python versions may still hit wheel-availability gaps — surface in PR-B if so.
+
+`lightgbm` was already installed (4.6.0) from the vanilla Step 4 path; listing it explicitly in `requirements-dev.txt` makes the dependency contract explicit (vanilla Step 4 currently imports it defensively, but heavy_ml_probe needs it as a first-class learner in the FLAML search space).
+
+---
+
+## §3 Deviations from intent doc
+
+None of substance. Two micro-additions explicitly flagged in the intent doc landed as planned:
+
+- `tests/heavy_ml_probe/test_io_manifest.py` (added per intent §3 "Two minor additions").
+- `scripts/heavy_ml_probe/__init__.py` (added per intent §3).
+
+Intent doc §11 listed both as flag-only; both included in PR-A as documented.
+
+One internal refactor not flagged in the intent doc but worth recording:
+
+- `core/heavy_ml_probe/pipeline.py::_build_lineage_dataframe()` is a thin shim around `core.features.pipeline.feature_lineage_dataframe()`. The indirection exists so tests can pass a hand-built lineage DataFrame via `apply_lineage_gate(..., lineage_df=...)` without importing the full v3 features stack (which triggers panel + cache imports — slow in CI). Same pattern that the sibling tests use; documented inline.
+
+---
+
+## §4 Flags for chat
+
+### §4.1 Non-blocking
+
+- **`scripts/heavy_ml_probe/run_probe.py` exit codes diverge slightly from intent doc.** The intent doc didn't specify exit codes. PR-A uses `0` for success, `1` for config / pool errors (FileNotFoundError / ValueError), and lets unhandled exceptions propagate to stderr with exit code 2 (the default `sys.exit(1)` from argparse error path is reserved for arg-parse failures). Chat may want a stricter spec when CI starts consuming exit codes; for PR-A this is documented in the module docstring.
+
+- **YAML schema is locked from PR-A forward.** PR-B/C/D add behaviour but should NOT add new top-level YAML sections without bumping `schema_version` in `configs/heavy_ml_probe/default.yaml`. The pipeline asserts the `schema_version` + `sub_protocol.name` fields on load. If chat wants per-section schema validation (e.g. via pydantic), flag at PR-B intent — for PR-A the light required-keys check is the only enforcement.
+
+- **`pipeline.stable_payload_sha256()` exposes a determinism-test helper as part of the public module surface.** It's narrow-purpose. Could move to `tests/heavy_ml_probe/_helpers.py` later if it stays unused outside tests. Not blocking; keeping it on `pipeline.py` matches the sibling's `core/discovery/io.py::write_manifest` location convention.
+
+### §4.2 Surfaced for PR-B intent
+
+- **FLAML's `max_iter` semantics on this Python 3.14 / FLAML 2.6.0 install** to be confirmed at PR-B's intent doc with a quick smoke (10-iter run, verify the budget counter increments by exactly 10). Q2 resolution accepted the 1-trial-per-eval reading at face value; PR-B's empirical check protects against API drift in the FLAML 2.6.0 line.
+
+- **`auc_roc` returns NaN on single-class folds** (a `roc_auc_score` would raise). This matches vanilla Step 4's per-fold AUC handling (`core/steps/step_4_extraction.py:182-184`). PR-B's FLAML wrapper should propagate the NaN — not coerce to 0.5 — because the FLAML leaderboard's metric column must distinguish "model could not be scored" from "model performed at chance."
+
+### §4.3 None
+
+No HALT conditions encountered during PR-A. WORKFLOW §6 unused.
+
+---
+
+## §5 Branch state at PR-time
+
+```
+git status
+On branch infra/heavy_ml_probe_pr_a
+Your branch is ahead of 'origin/main' by 1 commit  (parent: 7c238e8)
+nothing to commit, working tree clean
+```
+
+(State as of the commit + push that opens this PR. Files-touched list in §1 above is the authoritative diff.)
+
+PR-A target: `infra/heavy_ml_probe_build`. The build branch was published from `main` (`7c238e8`) in the same chat turn as PR-A development; it has no commits of its own — it exists only as the merge target for the per-PR series A → F.
+
+---
+
+## §6 What lands next (per dispatch §8)
+
+After PR-A merges into `infra/heavy_ml_probe_build`:
+
+- **PR-B (AutoML)** — `core/heavy_ml_probe/automl.py` + 11-fold TS-split + `max_iter=1000` enforcement + leaderboard + permutation importance + `test_automl.py`. Largest single PR (1-2 days). Intent doc lands first per WORKFLOW §2.
+- **PR-C (Meta-labeling)** — `core/heavy_ml_probe/meta_labeling.py` reusing the AutoML path with the reach-1R-before-SL target. ≤ 1 day.
+- **PR-D (Survival)** — Cox PH + RSF + the Q5b-resolved adapter pattern wrapping survival predictions into A4's `predict_admit` shape. ≤ 1 day.
+- **PR-E (Integration + Step 5 hook)** — gate PR. End-to-end determinism on synthetic data + `compute_budget_used.md` writer + `build_a2_config_from_heavy_ml` / `build_a6_config_from_heavy_ml` wrappers pointing at `step_4/heavy_ml/classifiers/`. ≤ 1 day.
+- **PR-F (Docs + polish)** — README / inline doc cleanup. ≤ 0.5 day.
+
+Per chat directive: I will not start PR-B work during the PR-A review window.
+
+---
+
+End of PR-A log.

--- a/docs/dispatches/heavy_ml_probe_pr_b_log.md
+++ b/docs/dispatches/heavy_ml_probe_pr_b_log.md
@@ -1,0 +1,259 @@
+# heavy_ml_probe PR-B — Log Doc
+
+> **Branch:** `infra/heavy_ml_probe_pr_b` → `infra/heavy_ml_probe_build` (cut from PR-A locally; chat's "PR-A merged" signal honoured at the head level).
+> **Dispatch:** chat prompt 2026-05-25 confirming PR-B scope + flag dispositions for PR-A.
+> **Intent doc:** [`docs/dispatches/heavy_ml_probe_build_intent.md`](heavy_ml_probe_build_intent.md).
+> **PR-A log:** [`docs/dispatches/heavy_ml_probe_pr_a_log.md`](heavy_ml_probe_pr_a_log.md).
+> **Sub-protocol spec:** [`docs/sub_protocols/heavy_ml_probe.md`](../sub_protocols/heavy_ml_probe.md) v1.0.
+> **Authoring CC session:** worktree `elegant-ride-ad9a57`.
+
+---
+
+## §1 Scope landed (verbatim against dispatch §6)
+
+| Path | Status | Purpose |
+|---|---|---|
+| `core/heavy_ml_probe/automl.py` | new | FLAML wrapper: 11-fold TimeSeriesSplit + per-fold AutoML.fit() + modelcount accounting + permutation importance + NaN-safe AUC + holdout-guard |
+| `core/heavy_ml_probe/pipeline.py` | extended | `run_pipeline` now orchestrates the AutoML stage; emits 3 new artefacts + extended manifest; PR-A skip-paths preserved |
+| `core/heavy_ml_probe/metrics.py` | unchanged | `auc_roc` already complete from PR-A; `concordance` / `integrated_brier_score` stay stubs for PR-D |
+| `scripts/heavy_ml_probe/run_probe.py` | tweaked | stdout summary surfaces AutoML stats; `HoldoutGuardViolation` + `AllFeaturesRejected` mapped to exit 1 |
+| `docs/sub_protocols/heavy_ml_probe.md` | tweaked | one-line CLI exit-code mapping appended per PR-A flag-1 disposition |
+| `tests/heavy_ml_probe/test_automl.py` | new | 19 tests (end-to-end, modelcount cap, determinism, NaN-AUC propagation, holdout-guard, lineage-rejects-all) |
+
+Artefact outputs landing per dispatch §6:
+
+- `step_4/heavy_ml/automl_leaderboard.csv` — per-fold FLAML model rankings + per-config AUC + modelcount
+- `step_4/heavy_ml/automl_feature_importance.csv` — permutation importance (mean + std + n_folds_present) per feature
+- `step_4/heavy_ml/compute_budget_used.md` — per-fold trial counts vs cap + aggregate AUC
+- `step_4/heavy_ml/manifest.json` — sha256 per artefact + `automl` extras block
+
+PR-B does NOT modify `core/architectures/**`, `L_PROTOCOL.md`, vanilla Step 1-6 mechanics, or any arc folders.
+
+---
+
+## §2 §3a — FLAML `max_iter` empirical verification (mandatory)
+
+**Finding: `flaml.AutoML.modelcount` equals `max_iter` exactly when FLAML runs to the cap. Ratio 1.0. Locked, proceed.**
+
+### §2.1 Probe methodology
+
+Before any PR-B implementation, FLAML 2.6.0 was installed and probed via three runs against a deterministic synthetic binary-classification pool (`seed=42`, 500 trades, 3 informative features). Probe varied `max_iter` ∈ {5, 10, 30, 100} both with the full default estimator list and with a single-estimator (`lgbm`-only) variant.
+
+### §2.2 Results
+
+```
+max_iter=  5  modelcount=  5  best_iteration=  2
+max_iter= 10  modelcount= 10  best_iteration=  9
+max_iter= 30  modelcount= 30  best_iteration= 22
+```
+
+Per dispatch §3a's three possible outcomes:
+
+| Outcome | Disposition |
+|---|---|
+| Exactly N | **Confirmed.** `modelcount == max_iter` in every probe. Ratio 1.0. Locked. |
+| Less than N (early-stop) | Did not materialise on noisy targets at `max_iter ≤ 30`. |
+| Greater than N (pre-warm trials uncounted) | Did not materialise. No HALT trigger. |
+
+`automl.best_iteration` is the 0-indexed position of the best trial (always ≤ `modelcount - 1`); it is NOT the trial counter. The trial counter is `automl.modelcount`. This module records `modelcount` per fold into the leaderboard CSV + the `compute_budget_used.md` per-fold table.
+
+### §2.3 Bound enforcement
+
+`core/heavy_ml_probe/automl.py:_run_one_fold` records `modelcount` after each FLAML fit. If `modelcount > max_iter` ever drifts upward in a future FLAML release, a `UserWarning` fires citing this log doc's §3a empirical claim. Test `test_modelcount_does_not_exceed_max_iter` enforces the inequality; `test_modelcount_matches_max_iter_on_learnable_target` asserts equality on the test fixture's noisy target.
+
+### §2.4 Estimator-set drift note
+
+FLAML 2.6.0's default classification estimator list on this install:
+
+```
+['lgbm', 'rf', 'xgboost', 'extra_tree', 'xgb_limitdepth', 'sgd', 'catboost', 'lrl1']
+```
+
+This differs slightly from the dispatch §1 spec (which listed `lrl2` instead of `xgb_limitdepth` / `sgd`). Per dispatch §1 "If defaults differ, log the actual set and proceed" — captured in `core/heavy_ml_probe/automl.py::DOCUMENTED_FLAML_2_6_0_ESTIMATORS` plus per-fold capture into `FoldResult.estimator_list` (manifest-bound for cross-env audit). Test `test_estimator_list_recorded_per_fold` asserts non-empty + the always-present `lgbm` / `rf` baseline so a benign FLAML minor-version drift doesn't break the test suite.
+
+---
+
+## §3 §3b — Single-class fold AUC handling (mandatory)
+
+**Finding: NaN propagates correctly; aggregate uses `nanmean`; `n_folds_valid` reported alongside.**
+
+### §3.1 Two-layer NaN propagation
+
+Two layers can produce a single-class fold:
+
+1. **Single-class training slice** — TimeSeriesSplit early folds against a temporally-stratified target can yield an all-zero (or all-one) train fold. FLAML's internal CV cannot fit on a single-class input. Per `core/heavy_ml_probe/automl.py:_run_one_fold`, this is detected up-front, AutoML is skipped, and `FoldResult.auc_val` / `auc_train` come back NaN. A `UserWarning` records the skip; the fold's `best_estimator` is recorded as `"<skipped:single_class_train>"` for grep-able audit.
+
+2. **Single-class validation slice** — FLAML fits cleanly but `roc_auc_score` returns NaN (modern sklearn behaviour — verified at PR-B time). `core/heavy_ml_probe/metrics.py:auc_roc` short-circuits to NaN on `len(set(y_true)) < 2` so the per-fold AUC is consistently NaN regardless of which sklearn path is taken.
+
+### §3.2 Aggregate
+
+```python
+auc_mean = float(np.nanmean(auc_vals)) if n_valid > 0 else float("nan")
+auc_std  = float(np.nanstd(auc_vals, ddof=0)) if n_valid > 0 else float("nan")
+n_valid  = int(np.isfinite(auc_vals).sum())
+```
+
+`AutoMLResult.n_folds_valid` is reported on the in-memory object, in the manifest's `automl` extras block, and in `compute_budget_used.md` (e.g. "across 7 valid folds; total 11"). Downstream readers know whether the aggregate spans every fold or fewer.
+
+### §3.3 Tests
+
+- `test_nan_auc_propagates_on_single_class_training` — builds a pool with the first 80% all-y=0 so early TimeSeriesSplit folds train on a single class; asserts ≥1 fold NaNs out and `n_folds_valid` reflects the live count.
+- `test_nan_auc_aggregate_uses_nanmean` — every fold NaN → `auc_mean` is NaN AND `n_folds_valid == 0`. Boundary case covered.
+
+---
+
+## §4 Verification
+
+### §4.1 Test suite
+
+```
+py -3 -m pytest tests/heavy_ml_probe -q -W ignore::UserWarning
+..................................................                       [100%]
+50 passed in 16.77s
+```
+
+50 tests: 31 carried over from PR-A (unchanged behaviour preserved) + 19 new in `test_automl.py`. Wall-clock under 60s per dispatch §4.
+
+Coverage breakdown for the 19 new tests:
+
+| Group | Count | Coverage |
+|---|---|---|
+| Core mechanics | 3 | end-to-end smoke; modelcount ≤ max_iter; modelcount == max_iter on noisy target |
+| NaN propagation | 2 | single-class training; aggregate nanmean semantics |
+| Guards | 5 | holdout-guard violation (interior + boundary); all-features-rejected; missing required column; non-binary target |
+| Determinism | 1 | two-run AutoMLResult equality (auc_mean, auc_std, modelcount, leaderboard, importance) |
+| FLAML capture | 1 | estimator_list recorded per fold |
+| Pipeline integration | 7 | full artefact set written; manifest sha256 matches on-disk; two-run determinism (4 artefacts + stable-payload manifest); holdout-guard surfaces with partial manifest; skip reasons (missing_entry_time, missing_y, no_clean_features); AUTOML_REQUIRED_COLUMNS contract |
+
+### §4.2 Sibling regression
+
+```
+py -3 -m pytest tests/discovery -q
+..........................................                               [100%]
+42 passed in 43.71s
+```
+
+42/42 — sibling sub-protocol untouched.
+
+### §4.3 Lint
+
+```
+py -3 -m ruff check core/heavy_ml_probe scripts/heavy_ml_probe tests/heavy_ml_probe
+All checks passed!
+```
+
+One initial E402 issue surfaced in `test_automl.py` because `pytest.importorskip("flaml")` precedes the module-level imports; resolved with explicit `# noqa: E402` annotations + a comment explaining the gate.
+
+### §4.4 CLI smoke
+
+End-to-end CLI invocation against a 200-trade synthetic pool + the locked `configs/heavy_ml_probe/default.yaml` (overridden to `n_folds=3 / max_iter_per_fold=5` for the smoke):
+
+```
+[heavy_ml_probe] pipeline run complete.
+  arc            : smoke
+  ...
+  lineage gate   : accepted=0 / rejected=5 / input=5
+  AutoML         : status=no_clean_features (skipped)
+exit_code: 0
+manifest artefacts: ['stub_summary']
+automl skip_reason: no_clean_features
+```
+
+This particular smoke skipped AutoML cleanly because the synthetic pool's feature names (`a`, `b`, `trade_id`, `entry_time`, `y`) aren't in the production feature registry, so the real lineage gate rejected every column. That's the right behaviour — the gate fired exactly as designed, AutoML was correctly bypassed, and the manifest records the reason. Exit code 0 because the pipeline ran to completion; the skip is informational, not a failure.
+
+### §4.5 Wall-clock probe at test scale
+
+```
+test-scale: n=400, n_folds=5, max_iter=10 -> 1.55s wall, total_modelcount=50, auc_mean=0.9884, valid_folds=5/5
+  per-fold fit times (s): [0.20, 0.28, 0.19, 0.24, 0.24]
+  per-fold modelcount  : [10, 10, 10, 10, 10]
+```
+
+50 model trials in 1.55s on this hardware → ~32ms per trial. Linear extrapolation to production scale (n_folds=11, max_iter_per_fold=1000, total trials = 11,000) suggests **~6 minutes wall-clock per cluster** under these assumptions. That's well inside the dispatch §4 expectation of "2-6 hours per cluster" — likely orders of magnitude faster, but the extrapolation is on a 4-feature toy problem; production has 20-30 features and FLAML's per-trial cost grows with column count. A production-scale run will surface the true number in PR-E's first end-to-end timing.
+
+### §4.6 Determinism — two-run byte equality
+
+`test_pipeline_automl_two_run_determinism` asserts byte equality for all four artefacts (`stub_summary.md`, `automl_leaderboard.csv`, `automl_feature_importance.csv`, `compute_budget_used.md`) plus the stable-payload manifest sha256 (timestamp excluded). Initially failed because `fit_wall_seconds` leaked into the leaderboard CSV + the markdown — wall-clock varies across runs. Fix: kept `fit_wall_seconds` on the in-memory `AutoMLResult` only; removed it from the on-disk artefacts and the manifest extras. Two-run determinism now holds. See `core/heavy_ml_probe/automl.py:leaderboard_to_dataframe` + `compute_budget_markdown` docstrings.
+
+---
+
+## §5 Deviations from intent doc / dispatch
+
+### §5.1 sklearn / FLAML compatibility shim for permutation_importance (real bug found and fixed)
+
+Initial implementation passed FLAML's outer `AutoML` object to `sklearn.inspection.permutation_importance`. sklearn 1.5+'s estimator-type check refuses the wrapper:
+
+```
+ValueError: AutoML should either be a classifier to be used with response_method=predict_proba
+or the response_method should be 'predict'. Got a regressor with response_method=predict_proba instead.
+```
+
+Fix: extract the inner fitted estimator (`automl.model.estimator`) and pass THAT to `permutation_importance`. The inner estimator is a proper sklearn-compatible classifier (`LGBMClassifier`, `RandomForestClassifier`, etc.). Predictions through the inner estimator are byte-identical to the outer wrapper for standard pipelines per FLAML's docs. Documented inline in `_run_one_fold`.
+
+Flagged here so future PR reviewers aren't surprised by the `getattr(automl, "model", None).estimator` extraction pattern.
+
+### §5.2 Wall-clock dropped from on-disk artefacts (not flagged in dispatch)
+
+Per §4.6 above. The dispatch §4 mentions wall-clock measurement but doesn't specify whether it lands in artefacts; for determinism, it can't. Documented in `compute_budget_markdown` docstring + the artefact body's "Wall-clock measurements live on the in-memory AutoMLResult" line. The in-memory `AutoMLResult.total_fit_wall_seconds` is still computed and surfaced through the CLI's stdout for operator visibility.
+
+### §5.3 Pipeline auto-skip when pool lacks `entry_time` / `y`
+
+Not explicitly in the dispatch but follows from the design — PR-A's smoke tests use 50-row pools without `entry_time` / `y` columns. Rather than break those tests, the pipeline detects missing required columns and skips AutoML with `skip_reason ∈ {missing_entry_time, missing_y}`. The skip reason lands in the manifest's `automl` extras block. Production arcs always have these columns; the skip path is purely a backward-compatibility shim.
+
+`AUTOML_REQUIRED_COLUMNS = ("entry_time", "y")` is exported from `pipeline.py` so consumers can introspect.
+
+### §5.4 Spec touch — `docs/sub_protocols/heavy_ml_probe.md`
+
+Per PR-A flag-1 disposition, added a 5-line "Invocation exit codes" block under "When invoked." Documents existing behaviour (0/1/2 mapping) without protocol surface change.
+
+### §5.5 YAML schema unchanged
+
+Per PR-A flag-2 disposition: no `schema_version` bump in PR-B. The AutoML config keys (`max_iter_per_fold`, `n_folds`, `metric`, etc.) were already locked in PR-A under the `automl` namespace; PR-B just started reading them. No breaking change.
+
+---
+
+## §6 Flags for chat
+
+### §6.1 Non-blocking
+
+- **`automl.model.estimator` extraction** (PR-B §5.1 above). FLAML's API surface for "the underlying sklearn classifier" is documented but not formally typed; a future FLAML major-version bump could rename this attribute. Test `test_estimator_list_recorded_per_fold` catches at least the "FLAML's estimator list became empty" regression; a deeper change to the `model.estimator` attribute would surface as test failure across all `permutation_importance`-using tests (most of `test_automl.py`). Worth pinning FLAML to a known-good major version when the production environment is locked.
+
+- **`xgb_limitdepth` + `sgd` in FLAML's default estimator list** (§2.4). The dispatch spec said `lrl2`; FLAML 2.6.0 actually defaults to a different mix. Captured in `DOCUMENTED_FLAML_2_6_0_ESTIMATORS` constant + per-fold capture. If chat prefers an explicit `estimator_list` override (e.g. force-include `lrl2` for parity with the spec doc), it's a one-line YAML change in `configs/heavy_ml_probe/default.yaml::automl.estimator_list`. PR-B reads from FLAML's default; an explicit override path is wired but commented out.
+
+- **scikit-survival install failure on Python 3.14** (carried over from PR-A risk note + surfaced here for real). `pip install scikit-survival lifelines` on the build machine fails because `ecos` (transitive dep) has no cp314 wheel and the source build requires MSVC. **FLAML + xgboost + catboost installed cleanly** — sufficient for PR-B. Survival deps need to install for PR-D; will be resolved at PR-D time either by (a) MSVC build tools install on the dev machine, (b) pinned older Python (3.11 / 3.12 where the wheels exist), or (c) conda-forge variants. Test `test_automl.py` import-guards FLAML so the module is skipped (not failed) on environments without FLAML, future-proofing for CI matrix.
+
+- **Wall-clock extrapolation** (§4.5) suggests production cost is order-of-minutes per cluster, not the dispatch's order-of-hours estimate. Could be very wrong — depends on feature count + FLAML's per-trial cost growth — but worth knowing the test-scale baseline before PR-E's first real production run.
+
+### §6.2 Surfaced for PR-C intent
+
+- **Meta-labeling target reuses AutoML path**: the spec says "binary target = reach +1R MFE before SL." PR-C will compute this target from the pool's MFE / MAE columns (consumed in the existing Step 1 pool schema, not added) and reuse `automl.run_automl` with `target_col` overridden. The shape contract is already in place — `target_col` is a parameter of `run_automl`. PR-C will add the target-construction logic + a thin wrapper, not a new AutoML loop.
+
+- **Threshold sweep storage**: meta-labeling produces a per-fold threshold sweep (precision/recall at `{0.30, 0.40, 0.50, 0.60, 0.70}` per the locked YAML). New artefact `meta_label_results.csv` per dispatch §7. PR-C intent should specify whether the threshold sweep replaces or augments the leaderboard CSV — current `automl_leaderboard.csv` has no threshold column.
+
+### §6.3 No HALT
+
+No HALT conditions encountered. §3a ratio == 1.0 (well under the 1.5× HALT threshold). §3b NaN propagation works as designed. All non-negotiables enforced. WORKFLOW §6 unused.
+
+---
+
+## §7 Branch state at PR-time
+
+- Build branch (`infra/heavy_ml_probe_build`) on origin is still at `7c238e8` (main's tip at PR-A time). PR-A's GitHub merge has not happened yet at the time PR-B is opened — chat's "PR-A merged" signal was interpreted at the head level (PR-A's code is conceptually in build; PR-B is layered on top locally).
+- PR-B branch (`infra/heavy_ml_probe_pr_b`) was cut from `infra/heavy_ml_probe_pr_a` locally so the head of PR-B includes PR-A's commits + PR-B's commit. When chat actually merges PR-A → build on GitHub, the PR-B diff against `infra/heavy_ml_probe_build` will recompute and show only PR-B's changes. If chat prefers a different sequencing (e.g. rebase PR-B onto a freshly-merged build), happy to redo.
+
+---
+
+## §8 What lands next (per dispatch §8)
+
+After PR-B merges into `infra/heavy_ml_probe_build`:
+
+- **PR-C (Meta-labeling)** — `core/heavy_ml_probe/meta_labeling.py` reusing the AutoML path with `target_col="reach_1r"`; new `meta_label_results.csv` artefact. ≤ 1 day.
+- **PR-D (Survival)** — Cox PH + RSF + Q5b-resolved adapter wrapping survival predictions into A4's `predict_admit` shape. Requires sksurv install (see §6.1 flag). ≤ 1 day.
+- **PR-E (Integration + Step 5 hook)** — gate PR; end-to-end determinism on synthetic data + `build_a2_config_from_heavy_ml` / `build_a6_config_from_heavy_ml` wrappers. ≤ 1 day.
+- **PR-F (Docs + polish)** — README / inline doc cleanup. ≤ 0.5 day.
+
+Per chat directive: I will not start PR-C work during the PR-B review window.
+
+---
+
+End of PR-B log.

--- a/docs/dispatches/heavy_ml_probe_pr_c_log.md
+++ b/docs/dispatches/heavy_ml_probe_pr_c_log.md
@@ -1,0 +1,261 @@
+# heavy_ml_probe PR-C — Log Doc
+
+> **Branch:** `infra/heavy_ml_probe_pr_c` → `infra/heavy_ml_probe_build` (cut from PR-B locally; chat's "PR-B merged" signal honoured at the head level — origin build branch still at main pre-merge per `git ls-remote`).
+> **Dispatch:** chat prompt 2026-05-25 confirming PR-C scope + PR-B flag dispositions.
+> **Intent doc:** [`docs/dispatches/heavy_ml_probe_build_intent.md`](heavy_ml_probe_build_intent.md).
+> **PR-B log:** [`docs/dispatches/heavy_ml_probe_pr_b_log.md`](heavy_ml_probe_pr_b_log.md).
+> **Sub-protocol spec:** [`docs/sub_protocols/heavy_ml_probe.md`](../sub_protocols/heavy_ml_probe.md) v1.0.
+> **Authoring CC session:** worktree `elegant-ride-ad9a57`.
+
+---
+
+## §1 Scope landed (verbatim against dispatch §7)
+
+| Path | Status | Purpose |
+|---|---|---|
+| `core/heavy_ml_probe/meta_labeling.py` | new | Target construction (reach-1R-before-SL, same-bar SL tie-break) + classifier pipeline + threshold sweep + per-fold persistence |
+| `core/heavy_ml_probe/automl.py` | refactored | Added `keep_classifiers` + `collect_oof_predictions` parameters (backwards-compatible, both default False) + `FoldResult.fitted_estimator` + `AutoMLResult.oof_predictions` |
+| `core/heavy_ml_probe/pipeline.py` | extended | `_run_meta_label_stage` orchestration; meta-labeling is INDEPENDENT of vanilla AutoML (parallel stages, not cascading) |
+| `scripts/heavy_ml_probe/run_probe.py` | tweaked | stdout surface adds meta-label stats |
+| `configs/heavy_ml_probe/default.yaml` | tweaked | `meta_labeling.threshold_sweep` updated to dispatch §3 grid `[0.50, 0.55, ..., 0.80]` (was `[0.30, 0.40, ..., 0.70]` in PR-A draft) |
+| `requirements-dev.txt` | tweaked | `joblib>=1.4,<1.6` pinned per dispatch §6 #7 |
+| `tests/heavy_ml_probe/test_meta_labeling.py` | new | 30 tests — target construction edge cases (per dispatch §1) + threshold sweep math + persistence + determinism + HALT-loud schema validation |
+
+Artefact outputs landing per dispatch §7:
+
+- `step_4/heavy_ml/meta_label_results.csv` — per-threshold precision/recall/f1 + n_kept/n_dropped + mean_R_kept/mean_R_dropped + edge_lift_r + diagnostic columns (target_positive_rate, OOF AUC, fold counts)
+- `step_4/heavy_ml/classifiers/meta_label/manifest.json` — sha256-bound per-fold classifier index + joblib version + classifier_type per fold
+- `step_4/heavy_ml/classifiers/meta_label/fold_{NN}.joblib` — inner sklearn-compatible classifier pickle per fold (skipped folds → no pickle, manifest records `path: null`)
+- Existing `step_4/heavy_ml/manifest.json` extended to cover the two new artefacts + new `meta_label` extras block (target distribution, positive rate, OOF AUC aggregates, threshold count)
+
+PR-C does NOT modify `core/architectures/**`, `L_PROTOCOL.md`, vanilla Step 1-6 mechanics, the sub-protocol spec (no behavioural change to surface), or any arc folders.
+
+---
+
+## §2 `automl.py` refactor diff summary (dispatch §7.2)
+
+Two opt-in additive parameters; PR-B callers see identical behaviour without changes.
+
+### §2.1 `FoldResult.fitted_estimator: Any | None = None`
+
+New trailing field. PR-B tests pass `keep_classifier=False` (default) → field stays None. PR-C's `run_meta_labeling` passes `keep_classifiers=True` → each fold's inner sklearn-compatible estimator (`automl.model.estimator`) carried out for persistence.
+
+### §2.2 `AutoMLResult.oof_predictions: pd.DataFrame = field(default_factory=pd.DataFrame)`
+
+New trailing field. PR-B path leaves it empty. PR-C populates with columns `(trade_id, fold, y_true, y_pred_proba)` sorted by `(fold, trade_id)` for determinism.
+
+### §2.3 `run_automl(...)` signature additions
+
+```diff
+ def run_automl(
+     pool: pd.DataFrame,
+     used_features: Sequence[str],
+     *,
+     train_end: pd.Timestamp,
+     n_folds: int = DEFAULT_N_FOLDS,
+     max_iter_per_fold: int = DEFAULT_MAX_ITER_PER_FOLD,
+     seed: int = DEFAULT_RANDOM_STATE,
+     metric: str = "roc_auc",
+     n_jobs: int = 1,
+     permutation_repeats: int = DEFAULT_PERMUTATION_REPEATS,
+     entry_time_col: str = "entry_time",
+     target_col: str = "y",
++    trade_id_col: str = "trade_id",
++    keep_classifiers: bool = False,
++    collect_oof_predictions: bool = False,
+ ) -> AutoMLResult:
+```
+
+`trade_id_col` was already used internally for OOF rows; raised to a parameter for arc-side flexibility.
+
+### §2.4 `_run_one_fold` signature additions
+
+Internal helper. Added `keep_classifier`, `collect_oof`, `trade_id_col` params; return shape grew from 3-tuple to 4-tuple (extra `oof_rows` DataFrame). All PR-B/PR-A test paths still flow because PR-B's `run_automl` now passes the defaults explicitly when invoking `_run_one_fold`.
+
+### §2.5 Backwards-compatibility verification
+
+`pytest tests/heavy_ml_probe/test_automl.py` — 19/19 pass unchanged after refactor (no test signatures touched). The PR-A baseline (`test_causal_lineage.py` + `test_io_manifest.py`) — 31/31 pass unchanged.
+
+---
+
+## §3 Joblib version pinned (dispatch §6 #7)
+
+`requirements-dev.txt` now pins `joblib>=1.4,<1.6` (was unpinned). Resolved runtime version on this machine: **joblib 1.5.3**.
+
+Captured into every classifier manifest under `joblib_version`. PR-E's A6 consumer (`build_a6_config_from_heavy_ml`) will read this field and emit a `UserWarning` on mismatch (same pattern as vanilla Step 4's `core/steps/classifier_persistence.py:_warn_on_version_drift`).
+
+Per dispatch §6 #7's caveat: joblib pickle bytes can vary across versions; **the get_params() snapshot of a pickle-loaded classifier matches across two runs at the same joblib version** (verified by `test_pipeline_classifier_pickle_params_match_across_runs`). NaN-aware comparison required because XGBoost's `get_params()` carries `'missing': nan` and Python's `nan != nan`.
+
+---
+
+## §4 Threshold-sweep sanity check (dispatch §7.4)
+
+Run against the synthetic 400-trade test pool (`n_folds=5, max_iter=10, target_strength=0.7`):
+
+```
+positive_rate          : 0.5200
+meta-label OOF AUC     : 0.9568 (across 5/5 folds)
+
+threshold | n_kept | n_dropped | precision | recall | mean_R_kept | mean_R_dropped | edge_lift_R
+  0.50    |  174   |   156     |   0.8851  | 0.8800 |   +1.4568   |    +0.0636     |   +1.3932
+  0.55    |  168   |   162     |   0.8929  | 0.8571 |   +1.4763   |    +0.0950     |   +1.3813
+  0.60    |  163   |   167     |   0.9018  | 0.8400 |   +1.4756   |    +0.1370     |   +1.3385
+  0.65    |  155   |   175     |   0.9097  | 0.8057 |   +1.4790   |    +0.1952     |   +1.2838
+  0.70    |  153   |   177     |   0.9216  | 0.8057 |   +1.5006   |    +0.1910     |   +1.3096
+  0.75    |  141   |   189     |   0.9362  | 0.7543 |   +1.5095   |    +0.2675     |   +1.2420
+  0.80    |  117   |   213     |   0.9402  | 0.6286 |   +1.5286   |    +0.3970     |   +1.1317
+```
+
+**Edge lift positive across every threshold.** Mean R on the kept set ≈ +1.5; mean R on the dropped set ≈ 0 — the meta-label is doing real work, not just trimming variance. Precision climbs monotonically (0.885 → 0.940) as the threshold tightens; recall falls (0.88 → 0.63) as expected. The `edge_lift_r` column is the load-bearing diagnostic per dispatch §3 — confirmed reading on synthetic data.
+
+On production data with a real signal, edge lift will be smaller (synthetic target is intentionally learnable). Reporting framework is in place; PR-E's first real arc run will surface production numbers.
+
+---
+
+## §5 Verification results
+
+### §5.1 Test suite
+
+```
+py -3 -m pytest tests/heavy_ml_probe -q -W ignore::UserWarning
+........................................................................ [ 90%]
+........                                                                 [100%]
+80 passed in 67.02s (0:01:07)
+```
+
+80 tests: 31 PR-A + 19 PR-B + 30 PR-C. Wall-clock 67s — under the dispatch §4 ceiling of 60s but close enough to acknowledge; meta-labeling triples the per-test compute (target construction → AutoML → persistence on top of the existing AutoML invocation). If CI runtime becomes an issue, the PR-C test fixture is already at `n_folds=5 / max_iter=10`; further reduction would compromise coverage.
+
+PR-C test coverage breakdown:
+
+| Group | Count | Coverage |
+|---|---|---|
+| Target construction edge cases (dispatch §1) | 11 | reached-before-close; never-reached / time-exit; SL on entry; same-bar tie (SL wins); same-bar tie (non-SL counts); exact +1R on bar 1; case-insensitive SL exit reason; vectorised mixed cases; HALT-loud on missing column; HALT-loud on NaN `bars_held`; rejects non-default `mfe_r_threshold` override |
+| Threshold sweep math | 3 | hand-computed kept/dropped mean R; empty-kept-set NaN handling; missing-OOF-column raises |
+| Pipeline integration | 4 | full artefact set (6 files); classifier manifest lists every fold + sha256-matches on-disk; CSV has all expected columns; edge-lift positive on learnable synthetic |
+| Determinism | 2 | seven artefacts byte-identical across runs + classifier-manifest stable sha256; classifier `get_params()` matches (NaN-aware) |
+| Skip paths | 2 | pool missing meta-label columns → meta-label skips with specific reason, AutoML runs; pool missing `entry_time` → both stages skip independently |
+| Direct `run_meta_labeling` | 3 | end-to-end unit test bypassing pipeline; HALT-loud on schema; HALT-loud on missing `final_r` |
+| Single-class fold NaN propagation | 1 | matches PR-B pattern; meta-label AUC NaN for single-class fold, aggregate unaffected |
+| Persistence corner cases | 2 | skipped folds recorded with `path: null`; persisting empty `AutoMLResult` still writes a manifest |
+| Public constants locked | 2 | `REQUIRED_POOL_COLUMNS` + `META_LABEL_TARGET_COL` |
+
+### §5.2 Sibling regression
+
+```
+py -3 -m pytest tests/discovery -q
+..........................................                               [100%]
+42 passed in 65.42s
+```
+
+42/42 — sibling signal_discovery_probe untouched.
+
+### §5.3 Lint
+
+```
+py -3 -m ruff check core/heavy_ml_probe scripts/heavy_ml_probe tests/heavy_ml_probe
+All checks passed!
+```
+
+One I001 (import sort) auto-fixed via `--fix`. No remaining warnings.
+
+### §5.4 CLI smoke
+
+```
+[heavy_ml_probe] pipeline run complete.
+  arc            : smoke
+  ...
+  lineage gate   : accepted=0 / rejected=5 / input=5
+  AutoML         : status=no_clean_features (skipped)
+  Meta-labeling  : status=no_clean_features (skipped)
+[heavy_ml_probe] Survival not yet implemented (PR-D).
+exit: 0
+```
+
+Both stages correctly skipped on the same `no_clean_features` reason (synthetic pool's column names aren't in the real registry). CLI surfaces both stage statuses; exit 0 because the pipeline ran to completion.
+
+### §5.5 Determinism
+
+`test_pipeline_meta_label_two_run_determinism` asserts byte-equality for all 5 on-disk artefacts (stub summary + 3 AutoML + meta_label_results.csv) AND the stable-payload sha256 of both the top-level manifest and the classifier sidecar manifest. PR-C added two real determinism issues, both fixed:
+
+1. **`fit_wall_seconds` already excluded** from on-disk artefacts in PR-B; carries through here.
+2. **Classifier-manifest timestamp drift** — PR-C's initial implementation included `generated_at` in `classifiers/meta_label/manifest.json`. The top-level manifest hashes the sidecar's bytes → sidecar timestamp drift broke top-level stable-payload determinism. Fix: dropped `generated_at` from the sidecar; the top-level manifest's `created_at` is the single source of truth for write time. The sidecar's `mtime` on disk covers any forensic need. Documented inline in `persist_fold_classifiers`.
+3. **`get_params()` NaN equality** — XGBoost's `get_params()` includes `'missing': nan` and Python's `nan != nan` returns True. Added `_params_equal_nan_aware` helper in the test; documented as a test-only concern (caller-side comparison utility, not a real determinism bug).
+
+---
+
+## §6 Deviations from dispatch / intent
+
+### §6.1 Meta-labeling is INDEPENDENT of vanilla AutoML (real architectural call)
+
+Dispatch §2 says "Same 11-fold TimeSeriesSplit on IS slice. Same `max_iter=1000` per fold cap. Same `seed=42` determinism." which is true at the FLAML wrapper level. But the dispatch doesn't specify whether meta-labeling runs only-when-AutoML-also-runs OR independently.
+
+Initial PR-C implementation cascaded — if AutoML skipped (e.g. pool lacks `y`), meta-labeling skipped with `automl_skipped`. That's wrong: meta-labeling's target is constructed from MFE/exit columns, not from `y`. They're semantically parallel: vanilla AutoML predicts cluster membership (`y`), meta-labeling predicts reach-1R-before-SL (`y_meta_label`). A pool can carry the meta-label schema without carrying `y` and vice versa.
+
+Fixed in `_should_run_meta_labeling`: now checks the meta-label schema directly without consulting `automl_result`. Skip reasons: `no_clean_features`, `missing_entry_time`, `missing_trade_id`, `missing_meta_label_columns:<list>`, `holdout_guard_violation`. The `automl_result` parameter is kept on the function signature for symmetry but unused (annotated `noqa: ARG001`).
+
+Surfaced because this is a non-obvious orchestration decision that could've gone either way; chat may want to re-examine for cross-stage error propagation.
+
+### §6.2 YAML threshold-sweep grid corrected to match dispatch §3
+
+PR-A's `configs/heavy_ml_probe/default.yaml` had `meta_labeling.threshold_sweep: [0.30, 0.40, 0.50, 0.60, 0.70]` — a placeholder. Dispatch §3 specifies `[0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80]`. Updated in PR-C.
+
+Per PR-A flag-2 disposition: no `schema_version` bump because the key already existed in PR-A's YAML; only the default values changed. The key's semantics are unchanged.
+
+### §6.3 Test wall-clock crept above the dispatch §4 ceiling
+
+Dispatch §4: "If `test_automl.py` blows past 60 seconds end-to-end, the test pool is too large — shrink it." Full `tests/heavy_ml_probe/` suite now takes **67s** (was 17s pre-PR-C). The increase is `test_meta_labeling.py` adding 19 tests that exercise full meta-labeling pipelines on 400-trade pools. Already at `n_folds=5 / max_iter=10` — the minimum that produces meaningful TimeSeriesSplit behaviour.
+
+If CI runtime is binding, options:
+- Drop `n_folds=5 → 3` (loses coverage of mid-fold dynamics)
+- Reduce `n` from 400 to 200 (may give the classifier too little signal)
+- Mark slowest tests `@pytest.mark.slow` and gate via `-m "not slow"` in CI
+
+Surfacing for chat — not changing in PR-C since 67s vs 60s is a soft boundary.
+
+### §6.4 `mfe_r_threshold` parameter intentionally rejects non-1.0 values
+
+`build_meta_label_target` accepts `mfe_r_threshold` but raises `ValueError` if anything other than 1.0 is passed. Reason: the pool's `bars_to_1r_mfe` column is computed upstream at +1R; running the target with `mfe_r_threshold=0.5` while still consuming `bars_to_1r_mfe` would silently produce nonsense. To run a sensitivity analysis at a different threshold, the upstream pool builder must pre-compute the equivalent `bars_to_<X>r_mfe` column, then PR-C exposes a future `bars_to_event_col` override. Documented inline; spec-conforming behaviour by construction.
+
+---
+
+## §7 Flags for chat
+
+### §7.1 Non-blocking
+
+- **Wall-clock at test scale ~67s** (vs dispatch §4 60s soft ceiling). See §6.3.
+- **Meta-labeling independence from vanilla AutoML** (§6.1) — architectural call worth a sanity-check on chat-side.
+- **Classifier-manifest has no timestamp** (§5.5 #2) — `mtime` on disk is the canonical write time for the sidecar. If audit-trail needs a baked-in timestamp, the top-level manifest's `created_at` already covers the umbrella run; sub-artefacts inherit by association.
+- **`xgb_limitdepth` / `sgd` in FLAML defaults** (carry-over from PR-B) — still flagged; no action.
+- **scikit-survival install** still failing on Python 3.14 (carry-over from PR-B). Per PR-B flag-1 disposition, chat already decided to drop RSF for PR-D; documented in `docs/sub_protocols/heavy_ml_probe.md` under the survival-models section will land in PR-D.
+
+### §7.2 Surfaced for PR-D intent
+
+- **`meta_labeling` and `survival` will share the +1R event definition.** Per dispatch §5 Q1: the survival target is `time_to_reach_1r_censored_at_sl_or_time_exit`. PR-C's `meta_labeling.py` module docstring already references this relationship. PR-D can import `REQUIRED_POOL_COLUMNS` from `meta_labeling` and add `bars_to_sl` / `bars_to_time_exit` if needed for separating censoring events (currently the meta-label schema only carries `bars_held` + `exit_reason`, which is sufficient for binary censoring but Cox PH may want the explicit split).
+- **PR-D A4 adapter pattern (B1)** — `MetaLabelResult.automl_result.fold_results[i].fitted_estimator` is already a `predict_proba`-shaped object that PR-E's `build_a6_config_from_heavy_ml` can consume directly. PR-D's adapter for Cox PH should mirror this shape — a `predict_proba`-like surface that converts `S(t | features)` at the configured horizon into a binary "exit / hold" probability.
+
+### §7.3 No HALT
+
+No HALT conditions encountered. Schema validation HALTs loudly (`PoolSchemaError`) per dispatch §1 last paragraph but the tests verify the loudness rather than ignore it. WORKFLOW §6 unused.
+
+---
+
+## §8 Branch state at PR-time
+
+- Build branch (`infra/heavy_ml_probe_build`) on origin still at `7c238e8` (main's tip at PR-A time). PR-A + PR-B's GitHub merges have not happened yet at PR-C-open time — chat's "merged" signals interpreted at the head level (PR-A+B's code is conceptually in build; PR-C is layered on top locally).
+- PR-C branch (`infra/heavy_ml_probe_pr_c`) was cut from `infra/heavy_ml_probe_pr_b` locally so the head of PR-C includes PR-A's + PR-B's commits + PR-C's commit. When chat actually merges PR-A → build then PR-B → build on GitHub, the PR-C diff against `infra/heavy_ml_probe_build` will recompute and show only PR-C's changes. PR-B's chat-side flag-5 ("verify PR-B's base updates to build HEAD after PR-A merges") applies here too.
+
+---
+
+## §9 What lands next (per dispatch §8)
+
+After PR-C merges into `infra/heavy_ml_probe_build`:
+
+- **PR-D (Survival, Cox PH only)** — `core/heavy_ml_probe/survival.py` + Cox PH via lifelines + adapter that wraps `S(t | features)` into A4's `predict_admit` shape. Per PR-B flag-1 disposition, RSF dropped (scikit-survival blocked on cp314); documented in spec at PR-D time. Requires `lifelines` install — needs MSVC build tools OR Python downgrade OR conda-forge wheel. Will surface in PR-D's environment prep.
+- **PR-E (Integration + Step 5 hook)** — gate PR; `build_a2_config_from_heavy_ml` / `build_a6_config_from_heavy_ml` wrappers pointing at `step_4/heavy_ml/classifiers/meta_label/`.
+- **PR-F (Docs + polish)** — README / inline doc cleanup.
+
+Per chat directive: I will not start PR-D work during the PR-C review window.
+
+---
+
+End of PR-C log.

--- a/docs/dispatches/heavy_ml_probe_pr_d_log.md
+++ b/docs/dispatches/heavy_ml_probe_pr_d_log.md
@@ -1,0 +1,289 @@
+# heavy_ml_probe PR-D — Log Doc
+
+> **Branch:** `infra/heavy_ml_probe_pr_d` → `infra/heavy_ml_probe_build` (cut from PR-C locally; chat's "PR-C merged" signal honoured at the head level — origin build branch still at main pre-merge per `git ls-remote`).
+> **Dispatch:** chat prompt 2026-05-25 with scope adjustments dropping RSF (no cp314 wheel) AND lifelines (also no cp314 wheel); swap to `statsmodels.duration.hazard_regression.PHReg` for Cox PH.
+> **Intent doc:** [`docs/dispatches/heavy_ml_probe_build_intent.md`](heavy_ml_probe_build_intent.md).
+> **PR-C log:** [`docs/dispatches/heavy_ml_probe_pr_c_log.md`](heavy_ml_probe_pr_c_log.md).
+> **Sub-protocol spec:** [`docs/sub_protocols/heavy_ml_probe.md`](../sub_protocols/heavy_ml_probe.md) v1.0 (updated PR-D for RSF deferral + library swap).
+> **Authoring CC session:** worktree `elegant-ride-ad9a57`.
+
+---
+
+## §1 statsmodels install verification (mandatory dispatch §1)
+
+**Verified clean on Python 3.14 / Windows x64. No HALT.**
+
+### §1.1 Wheel availability
+
+```
+py -3 -m pip install --dry-run statsmodels
+...
+Downloading statsmodels-0.14.6-cp314-cp314-win_amd64.whl (9.6 MB)
+Downloading patsy-1.0.2-py2.py3-none-any.whl (233 kB)
+Would install patsy-1.0.2 statsmodels-0.14.6
+```
+
+`statsmodels-0.14.6` has a clean `cp314-win_amd64` wheel. Only new transitive dep is `patsy` (pure-Python). No `ecos` involvement (that's what blocks lifelines + scikit-survival). No MSVC build tools required.
+
+### §1.2 Import + fit smoke
+
+```
+statsmodels: 0.14.6
+PHReg module: statsmodels.duration.hazard_regression
+params: [0.51620833 0.05383552 0.1833429 ]
+pvalues: [4.96708726e-04 6.66841077e-01 1.74842410e-01]
+bse: [0.14822817 0.12505711 0.13512817]
+```
+
+True coefficient on first feature was 1.0; recovered 0.52 on a tiny (n=100) noisy sample — directionally correct.
+
+### §1.3 Pickle round-trip
+
+```
+reload params match: True
+```
+
+`joblib.dump → joblib.load` round-trip preserves `params` exactly. Per dispatch §10 last paragraph's "if persisted PHRegResults object can't be reloaded across processes, HALT" check — passes.
+
+### §1.4 baseline_cumulative_hazard format (deviation note)
+
+Dispatch §8 docstring described it as `results.baseline_cumulative_hazard()` (callable). Actual API: `results.baseline_cumulative_hazard` is a property returning a `list` of strata, where each stratum is `[unique_times, cumulative_hazard, survival_function]` as 3 same-length ndarrays. For single-stratum models (the default), `bch[0]` is the relevant entry. PR-D's `_extract_baseline_cumulative_hazard` normalises this into a plain dict `{stratum, times, cumulative_hazard, survival_function}` for joblib-stable persistence.
+
+§1 outcome: **PROCEED**. statsmodels installs clean, PHReg fits + pickles, baseline hazard extractable. All four §1 acceptance criteria met.
+
+---
+
+## §2 Scope landed (verbatim against dispatch §2)
+
+| Path | Status | Purpose |
+|---|---|---|
+| `core/heavy_ml_probe/survival.py` | new | Target construction (time-to-+1R censored at SL/time-exit, same-bar SL tie-break) + per-fold PHReg fit + concordance eval + persistence (results + baseline hazard) |
+| `core/heavy_ml_probe/metrics.py` | refactored | `concordance` implemented from scratch (Harrell's C-index per dispatch §4); `integrated_brier_score` now raises `NotImplementedError` with RSF-deferral pointer |
+| `core/heavy_ml_probe/pipeline.py` | extended | `_run_survival_stage` orchestration; survival is INDEPENDENT of AutoML + meta-labeling (third parallel stage); new artefacts + extras in manifest; PipelineResult extended with survival fields |
+| `scripts/heavy_ml_probe/run_probe.py` | tweaked | stdout surfaces survival concordance + status; "Survival not yet implemented" message replaced |
+| `docs/sub_protocols/heavy_ml_probe.md` | extended | survival-models section updated: library swap (lifelines → statsmodels.PHReg) + RSF deferral documented |
+| `requirements-dev.txt` | tweaked | `statsmodels` added; `lifelines` + `scikit-survival` removed (both blocked on Py 3.14) |
+| `tests/heavy_ml_probe/test_survival.py` | new | 31 tests — target construction edge cases + concordance correctness + end-to-end + determinism + min-N warning + convergence-failure handling + pipeline integration |
+
+Artefact outputs landing per dispatch §2:
+
+- `step_4/heavy_ml/survival_model_results.csv` — long-form (fold × feature): `coefficient, p_value, std_err, concordance, n_train, n_train_event, convergence_warning`
+- `step_4/heavy_ml/classifiers/survival/manifest.json` — sha256-bound per-fold model index + statsmodels version + joblib version + per-fold (concordance, n_train_event, fit_message)
+- `step_4/heavy_ml/classifiers/survival/fold_NN.joblib` — pickled dict `{results, baseline_hazard, used_features, coefficients}` per fold (skipped folds → no pickle, manifest records `path: null`)
+- Existing `step_4/heavy_ml/manifest.json` extended with new `survival` extras block
+
+PR-D does NOT modify `core/architectures/**`, `L_PROTOCOL.md`, vanilla Step 1-6 mechanics, or any arc folders.
+
+---
+
+## §3 Concordance implementation cross-check (dispatch §4)
+
+Implemented from scratch in `core/heavy_ml_probe/metrics.py::concordance`. Standard Harrell C-index pairwise definition. Per dispatch §4 fallback: lifelines is blocked → no library reference available locally; cross-checked against a hand-computed synthetic case AND against the boundary behaviours that have closed-form answers.
+
+### §3.1 Test coverage
+
+| Test | Expected | Got |
+|---|---|---|
+| `test_concordance_perfectly_ranked` (risk inverse-rank to time, all events) | 1.0 | 1.0 ✓ |
+| `test_concordance_perfectly_reversed` (risk same-rank as time, all events) | 0.0 | 0.0 ✓ |
+| `test_concordance_random_close_to_half` (random risk + time, n=200) | ≈ 0.5 | 0.40–0.60 ✓ |
+| `test_concordance_hand_computed_with_censoring` (3 trades, 1 censored, traced) | 2/3 | 0.6667 ✓ |
+| `test_concordance_with_ties` (3 trades, tied risks contribute 0.5) | 2.5/3 | 0.8333 ✓ |
+| `test_concordance_no_comparable_pairs_returns_nan` (all-censored validation) | NaN | NaN ✓ |
+| `test_concordance_non_finite_dropped` (NaN-time row dropped, then 1.0) | 1.0 | 1.0 ✓ |
+| `test_concordance_shape_mismatch_raises` (shape mismatch) | ValueError | ValueError ✓ |
+
+The hand-computed case is the load-bearing reference. Trace:
+- Trades: `(event=1, time=1, risk=10), (event=0, time=5, risk=8), (event=1, time=3, risk=5)`
+- Comparable pairs `(i, j)` where `i` had event AND `t_i < t_j`:
+  - `(0, 1)`: t=1 < t=5, risk_i=10 > risk_j=8 → concordant
+  - `(0, 2)`: t=1 < t=3, risk_i=10 > risk_j=5 → concordant
+  - `(2, 1)`: t=3 < t=5, risk_i=5 < risk_j=8 → discordant
+- Result: `(2 + 0) / 3 = 0.6667` ✓
+
+No drift from the spec math. Implementation vectorised via numpy broadcasting (O(n²) memory; fine at validation-fold scale ~ few hundred trades).
+
+---
+
+## §4 Convergence-warning frequency
+
+### §4.1 Test-scale (n=400, n_folds=5, 4 features)
+
+Early folds (n_train=70, 136) trigger `MIN_N_WARN` (n_train < 200) → `convergence_warning=True` flagged on those rows. Later folds clean. Per-fold detail from a representative run:
+
+```
+fold 1: n_train= 70 ev=29 concordance=0.8510  WARN  msg=ok
+fold 2: n_train=136 ev=52 concordance=0.8021  WARN  msg=ok
+fold 3: n_train=202 ev=82 concordance=0.7799        msg=ok
+fold 4: n_train=268 ev=113 concordance=0.8788       msg=ok
+fold 5: n_train=334 ev=140 concordance=0.8195       msg=ok
+```
+
+statsmodels' own `ConvergenceWarning` did NOT fire on any of these — the convergence_warning flag in the output is purely from our min-N rule. PHReg's analytic optimiser handles small-N cleanly within this sample.
+
+### §4.2 Production-scale probe (n=5000, n_folds=11, 8 features)
+
+```
+wall-clock: 1.15s
+concordance: nanmean=0.7792 std=0.0168
+valid folds: 11/11
+total events: 10036
+folds with convergence_warning: 0/11
+fit failures: 0/11
+```
+
+Linearly scaling per-fold: 1.15s / 11 folds ≈ 0.1s per Cox PH fit on n_train ~ 2500. Per-arc cost at 8 features is negligible (PR-C's AutoML stage dominates wall-clock). Even at 30+ features this should stay well under 1 minute per arc — orders of magnitude below the dispatch's "could surface as material wall-clock" concern (none materialised).
+
+### §4.3 Pathological synthetic — convergence-failure path covered
+
+`test_run_survival_no_events_fold_skipped` constructs a pool where the first 90% of trades are all-censored (never reach +1R). TimeSeriesSplit's early folds train on slices with zero events. Cox PH refuses to fit on zero-event data; the survival module short-circuits with `fit_message="skipped:no_events_in_training_slice"`, marks `fit_succeeded=False`, sets concordance to NaN, and continues. No crash, full audit trail in manifest. Confirmed at least one fold skipped in the test.
+
+Real PHReg convergence failures (`ConvergenceWarning`, `LinAlgError`) are trapped at `_safe_phreg_fit`. If they fire in production, the corresponding fold's `fit_message` will carry `f"{ExcType}: {msg}"` and `convergence_warning=True` flags it for closure-doc audit.
+
+---
+
+## §5 Verification results
+
+### §5.1 Test suite
+
+```
+py -3 -m pytest tests/heavy_ml_probe -q -W ignore::UserWarning
+........................................................................ [ 64%]
+.......................................                                  [100%]
+111 passed in 137.85s
+```
+
+111 tests: 31 PR-A + 19 PR-B + 30 PR-C + 31 PR-D. Wall-clock 138s — increase over PR-C (~67s) is the new survival tests adding ~70s (mostly the determinism test which fits Cox PH twice + reloads pickles). Acceptable trade-off; all individual tests under 30s.
+
+PR-D test coverage breakdown:
+
+| Group | Count | Coverage |
+|---|---|---|
+| Target construction edge cases (dispatch §3) | 10 | event-before-close; never-reached/censored; SL on entry; same-bar SL tie-break; same-bar non-SL (event=1); 0-bar clipped to 1; vectorised mixed; HALT-loud schema; HALT-loud NaN bars_held; case-insensitive SL |
+| Concordance correctness (dispatch §4) | 8 | perfectly ranked (1.0); perfectly reversed (0.0); random ≈ 0.5; hand-computed w/ censoring; ties; no comparable pairs → NaN; shape mismatch raises; non-finite dropped |
+| End-to-end `run_survival` | 3 | smoke; positive `a` coefficient recovered on synthetic; baseline-hazard persisted (non-decreasing cumhaz, monotone-decreasing survival, values in [0,1]) |
+| Determinism | 1 | two runs → byte-identical CSV + identical pickle params + identical baseline-hazard arrays |
+| Min-N + convergence | 2 | n < 200 warning fires + run completes; zero-events fold skipped cleanly |
+| Pipeline integration | 4 | full artefact set written; CSV columns; two-run determinism through pipeline; survival skips with reason on missing columns |
+| Persistence corner | 1 | empty SurvivalResult still writes a manifest |
+| Constants locked | 2 | `SURVIVAL_REQUIRED_POOL_COLUMNS`, `MIN_N_WARN` |
+
+### §5.2 Sibling regression
+
+```
+py -3 -m pytest tests/discovery -q
+..........................................                               [100%]
+42 passed in 84.66s
+```
+
+42/42 — `signal_discovery_probe` untouched.
+
+### §5.3 Lint
+
+```
+py -3 -m ruff check core/heavy_ml_probe scripts/heavy_ml_probe tests/heavy_ml_probe
+All checks passed!
+```
+
+Two unused imports + one unused local auto-fixed via `--fix`. No remaining warnings.
+
+### §5.4 CLI smoke
+
+End-to-end CLI run against a 300-trade synthetic pool carrying ALL three schemas (vanilla `y`, meta-label MFE columns, survival columns):
+
+```
+[heavy_ml_probe] pipeline run complete.
+  ...
+  lineage gate   : accepted=0 / rejected=11 / input=11
+  AutoML         : status=no_clean_features (skipped)
+  Meta-labeling  : status=no_clean_features (skipped)
+  Survival (Cox) : status=no_clean_features (skipped)
+[heavy_ml_probe] PR-E (Step 5 augmentation hook) not yet implemented.
+exit: 0
+artefacts: ['stub_summary']
+automl skip: no_clean_features
+meta_label skip: no_clean_features
+survival skip: no_clean_features
+```
+
+All three stages cleanly skipped on the same reason (synthetic columns aren't in the real feature registry — gate rejected every column). Exit 0 because the pipeline ran to completion; the skip is informational.
+
+### §5.5 Determinism
+
+`test_pipeline_survival_two_run_determinism` asserts byte-equality on the survival CSV + the survival classifier manifest + the top-level manifest's stable payload across two consecutive pipeline runs. **Cox PH is deterministic** (analytic optimisation, no random seed needed) — confirmed empirically: per-fold coefficients + baseline-hazard arrays match exactly across runs. Two separate determinism layers covered:
+
+1. **CSV bytes** — sorted by `(fold, feature)`, written with `lineterminator='\n'`, NaN-safe formatting.
+2. **Classifier-manifest** — no embedded timestamp (carried PR-C convention forward); sha256 of the on-disk JSON matches across runs.
+3. **Pickled coefficients + baseline hazard** — `numpy.testing.assert_array_equal` passes across runs at the pickle-load layer.
+
+---
+
+## §6 Deviations from dispatch
+
+### §6.1 `integrated_brier_score` stubbed, not removed
+
+Dispatch §2 lists IBS as deferred (RSF dropped). PR-D keeps the function signature on the public API surface but the body now raises `NotImplementedError` with a pointer to the deferral rationale. This preserves backwards compatibility for any future caller that imports it — they get a clear error rather than `AttributeError`. Re-enabling it is a one-PR change when sksurv ships its cp314 wheel.
+
+### §6.2 `predict_proba` consciously NOT used
+
+Dispatch §4 hints at using `results.predict()`. PR-D's `_predicted_risk` instead computes `exp(X @ params)` directly. Rationale: `results.predict()` returns a `statsmodels.duration.hazard_regression.PHReg.predict.<locals>.bunch` object (not an ndarray) that's harder to keep stable across statsmodels versions. Computing the linear predictor manually is one line, dependency-free, and matches the textbook definition of Cox PH hazard ratio.
+
+### §6.3 baseline_cumulative_hazard format (already noted §1.4)
+
+Dispatch §8 said `results.baseline_cumulative_hazard()` — actual API is a property returning `list[list[ndarray]]`. Documented in `_extract_baseline_cumulative_hazard` docstring; the function normalises to a plain dict for joblib portability.
+
+### §6.4 Survival is INDEPENDENT of AutoML AND meta-labeling
+
+Same architectural pattern as PR-C's meta-labeling (PR-C log §6.1). The dispatch left this orchestration choice unspecified for survival; PR-D follows the meta-labeling precedent — survival's preconditions are evaluated independently of the other two stages. Skip reasons mirror PR-C's vocabulary.
+
+---
+
+## §7 Flags for chat
+
+### §7.1 Non-blocking
+
+- **Production-scale Cox PH is fast** (1.15s for n=5000 / 11 folds / 8 features). FLAML AutoML still dominates the heavy_ml_probe wall-clock; survival is a rounding error on top of it. No optimisation needed.
+- **Test wall-clock at 138s** (PR-A: 1s, PR-B: 17s, PR-C: 67s, PR-D: 138s). 70s of growth this PR — most of it the survival determinism test which fits Cox PH twice across 5 folds and reloads 10 pickles. If CI runtime tightens, the determinism test can drop to 3 folds.
+- **statsmodels version recorded in classifier manifest** for PR-E version-drift detection (same convention as joblib version in PR-C).
+
+### §7.2 Surfaced for PR-E intent
+
+- **`build_a4_adapter_from_heavy_ml` consumer surface.** PR-D's persistence format is the joblib pickle dict `{results, baseline_hazard, used_features, coefficients}`. PR-E's adapter (Q5b option B1) needs to:
+  - Load the per-fold pickle
+  - Compute `lp_at_N = features_at_N @ coefficients`
+  - Compute `hazard_ratio_at_N = exp(lp_at_N)`
+  - Look up `baseline_cumulative_hazard` at time `N` and `N+K` to get `H_0(N)` and `H_0(N+K)`
+  - Compute `S(N+K | N) = exp(-(H_0(N+K) - H_0(N)) * hazard_ratio)`
+  - Return `P(reach +1R in K bars) = 1 - S(N+K | N)` as A4's predict_admit signal
+  - The `baseline_hazard` dict stores time/cumhaz arrays; PR-E should bilinear-interpolate when N falls between observed event times.
+- **Which fold to deploy?** PR-D persists all 11 folds. PR-E decides: last fold (most data), full-IS refit, or ensemble of N best by concordance. Dispatch §7 explicitly defers this to PR-E.
+
+### §7.3 No HALT
+
+§1 install check passed; pickle round-trip works; no production-scale convergence failures observed. WORKFLOW §6 unused.
+
+---
+
+## §8 Branch state at PR-time
+
+- Build branch (`infra/heavy_ml_probe_build`) on origin still at `7c238e8` (main's tip at PR-A time). PR-A/B/C merges have not happened yet at PR-D-open time — chat's "merged" signals interpreted at the head level (each PR's branch contains all upstream).
+- PR-D branch (`infra/heavy_ml_probe_pr_d`) cut from `infra/heavy_ml_probe_pr_c` locally so the head of PR-D includes A+B+C+D commits. When chat merges A/B/C → build on GitHub, the PR-D diff will recompute and show only PR-D's changes.
+
+---
+
+## §9 What lands next (per dispatch §11)
+
+After PR-D merges into `infra/heavy_ml_probe_build`:
+
+- **PR-E (Integration + Step 5 augmentation hook)** — final integration PR. Wires AutoML + meta-labeling + survival into a single CLI invocation (already there in PR-D, but PR-E adds the consumer adapters). Provides:
+  - `build_a2_config_from_heavy_ml(cluster_id, step4_dir)` — wraps PR-C meta-label classifiers into A2Config
+  - `build_a6_config_from_heavy_ml(cluster_id, step4_dir)` — same, for A6
+  - `build_a4_adapter_from_heavy_ml(cluster_id, step4_dir, fold_choice, horizon_K)` — Q5b adapter wrapping PR-D Cox PH `S(t | features)` into A4's `predict_admit` shape
+  - Step 5 hook documentation explaining how an arc invokes these
+- **PR-F (Docs + polish)** — README / inline cleanup. Final PR.
+
+Per chat directive: I will not start PR-E work during the PR-D review window.
+
+---
+
+End of PR-D log.

--- a/docs/dispatches/heavy_ml_probe_pr_e_log.md
+++ b/docs/dispatches/heavy_ml_probe_pr_e_log.md
@@ -1,0 +1,266 @@
+# heavy_ml_probe PR-E — Log Doc (Gate PR)
+
+> **Branch:** `infra/heavy_ml_probe_pr_e` → `infra/heavy_ml_probe_build` (cut from PR-D locally; chat's "PR-D merged" signal honoured at the head level — origin build branch still at main pre-merge per `git ls-remote`).
+> **Dispatch:** chat prompt 2026-05-25 with PR-D flag dispositions + gate-PR scope.
+> **Intent doc:** [`docs/dispatches/heavy_ml_probe_build_intent.md`](heavy_ml_probe_build_intent.md).
+> **PR-D log:** [`docs/dispatches/heavy_ml_probe_pr_d_log.md`](heavy_ml_probe_pr_d_log.md).
+> **Sub-protocol spec:** [`docs/sub_protocols/heavy_ml_probe.md`](../sub_protocols/heavy_ml_probe.md) v1.0 (PR-E added Invocation section + scope clarification).
+> **Authoring CC session:** worktree `elegant-ride-ad9a57`.
+
+---
+
+## §1 Determinism gate (dispatch §5 — load-bearing)
+
+**Gate verdict: PASS. No HALT.**
+
+`test_determinism_gate_all_artefacts_byte_identical` in `tests/heavy_ml_probe/test_integration.py` runs the full pipeline twice on identical input + seed and asserts byte-identical sha256 for every single artefact:
+
+| Artefact | sha256 stable? |
+|---|---|
+| `stub_summary.md` | ✓ |
+| `compute_budget_used.md` (PR-E aggregate) | ✓ |
+| `automl_leaderboard.csv` | ✓ |
+| `automl_feature_importance.csv` | ✓ |
+| `meta_label_results.csv` | ✓ |
+| `meta_label_classifier_manifest` (sidecar JSON) | ✓ |
+| `survival_model_results.csv` | ✓ |
+| `survival_classifier_manifest` (sidecar JSON) | ✓ |
+| `step_5/heavy_ml_augmented/heavy_ml_manifest.json` | ✓ |
+| top-level `step_4/heavy_ml/manifest.json` (stable payload) | ✓ |
+
+10/10 artefacts byte-identical. Top-level manifest's `created_at` is the only field that varies; `stable_payload_sha256` excludes it for the comparison. All sidecar manifests (per-stage classifier manifests + Step 5 manifest) emit without timestamps per the PR-C convention so direct sha256 comparison works.
+
+Real determinism issues found + fixed during PR-E development:
+
+1. **`os.path.relpath` for sibling-directory paths.** First implementation used `Path.relative_to` for the Step 5 manifest's `classifier_manifest_path` entries; that requires the path to be a descendant. Step 4 and Step 5 dirs are siblings under `output_root`, so the relative path needs `..` segments. Switched to `os.path.relpath` which handles up-traversal cleanly.
+
+---
+
+## §2 Adapter contract verification (dispatch §2 + §8 — mandatory)
+
+**Confirmed all three adapter contracts match what `core/architectures/{A2,A4,A6}*.py` expects.** No HALT.
+
+### §2.1 A2 (`build_a2_from_heavy_ml`)
+
+A2's runtime per `core/architectures/a2_classifier_filter.py` consumes `A2Config(classifier=..., threshold=float, classifier_feature_order=tuple[str, ...], ...)` where `classifier.predict_proba(X)` returns `(n_samples, 2)` ndarray. PR-C's FLAML meta-label inner estimator (e.g. `LGBMClassifier`, `XGBClassifier`) IS sklearn-compatible and exposes `predict_proba` directly — drop-in. Test `test_build_a2_from_heavy_ml_returns_a2config` asserts:
+
+- Returns an `A2Config` instance
+- `cfg.classifier` exposes `predict_proba`
+- `cfg.classifier_feature_order` includes the lineage-gate-accepted columns
+
+### §2.2 A6 (`build_a6_from_heavy_ml`)
+
+Identical contract to A2. A6's `A6Config(classifier, lower_threshold, upper_threshold, classifier_feature_order, ...)` consumes the same predict_proba shape. Test `test_build_a6_from_heavy_ml_returns_a6config` passes.
+
+### §2.3 A4 (`build_a4_from_heavy_ml`) — the load-bearing one
+
+A4's runtime per `core/architectures/a4_pipeline_d_exits.py:_A4ExitPredicate.__call__` consumes a `PathClassifierFit` via `predict_admit(fit, feature_row) → (admit, proba)` from `core/architectures/_path_classifier.py`. `predict_admit` calls `fit.model.predict_proba(X)[0, 1]` where X is `(1, len(fit.feature_order))`.
+
+**PR-E's CoxPHAdapter implements that contract.** The adapter:
+
+- Exposes `hazard_predict(features_dict, bars_survived_at_N) → P` (dispatch §2.2 primary contract)
+- Exposes `predict_proba(X) → (n, 2)` that reads `bars_survived` from the last column (named `BARS_SURVIVED_FEATURE = "_bars_survived"`) and delegates to `hazard_predict`
+- Returns `feature_order = (*cox_features, BARS_SURVIVED_FEATURE)` so A4's feature-row assembly can splice in the bars-survived column
+
+Test `test_build_a4_predict_admit_handshake` is the **end-to-end contract test** — it loads the emitted manifest, builds the A4 bundle, constructs a feature_row with `BARS_SURVIVED_FEATURE` populated, and asserts `predict_admit(fit, feature_row)` returns `(bool, float in [0, 1])`. PASS.
+
+### §2.4 Hazard math correctness (dispatch §2.2)
+
+`test_coxph_adapter_hazard_predict_hand_computed` traces the dispatch §2.2 formula step-by-step:
+
+```
+coefficients   = [0.5, -0.3]
+features       = [1.0, 2.0]
+linear_pred    = 0.5*1 + (-0.3)*2 = -0.1
+relative_risk  = exp(-0.1) ≈ 0.9048
+baseline times = [2, 5, 10]
+baseline H_0   = [0.10, 0.40, 0.90]
+bars_survived  = 2 → H_0(2) = 0.10
+k_horizon      = 3 → t=5 → H_0(5) = 0.40
+integrated_hz  = (0.40 - 0.10) * 0.9048 = 0.27144
+P              = 1 - exp(-0.27144) ≈ 0.2378
+```
+
+Adapter returns `0.2378` (matches to 1e-9). PASS.
+
+Plus 6 boundary-case tests: step-function-flat region → P=0; pre-first-event → P=0; past-last-event clamps; NaN propagation on missing feature; predict_proba shape; feature_order includes BARS_SURVIVED_FEATURE.
+
+---
+
+## §3 Wall-clock for the synthetic end-to-end run
+
+Gate test scale (n=500 trades, n_folds=5, max_iter_per_fold=10, 4 features):
+
+```
+GATE-test scale (n=500, n_folds=5, max_iter=10): 5.47s wall
+  overall_status: all_ok
+  automl AUC:        0.9745
+  meta-label AUC:    0.9052
+  survival c-idx:    0.7880
+```
+
+5.47s wall-clock — well under the dispatch §5 target of ~30s. The full PR-E test file (`test_integration.py` — 9 tests) completes in **39s** total because most tests reuse the pipeline_run fixture (which executes once per call).
+
+Full test suite (149 tests = 31 PR-A + 19 PR-B + 30 PR-C + 31 PR-D + 9 integration + 29 adapter) completes in **241s** end-to-end. Lint: clean.
+
+---
+
+## §4 Step 5 augmented scope decision (dispatch §6)
+
+**Narrow scope selected and implemented.** Per dispatch §6's default recommendation: PR-E ships the adapters + emits `step_5/heavy_ml_augmented/heavy_ml_manifest.json` describing what's adapter-buildable. PR-E does **NOT** invoke `core/architectures/{A2,A4,A6}*.py` itself — that's the overseer Step 5 loop's job when it runs against an arc declaring `sub_protocol: heavy_ml_probe`.
+
+Documented in:
+- `docs/sub_protocols/heavy_ml_probe.md` — new "Scope clarification (PR-E)" paragraph in §"Output" section
+- `core/heavy_ml_probe/adapters.py` module docstring
+- `core/heavy_ml_probe/pipeline.py::_emit_step5_manifest` docstring + schema
+
+Wide scope (PR-E runs A2/A4/A6 directly) was NOT pursued — would cross dispatch §3's "do not touch `core/architectures/**`" boundary. If chat wants wide scope, surface in a follow-up PR; the adapters are already in place to make it a small extension.
+
+---
+
+## §5 Scope landed (verbatim against dispatch §8)
+
+| Path | Status | Purpose |
+|---|---|---|
+| `core/heavy_ml_probe/adapters.py` | new | A2/A4/A6 adapter builders + `CoxPHAdapter` (Cox PH wrapper with `hazard_predict` + sklearn `predict_proba` shim) + `FoldSelectionStrategy` enum + manifest reader + per-stage status taxonomy |
+| `core/heavy_ml_probe/pipeline.py` | extended | `_compute_budget_aggregate_markdown` (cross-stage budget); `_emit_step5_manifest` (Step 5 augmentation manifest); `_pipeline_overall_status` (drives exit code 3); `PipelineResult` gains `step5_manifest_path` + `overall_status` |
+| `scripts/heavy_ml_probe/run_probe.py` | extended | Exit code 3 partial-success handling; constants `EXIT_OK / EXIT_RUNTIME_ERROR / EXIT_ARGPARSE_ERROR / EXIT_PARTIAL_SUCCESS`; stdout surface adds `overall status` line + step5 manifest path |
+| `docs/sub_protocols/heavy_ml_probe.md` | extended | Operator invocation section + adapter manifest format + scope clarification (narrow) |
+| `tests/heavy_ml_probe/test_adapters.py` | new | 29 tests — hand-computed Cox PH math, manifest schema validation, partial-success error handling, fold strategies |
+| `tests/heavy_ml_probe/test_integration.py` | new | 9 tests — end-to-end, byte-identical determinism gate, adapter handshake, CLI exit codes (0 / 0 / 3 / 1) |
+
+Artefact outputs per dispatch §47:
+
+- All PR-B/C/D artefacts already landing under `step_4/heavy_ml/` — PR-E ensures they're emitted in a single CLI call (the orchestrator already does this; PR-E added the cross-stage `compute_budget_used.md` writer at pipeline end)
+- `step_5/heavy_ml_augmented/heavy_ml_manifest.json` — NEW — locked schema version `1.0`
+- `compute_budget_used.md` — extended to cover all three stages (was AutoML-only in PR-B; PR-E moved the writer to pipeline end)
+
+PR-E does NOT modify `core/architectures/**`, `L_PROTOCOL.md`, or any arc folders.
+
+---
+
+## §6 Verification
+
+### §6.1 Test suite
+
+```
+py -3 -m pytest tests/heavy_ml_probe -q -W ignore::UserWarning
+........................................................................ [ 48%]
+........................................................................ [ 96%]
+.....                                                                    [100%]
+149 passed in 241.35s (0:04:01)
+```
+
+149 tests: 31 PR-A + 19 PR-B + 30 PR-C + 31 PR-D + **9 integration + 29 adapter** (new in PR-E). All pass first run.
+
+PR-E test breakdown:
+
+| Group | Count | Coverage |
+|---|---|---|
+| CoxPH adapter math (dispatch §2.2) | 12 | hand-computed; step-function flat; pre-first-event; past-last clamp; NaN on missing feature; predict_proba shape; feature_order; rejects FULL_REFIT; rejects empty payloads; rejects k_horizon ≤ 0; ENSEMBLE_MEAN coefficient averaging; ENSEMBLE_MEAN feature-mismatch rejection |
+| `_interp_cumulative_hazard` step semantics | 1 | exhaustive boundary checks at + between + outside observed event times |
+| `_coxph_payload_from_pickle` | 2 | minimal dict round-trip; raises on missing key |
+| `EnsembleMeanProbaClassifier` | 2 | averages member predictions; empty members raises |
+| Manifest emission | 1 | schema version + sub_protocol + stages + adapters block + used_features |
+| A2/A6 builders | 2 | returns correct config type + predict_proba + feature_order |
+| A4 builder + predict_admit handshake | 2 | returns bundle; predict_admit + BARS_SURVIVED_FEATURE path |
+| Fold-selection strategies | 2 | LAST_FOLD vs ENSEMBLE_MEAN both work; FULL_REFIT raises |
+| Manifest schema validation | 4 | missing manifest; bad schema_version; wrong sub_protocol; stage != ok |
+| Integration end-to-end | 9 | full artefact set; **determinism gate**; adapter handshake; ensemble strategy; CLI exit 0 (all_ok); CLI exit 0 (all_skipped); CLI exit 3 (partial); CLI exit 1 (holdout); diagnostic-message smoke |
+
+### §6.2 Sibling regression
+
+```
+py -3 -m pytest tests/discovery -q
+..........................................                               [100%]
+42 passed in 54.34s
+```
+
+42/42 — `signal_discovery_probe` untouched.
+
+### §6.3 Lint
+
+```
+py -3 -m ruff check core/heavy_ml_probe scripts/heavy_ml_probe tests/heavy_ml_probe
+All checks passed!
+```
+
+7 initial unused-import warnings auto-fixed via `--fix`.
+
+### §6.4 CLI exit code semantics
+
+Verified in `test_integration.py`:
+
+| Pool shape | Expected exit | Actual |
+|---|---|---|
+| Full schema + monkey-patched lineage → all stages succeed | 0 (`EXIT_OK`) | ✓ |
+| Full schema + real-registry lineage (rejects all) → all stages skip on `no_clean_features` | 0 (`EXIT_OK` — clean skip, not failure) | ✓ |
+| Schema missing `bars_held` + `final_r` → AutoML ok, meta-label + survival skip | 3 (`EXIT_PARTIAL_SUCCESS`) | ✓ |
+| Pool entry_time inside holdout window → HoldoutGuardViolation raised | 1 (`EXIT_RUNTIME_ERROR`) | ✓ |
+
+---
+
+## §7 Deviations from dispatch
+
+### §7.1 A2 sources from PR-C's meta-label classifier (not separate AutoML output)
+
+Dispatch §2.1 calls for A2 to wrap "the FLAML classifier(s) from PR-B's AutoML stage." PR-B currently persists only the AutoML leaderboard + importance — **not** the inner classifier objects. PR-C persists the FLAML inner estimators for the meta-label target. Since both are FLAML AutoML outputs (same wrapper, different target), PR-E points A2 at the PR-C artefact set.
+
+This is a small contract gap that came up only at PR-E integration. A future enhancement (PR-F or post-PR-F) could add separate AutoML-target persistence to PR-B; PR-E's adapter would change one path lookup. Surfaced in `build_a2_from_heavy_ml` docstring + log §7.1.
+
+The semantic implication: A2 in heavy_ml_probe is effectively "the meta-label classifier used as a hard filter rather than a sizing signal." If chat wants A2 to consume a true `y` (cluster-membership) classifier, PR-B needs the persistence extension. Documented but not blocking PR-E.
+
+### §7.2 `compute_budget_used.md` writer moved from `_run_automl_stage` to pipeline end
+
+Necessary to cover all 3 stages (was AutoML-only in PR-B). PR-B tests asserted the file's existence after AutoML ran; still passes because the file is written before pipeline returns. Test assertions updated to allow the file to land even when AutoML skips (it now contains skip-reason narrative for every stage).
+
+### §7.3 Exit code 3 only on `partial` overall status
+
+Dispatch §4 says exit 3 when "at least one stage succeeded, at least one stage failed cleanly." Implemented as: `partial = mix of ok + skipped`. `all_skipped` → exit 0 (per dispatch §4 wording "all three cleanly skipped"). Tests cover both branches.
+
+### §7.4 `_emit_partial_manifest` does NOT emit Step 5 manifest
+
+When an exception (HoldoutGuardViolation, AllFeaturesRejected) is being re-raised, the partial-manifest path writes the Step 4 stub_summary + Step 4 manifest but NOT the Step 5 manifest. Rationale: an exception path means the pipeline didn't complete cleanly; adapter consumers reading a missing Step 5 manifest get a clear "manifest not found" error from `HeavyMLManifestError`. Could be revisited if chat prefers a stub Step 5 manifest with all stages marked failed.
+
+---
+
+## §8 Flags for chat
+
+### §8.1 Non-blocking
+
+- **A2 sources from PR-C's meta-label classifier** (§7.1 above). If chat wants A2 to consume a vanilla-target classifier, PR-B needs a persistence extension. Documented in `build_a2_from_heavy_ml` docstring.
+- **`build_a4_from_heavy_ml` returns a tuple `(A4Config, CoxPHAdapter)`** rather than mutating A4Config. The dispatch §2.2 says "A4Config object exposing a callable hazard_predict" — ambiguous between "A4Config with new attribute" (would require touching `core/architectures/A4.py`) and "bundle exposing both." Chose the bundle because it respects dispatch §3's "do not touch core/architectures/**." If chat wants A4Config to directly carry `hazard_predict`, a one-line subclass would do it; flag for PR-F or post-merge.
+- **Test wall-clock at 241s** (was 138s after PR-D). 100s growth this PR — 9 integration tests + 29 adapter tests with hand-computed Cox PH on synthetic data. Acceptable; integration tests are the load-bearing determinism gate so reducing coverage there isn't a fair trade.
+- **`FULL_REFIT` fold strategy is `NotImplementedError`.** Dispatch §3 marks it as "not implemented in PR-E; raise NotImplementedError. Future enhancement." Implemented as such; tested.
+
+### §8.2 Surfaced for PR-F intent
+
+- **README / operator notes** in `docs/sub_protocols/heavy_ml_probe.md` got an Invocation section in PR-E — PR-F can extend with full chat-side analysis examples (sweeping `k_horizon`, comparing LAST_FOLD vs ENSEMBLE_MEAN, etc.).
+- **Lineage gate doc polish** — the existing `causal_lineage.py` docstrings are stable but a top-level reader on what "lineage gate is binding" means in practice could land in PR-F.
+- **Minimum-N spec doc paragraph** — PR-D added the warning machinery; PR-F can promote it to a dedicated subsection in `heavy_ml_probe.md`.
+
+### §8.3 No HALT
+
+Determinism gate passes (§1). All adapter contracts verified (§2). No `core/architectures/**` modifications (dispatch §3 boundary respected). WORKFLOW §6 unused.
+
+---
+
+## §9 Branch state at PR-time
+
+- Build branch (`infra/heavy_ml_probe_build`) on origin still at `7c238e8` (main's tip at PR-A time). PR-A/B/C/D's GitHub merges have not happened yet at PR-E-open time — chat's "merged" signals interpreted at the head level (each PR's branch contains all upstream).
+- PR-E branch (`infra/heavy_ml_probe_pr_e`) cut from `infra/heavy_ml_probe_pr_d` locally so the head includes A+B+C+D+E commits. When chat merges A/B/C/D → build on GitHub, the PR-E diff will recompute and show only PR-E's changes.
+
+---
+
+## §10 What lands next (per dispatch §9)
+
+After PR-E merges into `infra/heavy_ml_probe_build`:
+
+- **PR-F (Documentation + polish — final PR)** — README extensions, inline doc cleanup surfaced during build, possible spec-doc polish (minimum-N subsection, lineage-gate-explanation), final readiness check. ≤ 0.5 day.
+- **Build-branch merge to main** — after PR-F lands.
+
+Per chat directive: I will not start PR-F work during the PR-E review window.
+
+---
+
+End of PR-E log.

--- a/docs/sub_protocols/heavy_ml_probe.md
+++ b/docs/sub_protocols/heavy_ml_probe.md
@@ -40,7 +40,11 @@ Vanilla Step 4 (three classifiers with fixed defaults, 5-fold TimeSeriesSplit AU
 
 2. **Meta-labeling target.** Binary target = "did this trade reach +1R MFE before hitting SL?" instead of cluster membership. Aligns with the actual deployment question.
 
-3. **Survival model variant for Pipeline D.** When arc declares `pipeline_d_exits` as a target architecture, also train Cox Proportional Hazards model and Random Survival Forest on time-to-exit. Predicted hazard at each post-entry bar feeds Step 5 Pipeline D exit policy.
+3. **Survival model variant for Pipeline D.** When arc declares `pipeline_d_exits` as a target architecture, also train a Cox Proportional Hazards model on time-to-+1R-MFE censored at SL/time-exit (per chat resolution Q1). Predicted hazard at each post-entry bar feeds Step 5 Pipeline D exit policy via the adapter pattern (Q5b).
+
+   **Library:** Cox PH via `statsmodels.duration.hazard_regression.PHReg` (PR-D). The original dispatch named `lifelines`; replaced because lifelines is blocked on Python 3.14 (its transitive dep `ecos` has no cp314 wheel). statsmodels has a clean cp314 wheel and PHReg covers the Cox PH path with the same modelling semantics.
+
+   **Random Survival Forest — DEFERRED.** scikit-survival (RSF) is also blocked on Py 3.14 by the same `ecos` cp314 gap. Per PR-B flag-1 disposition, PR-D ships Cox PH only. RSF can be added later when the wheel ships; the spec section reserves the slot.
 
 4. **Per-feature causal lineage.** Every feature consumed by AutoML must carry a causal lineage tag from Step 1. Features without a clean tag are excluded from AutoML training set. No exceptions — Arc 9 lookahead lesson.
 

--- a/docs/sub_protocols/heavy_ml_probe.md
+++ b/docs/sub_protocols/heavy_ml_probe.md
@@ -16,6 +16,12 @@ An arc's `ARC_OPEN.md` declares `sub_protocol: heavy_ml_probe`. Typical use:
 
 Not invoked by default. Compute-heavy. Run on selected arcs only.
 
+**Invocation (`scripts/heavy_ml_probe/run_probe.py`) exit codes** — standard Unix mapping; documented here for CI consumers (PR-A flag-1 disposition):
+
+- `0` — success; artefact set written
+- `1` — runtime failure (e.g. pool not found, holdout-guard violated, lineage gate rejected every feature)
+- `2` — argparse misuse (missing required flag, etc.; emitted by Python's argparse on its own)
+
 ---
 
 ## What overrides the overseer

--- a/docs/sub_protocols/heavy_ml_probe.md
+++ b/docs/sub_protocols/heavy_ml_probe.md
@@ -75,6 +75,47 @@ Causal audit runs identically to overseer §2 Step 6. Heavy ML doesn't bypass it
 
 `step_5/heavy_ml_augmented_architectures.csv` — A2/A4/A6 results using heavy-ML-trained components
 
+**Scope clarification (PR-E):** the augmented-architectures CSV is produced by the **overseer Step 5 loop**, not by `heavy_ml_probe` itself. PR-E ships **adapters** that translate heavy-ML-trained components into the existing `core/architectures/{A2,A4,A6}*.py` config shapes (per Q5a + Q5b), and emits `step_5/heavy_ml_augmented/heavy_ml_manifest.json` describing what's adapter-buildable. When the overseer's Step 5 loop runs against an arc whose `ARC_OPEN.md` declares `sub_protocol: heavy_ml_probe`, the loop reads this manifest, builds A2/A4/A6 via the adapters, runs them, and writes the augmented-architectures CSV alongside its vanilla Step 5 outputs. This keeps heavy_ml_probe narrow-scope (no direct A2/A4/A6 invocation).
+
+---
+
+## Invocation
+
+```
+python -m scripts.heavy_ml_probe.run_probe \
+    --arc <arc_name> \
+    --pool <path/to/step_1/pool.parquet> \
+    --cluster-id <int> \
+    [--config configs/heavy_ml_probe/default.yaml] \
+    [--output-root results/<arc_name>]
+```
+
+A single invocation runs AutoML (PR-B) + meta-labeling (PR-C) + Cox PH survival (PR-D) end-to-end. Stages are independent: each auto-skips if the pool lacks its required schema columns; skip reasons land in the manifest. Survival uses `statsmodels.duration.hazard_regression.PHReg` rather than the originally-spec'd `lifelines` (Python 3.14 cp314 wheel gap); RSF is deferred for the same reason.
+
+**Exit codes** (PR-E):
+
+- `0` — every stage succeeded OR every stage cleanly skipped with documented reason
+- `1` — runtime failure (pool not found, holdout-guard violated, lineage gate rejected every feature, uncaught exception)
+- `2` — argparse misuse (missing required flag — argparse's default)
+- `3` — partial success: at least one stage succeeded AND at least one stage was skipped. Adapters for `ok` stages will build cleanly; adapters for skipped stages raise `StageUnavailableError` with the skip reason
+
+**Step 5 adapter manifest** (PR-E) — `step_5/heavy_ml_augmented/heavy_ml_manifest.json` carries per-stage status + paths + buildability flags. Schema locked at `STEP5_MANIFEST_SCHEMA_VERSION = "1.0"`; adapters refuse to consume an unknown schema. The downstream overseer Step 5 loop (and any chat-side analysis script) constructs A2/A4/A6 via:
+
+```python
+from core.heavy_ml_probe.adapters import (
+    build_a2_from_heavy_ml,
+    build_a4_from_heavy_ml,
+    build_a6_from_heavy_ml,
+    FoldSelectionStrategy,
+)
+
+a2_cfg = build_a2_from_heavy_ml("results/<arc>/step_5/heavy_ml_augmented/heavy_ml_manifest.json")
+a4_cfg, cox_adapter = build_a4_from_heavy_ml(manifest_path, k_horizon=5, exit_threshold=0.4)
+a6_cfg = build_a6_from_heavy_ml(manifest_path, lower_threshold=0.3, upper_threshold=0.7)
+```
+
+Fold-selection strategy (per dispatch §3): `LAST_FOLD` (default — fold N classifier / Cox PH coefficients), `ENSEMBLE_MEAN` (average across all valid folds for sensitivity analysis), or `FULL_REFIT` (reserved — raises `NotImplementedError` in PR-E).
+
 ---
 
 ## Discipline rules specific to this sub-protocol

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,13 @@ pyyaml
 pydantic
 scipy
 scikit-learn
-joblib
+# joblib pinned to a minor version for cross-env classifier-pickle
+# stability — heavy_ml_probe PR-C persists per-fold classifiers via
+# joblib.dump for PR-E's A6 consumer, and joblib's pickle format has
+# evolved between 1.3 / 1.4 / 1.5. Bump in lockstep with vanilla Step 4
+# manifest's `joblib_version` audit field (see
+# core/steps/step_4_extraction.py:_write_manifest).
+joblib>=1.4,<1.6
 
 # heavy_ml_probe sub-protocol (docs/sub_protocols/heavy_ml_probe.md v1.0)
 # Used by core/heavy_ml_probe/* and tests/heavy_ml_probe/*.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,20 @@ pydantic
 scipy
 scikit-learn
 joblib
+
+# heavy_ml_probe sub-protocol (docs/sub_protocols/heavy_ml_probe.md v1.0)
+# Used by core/heavy_ml_probe/* and tests/heavy_ml_probe/*.
+# Pinned-version table lives in configs/heavy_ml_probe/default.yaml under
+# library_versions; the Step 4 manifest captures actual resolved versions
+# at runtime for env-drift audit (same convention as vanilla Step 4).
+flaml
+# Cox PH via statsmodels.duration.hazard_regression.PHReg (PR-D). The
+# original dispatch spec listed `lifelines` for Cox PH and
+# `scikit-survival` for RSF, but both are blocked on Python 3.14 because
+# their transitive dep `ecos` has no cp314 wheel. statsmodels has a
+# clean cp314 wheel and PHReg covers the Cox PH path; RSF is deferred
+# per PR-B flag-1 disposition.
+statsmodels
+xgboost
+catboost
+lightgbm

--- a/scripts/heavy_ml_probe/__init__.py
+++ b/scripts/heavy_ml_probe/__init__.py
@@ -1,0 +1,8 @@
+"""scripts/heavy_ml_probe — CLI entry points for the heavy_ml_probe sub-protocol.
+
+Mirrors ``scripts/arc_discovery_01/`` shape (package marker so the
+script can be invoked as ``python -m scripts.heavy_ml_probe.run_probe``
+or directly via ``python scripts/heavy_ml_probe/run_probe.py``).
+"""
+
+from __future__ import annotations

--- a/scripts/heavy_ml_probe/run_probe.py
+++ b/scripts/heavy_ml_probe/run_probe.py
@@ -1,12 +1,13 @@
 """CLI for the heavy_ml_probe sub-protocol.
 
-PR-D surface: load + validate config, load pool, apply causal lineage
+PR-E surface: load + validate config, load pool, apply causal lineage
 gate, run AutoML (PR-B) + meta-labeling (PR-C) + Cox PH survival (PR-D
 via statsmodels.PHReg) — each stage auto-skips when the pool lacks its
-required schema. Writes the full artefact set + manifest. PR-E adds the
-Step 5 augmentation hook.
+required schema. Writes the full ``step_4/heavy_ml/`` artefact set +
+``step_5/heavy_ml_augmented/heavy_ml_manifest.json`` for downstream
+A2/A4/A6 adapter consumers (see ``core.heavy_ml_probe.adapters``).
 
-Usage:
+Usage::
 
     python -m scripts.heavy_ml_probe.run_probe \\
         --arc <arc_name> \\
@@ -19,11 +20,17 @@ Default config path: ``configs/heavy_ml_probe/default.yaml``.
 Default output root: ``results/<arc_name>``.
 
 Exit codes (also documented in docs/sub_protocols/heavy_ml_probe.md):
-  0  pipeline ran successfully (artefact set written)
+  0  pipeline ran successfully — all three stages succeeded OR all
+     three cleanly skipped for documented reasons
   1  runtime failure (pool not found, holdout-guard violated, lineage
-     gate rejected every feature, etc.)
+     gate rejected every feature, etc.) — uncaught exception
   2  argparse misuse (missing required flag, etc. — argparse's own
      default exit code)
+  3  partial success — at least one stage succeeded AND at least one
+     stage was skipped. Downstream adapters can still build for the
+     `ok` stages; the skipped-stage adapters will refuse to build
+     with a clear error message. Signals "manifests are emitted but
+     not every stage's input is available."
 """
 
 from __future__ import annotations
@@ -41,6 +48,12 @@ from core.heavy_ml_probe.pipeline import (
 
 DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
 
+# Exit-code constants — public to make CI / shell-script use clearer.
+EXIT_OK: int = 0
+EXIT_RUNTIME_ERROR: int = 1
+EXIT_ARGPARSE_ERROR: int = 2  # argparse's own default
+EXIT_PARTIAL_SUCCESS: int = 3
+
 
 def _print_result_summary(result: PipelineResult) -> None:
     print("[heavy_ml_probe] pipeline run complete.")
@@ -50,6 +63,10 @@ def _print_result_summary(result: PipelineResult) -> None:
     print(f"  step4_dir      : {result.cfg.step4_dir.as_posix()}")
     print(f"  stub_summary   : {result.stub_summary_path.as_posix()}")
     print(f"  manifest       : {result.step4_manifest_path.as_posix()}")
+    if result.compute_budget_path is not None:
+        print(f"  budget         : {result.compute_budget_path.as_posix()}")
+    if result.step5_manifest_path is not None:
+        print(f"  step5 manifest : {result.step5_manifest_path.as_posix()}")
     print(
         f"  lineage gate   : accepted={result.lineage_gate.n_accepted} "
         f"/ rejected={result.lineage_gate.n_rejected} "
@@ -107,12 +124,37 @@ def _print_result_summary(result: PipelineResult) -> None:
         print(
             f"  Survival (Cox) : status={result.survival_skip_reason} (skipped)"
         )
-    print("[heavy_ml_probe] PR-E (Step 5 augmentation hook) not yet implemented.")
+    print(f"  overall status : {result.overall_status}")
+
+
+def _exit_code_from_overall_status(overall_status: str) -> int:
+    """Map :attr:`PipelineResult.overall_status` to a process exit code.
+
+    Per dispatch §4:
+
+      * ``"all_ok"``      → 0 (every stage succeeded)
+      * ``"all_skipped"`` → 0 (every stage cleanly skipped; documented
+                              reason in the manifest — no failure)
+      * ``"partial"``     → 3 (mix of success + skip; adapters for the
+                              `ok` stages will work, others raise)
+
+    Runtime failures (uncaught exceptions) are handled upstream and
+    return :data:`EXIT_RUNTIME_ERROR`.
+    """
+    if overall_status in ("all_ok", "all_skipped"):
+        return EXIT_OK
+    if overall_status == "partial":
+        return EXIT_PARTIAL_SUCCESS
+    # Unknown / future status → treat as partial (safe upper bound).
+    return EXIT_PARTIAL_SUCCESS
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Run the heavy_ml_probe sub-protocol (PR-A: scaffolding + lineage gate).",
+        description=(
+            "Run the heavy_ml_probe sub-protocol (PR-E: AutoML + "
+            "meta-labeling + Cox PH survival + Step 5 manifest)."
+        ),
     )
     parser.add_argument(
         "--arc",
@@ -158,17 +200,17 @@ def main(argv: list[str] | None = None) -> int:
         result = run_pipeline(cfg)
     except (FileNotFoundError, ValueError) as e:
         print(f"[heavy_ml_probe] config / pool error: {e}", file=sys.stderr)
-        return 1
+        return EXIT_RUNTIME_ERROR
     except HoldoutGuardViolation as e:
         print(f"[heavy_ml_probe] holdout-guard violation: {e}", file=sys.stderr)
-        return 1
+        return EXIT_RUNTIME_ERROR
     except AllFeaturesRejected as e:
         print(f"[heavy_ml_probe] lineage gate rejected every feature: {e}",
               file=sys.stderr)
-        return 1
+        return EXIT_RUNTIME_ERROR
 
     _print_result_summary(result)
-    return 0
+    return _exit_code_from_overall_status(result.overall_status)
 
 
 if __name__ == "__main__":

--- a/scripts/heavy_ml_probe/run_probe.py
+++ b/scripts/heavy_ml_probe/run_probe.py
@@ -1,11 +1,10 @@
 """CLI for the heavy_ml_probe sub-protocol.
 
-PR-C surface: load + validate config, load pool, apply causal lineage
-gate, run AutoML across an 11-fold TimeSeriesSplit (when the pool
-supports it), run meta-labeling (reach-1R-before-SL target + threshold
-sweep + per-fold classifier persistence) when the pool carries the
-meta-label schema, write the artefact set + manifest. Survival flow
-lands in PR-D.
+PR-D surface: load + validate config, load pool, apply causal lineage
+gate, run AutoML (PR-B) + meta-labeling (PR-C) + Cox PH survival (PR-D
+via statsmodels.PHReg) — each stage auto-skips when the pool lacks its
+required schema. Writes the full artefact set + manifest. PR-E adds the
+Step 5 augmentation hook.
 
 Usage:
 
@@ -86,7 +85,29 @@ def _print_result_summary(result: PipelineResult) -> None:
         print(
             f"  Meta-labeling  : status={result.meta_label_skip_reason} (skipped)"
         )
-    print("[heavy_ml_probe] Survival not yet implemented (PR-D).")
+    if result.survival_result is not None:
+        sr = result.survival_result
+        c_mean = sr.concordance_mean
+        c_str = (
+            f"{c_mean:.4f}" if c_mean == c_mean else "NaN"  # NaN-safe
+        )
+        print(
+            f"  Survival (Cox) : status=ok  folds={sr.n_folds_total} "
+            f"(valid={sr.n_folds_valid})  "
+            f"concordance nanmean={c_str}  "
+            f"total_events={sr.total_n_events}  "
+            f"statsmodels={sr.statsmodels_version}"
+        )
+        print(f"  survival CSV   : {result.survival_results_path.as_posix()}")
+        print(
+            f"  survival models: "
+            f"{result.survival_classifier_manifest_path.parent.as_posix()}/"
+        )
+    else:
+        print(
+            f"  Survival (Cox) : status={result.survival_skip_reason} (skipped)"
+        )
+    print("[heavy_ml_probe] PR-E (Step 5 augmentation hook) not yet implemented.")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/heavy_ml_probe/run_probe.py
+++ b/scripts/heavy_ml_probe/run_probe.py
@@ -1,25 +1,28 @@
 """CLI for the heavy_ml_probe sub-protocol.
 
-PR-A surface: load + validate config, load the pool, apply the causal
-lineage gate, write the stub summary + skeleton manifest. AutoML /
-meta-labeling / survival flows land in PR-B/C/D.
+PR-B surface: load + validate config, load pool, apply causal lineage
+gate, run AutoML across an 11-fold TimeSeriesSplit (when the pool
+supports it), write the artefact set + manifest. Meta-labeling /
+survival flows land in PR-C/D.
 
 Usage:
 
-    python -m scripts.heavy_ml_probe.run_probe \
-        --arc <arc_name> \
-        --pool <path/to/step_1/pool.parquet> \
-        --cluster-id <int> \
-        [--config configs/heavy_ml_probe/default.yaml] \
+    python -m scripts.heavy_ml_probe.run_probe \\
+        --arc <arc_name> \\
+        --pool <path/to/step_1/pool.parquet> \\
+        --cluster-id <int> \\
+        [--config configs/heavy_ml_probe/default.yaml] \\
         [--output-root results/<arc_name>]
 
 Default config path: ``configs/heavy_ml_probe/default.yaml``.
 Default output root: ``results/<arc_name>``.
 
-Exit codes:
-  0  pipeline ran successfully (stub artefacts written)
-  1  config / pool error (FileNotFoundError, schema mismatch, etc.)
-  2  internal error (re-raised to stderr for debugging)
+Exit codes (also documented in docs/sub_protocols/heavy_ml_probe.md):
+  0  pipeline ran successfully (artefact set written)
+  1  runtime failure (pool not found, holdout-guard violated, lineage
+     gate rejected every feature, etc.)
+  2  argparse misuse (missing required flag, etc. — argparse's own
+     default exit code)
 """
 
 from __future__ import annotations
@@ -28,6 +31,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from core.heavy_ml_probe.automl import AllFeaturesRejected, HoldoutGuardViolation
 from core.heavy_ml_probe.pipeline import (
     PipelineResult,
     load_config,
@@ -38,7 +42,7 @@ DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
 
 
 def _print_result_summary(result: PipelineResult) -> None:
-    print("[heavy_ml_probe] PR-A scaffolding run complete.")
+    print("[heavy_ml_probe] pipeline run complete.")
     print(f"  arc            : {result.cfg.arc_name}")
     print(f"  cluster_id     : {result.cfg.cluster_id}")
     print(f"  pool           : {result.cfg.pool_path.as_posix()}")
@@ -50,9 +54,19 @@ def _print_result_summary(result: PipelineResult) -> None:
         f"/ rejected={result.lineage_gate.n_rejected} "
         f"/ input={result.lineage_gate.n_input_columns}"
     )
+    if result.automl_result is not None:
+        ar = result.automl_result
+        print(
+            f"  AutoML         : status=ok  folds={ar.n_folds_total} "
+            f"(valid={ar.n_folds_valid})  "
+            f"AUC nanmean={ar.auc_mean:.4f}  "
+            f"total_modelcount={ar.total_modelcount}  "
+            f"wall={ar.total_fit_wall_seconds:.2f}s"
+        )
+    else:
+        print(f"  AutoML         : status={result.automl_skip_reason} (skipped)")
     print(
-        "[heavy_ml_probe] AutoML / meta-labeling / survival not yet implemented "
-        "(PR-B/C/D)."
+        "[heavy_ml_probe] Meta-labeling / survival not yet implemented (PR-C/D)."
     )
 
 
@@ -104,6 +118,13 @@ def main(argv: list[str] | None = None) -> int:
         result = run_pipeline(cfg)
     except (FileNotFoundError, ValueError) as e:
         print(f"[heavy_ml_probe] config / pool error: {e}", file=sys.stderr)
+        return 1
+    except HoldoutGuardViolation as e:
+        print(f"[heavy_ml_probe] holdout-guard violation: {e}", file=sys.stderr)
+        return 1
+    except AllFeaturesRejected as e:
+        print(f"[heavy_ml_probe] lineage gate rejected every feature: {e}",
+              file=sys.stderr)
         return 1
 
     _print_result_summary(result)

--- a/scripts/heavy_ml_probe/run_probe.py
+++ b/scripts/heavy_ml_probe/run_probe.py
@@ -1,9 +1,11 @@
 """CLI for the heavy_ml_probe sub-protocol.
 
-PR-B surface: load + validate config, load pool, apply causal lineage
+PR-C surface: load + validate config, load pool, apply causal lineage
 gate, run AutoML across an 11-fold TimeSeriesSplit (when the pool
-supports it), write the artefact set + manifest. Meta-labeling /
-survival flows land in PR-C/D.
+supports it), run meta-labeling (reach-1R-before-SL target + threshold
+sweep + per-fold classifier persistence) when the pool carries the
+meta-label schema, write the artefact set + manifest. Survival flow
+lands in PR-D.
 
 Usage:
 
@@ -65,9 +67,26 @@ def _print_result_summary(result: PipelineResult) -> None:
         )
     else:
         print(f"  AutoML         : status={result.automl_skip_reason} (skipped)")
-    print(
-        "[heavy_ml_probe] Meta-labeling / survival not yet implemented (PR-C/D)."
-    )
+    if result.meta_label_result is not None:
+        mr = result.meta_label_result
+        mr_ar = mr.automl_result
+        print(
+            f"  Meta-labeling  : status=ok  folds={mr_ar.n_folds_total} "
+            f"(valid={mr_ar.n_folds_valid})  "
+            f"AUC nanmean={mr_ar.auc_mean:.4f}  "
+            f"positive_rate={mr.positive_rate:.4f}  "
+            f"n_thresholds={len(mr.threshold_sweep)}"
+        )
+        print(f"  meta_label CSV : {result.meta_label_results_path.as_posix()}")
+        print(
+            f"  meta_label clfs: "
+            f"{result.meta_label_classifier_manifest_path.parent.as_posix()}/"
+        )
+    else:
+        print(
+            f"  Meta-labeling  : status={result.meta_label_skip_reason} (skipped)"
+        )
+    print("[heavy_ml_probe] Survival not yet implemented (PR-D).")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/heavy_ml_probe/run_probe.py
+++ b/scripts/heavy_ml_probe/run_probe.py
@@ -1,0 +1,114 @@
+"""CLI for the heavy_ml_probe sub-protocol.
+
+PR-A surface: load + validate config, load the pool, apply the causal
+lineage gate, write the stub summary + skeleton manifest. AutoML /
+meta-labeling / survival flows land in PR-B/C/D.
+
+Usage:
+
+    python -m scripts.heavy_ml_probe.run_probe \
+        --arc <arc_name> \
+        --pool <path/to/step_1/pool.parquet> \
+        --cluster-id <int> \
+        [--config configs/heavy_ml_probe/default.yaml] \
+        [--output-root results/<arc_name>]
+
+Default config path: ``configs/heavy_ml_probe/default.yaml``.
+Default output root: ``results/<arc_name>``.
+
+Exit codes:
+  0  pipeline ran successfully (stub artefacts written)
+  1  config / pool error (FileNotFoundError, schema mismatch, etc.)
+  2  internal error (re-raised to stderr for debugging)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from core.heavy_ml_probe.pipeline import (
+    PipelineResult,
+    load_config,
+    run_pipeline,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
+
+
+def _print_result_summary(result: PipelineResult) -> None:
+    print("[heavy_ml_probe] PR-A scaffolding run complete.")
+    print(f"  arc            : {result.cfg.arc_name}")
+    print(f"  cluster_id     : {result.cfg.cluster_id}")
+    print(f"  pool           : {result.cfg.pool_path.as_posix()}")
+    print(f"  step4_dir      : {result.cfg.step4_dir.as_posix()}")
+    print(f"  stub_summary   : {result.stub_summary_path.as_posix()}")
+    print(f"  manifest       : {result.step4_manifest_path.as_posix()}")
+    print(
+        f"  lineage gate   : accepted={result.lineage_gate.n_accepted} "
+        f"/ rejected={result.lineage_gate.n_rejected} "
+        f"/ input={result.lineage_gate.n_input_columns}"
+    )
+    print(
+        "[heavy_ml_probe] AutoML / meta-labeling / survival not yet implemented "
+        "(PR-B/C/D)."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the heavy_ml_probe sub-protocol (PR-A: scaffolding + lineage gate).",
+    )
+    parser.add_argument(
+        "--arc",
+        required=True,
+        help="Arc name (e.g. l_arc_10_heavy_ml). Used in manifest + output paths.",
+    )
+    parser.add_argument(
+        "--pool",
+        type=Path,
+        required=True,
+        help="Path to the Step 1 pool parquet for this arc.",
+    )
+    parser.add_argument(
+        "--cluster-id",
+        type=int,
+        required=True,
+        help="Candidate cluster ID from Step 3 to evaluate.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_PATH,
+        help=f"Heavy_ml_probe config YAML (default: {DEFAULT_CONFIG_PATH}).",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=None,
+        help="Override results root. Default: results/<arc>",
+    )
+    args = parser.parse_args(argv)
+
+    output_root: Path = args.output_root or Path("results") / args.arc
+
+    try:
+        cfg = load_config(
+            args.config,
+            arc_name=args.arc,
+            cluster_id=args.cluster_id,
+            pool_path=args.pool,
+            output_root=output_root,
+        )
+        result = run_pipeline(cfg)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"[heavy_ml_probe] config / pool error: {e}", file=sys.stderr)
+        return 1
+
+    _print_result_summary(result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/heavy_ml_probe/__init__.py
+++ b/tests/heavy_ml_probe/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for the heavy_ml_probe sub-protocol package."""
+
+from __future__ import annotations

--- a/tests/heavy_ml_probe/test_adapters.py
+++ b/tests/heavy_ml_probe/test_adapters.py
@@ -1,0 +1,601 @@
+"""Unit tests for core.heavy_ml_probe.adapters (PR-E).
+
+Per dispatch §2 / §8: adapter contracts must match what
+``core/architectures/A2.py``, ``A4.py``, ``A6.py`` actually expect.
+This test module verifies:
+
+  * `build_a2_from_heavy_ml` returns an :class:`A2Config` with a
+    `predict_proba`-shaped classifier and the right feature order.
+  * `build_a4_from_heavy_ml` returns ``(A4Config, CoxPHAdapter)`` and
+    the adapter's `hazard_predict` math matches a hand-computed
+    synthetic case (dispatch §2.2 formula).
+  * `build_a6_from_heavy_ml` returns an :class:`A6Config` with the
+    same predict_proba contract as A2.
+  * Fold selection strategies: `LAST_FOLD` (default) and
+    `ENSEMBLE_MEAN` both produce valid configs; `FULL_REFIT` raises
+    `NotImplementedError`.
+  * Manifest schema validation: bad schema_version → `HeavyMLManifestError`.
+  * Partial-success manifest: `survival.status != "ok"` → A4 build
+    raises `StageUnavailableError` with a clear message.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Import-guard FLAML + statsmodels — both required for adapter tests.
+pytest.importorskip("flaml")  # noqa: F841
+pytest.importorskip("statsmodels")  # noqa: F841
+
+from core.heavy_ml_probe.adapters import (  # noqa: E402
+    BARS_SURVIVED_FEATURE,
+    STEP5_MANIFEST_SCHEMA_VERSION,
+    CoxPHAdapter,
+    EnsembleMeanProbaClassifier,
+    FoldSelectionStrategy,
+    HeavyMLManifestError,
+    StageUnavailableError,
+    _coxph_payload_from_pickle,
+    _CoxPHFoldPayload,
+    _interp_cumulative_hazard,
+    build_a2_from_heavy_ml,
+    build_a4_from_heavy_ml,
+    build_a6_from_heavy_ml,
+)
+from core.heavy_ml_probe.pipeline import load_config, run_pipeline  # noqa: E402
+
+DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
+TEST_N_FOLDS = 5
+N_TRADES = 400
+
+
+# ── Synthetic pool reused from PR-C / PR-D tests ────────────────────
+
+
+def _full_schema_pool(n: int = N_TRADES, seed: int = 1) -> pd.DataFrame:
+    """Pool carrying ALL three stage schemas so the full pipeline runs."""
+    rng = np.random.default_rng(seed)
+    feats = rng.standard_normal((n, 4))
+    df = pd.DataFrame({"a": feats[:, 0], "b": feats[:, 1],
+                       "c": feats[:, 2], "d": feats[:, 3]})
+    df["entry_time"] = pd.date_range(
+        end="2020-12-15", periods=n, freq="h", tz="UTC"
+    )
+    df["trade_id"] = np.arange(n)
+    noise = rng.standard_normal(n) * 0.3
+    score = df["a"] + 0.5 * df["b"] + noise
+    reached = (score > 0).values
+    df["bars_to_1r_mfe"] = np.where(
+        reached, rng.integers(low=1, high=15, size=n), np.nan
+    )
+    df["bars_held"] = rng.integers(low=3, high=30, size=n)
+    df["exit_reason"] = np.where(reached, "tp", "sl")
+    df["final_r"] = np.where(
+        reached, rng.uniform(0.5, 3.0, size=n), rng.uniform(-1.0, 0.5, size=n)
+    )
+    df["y"] = reached.astype(int)
+    return df
+
+
+def _lineage_df_clean_features() -> pd.DataFrame:
+    return pd.DataFrame([
+        {"name": "a", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "b", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "c", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "d", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "trade_id", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "entry_time", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "bars_to_1r_mfe", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "bars_held", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "exit_reason", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "final_r", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "y", "causal_lineage": "suspect", "feature_class": "meta"},
+    ])
+
+
+def _override_config(tmp_path: Path) -> Path:
+    import yaml
+    with DEFAULT_CONFIG_PATH.open("r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    raw["automl"]["n_folds"] = TEST_N_FOLDS
+    raw["automl"]["max_iter_per_fold"] = 10
+    p = tmp_path / "test_config.yaml"
+    p.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def pipeline_run(tmp_path):
+    pool = _full_schema_pool()
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    lineage = _lineage_df_clean_features()
+    cfg = load_config(
+        cfg_path, arc_name="adapter_test", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = run_pipeline(cfg, lineage_df=lineage)
+    return result
+
+
+# ── CoxPHAdapter hand-computed math (dispatch §2.2 formula) ─────────
+
+
+def _build_synthetic_cox_payload(
+    coefficients: tuple[float, ...] = (0.5, -0.3),
+    used_features: tuple[str, ...] = ("a", "b"),
+    times: tuple[float, ...] = (2.0, 5.0, 10.0),
+    cumulative_hazard: tuple[float, ...] = (0.10, 0.40, 0.90),
+) -> _CoxPHFoldPayload:
+    """Build a tiny Cox PH payload for hand-computed verification."""
+    surv = tuple(math.exp(-h) for h in cumulative_hazard)
+    return _CoxPHFoldPayload(
+        coefficients=coefficients,
+        used_features=used_features,
+        baseline_times=times,
+        baseline_cumulative_hazard=cumulative_hazard,
+        baseline_survival=surv,
+    )
+
+
+def test_coxph_adapter_hazard_predict_hand_computed():
+    """Per dispatch §2.2 formula:
+
+      relative_risk     = exp(features @ coefficients)
+      integrated_hazard = (H_0(N+K) - H_0(N)) * relative_risk
+      P                 = 1 - exp(-integrated_hazard)
+
+    Setup:
+      coefficients = [0.5, -0.3]
+      features     = [1.0, 2.0] → linpred = 0.5*1 + (-0.3)*2 = -0.1
+                                relative_risk = exp(-0.1) ≈ 0.9048
+      baseline times      = [2, 5, 10]
+      baseline cumhaz     = [0.10, 0.40, 0.90]
+      bars_survived_at_N  = 2 (lookup → H_0(2) = 0.10)
+      k_horizon           = 3 (so N+K = 5, lookup → H_0(5) = 0.40)
+      integrated_hazard   = (0.40 - 0.10) * 0.9048 = 0.30 * 0.9048 = 0.2714
+      P                   = 1 - exp(-0.2714) ≈ 0.2378
+    """
+    payload = _build_synthetic_cox_payload()
+    adapter = CoxPHAdapter(
+        payloads=(payload,),
+        strategy=FoldSelectionStrategy.LAST_FOLD,
+        k_horizon=3,
+    )
+    p = adapter.hazard_predict({"a": 1.0, "b": 2.0}, bars_survived_at_N=2)
+    expected = 1.0 - math.exp(-0.30 * math.exp(-0.1))
+    assert p == pytest.approx(expected, rel=1e-9)
+
+
+def test_coxph_adapter_hazard_predict_zero_when_step_function_flat():
+    """If N and N+K both fall in the same step-function plateau,
+    H_0(N+K) == H_0(N), integrated hazard is 0, P = 0."""
+    payload = _build_synthetic_cox_payload(
+        times=(2.0, 5.0, 10.0), cumulative_hazard=(0.10, 0.40, 0.90),
+    )
+    adapter = CoxPHAdapter(
+        payloads=(payload,),
+        strategy=FoldSelectionStrategy.LAST_FOLD,
+        k_horizon=1,
+    )
+    # Bars survived 2 → H_0(2) = 0.10; N+K = 3 → step-function flat
+    # below time 5, so H_0(3) = H_0(2) = 0.10 → integrated hazard 0.
+    p = adapter.hazard_predict({"a": 1.0, "b": 2.0}, bars_survived_at_N=2)
+    assert p == pytest.approx(0.0, abs=1e-12)
+
+
+def test_coxph_adapter_hazard_predict_before_first_event_time():
+    """H_0(t) for t < first event time should be 0 (Breslow estimator
+    convention)."""
+    payload = _build_synthetic_cox_payload(
+        times=(5.0, 10.0), cumulative_hazard=(0.4, 0.9),
+    )
+    adapter = CoxPHAdapter(
+        payloads=(payload,),
+        strategy=FoldSelectionStrategy.LAST_FOLD,
+        k_horizon=2,
+    )
+    # bars=1: H_0(1) = 0; H_0(3) still < first event time = 0
+    # → integrated = 0 → P = 0.
+    p = adapter.hazard_predict({"a": 0.0, "b": 0.0}, bars_survived_at_N=1)
+    assert p == pytest.approx(0.0, abs=1e-12)
+
+
+def test_coxph_adapter_hazard_predict_past_last_event_clamps():
+    """Beyond the last observed event time, H_0 is clamped at the last
+    observed value (Breslow convention)."""
+    payload = _build_synthetic_cox_payload(
+        times=(2.0, 5.0, 10.0), cumulative_hazard=(0.10, 0.40, 0.90),
+    )
+    adapter = CoxPHAdapter(
+        payloads=(payload,),
+        strategy=FoldSelectionStrategy.LAST_FOLD,
+        k_horizon=5,
+    )
+    # bars=100 + horizon=5: both well past last time. H_0(both) = 0.90
+    # → integrated = 0 → P = 0.
+    p = adapter.hazard_predict({"a": 1.0, "b": 0.0}, bars_survived_at_N=100)
+    assert p == pytest.approx(0.0, abs=1e-12)
+
+
+def test_coxph_adapter_hazard_predict_returns_nan_on_missing_feature():
+    payload = _build_synthetic_cox_payload()
+    adapter = CoxPHAdapter(
+        payloads=(payload,), strategy=FoldSelectionStrategy.LAST_FOLD, k_horizon=3,
+    )
+    p = adapter.hazard_predict({"a": 1.0}, bars_survived_at_N=2)  # no `b`
+    assert not np.isfinite(p)
+
+
+def test_coxph_adapter_predict_proba_shape():
+    """predict_proba(X) returns (n_samples, 2); column 1 is P(event)."""
+    payload = _build_synthetic_cox_payload()
+    adapter = CoxPHAdapter(
+        payloads=(payload,), strategy=FoldSelectionStrategy.LAST_FOLD, k_horizon=3,
+    )
+    # X shape = (n, len(used_features) + 1) — last col is bars_survived
+    X = np.array([
+        [1.0, 2.0, 2],   # row 1: features [1,2], bars=2
+        [0.5, -1.0, 1],  # row 2: features [0.5, -1], bars=1
+    ])
+    out = adapter.predict_proba(X)
+    assert out.shape == (2, 2)
+    # Each row sums to 1
+    assert np.allclose(out.sum(axis=1), 1.0)
+    # Both probabilities in [0, 1]
+    assert ((out >= 0) & (out <= 1)).all()
+
+
+def test_coxph_adapter_feature_order_includes_bars_survived():
+    payload = _build_synthetic_cox_payload(used_features=("alpha", "beta"))
+    adapter = CoxPHAdapter(
+        payloads=(payload,), strategy=FoldSelectionStrategy.LAST_FOLD, k_horizon=1,
+    )
+    assert adapter.feature_order == ("alpha", "beta", BARS_SURVIVED_FEATURE)
+
+
+def test_coxph_adapter_rejects_full_refit_strategy():
+    payload = _build_synthetic_cox_payload()
+    with pytest.raises(NotImplementedError, match="FULL_REFIT"):
+        CoxPHAdapter(
+            payloads=(payload,),
+            strategy=FoldSelectionStrategy.FULL_REFIT,
+            k_horizon=3,
+        )
+
+
+def test_coxph_adapter_rejects_empty_payloads():
+    with pytest.raises(ValueError, match="at least one fold"):
+        CoxPHAdapter(
+            payloads=(), strategy=FoldSelectionStrategy.LAST_FOLD, k_horizon=3,
+        )
+
+
+def test_coxph_adapter_rejects_non_positive_horizon():
+    payload = _build_synthetic_cox_payload()
+    with pytest.raises(ValueError, match="k_horizon must be > 0"):
+        CoxPHAdapter(
+            payloads=(payload,), strategy=FoldSelectionStrategy.LAST_FOLD, k_horizon=0,
+        )
+
+
+def test_coxph_adapter_ensemble_mean_averages_coefficients():
+    """ENSEMBLE_MEAN averages coefficients across folds. With two
+    folds having coefs (0.5, -0.3) and (0.7, -0.1), the mean coefs are
+    (0.6, -0.2)."""
+    p1 = _build_synthetic_cox_payload(coefficients=(0.5, -0.3))
+    p2 = _build_synthetic_cox_payload(coefficients=(0.7, -0.1))
+    adapter = CoxPHAdapter(
+        payloads=(p1, p2),
+        strategy=FoldSelectionStrategy.ENSEMBLE_MEAN,
+        k_horizon=3,
+    )
+    eff = getattr(adapter, "_effective")
+    assert eff.coefficients == pytest.approx((0.6, -0.2), rel=1e-12)
+
+
+def test_coxph_adapter_ensemble_mean_rejects_mismatched_features():
+    p1 = _build_synthetic_cox_payload(used_features=("a", "b"))
+    p2 = _build_synthetic_cox_payload(used_features=("a", "c"))
+    with pytest.raises(ValueError, match="mismatched used_features"):
+        CoxPHAdapter(
+            payloads=(p1, p2),
+            strategy=FoldSelectionStrategy.ENSEMBLE_MEAN,
+            k_horizon=3,
+        )
+
+
+# ── _interp_cumulative_hazard step function ─────────────────────────
+
+
+def test_interp_cumulative_hazard_step_function():
+    payload = _build_synthetic_cox_payload(
+        times=(2.0, 5.0, 10.0), cumulative_hazard=(0.10, 0.40, 0.90),
+    )
+    # Before first event time
+    assert _interp_cumulative_hazard(payload, 0.0) == 0.0
+    assert _interp_cumulative_hazard(payload, 1.99) == 0.0
+    # At first event time (inclusive)
+    assert _interp_cumulative_hazard(payload, 2.0) == 0.10
+    # Between events: takes the last observed
+    assert _interp_cumulative_hazard(payload, 3.5) == 0.10
+    assert _interp_cumulative_hazard(payload, 4.99) == 0.10
+    assert _interp_cumulative_hazard(payload, 5.0) == 0.40
+    assert _interp_cumulative_hazard(payload, 7.5) == 0.40
+    assert _interp_cumulative_hazard(payload, 10.0) == 0.90
+    # Past last: clamps
+    assert _interp_cumulative_hazard(payload, 100.0) == 0.90
+
+
+# ── _coxph_payload_from_pickle ──────────────────────────────────────
+
+
+def test_coxph_payload_from_pickle_minimal_dict():
+    payload_dict = {
+        "coefficients": [0.5, -0.3],
+        "used_features": ["a", "b"],
+        "baseline_hazard": {
+            "times": [1, 2, 3],
+            "cumulative_hazard": [0.1, 0.3, 0.5],
+            "survival_function": [0.9, 0.74, 0.61],
+        },
+    }
+    p = _coxph_payload_from_pickle(payload_dict)
+    assert p.coefficients == (0.5, -0.3)
+    assert p.used_features == ("a", "b")
+    assert p.baseline_times == (1.0, 2.0, 3.0)
+
+
+def test_coxph_payload_from_pickle_raises_on_missing_key():
+    with pytest.raises(ValueError, match="missing keys"):
+        _coxph_payload_from_pickle({"coefficients": [], "used_features": []})
+
+
+# ── EnsembleMeanProbaClassifier ──────────────────────────────────────
+
+
+class _StubClassifier:
+    """Minimal stub exposing predict_proba for ensemble testing."""
+    def __init__(self, proba_value: float) -> None:
+        self.proba_value = proba_value
+
+    def predict_proba(self, X) -> np.ndarray:
+        X = np.asarray(X)
+        n = X.shape[0] if X.ndim > 1 else 1
+        out = np.zeros((n, 2))
+        out[:, 1] = self.proba_value
+        out[:, 0] = 1.0 - self.proba_value
+        return out
+
+
+def test_ensemble_mean_classifier_averages():
+    c1 = _StubClassifier(0.2)
+    c2 = _StubClassifier(0.8)
+    c3 = _StubClassifier(0.5)
+    ens = EnsembleMeanProbaClassifier(members=(c1, c2, c3))
+    out = ens.predict_proba(np.zeros((1, 3)))
+    assert out[0, 1] == pytest.approx(0.5)  # (0.2 + 0.8 + 0.5) / 3
+    assert out[0, 0] == pytest.approx(0.5)
+
+
+def test_ensemble_mean_classifier_empty_raises():
+    ens = EnsembleMeanProbaClassifier(members=())
+    with pytest.raises(RuntimeError, match="no members"):
+        ens.predict_proba(np.zeros((1, 1)))
+
+
+# ── Manifest readers + adapter builders against real pipeline ───────
+
+
+def test_step5_manifest_emitted_with_correct_schema(pipeline_run):
+    assert pipeline_run.step5_manifest_path is not None
+    assert pipeline_run.step5_manifest_path.exists()
+    payload = json.loads(pipeline_run.step5_manifest_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == STEP5_MANIFEST_SCHEMA_VERSION
+    assert payload["sub_protocol"] == "heavy_ml_probe"
+    assert payload["arc_name"] == "adapter_test"
+    assert payload["cluster_id"] == 0
+    assert {"automl", "meta_label", "survival"} <= set(payload["stages"].keys())
+    # Adapters block reflects per-stage status
+    for key in ("a2_buildable", "a4_buildable", "a6_buildable"):
+        assert isinstance(payload["adapters"][key], bool)
+    # Used features include the lineage-gate-accepted columns
+    assert {"a", "b", "c", "d"} <= set(payload["used_features"])
+
+
+def test_build_a2_from_heavy_ml_returns_a2config(pipeline_run):
+    from core.architectures.a2_classifier_filter import A2Config
+    cfg = build_a2_from_heavy_ml(pipeline_run.step5_manifest_path)
+    assert isinstance(cfg, A2Config)
+    # A2Config requires a predict_proba-shaped classifier — verify by call.
+    assert hasattr(cfg.classifier, "predict_proba")
+    # Feature order matches the manifest's used_features
+    assert set(cfg.classifier_feature_order) >= {"a", "b", "c", "d"}
+
+
+def test_build_a6_from_heavy_ml_returns_a6config(pipeline_run):
+    from core.architectures.a6_meta_labeling import A6Config
+    cfg = build_a6_from_heavy_ml(
+        pipeline_run.step5_manifest_path,
+        lower_threshold=0.3, upper_threshold=0.7,
+    )
+    assert isinstance(cfg, A6Config)
+    assert hasattr(cfg.classifier, "predict_proba")
+    assert cfg.lower_threshold == 0.3
+    assert cfg.upper_threshold == 0.7
+
+
+def test_build_a4_from_heavy_ml_returns_bundle(pipeline_run):
+    from core.architectures._path_classifier import PathClassifierFit
+    from core.architectures.a4_pipeline_d_exits import A4Config
+
+    a4_cfg, cox_adapter = build_a4_from_heavy_ml(
+        pipeline_run.step5_manifest_path,
+        k_horizon=5, exit_threshold=0.4,
+    )
+    assert isinstance(a4_cfg, A4Config)
+    assert isinstance(cox_adapter, CoxPHAdapter)
+    # A4Config carries a PathClassifierFit whose .model exposes predict_proba.
+    fit = a4_cfg.classifier_fit
+    assert isinstance(fit, PathClassifierFit)
+    assert hasattr(fit.model, "predict_proba")
+    # The fit's feature_order includes BARS_SURVIVED_FEATURE at the end.
+    assert fit.feature_order[-1] == BARS_SURVIVED_FEATURE
+    # Sanity: hazard_predict returns a finite P in [0, 1] when given
+    # valid features + bars.
+    sample_features = {f: 0.0 for f in cox_adapter._effective.used_features}
+    p = cox_adapter.hazard_predict(sample_features, bars_survived_at_N=3)
+    assert np.isfinite(p)
+    assert 0.0 <= p <= 1.0
+
+
+def test_build_a4_predict_admit_handshake(pipeline_run):
+    """End-to-end: the A4Config.classifier_fit + predict_admit pair
+    works on a feature_row including BARS_SURVIVED_FEATURE.
+
+    This is the load-bearing contract test — A4's runtime consumes
+    via predict_admit(fit, feature_row) per
+    core.architectures._path_classifier.
+    """
+    from core.architectures._path_classifier import predict_admit
+
+    a4_cfg, cox_adapter = build_a4_from_heavy_ml(
+        pipeline_run.step5_manifest_path,
+        k_horizon=5, exit_threshold=0.4,
+    )
+    fit = a4_cfg.classifier_fit
+    # Build a feature_row with every feature in fit.feature_order
+    feature_row = {f: 0.0 for f in fit.feature_order}
+    feature_row[BARS_SURVIVED_FEATURE] = 3
+    admit, proba = predict_admit(fit, feature_row)
+    assert isinstance(admit, bool)
+    assert 0.0 <= proba <= 1.0
+
+
+# ── Fold selection strategy ─────────────────────────────────────────
+
+
+def test_fold_selection_last_vs_ensemble_different_predictions(pipeline_run):
+    """LAST_FOLD and ENSEMBLE_MEAN both produce valid adapters but
+    typically different P values (mean across folds ≠ last fold)."""
+    _, adapter_last = build_a4_from_heavy_ml(
+        pipeline_run.step5_manifest_path,
+        fold_selection_strategy=FoldSelectionStrategy.LAST_FOLD,
+        k_horizon=3,
+    )
+    _, adapter_ens = build_a4_from_heavy_ml(
+        pipeline_run.step5_manifest_path,
+        fold_selection_strategy=FoldSelectionStrategy.ENSEMBLE_MEAN,
+        k_horizon=3,
+    )
+    # Same input → typically different output (different effective coefs)
+    feats = {f: 0.5 for f in adapter_last._effective.used_features}
+    p_last = adapter_last.hazard_predict(feats, bars_survived_at_N=3)
+    p_ens = adapter_ens.hazard_predict(feats, bars_survived_at_N=3)
+    assert np.isfinite(p_last) and np.isfinite(p_ens)
+    # Both in [0, 1]; soft assertion that they differ
+    assert 0.0 <= p_last <= 1.0
+    assert 0.0 <= p_ens <= 1.0
+
+
+def test_fold_selection_full_refit_raises_on_build(pipeline_run):
+    with pytest.raises(NotImplementedError, match="FULL_REFIT"):
+        build_a4_from_heavy_ml(
+            pipeline_run.step5_manifest_path,
+            fold_selection_strategy=FoldSelectionStrategy.FULL_REFIT,
+            k_horizon=3,
+        )
+
+
+# ── Manifest schema validation ──────────────────────────────────────
+
+
+def test_adapter_raises_on_missing_manifest(tmp_path):
+    bad = tmp_path / "does_not_exist.json"
+    with pytest.raises(HeavyMLManifestError, match="not found"):
+        build_a2_from_heavy_ml(bad)
+
+
+def test_adapter_raises_on_bad_schema_version(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({
+        "schema_version": "999.999",
+        "sub_protocol": "heavy_ml_probe",
+        "stages": {},
+    }), encoding="utf-8")
+    with pytest.raises(HeavyMLManifestError, match="schema mismatch"):
+        build_a2_from_heavy_ml(bad)
+
+
+def test_adapter_raises_on_wrong_sub_protocol(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({
+        "schema_version": STEP5_MANIFEST_SCHEMA_VERSION,
+        "sub_protocol": "vanilla",
+        "stages": {},
+    }), encoding="utf-8")
+    with pytest.raises(HeavyMLManifestError, match="sub_protocol"):
+        build_a2_from_heavy_ml(bad)
+
+
+def test_adapter_raises_on_stage_not_ok(tmp_path):
+    """Stage status != "ok" → StageUnavailableError with diagnostic."""
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({
+        "schema_version": STEP5_MANIFEST_SCHEMA_VERSION,
+        "sub_protocol": "heavy_ml_probe",
+        "arc_name": "x", "cluster_id": 0,
+        "stages": {
+            "survival": {
+                "status": "skipped",
+                "skip_reason": "missing_survival_columns:bars_to_1r_mfe",
+                "classifier_manifest_path": None,
+            }
+        },
+        "used_features": ["a"],
+    }), encoding="utf-8")
+    with pytest.raises(StageUnavailableError, match="survival"):
+        build_a4_from_heavy_ml(bad)
+
+
+def test_adapter_raises_on_partial_success_for_unavailable_stage(tmp_path):
+    """Per dispatch §4: exit-code-3 partial success → adapter for the
+    unavailable stage raises StageUnavailableError with a clear msg."""
+    bad = tmp_path / "partial.json"
+    bad.write_text(json.dumps({
+        "schema_version": STEP5_MANIFEST_SCHEMA_VERSION,
+        "sub_protocol": "heavy_ml_probe",
+        "arc_name": "x", "cluster_id": 0,
+        "stages": {
+            "automl": {
+                "status": "ok",
+                "skip_reason": "ok",
+                "classifier_manifest_path": "classifiers/meta_label/manifest.json",
+            },
+            "meta_label": {
+                "status": "ok",
+                "skip_reason": "ok",
+                "classifier_manifest_path": "classifiers/meta_label/manifest.json",
+            },
+            "survival": {
+                "status": "skipped",
+                "skip_reason": "missing_survival_columns:bars_held",
+                "classifier_manifest_path": None,
+            },
+        },
+        "used_features": ["a"],
+    }), encoding="utf-8")
+    # A4 adapter (needs survival) raises with clear message
+    with pytest.raises(StageUnavailableError) as excinfo:
+        build_a4_from_heavy_ml(bad)
+    assert "missing_survival_columns:bars_held" in str(excinfo.value)

--- a/tests/heavy_ml_probe/test_automl.py
+++ b/tests/heavy_ml_probe/test_automl.py
@@ -1,0 +1,554 @@
+"""Tests for core.heavy_ml_probe.automl + the PR-B pipeline integration.
+
+Per dispatch §6: covers end-to-end run, evaluation-cap respect,
+determinism, NaN-AUC propagation, holdout-guard, and lineage-rejects-all
+fast-fail.
+
+Pool fixtures stay small (≤400 rows, ≤5 folds, ≤10 max_iter) so the
+full file runs in well under the dispatch §4 ceiling (60s) — synthetic
+pools exist to verify mechanics, not to stress FLAML.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Import-guard FLAML — heavy dep; if missing the test module is skipped.
+# Imports below are intentionally module-level (noqa E402) so the
+# importorskip can gate the entire module.
+flaml = pytest.importorskip("flaml")  # noqa: F841 — kept for diagnostics if a future test asserts FLAML version
+
+from core.heavy_ml_probe.automl import (  # noqa: E402
+    DOCUMENTED_FLAML_2_6_0_ESTIMATORS,
+    AllFeaturesRejected,
+    AutoMLResult,
+    HoldoutGuardViolation,
+    compute_budget_markdown,
+    importance_to_dataframe,
+    leaderboard_to_dataframe,
+    run_automl,
+)
+from core.heavy_ml_probe.io import sha256_file  # noqa: E402
+from core.heavy_ml_probe.pipeline import (  # noqa: E402
+    AUTOML_REQUIRED_COLUMNS,
+    load_config,
+    run_pipeline,
+    stable_payload_sha256,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
+
+# Small problem sizes to keep the file fast. n_folds=5 + max_iter=10
+# keeps single-cluster wall-clock under a second on this hardware.
+TEST_N_FOLDS = 5
+TEST_MAX_ITER = 10
+TEST_PERMUTATION_REPEATS = 3  # smaller than default to save synthetic-pool time
+N_TRADES = 400
+
+
+# ── Synthetic data fixtures ──────────────────────────────────────────
+
+
+def _synthetic_pool(
+    *,
+    n: int = N_TRADES,
+    seed: int = 1,
+    last_entry: pd.Timestamp = pd.Timestamp("2020-12-15", tz="UTC"),
+    include_y: bool = True,
+    include_entry_time: bool = True,
+    target_strength: float = 1.0,
+    single_class_y: bool = False,
+) -> pd.DataFrame:
+    """Build a small classification pool with a learnable target.
+
+    Default target: ``y = (a + 0.5*b + noise) > 0`` where noise is
+    scaled by ``1 - target_strength``. ``target_strength=1.0`` →
+    near-perfect; ``0.0`` → pure noise.
+
+    ``entry_time`` is monotonically increasing over the trade window
+    ending at ``last_entry`` so TimeSeriesSplit slices the trades
+    causally.
+
+    ``single_class_y=True`` overrides ``y`` to all-zeros; useful for
+    NaN-propagation tests.
+    """
+    rng = np.random.default_rng(seed)
+    n_features = 4
+    feats = rng.standard_normal((n, n_features))
+    df = pd.DataFrame({
+        "a": feats[:, 0],
+        "b": feats[:, 1],
+        "c": feats[:, 2],
+        "d": feats[:, 3],
+    })
+    if include_y:
+        if single_class_y:
+            df["y"] = 0
+        else:
+            noise = rng.standard_normal(n) * (1.0 - target_strength)
+            df["y"] = ((df["a"] + 0.5 * df["b"] + noise) > 0).astype(int)
+    if include_entry_time:
+        # Even per-hour spacing ending at last_entry
+        end = pd.Timestamp(last_entry)
+        if end.tzinfo is None:
+            end = end.tz_localize("UTC")
+        idx = pd.date_range(end=end, periods=n, freq="h")
+        df["entry_time"] = idx
+    df["trade_id"] = np.arange(n)
+    return df
+
+
+def _synthetic_lineage_df() -> pd.DataFrame:
+    """Four feature columns marked clean; metadata columns marked
+    suspect so the lineage gate filters them out of the training matrix."""
+    return pd.DataFrame([
+        {"name": "trade_id", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "a", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "b", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "c", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "d", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "entry_time", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "y", "causal_lineage": "suspect", "feature_class": "meta"},
+    ])
+
+
+def _used_features(pool: pd.DataFrame) -> tuple[str, ...]:
+    """Pretend the lineage gate let only the 4 feature columns through."""
+    return tuple(c for c in pool.columns if c in {"a", "b", "c", "d"})
+
+
+# ── Core: run_automl directly ────────────────────────────────────────
+
+
+def test_run_automl_smoke():
+    """End-to-end run on a learnable target — AutoML produces a non-NaN
+    aggregate AUC and the artefact-shape helpers don't crash."""
+    pool = _synthetic_pool()
+    result = run_automl(
+        pool=pool,
+        used_features=_used_features(pool),
+        train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+        n_folds=TEST_N_FOLDS,
+        max_iter_per_fold=TEST_MAX_ITER,
+        permutation_repeats=TEST_PERMUTATION_REPEATS,
+    )
+    assert isinstance(result, AutoMLResult)
+    assert result.n_folds_total == TEST_N_FOLDS
+    assert result.n_folds_valid == TEST_N_FOLDS  # learnable target → every fold valid
+    assert np.isfinite(result.auc_mean)
+    # The target is learnable, so AUC should be materially above 0.5;
+    # be generous (0.6) to absorb FLAML small-pool wobble.
+    assert result.auc_mean > 0.6, f"expected AUC > 0.6, got {result.auc_mean:.4f}"
+    # Smoke-check artefact helpers
+    lb = leaderboard_to_dataframe(result)
+    imp = importance_to_dataframe(result)
+    md = compute_budget_markdown(result, train_end=pd.Timestamp("2021-01-01", tz="UTC"))
+    assert not lb.empty
+    assert {"fold", "estimator", "best_loss", "auc_val", "auc_train",
+            "modelcount", "max_iter"} <= set(lb.columns)
+    assert {"feature", "importance_mean", "importance_std", "n_folds_present"} <= set(imp.columns)
+    assert "compute budget audit" in md.lower()
+
+
+# ── §3a: modelcount respects max_iter ─────────────────────────────────
+
+
+def test_modelcount_does_not_exceed_max_iter():
+    """Per dispatch §3a + PR-B empirical: modelcount ≤ max_iter per fold."""
+    pool = _synthetic_pool()
+    result = run_automl(
+        pool=pool, used_features=_used_features(pool),
+        train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+        n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+        permutation_repeats=TEST_PERMUTATION_REPEATS,
+    )
+    for fr in result.fold_results:
+        assert fr.modelcount <= fr.max_iter, (
+            f"fold {fr.fold}: modelcount={fr.modelcount} > max_iter={fr.max_iter}"
+        )
+    # Total over folds should equal the per-fold sum.
+    assert result.total_modelcount == sum(fr.modelcount for fr in result.fold_results)
+
+
+def test_modelcount_matches_max_iter_on_learnable_target():
+    """On a real (non-edge) problem with `max_iter=10`, FLAML 2.6.0 runs
+    the full budget. Documents the §3a empirical: ratio == 1.0."""
+    pool = _synthetic_pool(target_strength=0.5)  # noisier so FLAML doesn't early-stop
+    result = run_automl(
+        pool=pool, used_features=_used_features(pool),
+        train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+        n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+        permutation_repeats=TEST_PERMUTATION_REPEATS,
+    )
+    # On this small + noisy problem, each fold should hit the cap.
+    for fr in result.fold_results:
+        assert fr.modelcount == fr.max_iter, (
+            f"fold {fr.fold}: modelcount={fr.modelcount} != max_iter={fr.max_iter} "
+            "— FLAML budget accounting drift; review PR-B log §3a"
+        )
+
+
+# ── §3b: NaN-AUC propagation on single-class folds ────────────────────
+
+
+def test_nan_auc_propagates_on_single_class_training():
+    """Force a single-class fold and verify NaN propagates without
+    poisoning the aggregate."""
+    # Build a pool whose first 80% is all y=0 and last 20% is mostly
+    # y=1. The earliest TimeSeriesSplit fold(s) train on the all-zero
+    # slice → single-class training → AutoML skipped → NaN.
+    n = 400
+    rng = np.random.default_rng(7)
+    df = pd.DataFrame({
+        "a": rng.standard_normal(n),
+        "b": rng.standard_normal(n),
+        "c": rng.standard_normal(n),
+        "d": rng.standard_normal(n),
+        "trade_id": np.arange(n),
+        "entry_time": pd.date_range(end="2020-12-15", periods=n, freq="h", tz="UTC"),
+    })
+    # First 320 trades all y=0; last 80 are 50/50
+    y = np.zeros(n, dtype=int)
+    cutoff = int(0.8 * n)
+    y[cutoff:] = (rng.random(n - cutoff) > 0.5).astype(int)
+    df["y"] = y
+
+    # Suppress the "single-class training" UserWarning we emit on purpose.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = run_automl(
+            pool=df, used_features=("a", "b", "c", "d"),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+    # At least one fold should have been skipped / NaN.
+    nan_folds = [fr for fr in result.fold_results if not np.isfinite(fr.auc_val)]
+    assert len(nan_folds) >= 1, "expected at least one single-class fold to NaN out"
+    # n_folds_valid reflects the live count.
+    assert result.n_folds_valid == result.n_folds_total - len(nan_folds)
+    # auc_mean must be finite (nanmean) as long as at least one fold was valid.
+    if result.n_folds_valid > 0:
+        assert np.isfinite(result.auc_mean)
+    else:
+        assert not np.isfinite(result.auc_mean)
+
+
+def test_nan_auc_aggregate_uses_nanmean():
+    """Trivial unit-check on the aggregation logic: when every fold is
+    NaN, auc_mean is NaN; when some are valid, auc_mean ignores the
+    NaNs (nanmean semantics)."""
+    pool_all_zero = _synthetic_pool(single_class_y=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)  # nanmean-of-all-nan
+            result = run_automl(
+                pool=pool_all_zero, used_features=_used_features(pool_all_zero),
+                train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+                n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+                permutation_repeats=TEST_PERMUTATION_REPEATS,
+            )
+    # Every fold should NaN out (single-class training across the board).
+    assert result.n_folds_valid == 0
+    assert not np.isfinite(result.auc_mean)
+    for fr in result.fold_results:
+        assert not np.isfinite(fr.auc_val)
+
+
+# ── Guards: holdout + all-features-rejected ──────────────────────────
+
+
+def test_holdout_guard_violation():
+    """Pool with an entry_time inside the holdout window must raise
+    HoldoutGuardViolation before any AutoML call."""
+    pool = _synthetic_pool(last_entry=pd.Timestamp("2022-06-01", tz="UTC"))
+    with pytest.raises(HoldoutGuardViolation, match="holdout-guard violated"):
+        run_automl(
+            pool=pool, used_features=_used_features(pool),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+
+
+def test_holdout_guard_at_boundary_raises():
+    """entry_time exactly equal to train_end must also be rejected
+    (strict less-than per L_PROTOCOL §1)."""
+    boundary = pd.Timestamp("2021-01-01", tz="UTC")
+    pool = _synthetic_pool(last_entry=boundary)
+    with pytest.raises(HoldoutGuardViolation):
+        run_automl(
+            pool=pool, used_features=_used_features(pool),
+            train_end=boundary,
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+
+
+def test_all_features_rejected_fast_fail():
+    pool = _synthetic_pool()
+    with pytest.raises(AllFeaturesRejected, match="empty design matrix"):
+        run_automl(
+            pool=pool, used_features=(),  # nothing past the gate
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+
+
+def test_missing_required_column_raises():
+    pool = _synthetic_pool(include_y=False)
+    with pytest.raises(ValueError, match="must contain 'y' column"):
+        run_automl(
+            pool=pool, used_features=_used_features(pool),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+
+
+def test_non_binary_target_raises():
+    pool = _synthetic_pool()
+    pool["y"] = pool["y"] + 2  # values {2, 3}, not {0, 1}
+    with pytest.raises(ValueError, match="target must be binary"):
+        run_automl(
+            pool=pool, used_features=_used_features(pool),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+
+
+# ── Determinism: two runs → identical artefacts ───────────────────────
+
+
+def test_two_run_determinism_automl_aggregates():
+    """Same input → same auc_mean, modelcount, leaderboard, importance."""
+    pool = _synthetic_pool()
+    feats = _used_features(pool)
+    end = pd.Timestamp("2021-01-01", tz="UTC")
+    kwargs = dict(
+        train_end=end, n_folds=TEST_N_FOLDS,
+        max_iter_per_fold=TEST_MAX_ITER,
+        permutation_repeats=TEST_PERMUTATION_REPEATS,
+    )
+    r1 = run_automl(pool=pool.copy(), used_features=feats, **kwargs)
+    r2 = run_automl(pool=pool.copy(), used_features=feats, **kwargs)
+    assert r1.auc_mean == r2.auc_mean
+    assert r1.auc_std == r2.auc_std
+    assert r1.total_modelcount == r2.total_modelcount
+    # Leaderboards: same content
+    pd.testing.assert_frame_equal(
+        r1.leaderboard.reset_index(drop=True),
+        r2.leaderboard.reset_index(drop=True),
+    )
+    # Importance: same content
+    pd.testing.assert_frame_equal(
+        r1.importance.reset_index(drop=True),
+        r2.importance.reset_index(drop=True),
+    )
+
+
+# ── FLAML estimator-set capture ──────────────────────────────────────
+
+
+def test_estimator_list_recorded_per_fold():
+    """The actual FLAML 2.6.0 estimator list is captured so cross-env
+    audit catches drift if it ever shows up."""
+    pool = _synthetic_pool()
+    result = run_automl(
+        pool=pool, used_features=_used_features(pool),
+        train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+        n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+        permutation_repeats=TEST_PERMUTATION_REPEATS,
+    )
+    for fr in result.fold_results:
+        # FLAML defaults can drift across minor versions; the documented
+        # set is the FLAML 2.6.0 baseline. We assert non-empty + a couple
+        # of always-present learners rather than equality so a benign
+        # FLAML upgrade doesn't break the test.
+        assert len(fr.estimator_list) > 0
+        assert {"lgbm", "rf"}.issubset(set(fr.estimator_list))
+    # The constant lists the documented baseline; test stays for audit.
+    assert "lgbm" in DOCUMENTED_FLAML_2_6_0_ESTIMATORS
+
+
+# ── Pipeline integration: artefacts + manifest + determinism ─────────
+
+
+def _pipeline_pool(tmp_path: Path) -> Path:
+    pool = _synthetic_pool()
+    p = tmp_path / "pool.parquet"
+    pool.to_parquet(p, compression="snappy", index=False)
+    return p
+
+
+def _override_config(tmp_path: Path) -> Path:
+    """Write a config that overrides the heavy production defaults
+    (n_folds=11, max_iter=1000) with test-fast values."""
+    import yaml
+    with DEFAULT_CONFIG_PATH.open("r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    raw["automl"]["n_folds"] = TEST_N_FOLDS
+    raw["automl"]["max_iter_per_fold"] = TEST_MAX_ITER
+    p = tmp_path / "test_config.yaml"
+    p.write_text(
+        yaml.safe_dump(raw, sort_keys=False),
+        encoding="utf-8",
+    )
+    return p
+
+
+@pytest.fixture
+def pipeline_run(tmp_path):
+    """Two pipeline runs against the same pool + override config."""
+    pool_path = _pipeline_pool(tmp_path)
+    cfg_path = _override_config(tmp_path)
+    lineage = _synthetic_lineage_df()
+
+    def _run(label: str):
+        out_root = tmp_path / label
+        cfg = load_config(
+            cfg_path,
+            arc_name="test_arc",
+            cluster_id=0,
+            pool_path=pool_path,
+            output_root=out_root,
+        )
+        return run_pipeline(cfg, lineage_df=lineage)
+
+    return _run
+
+
+def test_pipeline_writes_full_automl_artefact_set(pipeline_run):
+    r = pipeline_run("run1")
+    # AutoML stage ran (pool has entry_time + y)
+    assert r.automl_skip_reason == "ok"
+    assert r.automl_result is not None
+    assert r.automl_leaderboard_path is not None and r.automl_leaderboard_path.exists()
+    assert r.automl_importance_path is not None and r.automl_importance_path.exists()
+    assert r.compute_budget_path is not None and r.compute_budget_path.exists()
+    # Manifest lists all four artefacts
+    payload = json.loads(r.step4_manifest_path.read_text(encoding="utf-8"))
+    assert set(payload["artefacts"].keys()) == {
+        "stub_summary",
+        "automl_leaderboard",
+        "automl_feature_importance",
+        "compute_budget_used",
+    }
+    # Each path is recorded relative to step4_dir with forward slashes.
+    for name in ("automl_leaderboard", "automl_feature_importance",
+                 "compute_budget_used"):
+        entry = payload["artefacts"][name]
+        assert "\\" not in entry["path"]
+        # SHA256 matches the on-disk file.
+        on_disk = r.step4_manifest_path.parent / entry["path"]
+        assert entry["sha256"] == sha256_file(on_disk)
+
+    # Manifest's automl extras block
+    automl_block = payload["automl"]
+    assert automl_block["skip_reason"] == "ok"
+    assert automl_block["n_folds_total"] == TEST_N_FOLDS
+    assert automl_block["n_folds_valid"] >= 1
+    assert automl_block["total_modelcount"] >= 1
+    assert automl_block["n_features_used"] == 4
+
+
+def test_pipeline_automl_two_run_determinism(pipeline_run):
+    r1 = pipeline_run("run1")
+    r2 = pipeline_run("run2")
+    # All four artefact sha256s identical across runs
+    for path_attr in ("stub_summary_path", "automl_leaderboard_path",
+                      "automl_importance_path", "compute_budget_path"):
+        p1 = getattr(r1, path_attr)
+        p2 = getattr(r2, path_attr)
+        assert sha256_file(p1) == sha256_file(p2), f"{path_attr} differs across runs"
+    # Manifest stable payload identical.
+    assert stable_payload_sha256(r1.step4_manifest_path) == stable_payload_sha256(
+        r2.step4_manifest_path
+    )
+
+
+def test_pipeline_holdout_guard_violation_surfaces(tmp_path):
+    """A pool whose max entry_time is inside the holdout window must
+    raise HoldoutGuardViolation. The pipeline writes a partial manifest
+    recording the skip reason before re-raising."""
+    pool = _synthetic_pool(last_entry=pd.Timestamp("2022-06-01", tz="UTC"))
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    cfg = load_config(
+        cfg_path, arc_name="x", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    with pytest.raises(HoldoutGuardViolation):
+        run_pipeline(cfg, lineage_df=_synthetic_lineage_df())
+    # Partial manifest was emitted.
+    mp = cfg.step4_dir / "manifest.json"
+    assert mp.exists()
+    payload = json.loads(mp.read_text(encoding="utf-8"))
+    assert payload["automl"]["skip_reason"] == "holdout_guard_violation"
+
+
+def test_pipeline_skip_reason_missing_entry_time(tmp_path):
+    """PR-A's synthetic pool has no entry_time — pipeline should skip
+    AutoML with the right reason rather than crash."""
+    pool = _synthetic_pool(include_entry_time=False, include_y=False)
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    cfg = load_config(
+        cfg_path, arc_name="x", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    r = run_pipeline(cfg, lineage_df=_synthetic_lineage_df())
+    assert r.automl_skip_reason == "missing_entry_time"
+    assert r.automl_result is None
+    # Only the stub_summary artefact lands when AutoML is skipped.
+    payload = json.loads(r.step4_manifest_path.read_text(encoding="utf-8"))
+    assert set(payload["artefacts"].keys()) == {"stub_summary"}
+    assert payload["automl"]["skip_reason"] == "missing_entry_time"
+
+
+def test_pipeline_skip_reason_missing_target(tmp_path):
+    pool = _synthetic_pool(include_y=False)
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    cfg = load_config(
+        cfg_path, arc_name="x", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    r = run_pipeline(cfg, lineage_df=_synthetic_lineage_df())
+    assert r.automl_skip_reason == "missing_y"
+    assert r.automl_result is None
+
+
+def test_pipeline_skip_reason_no_clean_features(tmp_path):
+    """When the lineage gate rejects every column, AutoML skips with
+    reason `no_clean_features` (and does NOT raise — the pipeline
+    surfaces the situation through the manifest)."""
+    pool = _synthetic_pool()
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    cfg = load_config(
+        cfg_path, arc_name="x", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    # Mark every feature suspect so the gate rejects them all
+    all_suspect = _synthetic_lineage_df().assign(causal_lineage="suspect")
+    r = run_pipeline(cfg, lineage_df=all_suspect)
+    assert r.automl_skip_reason == "no_clean_features"
+    assert r.automl_result is None
+
+
+def test_pool_required_columns_constant_matches_implementation():
+    assert AUTOML_REQUIRED_COLUMNS == ("entry_time", "y")

--- a/tests/heavy_ml_probe/test_automl.py
+++ b/tests/heavy_ml_probe/test_automl.py
@@ -435,14 +435,18 @@ def test_pipeline_writes_full_automl_artefact_set(pipeline_run):
     assert r.automl_leaderboard_path is not None and r.automl_leaderboard_path.exists()
     assert r.automl_importance_path is not None and r.automl_importance_path.exists()
     assert r.compute_budget_path is not None and r.compute_budget_path.exists()
-    # Manifest lists all four artefacts
+    # Manifest lists at minimum the four AutoML artefacts. PR-C/D add
+    # meta-label + survival when the pool carries those schemas — this
+    # test's pool doesn't, so only the AutoML set + the always-present
+    # stub_summary + aggregate compute_budget_used should appear.
     payload = json.loads(r.step4_manifest_path.read_text(encoding="utf-8"))
-    assert set(payload["artefacts"].keys()) == {
+    required = {
         "stub_summary",
         "automl_leaderboard",
         "automl_feature_importance",
         "compute_budget_used",
     }
+    assert required <= set(payload["artefacts"].keys())
     # Each path is recorded relative to step4_dir with forward slashes.
     for name in ("automl_leaderboard", "automl_feature_importance",
                  "compute_budget_used"):
@@ -511,9 +515,10 @@ def test_pipeline_skip_reason_missing_entry_time(tmp_path):
     r = run_pipeline(cfg, lineage_df=_synthetic_lineage_df())
     assert r.automl_skip_reason == "missing_entry_time"
     assert r.automl_result is None
-    # Only the stub_summary artefact lands when AutoML is skipped.
+    # When AutoML skips, only the always-present pipeline artefacts
+    # land: stub_summary + the PR-E aggregate compute_budget_used.md.
     payload = json.loads(r.step4_manifest_path.read_text(encoding="utf-8"))
-    assert set(payload["artefacts"].keys()) == {"stub_summary"}
+    assert set(payload["artefacts"].keys()) == {"stub_summary", "compute_budget_used"}
     assert payload["automl"]["skip_reason"] == "missing_entry_time"
 
 

--- a/tests/heavy_ml_probe/test_causal_lineage.py
+++ b/tests/heavy_ml_probe/test_causal_lineage.py
@@ -1,0 +1,180 @@
+"""Tests for core.heavy_ml_probe.causal_lineage.
+
+Per dispatch §6 #2 + spec §"Per-feature causal lineage": the gate is
+pre-evaluation. Features without a clean lineage tag are excluded from
+the training column set BEFORE AutoML touches the data. These tests
+exercise:
+
+  * clean features pass
+  * suspect / unverified / unknown / excluded-class features are rejected
+    with the right reason code
+  * the gate result accounts for every input column
+  * the markdown summary is stable + grep-able
+  * the gate is pure (no side effects on the input lineage_df)
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pandas as pd
+import pytest
+
+from core.heavy_ml_probe.causal_lineage import (
+    DEFAULT_ACCEPTED_LINEAGE,
+    REASON_EXCLUDED_CLASS,
+    REASON_NON_CLEAN_LINEAGE,
+    REASON_UNKNOWN_FEATURE,
+    LineageGateResult,
+    filter_training_columns,
+    lineage_summary_markdown,
+)
+
+# Matches the schema produced by core.features.pipeline.feature_lineage_dataframe().
+LINEAGE_DF = pd.DataFrame(
+    [
+        {"name": "atr_14", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "session_london", "causal_lineage": "clean", "feature_class": "session"},
+        {"name": "kijun_26_distance", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "experimental_x", "causal_lineage": "clean", "feature_class": "experimental"},
+        {"name": "dxy_state", "causal_lineage": "suspect", "feature_class": "cross_asset"},
+        {"name": "raw_volume_rank", "causal_lineage": "unverified", "feature_class": "volume"},
+    ]
+)
+
+
+def test_accepts_all_clean_features():
+    cols = ["atr_14", "session_london", "kijun_26_distance"]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert isinstance(res, LineageGateResult)
+    assert res.n_input_columns == 3
+    assert res.n_accepted == 3
+    assert res.n_rejected == 0
+    assert res.accepted_features == tuple(sorted(cols))
+
+
+def test_rejects_suspect_lineage():
+    cols = ["atr_14", "dxy_state"]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert res.n_accepted == 1
+    assert res.accepted_features == ("atr_14",)
+    assert res.n_rejected == 1
+    [rej] = res.rejected
+    assert rej["feature"] == "dxy_state"
+    assert rej["reason"] == REASON_NON_CLEAN_LINEAGE
+    assert "suspect" in rej["detail"]
+
+
+def test_rejects_unverified_lineage():
+    cols = ["atr_14", "raw_volume_rank"]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert res.n_rejected == 1
+    [rej] = res.rejected
+    assert rej["feature"] == "raw_volume_rank"
+    assert rej["reason"] == REASON_NON_CLEAN_LINEAGE
+    assert "unverified" in rej["detail"]
+
+
+def test_rejects_unknown_feature_with_clear_reason():
+    cols = ["atr_14", "totally_made_up_feature"]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert res.n_accepted == 1
+    assert res.n_rejected == 1
+    [rej] = res.rejected
+    assert rej["feature"] == "totally_made_up_feature"
+    assert rej["reason"] == REASON_UNKNOWN_FEATURE
+
+
+def test_exclude_class_overrides_clean_lineage():
+    """Even a clean-tagged feature is rejected if its class is excluded."""
+    cols = ["atr_14", "experimental_x"]
+    res = filter_training_columns(
+        cols, LINEAGE_DF, exclude_classes=("experimental",)
+    )
+    assert res.n_accepted == 1
+    assert res.accepted_features == ("atr_14",)
+    [rej] = res.rejected
+    assert rej["feature"] == "experimental_x"
+    assert rej["reason"] == REASON_EXCLUDED_CLASS
+    assert "experimental" in rej["detail"]
+
+
+def test_mixed_pool_accounts_for_every_column():
+    cols = [
+        "atr_14",                # clean -> accept
+        "dxy_state",             # suspect -> reject
+        "raw_volume_rank",       # unverified -> reject
+        "totally_made_up",       # unknown -> reject
+        "session_london",        # clean -> accept
+    ]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert res.n_input_columns == 5
+    assert res.n_accepted == 2
+    assert res.n_rejected == 3
+    assert set(res.accepted_features) == {"atr_14", "session_london"}
+    reasons = {r["feature"]: r["reason"] for r in res.rejected}
+    assert reasons["dxy_state"] == REASON_NON_CLEAN_LINEAGE
+    assert reasons["raw_volume_rank"] == REASON_NON_CLEAN_LINEAGE
+    assert reasons["totally_made_up"] == REASON_UNKNOWN_FEATURE
+
+
+def test_duplicate_columns_dedup():
+    """Duplicate column names in the input are deduplicated before gating."""
+    cols = ["atr_14", "atr_14", "session_london"]
+    res = filter_training_columns(cols, LINEAGE_DF)
+    assert res.n_input_columns == 2
+    assert res.n_accepted == 2
+
+
+def test_accepted_lineage_default_is_clean_only():
+    assert DEFAULT_ACCEPTED_LINEAGE == ("clean",)
+
+
+def test_gate_is_pure_does_not_mutate_lineage_df():
+    snapshot = copy.deepcopy(LINEAGE_DF)
+    _ = filter_training_columns(["atr_14"], LINEAGE_DF)
+    pd.testing.assert_frame_equal(LINEAGE_DF, snapshot)
+
+
+def test_missing_required_column_raises():
+    bad = pd.DataFrame([{"name": "x", "causal_lineage": "clean"}])  # no feature_class
+    with pytest.raises(ValueError, match="missing required columns"):
+        filter_training_columns(["x"], bad)
+
+
+def test_lineage_summary_markdown_renders_stably():
+    res = filter_training_columns(
+        ["atr_14", "dxy_state", "raw_volume_rank", "totally_made_up"],
+        LINEAGE_DF,
+    )
+    md1 = lineage_summary_markdown(res)
+    md2 = lineage_summary_markdown(res)
+    assert md1 == md2  # deterministic
+    # Spot-check expected sections render
+    assert "# Causal lineage gate — heavy_ml_probe" in md1
+    assert "Accepted (clean): **1**" in md1
+    assert "Rejected: **3**" in md1
+    assert "Rejection breakdown" in md1
+    assert REASON_NON_CLEAN_LINEAGE in md1
+    assert REASON_UNKNOWN_FEATURE in md1
+
+
+def test_lineage_summary_markdown_when_no_rejections():
+    res = filter_training_columns(["atr_14"], LINEAGE_DF)
+    md = lineage_summary_markdown(res)
+    assert "Accepted (clean): **1**" in md
+    assert "Rejected: **0**" in md
+    # When nothing was rejected, the detail tables should not appear.
+    assert "Rejection breakdown" not in md
+    assert "Rejected features (sorted)" not in md
+
+
+def test_accepts_clean_features_with_lineage_case_insensitive():
+    """Real-world lineage_df values use lowercase, but the gate
+    should not be case-sensitive (defensive against producer drift)."""
+    upper = pd.DataFrame([
+        {"name": "x", "causal_lineage": "CLEAN", "feature_class": "Price_Geometry"},
+    ])
+    res = filter_training_columns(["x"], upper)
+    assert res.n_accepted == 1
+    assert res.accepted_features == ("x",)

--- a/tests/heavy_ml_probe/test_integration.py
+++ b/tests/heavy_ml_probe/test_integration.py
@@ -1,0 +1,434 @@
+"""End-to-end integration test for heavy_ml_probe (PR-E — gate PR).
+
+Per dispatch §5: this is the **load-bearing determinism gate** for
+the whole heavy_ml_probe stack. If two runs on the same input + seed
+do not produce byte-identical artefacts, HALT per WORKFLOW §6.
+
+Coverage:
+
+  1. **Full end-to-end run on synthetic pool.** All three stages
+     (AutoML + meta-labeling + survival) plus the Step 5 manifest are
+     emitted in a single ``run_pipeline`` call. Wall-clock target:
+     ~30s on this hardware (small synthetic pool).
+  2. **Byte-identical determinism.** Every artefact under
+     ``step_4/heavy_ml/`` AND ``step_5/heavy_ml_augmented/`` must
+     match sha256 across two runs on identical input. Stable-payload
+     manifests (``created_at`` excluded) compared via
+     :func:`stable_payload_sha256`.
+  3. **Adapter handshake.** Load the emitted Step 5 manifest; build
+     all three adapters; verify their primary calls (``predict_proba``
+     for A2/A6; ``hazard_predict`` + ``predict_proba`` for A4) return
+     the expected output shape.
+  4. **CLI smoke + exit code.** Invoke ``run_probe.main`` end-to-end;
+     assert exit 0 for full-success / all-skip, exit 3 for partial.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Both heavy deps required for the gate test.
+pytest.importorskip("flaml")  # noqa: F841
+pytest.importorskip("statsmodels")  # noqa: F841
+
+from core.heavy_ml_probe.adapters import (  # noqa: E402
+    BARS_SURVIVED_FEATURE,
+    FoldSelectionStrategy,
+    build_a2_from_heavy_ml,
+    build_a4_from_heavy_ml,
+    build_a6_from_heavy_ml,
+)
+from core.heavy_ml_probe.io import sha256_file  # noqa: E402
+from core.heavy_ml_probe.pipeline import (  # noqa: E402
+    load_config,
+    run_pipeline,
+    stable_payload_sha256,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
+
+# Per dispatch §5 — n=500 / ~30s wall-clock target. Small enough to
+# keep the gate test fast; large enough to exercise all three stages
+# on a learnable target.
+N_TRADES_INTEGRATION = 500
+TEST_N_FOLDS = 5
+TEST_MAX_ITER = 10
+
+
+# ── Synthetic pool ──────────────────────────────────────────────────
+
+
+def _integration_pool(
+    *,
+    n: int = N_TRADES_INTEGRATION,
+    seed: int = 7,
+) -> pd.DataFrame:
+    """Pool carrying ALL three stage schemas + a learnable target."""
+    rng = np.random.default_rng(seed)
+    feats = rng.standard_normal((n, 4))
+    df = pd.DataFrame({"a": feats[:, 0], "b": feats[:, 1],
+                       "c": feats[:, 2], "d": feats[:, 3]})
+    df["entry_time"] = pd.date_range(
+        end="2020-12-15", periods=n, freq="h", tz="UTC"
+    )
+    df["trade_id"] = np.arange(n)
+    noise = rng.standard_normal(n) * 0.3
+    score = df["a"] + 0.5 * df["b"] + noise
+    reached = (score > 0).values
+    df["bars_to_1r_mfe"] = np.where(
+        reached, rng.integers(low=1, high=15, size=n), np.nan
+    )
+    df["bars_held"] = rng.integers(low=3, high=30, size=n)
+    df["exit_reason"] = np.where(reached, "tp", "sl")
+    df["final_r"] = np.where(
+        reached, rng.uniform(0.5, 3.0, size=n), rng.uniform(-1.0, 0.5, size=n)
+    )
+    df["y"] = reached.astype(int)
+    return df
+
+
+def _integration_lineage_df() -> pd.DataFrame:
+    return pd.DataFrame([
+        {"name": "a", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "b", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "c", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "d", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "trade_id", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "entry_time", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "bars_to_1r_mfe", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "bars_held", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "exit_reason", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "final_r", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "y", "causal_lineage": "suspect", "feature_class": "meta"},
+    ])
+
+
+def _override_config(tmp_path: Path) -> Path:
+    import yaml
+    with DEFAULT_CONFIG_PATH.open("r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    raw["automl"]["n_folds"] = TEST_N_FOLDS
+    raw["automl"]["max_iter_per_fold"] = TEST_MAX_ITER
+    p = tmp_path / "test_config.yaml"
+    p.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def integration_run(tmp_path):
+    pool = _integration_pool()
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    lineage = _integration_lineage_df()
+
+    def _run(label: str):
+        out_root = tmp_path / label
+        cfg = load_config(
+            cfg_path, arc_name="integration_test", cluster_id=0,
+            pool_path=pool_path, output_root=out_root,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            return run_pipeline(cfg, lineage_df=lineage)
+
+    return _run
+
+
+# ── (1) Full end-to-end ─────────────────────────────────────────────
+
+
+def test_full_end_to_end_pipeline_emits_all_artefacts(integration_run):
+    """Single ``run_pipeline`` call produces every PR-A..D artefact +
+    the PR-E Step 5 manifest."""
+    r = integration_run("run1")
+    # All three stages succeeded
+    assert r.automl_skip_reason == "ok"
+    assert r.meta_label_skip_reason == "ok"
+    assert r.survival_skip_reason == "ok"
+    assert r.overall_status == "all_ok"
+    # Step 4 manifest lists everything
+    payload = json.loads(r.step4_manifest_path.read_text(encoding="utf-8"))
+    artefacts = set(payload["artefacts"].keys())
+    expected_step4 = {
+        "stub_summary",
+        "compute_budget_used",
+        "automl_leaderboard",
+        "automl_feature_importance",
+        "meta_label_results",
+        "meta_label_classifier_manifest",
+        "survival_model_results",
+        "survival_classifier_manifest",
+    }
+    assert expected_step4 == artefacts
+    # Step 5 manifest emitted with all-buildable adapters
+    assert r.step5_manifest_path is not None
+    assert r.step5_manifest_path.exists()
+    s5 = json.loads(r.step5_manifest_path.read_text(encoding="utf-8"))
+    assert s5["adapters"]["a2_buildable"] is True
+    assert s5["adapters"]["a4_buildable"] is True
+    assert s5["adapters"]["a6_buildable"] is True
+
+
+# ── (2) Determinism gate — the load-bearing test for the build ──────
+
+
+def test_determinism_gate_all_artefacts_byte_identical(integration_run):
+    """Per dispatch §5: every artefact under step_4/heavy_ml/ AND
+    step_5/heavy_ml_augmented/ must match byte-for-byte across two
+    consecutive runs on identical input. Stable-payload manifests
+    excluded ``created_at``.
+    """
+    r1 = integration_run("run1")
+    r2 = integration_run("run2")
+
+    # All non-manifest artefacts should be byte-identical
+    for path_attr in (
+        "stub_summary_path",
+        "compute_budget_path",
+        "automl_leaderboard_path", "automl_importance_path",
+        "meta_label_results_path",
+        "survival_results_path",
+    ):
+        p1, p2 = getattr(r1, path_attr), getattr(r2, path_attr)
+        assert sha256_file(p1) == sha256_file(p2), (
+            f"DETERMINISM BREAK: {path_attr} differs across runs. "
+            f"This is a gate-PR HALT condition per WORKFLOW §6."
+        )
+
+    # Per-stage classifier manifests — both stamped without timestamps
+    # in PR-C/D so direct sha256 should match
+    for path_attr in (
+        "meta_label_classifier_manifest_path",
+        "survival_classifier_manifest_path",
+    ):
+        p1, p2 = getattr(r1, path_attr), getattr(r2, path_attr)
+        assert sha256_file(p1) == sha256_file(p2), (
+            f"DETERMINISM BREAK: {path_attr} differs across runs."
+        )
+
+    # Step 5 manifest is timestamp-free (PR-E mirrors PR-C/D convention)
+    assert sha256_file(r1.step5_manifest_path) == sha256_file(r2.step5_manifest_path), (
+        "DETERMINISM BREAK: step5_manifest_path differs across runs."
+    )
+
+    # Top-level Step 4 manifest carries created_at → compare stable payload
+    assert stable_payload_sha256(r1.step4_manifest_path) == stable_payload_sha256(
+        r2.step4_manifest_path
+    ), "DETERMINISM BREAK: top-level step4 manifest stable payload differs."
+
+
+# ── (3) Adapter handshake on the emitted manifest ───────────────────
+
+
+def test_adapters_build_and_call_on_emitted_manifest(integration_run):
+    """Build all three adapters from the just-emitted manifest; verify
+    each adapter's primary call returns the expected shape on
+    synthetic input."""
+    r = integration_run("run1")
+    manifest_path = r.step5_manifest_path
+
+    # A2
+    a2 = build_a2_from_heavy_ml(manifest_path)
+    X_synthetic = np.array([[0.5, -0.3, 1.0, -1.0]])
+    out_a2 = a2.classifier.predict_proba(X_synthetic)
+    assert out_a2.shape == (1, 2)
+    assert ((out_a2 >= 0) & (out_a2 <= 1)).all()
+    assert np.isclose(out_a2.sum(), 1.0, atol=1e-6)
+
+    # A6
+    a6 = build_a6_from_heavy_ml(manifest_path)
+    out_a6 = a6.classifier.predict_proba(X_synthetic)
+    assert out_a6.shape == (1, 2)
+    assert ((out_a6 >= 0) & (out_a6 <= 1)).all()
+
+    # A4 — hazard_predict primary contract
+    a4_cfg, cox_adapter = build_a4_from_heavy_ml(
+        manifest_path, k_horizon=5, exit_threshold=0.4,
+    )
+    feats = {f: 0.0 for f in cox_adapter._effective.used_features}
+    p = cox_adapter.hazard_predict(feats, bars_survived_at_N=3)
+    assert np.isfinite(p)
+    assert 0.0 <= p <= 1.0
+    # A4 predict_admit handshake — what A4's runtime actually calls
+    from core.architectures._path_classifier import predict_admit
+    feature_row = {f: 0.0 for f in a4_cfg.classifier_fit.feature_order}
+    feature_row[BARS_SURVIVED_FEATURE] = 3
+    admit, proba = predict_admit(a4_cfg.classifier_fit, feature_row)
+    assert isinstance(admit, bool)
+    assert 0.0 <= proba <= 1.0
+
+
+def test_adapters_ensemble_mean_strategy_works(integration_run):
+    """ENSEMBLE_MEAN reduces multi-fold to a single classifier /
+    averaged Cox PH coefficients; primary calls still succeed."""
+    r = integration_run("run1")
+    a2 = build_a2_from_heavy_ml(
+        r.step5_manifest_path,
+        fold_selection_strategy=FoldSelectionStrategy.ENSEMBLE_MEAN,
+    )
+    X = np.array([[0.5, -0.3, 1.0, -1.0]])
+    out = a2.classifier.predict_proba(X)
+    assert out.shape == (1, 2)
+
+    _, cox = build_a4_from_heavy_ml(
+        r.step5_manifest_path,
+        fold_selection_strategy=FoldSelectionStrategy.ENSEMBLE_MEAN,
+        k_horizon=3,
+    )
+    feats = {f: 0.0 for f in cox._effective.used_features}
+    p = cox.hazard_predict(feats, bars_survived_at_N=2)
+    assert np.isfinite(p)
+
+
+# ── (4) CLI smoke + exit code semantics ─────────────────────────────
+
+
+def test_cli_exit_0_when_all_stages_succeed(tmp_path):
+    """Full schema pool → all three stages run → exit 0."""
+    from scripts.heavy_ml_probe.run_probe import EXIT_OK, main
+
+    pool = _integration_pool()
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+
+    # Patch the registry-backed lineage to use the test lineage so the
+    # gate accepts a/b/c/d. Done via core.heavy_ml_probe.pipeline's
+    # private shim — monkey-patch.
+    import core.heavy_ml_probe.pipeline as pipeline_mod
+    original = pipeline_mod._build_lineage_dataframe
+    pipeline_mod._build_lineage_dataframe = _integration_lineage_df
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            rc = main([
+                "--arc", "smoke",
+                "--pool", str(pool_path),
+                "--cluster-id", "0",
+                "--config", str(cfg_path),
+                "--output-root", str(tmp_path / "out"),
+            ])
+    finally:
+        pipeline_mod._build_lineage_dataframe = original
+
+    assert rc == EXIT_OK
+
+
+def test_cli_exit_0_when_all_stages_cleanly_skip(tmp_path):
+    """Default pipeline.lineage shim against a synthetic pool whose
+    columns aren't in the real registry → all three stages skip on
+    no_clean_features → exit 0 (clean skip, not failure)."""
+    from scripts.heavy_ml_probe.run_probe import EXIT_OK, main
+
+    pool = _integration_pool()
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+
+    # No monkey-patch — real registry rejects synthetic columns
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        rc = main([
+            "--arc", "all_skip_smoke",
+            "--pool", str(pool_path),
+            "--cluster-id", "0",
+            "--config", str(cfg_path),
+            "--output-root", str(tmp_path / "out"),
+        ])
+    assert rc == EXIT_OK  # all_skipped → exit 0 per dispatch §4
+
+
+def test_cli_exit_3_on_partial_success(tmp_path):
+    """Pool that supports AutoML + meta-labeling but NOT survival
+    (missing bars_held) → AutoML + meta-label succeed, survival skips
+    → overall_status=partial → exit 3."""
+    from scripts.heavy_ml_probe.run_probe import EXIT_PARTIAL_SUCCESS, main
+
+    pool = _integration_pool()
+    # Drop a survival-required column → survival stage skips
+    pool = pool.drop(columns=["bars_held"])
+    # ALSO drop final_r so meta-label skips → only AutoML runs → still partial
+    # (AutoML alone is enough for the partial designation)
+    pool = pool.drop(columns=["final_r"])
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+
+    import core.heavy_ml_probe.pipeline as pipeline_mod
+    original = pipeline_mod._build_lineage_dataframe
+    pipeline_mod._build_lineage_dataframe = _integration_lineage_df
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            rc = main([
+                "--arc", "partial_smoke",
+                "--pool", str(pool_path),
+                "--cluster-id", "0",
+                "--config", str(cfg_path),
+                "--output-root", str(tmp_path / "out"),
+            ])
+    finally:
+        pipeline_mod._build_lineage_dataframe = original
+
+    assert rc == EXIT_PARTIAL_SUCCESS
+
+
+def test_cli_exit_1_on_holdout_violation(tmp_path):
+    """Pool with entry_time inside the holdout window → exit 1."""
+    from scripts.heavy_ml_probe.run_probe import EXIT_RUNTIME_ERROR, main
+
+    pool = _integration_pool()
+    # Shift entry_time so the max is inside the holdout window
+    pool["entry_time"] = pd.date_range(
+        end="2022-06-01", periods=len(pool), freq="h", tz="UTC"
+    )
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+
+    import core.heavy_ml_probe.pipeline as pipeline_mod
+    original = pipeline_mod._build_lineage_dataframe
+    pipeline_mod._build_lineage_dataframe = _integration_lineage_df
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            rc = main([
+                "--arc", "holdout_smoke",
+                "--pool", str(pool_path),
+                "--cluster-id", "0",
+                "--config", str(cfg_path),
+                "--output-root", str(tmp_path / "out"),
+            ])
+    finally:
+        pipeline_mod._build_lineage_dataframe = original
+    assert rc == EXIT_RUNTIME_ERROR
+
+
+# ── Determinism narrative output for log doc ────────────────────────
+
+
+def test_determinism_emits_useful_diagnostic_on_failure(integration_run):
+    """If determinism breaks, the assertion message includes the path
+    attribute so HALT diagnostic doc can locate the offending file
+    quickly. This test verifies the assertion-message format — not
+    a determinism test itself."""
+    # Smoke-check that the assertion fires with a useful message when
+    # we monkey-construct a fake byte-mismatch. We do this by
+    # comparing two different files' sha256s directly — the assertion
+    # in test_determinism_gate_all_artefacts_byte_identical would emit
+    # a message of the form "DETERMINISM BREAK: <path_attr> differs".
+    r = integration_run("run1")
+    # Write a perturbed version and confirm sha256 differs
+    other = r.stub_summary_path.parent / "stub_summary_other.md"
+    other.write_text(
+        r.stub_summary_path.read_text(encoding="utf-8") + "\n# additional\n",
+        encoding="utf-8",
+    )
+    assert sha256_file(r.stub_summary_path) != sha256_file(other)

--- a/tests/heavy_ml_probe/test_io_manifest.py
+++ b/tests/heavy_ml_probe/test_io_manifest.py
@@ -254,8 +254,10 @@ def test_pipeline_writes_manifest_and_stub_summary(synthetic_run):
     assert payload["cluster_id"] == 0
     assert payload["pool_size"] == 50
     assert payload["lineage_gate"]["n_accepted"] >= 3  # at least the clean cols above
-    # The stub summary should be the only listed artefact in PR-A.
-    assert set(payload["artefacts"].keys()) == {"stub_summary"}
+    # When all stages skip on this PR-A-vintage synthetic pool, the
+    # always-present pipeline artefacts are stub_summary + the PR-E
+    # aggregate compute_budget_used.md.
+    assert set(payload["artefacts"].keys()) == {"stub_summary", "compute_budget_used"}
     # And its recorded sha256 should match the on-disk file.
     listed = payload["artefacts"]["stub_summary"]
     assert listed["sha256"] == sha256_file(res.stub_summary_path)

--- a/tests/heavy_ml_probe/test_io_manifest.py
+++ b/tests/heavy_ml_probe/test_io_manifest.py
@@ -1,0 +1,336 @@
+"""Tests for core.heavy_ml_probe.io + the PR-A pipeline manifest path.
+
+Coverage:
+
+  * deterministic CSV / parquet / text writes (lineterminator='\n', sorted
+    rows, sorted keys, no platform-dependent encoding)
+  * sha256_file matches a hand-computed digest
+  * manifest schema includes schema_version + sub_protocol + arc_name +
+    step + artefacts + extras
+  * manifest path entries are recorded relative to the manifest's parent
+    directory with forward-slash separators (Windows / POSIX parity)
+  * two-run determinism: same inputs → same artefact sha256s + same
+    stable-payload manifest sha256 (timestamp excluded)
+  * collision between extras and reserved fields raises
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.heavy_ml_probe.io import (
+    MANIFEST_SCHEMA_VERSION,
+    sha256_file,
+    write_csv,
+    write_manifest,
+    write_parquet,
+    write_text,
+)
+from core.heavy_ml_probe.pipeline import (
+    load_config,
+    run_pipeline,
+    stable_payload_sha256,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
+
+
+# ── io.write_text / write_csv / write_parquet ──────────────────────────
+
+
+def test_write_text_appends_single_newline(tmp_path):
+    p = tmp_path / "out.md"
+    sha_no_nl = write_text(p, "hello world")
+    sha_with_nl = write_text(p, "hello world\n")
+    assert sha_no_nl == sha_with_nl
+    # The file should contain exactly one trailing '\n', regardless of
+    # what was passed in.
+    assert p.read_bytes() == b"hello world\n"
+
+
+def test_write_text_lineterminator_is_lf(tmp_path):
+    """No CR characters even on Windows."""
+    p = tmp_path / "out.md"
+    write_text(p, "line1\nline2")
+    raw = p.read_bytes()
+    assert b"\r" not in raw
+    assert raw == b"line1\nline2\n"
+
+
+def test_write_csv_is_deterministic_with_sort(tmp_path):
+    df = pd.DataFrame(
+        [
+            {"k": "b", "v": 1.0},
+            {"k": "a", "v": 2.0},
+            {"k": "c", "v": 3.0},
+        ]
+    )
+    p1 = tmp_path / "1.csv"
+    p2 = tmp_path / "2.csv"
+    sha1 = write_csv(p1, df, sort_by=["k"], columns=["k", "v"])
+    sha2 = write_csv(p2, df.sample(frac=1, random_state=99), sort_by=["k"], columns=["k", "v"])
+    assert sha1 == sha2
+    # Confirm row order on disk is alphabetic.
+    raw = p1.read_text(encoding="utf-8")
+    assert "\r" not in raw
+    assert raw.splitlines() == ["k,v", "a,2.0", "b,1.0", "c,3.0"]
+
+
+def test_write_csv_raises_on_missing_requested_column(tmp_path):
+    df = pd.DataFrame([{"a": 1}])
+    with pytest.raises(ValueError, match="missing requested columns"):
+        write_csv(tmp_path / "x.csv", df, columns=["a", "b"])
+
+
+def test_write_parquet_round_trip(tmp_path):
+    df = pd.DataFrame(
+        [{"id": 2, "val": "b"}, {"id": 1, "val": "a"}]
+    )
+    p = tmp_path / "out.parquet"
+    sha = write_parquet(p, df, sort_by=["id"], columns=["id", "val"])
+    back = pd.read_parquet(p)
+    assert back["id"].tolist() == [1, 2]
+    assert back["val"].tolist() == ["a", "b"]
+    # Two writes match.
+    sha2 = write_parquet(p, df, sort_by=["id"], columns=["id", "val"])
+    assert sha == sha2
+
+
+def test_sha256_file_matches_hand_computed(tmp_path):
+    p = tmp_path / "x.bin"
+    payload = b"deterministic payload \xff\x00\x7f"
+    p.write_bytes(payload)
+    assert sha256_file(p) == hashlib.sha256(payload).hexdigest()
+
+
+# ── io.write_manifest ──────────────────────────────────────────────────
+
+
+def test_manifest_records_schema_version_and_sub_protocol(tmp_path):
+    art_path = tmp_path / "art.md"
+    write_text(art_path, "art body")
+    manifest_path = tmp_path / "manifest.json"
+    write_manifest(
+        manifest_path,
+        arc_name="test_arc",
+        step="step_4/heavy_ml",
+        artefact_paths={"art": art_path},
+    )
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == MANIFEST_SCHEMA_VERSION
+    assert payload["sub_protocol"] == "heavy_ml_probe"
+    assert payload["arc_name"] == "test_arc"
+    assert payload["step"] == "step_4/heavy_ml"
+    assert "created_at" in payload
+    assert set(payload["artefacts"].keys()) == {"art"}
+    entry = payload["artefacts"]["art"]
+    assert entry["path"] == "art.md"  # forward-slash, relative
+    assert entry["sha256"] == sha256_file(art_path)
+
+
+def test_manifest_path_uses_forward_slashes_for_nested(tmp_path):
+    nested = tmp_path / "classifiers" / "0.pkl"
+    nested.parent.mkdir(parents=True, exist_ok=True)
+    nested.write_bytes(b"pickled bytes")
+    manifest_path = tmp_path / "manifest.json"
+    write_manifest(
+        manifest_path,
+        arc_name="a",
+        step="step_4/heavy_ml",
+        artefact_paths={"clf": nested},
+    )
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    # Always forward-slash, even on Windows
+    assert payload["artefacts"]["clf"]["path"] == "classifiers/0.pkl"
+
+
+def test_manifest_sorts_artefacts_for_determinism(tmp_path):
+    a = tmp_path / "a.md"
+    b = tmp_path / "b.md"
+    c = tmp_path / "c.md"
+    for p in (a, b, c):
+        write_text(p, p.name)
+    mp = tmp_path / "manifest.json"
+    write_manifest(
+        mp, arc_name="x", step="step_4/heavy_ml",
+        artefact_paths={"c": c, "a": a, "b": b},  # unsorted on input
+    )
+    payload = json.loads(mp.read_text(encoding="utf-8"))
+    assert list(payload["artefacts"].keys()) == ["a", "b", "c"]
+
+
+def test_manifest_extras_collision_raises(tmp_path):
+    art = tmp_path / "x.md"
+    write_text(art, "x")
+    with pytest.raises(ValueError, match="collides with reserved field"):
+        write_manifest(
+            tmp_path / "manifest.json",
+            arc_name="a",
+            step="step_4/heavy_ml",
+            artefact_paths={"art": art},
+            extras={"arc_name": "trying-to-override"},
+        )
+
+
+def test_manifest_extras_recorded(tmp_path):
+    art = tmp_path / "x.md"
+    write_text(art, "x")
+    mp = tmp_path / "manifest.json"
+    write_manifest(
+        mp, arc_name="a", step="step_4/heavy_ml",
+        artefact_paths={"art": art},
+        extras={"pool_size": 1234, "lineage_gate": {"n_accepted": 7}},
+    )
+    payload = json.loads(mp.read_text(encoding="utf-8"))
+    assert payload["pool_size"] == 1234
+    assert payload["lineage_gate"]["n_accepted"] == 7
+
+
+# ── pipeline.run_pipeline end-to-end stub ──────────────────────────────
+
+
+def _synthetic_pool(tmp_path: Path) -> Path:
+    """Write a tiny pool parquet with a mix of clean / suspect features.
+
+    The lineage_df parameter to apply_lineage_gate gets monkey-patched
+    in :func:`_synthetic_lineage_df` to match these column names. We
+    don't depend on the real registry — keeps tests fast and isolated.
+    """
+    df = pd.DataFrame(
+        [
+            {"trade_id": i, "atr_14": 0.001 + i * 1e-5, "session_london": 1,
+             "dxy_state": 0, "raw_volume_rank": i % 5}
+            for i in range(50)
+        ]
+    )
+    p = tmp_path / "pool.parquet"
+    df.to_parquet(p, compression="snappy", index=False)
+    return p
+
+
+def _synthetic_lineage_df() -> pd.DataFrame:
+    return pd.DataFrame([
+        {"name": "trade_id", "causal_lineage": "clean", "feature_class": "id"},
+        {"name": "atr_14", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "session_london", "causal_lineage": "clean", "feature_class": "session"},
+        {"name": "dxy_state", "causal_lineage": "suspect", "feature_class": "cross_asset"},
+        {"name": "raw_volume_rank", "causal_lineage": "unverified", "feature_class": "volume"},
+    ])
+
+
+@pytest.fixture
+def synthetic_run(tmp_path):
+    """Two pipeline runs against the same synthetic pool + config + lineage."""
+    pool_path = _synthetic_pool(tmp_path)
+    lineage_df = _synthetic_lineage_df()
+
+    def _run(label: str):
+        out_root = tmp_path / label
+        cfg = load_config(
+            DEFAULT_CONFIG_PATH,
+            arc_name="test_arc",
+            cluster_id=0,
+            pool_path=pool_path,
+            output_root=out_root,
+        )
+        return run_pipeline(cfg, lineage_df=lineage_df)
+
+    return _run
+
+
+def test_pipeline_writes_manifest_and_stub_summary(synthetic_run):
+    res = synthetic_run("run1")
+    assert res.step4_manifest_path.exists()
+    assert res.stub_summary_path.exists()
+    payload = json.loads(res.step4_manifest_path.read_text(encoding="utf-8"))
+    # Sanity-check shape
+    assert payload["sub_protocol"] == "heavy_ml_probe"
+    assert payload["arc_name"] == "test_arc"
+    assert payload["cluster_id"] == 0
+    assert payload["pool_size"] == 50
+    assert payload["lineage_gate"]["n_accepted"] >= 3  # at least the clean cols above
+    # The stub summary should be the only listed artefact in PR-A.
+    assert set(payload["artefacts"].keys()) == {"stub_summary"}
+    # And its recorded sha256 should match the on-disk file.
+    listed = payload["artefacts"]["stub_summary"]
+    assert listed["sha256"] == sha256_file(res.stub_summary_path)
+    assert listed["path"] == "stub_summary.md"
+
+
+def test_pipeline_lineage_gate_rejects_suspect_columns(synthetic_run):
+    res = synthetic_run("run1")
+    accepted = set(res.lineage_gate.accepted_features)
+    assert "atr_14" in accepted
+    assert "session_london" in accepted
+    assert "dxy_state" not in accepted
+    assert "raw_volume_rank" not in accepted
+
+
+def test_pipeline_two_run_determinism_artefact_bytes(synthetic_run):
+    r1 = synthetic_run("run1")
+    r2 = synthetic_run("run2")
+    # Stub summary is timestamp-free → identical bytes across runs
+    assert sha256_file(r1.stub_summary_path) == sha256_file(r2.stub_summary_path)
+
+
+def test_pipeline_two_run_determinism_stable_manifest(synthetic_run):
+    """Manifest sha256s differ by ``created_at`` only; stable payload matches."""
+    r1 = synthetic_run("run1")
+    r2 = synthetic_run("run2")
+    assert stable_payload_sha256(r1.step4_manifest_path) == stable_payload_sha256(
+        r2.step4_manifest_path
+    )
+
+
+def test_pipeline_rejects_missing_pool(tmp_path):
+    bad_pool = tmp_path / "does_not_exist.parquet"
+    cfg = load_config(
+        DEFAULT_CONFIG_PATH,
+        arc_name="test_arc",
+        cluster_id=0,
+        pool_path=bad_pool,
+        output_root=tmp_path / "out",
+    )
+    with pytest.raises(FileNotFoundError):
+        run_pipeline(cfg, lineage_df=_synthetic_lineage_df())
+
+
+def test_pipeline_rejects_bad_config_sub_protocol_name(tmp_path):
+    bad_yaml = tmp_path / "bad.yaml"
+    bad_yaml.write_text(
+        "schema_version: '1.0'\n"
+        "sub_protocol:\n  name: not_heavy_ml_probe\n"
+        "automl: {}\nmeta_labeling: {}\nsurvival: {}\n"
+        "training_window: {}\ncausal_filter: {}\ndeterminism: {}\n"
+        "output: {}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="sub_protocol.name must be"):
+        load_config(
+            bad_yaml,
+            arc_name="x",
+            cluster_id=0,
+            pool_path=tmp_path / "pool.parquet",
+            output_root=tmp_path / "out",
+        )
+
+
+def test_pipeline_rejects_config_missing_required_section(tmp_path):
+    bad_yaml = tmp_path / "bad2.yaml"
+    bad_yaml.write_text(
+        "schema_version: '1.0'\nsub_protocol: {name: heavy_ml_probe}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="missing top-level sections"):
+        load_config(
+            bad_yaml,
+            arc_name="x",
+            cluster_id=0,
+            pool_path=tmp_path / "pool.parquet",
+            output_root=tmp_path / "out",
+        )

--- a/tests/heavy_ml_probe/test_meta_labeling.py
+++ b/tests/heavy_ml_probe/test_meta_labeling.py
@@ -1,0 +1,748 @@
+"""Tests for core.heavy_ml_probe.meta_labeling + PR-C pipeline integration.
+
+Per dispatch §6: covers target construction (incl. edge cases per §1),
+end-to-end run, classifier persistence + sha256 manifest, two-run
+determinism, threshold-sweep mean-R math correctness, single-class
+fold NaN propagation (reuses PR-B pattern), and HALT-loud pool-schema
+validation.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+import joblib
+import numpy as np
+import pandas as pd
+import pytest
+
+# Import-guard FLAML — heavy dep; if missing the test module is skipped.
+flaml = pytest.importorskip("flaml")  # noqa: F841
+
+from core.heavy_ml_probe.io import sha256_file  # noqa: E402
+from core.heavy_ml_probe.meta_labeling import (  # noqa: E402
+    DEFAULT_THRESHOLD_SWEEP,
+    META_LABEL_TARGET_COL,
+    REQUIRED_POOL_COLUMNS,
+    MetaLabelResult,
+    PoolSchemaError,
+    build_meta_label_target,
+    persist_fold_classifiers,
+    run_meta_labeling,
+    stable_classifier_manifest_sha256,
+    threshold_sweep,
+)
+from core.heavy_ml_probe.pipeline import (  # noqa: E402
+    load_config,
+    run_pipeline,
+    stable_payload_sha256,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
+
+# Small scale for fast tests (same convention as test_automl.py).
+TEST_N_FOLDS = 5
+TEST_MAX_ITER = 10
+TEST_PERMUTATION_REPEATS = 3
+N_TRADES = 400
+
+
+# ── Synthetic data ──────────────────────────────────────────────────
+
+
+def _meta_label_pool(
+    *,
+    n: int = N_TRADES,
+    seed: int = 1,
+    last_entry: pd.Timestamp = pd.Timestamp("2020-12-15", tz="UTC"),
+    target_strength: float = 0.7,
+) -> pd.DataFrame:
+    """Build a pool with the meta-label schema + a target the
+    classifier can learn from.
+
+    Synthetic semantics:
+
+      * 4 features (a, b, c, d) plus entry_time + trade_id.
+      * ``reached_1r_proxy = sigmoid(a + 0.5*b) > 0.5`` with optional
+        noise — this drives the meta-label target via the schema columns.
+      * Each trade gets a ``bars_to_1r_mfe`` (NaN if not reached),
+        ``bars_held``, ``exit_reason`` ("sl"/"time_exit"/"tp"), and
+        ``final_r`` proportional to whether the trade reached +1R.
+    """
+    rng = np.random.default_rng(seed)
+    feats = rng.standard_normal((n, 4))
+    df = pd.DataFrame({
+        "a": feats[:, 0],
+        "b": feats[:, 1],
+        "c": feats[:, 2],
+        "d": feats[:, 3],
+    })
+
+    end = pd.Timestamp(last_entry)
+    if end.tzinfo is None:
+        end = end.tz_localize("UTC")
+    df["entry_time"] = pd.date_range(end=end, periods=n, freq="h")
+    df["trade_id"] = np.arange(n)
+
+    # Probability of reaching +1R MFE before SL — driven by (a, b).
+    noise = rng.standard_normal(n) * (1.0 - target_strength)
+    score = df["a"] + 0.5 * df["b"] + noise
+    reached = (score > 0).values  # roughly 50/50
+
+    bars_held = rng.integers(low=3, high=30, size=n)
+    bars_to_1r_mfe = np.where(
+        reached,
+        rng.integers(low=1, high=np.maximum(bars_held, 2), size=n),
+        np.nan,
+    )
+    exit_reasons = np.where(
+        reached & (rng.random(n) > 0.3),
+        "tp",
+        np.where(reached, "time_exit", "sl"),
+    )
+    # Realised R: reached → uniform[0.5, 3.0]; not reached → uniform[-1.0, 0.5]
+    final_r = np.where(
+        reached,
+        rng.uniform(0.5, 3.0, size=n),
+        rng.uniform(-1.0, 0.5, size=n),
+    )
+
+    df["bars_to_1r_mfe"] = bars_to_1r_mfe
+    df["bars_held"] = bars_held
+    df["exit_reason"] = exit_reasons
+    df["final_r"] = final_r
+    # Vanilla AutoML target so the pipeline's PR-B stage also runs in
+    # the end-to-end test. Production pools have both; testing only the
+    # meta-label half would leave AutoML skipping with "missing_y" and
+    # the artefact-set assertion would only see 3 instead of 6 files.
+    df["y"] = reached.astype(int)
+    return df
+
+
+def _meta_label_lineage_df() -> pd.DataFrame:
+    """Four feature columns marked clean; everything else marked
+    suspect so the lineage gate filters them out."""
+    return pd.DataFrame([
+        {"name": "a", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "b", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "c", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "d", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "trade_id", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "entry_time", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "bars_to_1r_mfe", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "bars_held", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "exit_reason", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "final_r", "causal_lineage": "suspect", "feature_class": "meta"},
+    ])
+
+
+# ── Target construction (dispatch §1 edge cases) ────────────────────
+
+
+def test_target_reached_before_close():
+    """Trade reaches +1R strictly before close → target = 1."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 3.0,
+        "bars_held": 10.0,
+        "exit_reason": "tp",
+        "final_r": 2.0,
+    }])
+    y = build_meta_label_target(pool)
+    assert y.tolist() == [1]
+
+
+def test_target_never_reached_time_exit():
+    """Trade never reaches +1R, exits at time-exit → target = 0."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": np.nan,
+        "bars_held": 30.0,
+        "exit_reason": "time_exit",
+        "final_r": -0.2,
+    }])
+    y = build_meta_label_target(pool)
+    assert y.tolist() == [0]
+
+
+def test_target_sl_on_entry_bar():
+    """Trade hits SL on entry bar (MFE never reached +1R) → target = 0."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": np.nan,
+        "bars_held": 1.0,
+        "exit_reason": "sl",
+        "final_r": -1.0,
+    }])
+    y = build_meta_label_target(pool)
+    assert y.tolist() == [0]
+
+
+def test_target_same_bar_tie_sl_wins():
+    """Per dispatch §1: +1R and SL on the same bar → SL wins → target = 0."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 5.0,
+        "bars_held": 5.0,
+        "exit_reason": "sl",
+        "final_r": -1.0,
+    }])
+    y = build_meta_label_target(pool)
+    assert y.tolist() == [0]
+
+
+def test_target_same_bar_tie_non_sl_counts_as_reached():
+    """If MFE and time-exit fall on same bar (not SL), the +1R event
+    happened before the (non-adverse) close → target = 1."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 7.0,
+        "bars_held": 7.0,
+        "exit_reason": "time_exit",
+        "final_r": 1.2,
+    }])
+    y = build_meta_label_target(pool)
+    assert y.tolist() == [1]
+
+
+def test_target_exact_1r_on_first_bar():
+    """Trade hits exactly +1R on bar 1, then moves to close at +1.2R
+    over 10 bars → target = 1 (reached strictly before close)."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 1.0,
+        "bars_held": 10.0,
+        "exit_reason": "time_exit",
+        "final_r": 1.2,
+    }])
+    y = build_meta_label_target(pool)
+    assert y.tolist() == [1]
+
+
+def test_target_case_insensitive_sl_exit_reason():
+    """Exit-reason comparison is case-insensitive — 'SL' / 'Sl' / 'sl'
+    all trigger the same-bar tie-break."""
+    for er in ("sl", "SL", "Sl", "sL"):
+        pool = pd.DataFrame([{
+            "bars_to_1r_mfe": 5.0, "bars_held": 5.0,
+            "exit_reason": er, "final_r": -1.0,
+        }])
+        y = build_meta_label_target(pool)
+        assert y.tolist() == [0], f"exit_reason={er!r} should trigger SL tie-break"
+
+
+def test_target_vectorised_over_pool():
+    """Mixed cases vectorise correctly."""
+    pool = pd.DataFrame([
+        {"bars_to_1r_mfe": 2.0, "bars_held": 5.0, "exit_reason": "tp", "final_r": 2.0},          # 1
+        {"bars_to_1r_mfe": np.nan, "bars_held": 10.0, "exit_reason": "sl", "final_r": -1.0},      # 0
+        {"bars_to_1r_mfe": 5.0, "bars_held": 5.0, "exit_reason": "sl", "final_r": -1.0},          # 0 (tie + SL)
+        {"bars_to_1r_mfe": 5.0, "bars_held": 5.0, "exit_reason": "time_exit", "final_r": 1.0},    # 1 (tie + non-SL)
+        {"bars_to_1r_mfe": np.nan, "bars_held": 30.0, "exit_reason": "time_exit", "final_r": 0.3},  # 0
+    ])
+    y = build_meta_label_target(pool)
+    assert y.tolist() == [1, 0, 0, 1, 0]
+
+
+def test_target_halts_loud_on_missing_column():
+    """Per dispatch §1 last paragraph: schema mismatches HALT loudly."""
+    pool = pd.DataFrame([{"bars_to_1r_mfe": 1.0, "bars_held": 2.0}])  # no exit_reason / final_r
+    with pytest.raises(PoolSchemaError, match="requires pool columns"):
+        build_meta_label_target(pool)
+
+
+def test_target_halts_loud_on_nan_bars_held():
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 1.0, "bars_held": np.nan,
+        "exit_reason": "sl", "final_r": -1.0,
+    }])
+    with pytest.raises(ValueError, match="bars_held column has NaN"):
+        build_meta_label_target(pool)
+
+
+def test_target_rejects_non_default_threshold_override():
+    """Sensitivity probes need an upstream pre-computed column; we
+    refuse silent column substitution per docstring."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 5.0, "bars_held": 10.0,
+        "exit_reason": "tp", "final_r": 1.0,
+    }])
+    with pytest.raises(ValueError, match="not supported in"):
+        build_meta_label_target(pool, mfe_r_threshold=0.5)
+
+
+# ── Threshold sweep math (dispatch §3) ──────────────────────────────
+
+
+def test_threshold_sweep_hand_computed_mean_r():
+    """Synthetic 6-trade pool with hand-computed kept/dropped mean R."""
+    # trade_ids 0..5; OOF preds chosen so threshold 0.5 splits cleanly
+    oof = pd.DataFrame([
+        {"trade_id": 0, "fold": 1, "y_true": 1, "y_pred_proba": 0.9},
+        {"trade_id": 1, "fold": 1, "y_true": 1, "y_pred_proba": 0.7},
+        {"trade_id": 2, "fold": 2, "y_true": 1, "y_pred_proba": 0.6},
+        {"trade_id": 3, "fold": 2, "y_true": 0, "y_pred_proba": 0.4},
+        {"trade_id": 4, "fold": 3, "y_true": 0, "y_pred_proba": 0.2},
+        {"trade_id": 5, "fold": 3, "y_true": 0, "y_pred_proba": 0.1},
+    ])
+    realised_r = pd.Series(
+        [2.0, 1.5, 1.0, -0.5, -1.0, -1.0],
+        index=[0, 1, 2, 3, 4, 5],
+    )
+    sweep = threshold_sweep(oof, realised_r, thresholds=(0.5,))
+    [row] = sweep.to_dict("records")
+    assert row["threshold"] == 0.5
+    # At threshold 0.5: kept = trades 0,1,2 (all y_true=1); dropped = 3,4,5 (all y_true=0)
+    assert row["n_trades_kept"] == 3
+    assert row["n_trades_dropped"] == 3
+    assert row["precision"] == pytest.approx(1.0)
+    assert row["recall"] == pytest.approx(1.0)
+    assert row["f1"] == pytest.approx(1.0)
+    # Mean R kept = (2.0 + 1.5 + 1.0) / 3 = 1.5
+    assert row["mean_r_kept_set"] == pytest.approx(1.5)
+    # Mean R dropped = (-0.5 + -1.0 + -1.0) / 3 ≈ -0.8333
+    assert row["mean_r_dropped_set"] == pytest.approx(-0.8333333333, rel=1e-6)
+    # Edge lift = kept - dropped = 1.5 - (-0.8333) ≈ 2.3333
+    assert row["edge_lift_r"] == pytest.approx(2.3333333333, rel=1e-6)
+
+
+def test_threshold_sweep_empty_kept_set():
+    """Threshold higher than any prediction → kept set empty → NaN mean R."""
+    oof = pd.DataFrame([
+        {"trade_id": 0, "fold": 1, "y_true": 0, "y_pred_proba": 0.1},
+        {"trade_id": 1, "fold": 1, "y_true": 1, "y_pred_proba": 0.2},
+    ])
+    realised_r = pd.Series([0.5, 1.0], index=[0, 1])
+    sweep = threshold_sweep(oof, realised_r, thresholds=(0.99,))
+    [row] = sweep.to_dict("records")
+    assert row["n_trades_kept"] == 0
+    assert row["n_trades_dropped"] == 2
+    assert not np.isfinite(row["mean_r_kept_set"])
+    assert row["mean_r_dropped_set"] == pytest.approx(0.75)
+    assert not np.isfinite(row["edge_lift_r"])
+
+
+def test_threshold_sweep_missing_required_oof_columns():
+    bad_oof = pd.DataFrame([{"trade_id": 0, "y_true": 1}])  # missing y_pred_proba
+    with pytest.raises(ValueError, match="requires OOF columns"):
+        threshold_sweep(bad_oof, pd.Series(dtype=float), thresholds=(0.5,))
+
+
+# ── End-to-end run + persistence ────────────────────────────────────
+
+
+def _override_config(tmp_path: Path) -> Path:
+    import yaml
+    with DEFAULT_CONFIG_PATH.open("r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    raw["automl"]["n_folds"] = TEST_N_FOLDS
+    raw["automl"]["max_iter_per_fold"] = TEST_MAX_ITER
+    p = tmp_path / "test_config.yaml"
+    p.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def pipeline_run(tmp_path):
+    pool = _meta_label_pool()
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    lineage = _meta_label_lineage_df()
+
+    def _run(label: str):
+        out_root = tmp_path / label
+        cfg = load_config(
+            cfg_path, arc_name="test_arc", cluster_id=0,
+            pool_path=pool_path, output_root=out_root,
+        )
+        return run_pipeline(cfg, lineage_df=lineage)
+
+    return _run
+
+
+def test_pipeline_writes_meta_label_artefacts(pipeline_run):
+    r = pipeline_run("run1")
+    assert r.meta_label_skip_reason == "ok"
+    assert r.meta_label_result is not None
+    assert r.meta_label_results_path is not None and r.meta_label_results_path.exists()
+    assert (
+        r.meta_label_classifier_manifest_path is not None
+        and r.meta_label_classifier_manifest_path.exists()
+    )
+
+    # Manifest should list all six artefacts now (stub + 3 AutoML + 2 meta-label)
+    payload = json.loads(r.step4_manifest_path.read_text(encoding="utf-8"))
+    assert set(payload["artefacts"].keys()) == {
+        "stub_summary",
+        "automl_leaderboard",
+        "automl_feature_importance",
+        "compute_budget_used",
+        "meta_label_results",
+        "meta_label_classifier_manifest",
+    }
+    # Meta-label extras block
+    ml = payload["meta_label"]
+    assert ml["skip_reason"] == "ok"
+    assert ml["n_folds_total"] == TEST_N_FOLDS
+    assert ml["target_distribution"]["0"] + ml["target_distribution"]["1"] == N_TRADES
+    assert ml["n_thresholds_swept"] == len(DEFAULT_THRESHOLD_SWEEP)
+    assert isinstance(ml["positive_rate"], float)
+
+
+def test_pipeline_classifier_manifest_lists_every_fold(pipeline_run):
+    r = pipeline_run("run1")
+    cm = json.loads(r.meta_label_classifier_manifest_path.read_text(encoding="utf-8"))
+    assert cm["sub_protocol"] == "heavy_ml_probe"
+    assert cm["stage"] == "meta_label"
+    assert cm["cluster_id"] == 0
+    assert len(cm["folds"]) == TEST_N_FOLDS
+    assert cm["n_folds_persisted"] >= 1
+    # Every persisted fold has a valid sha256 + on-disk file
+    persisted = [f for f in cm["folds"] if f["path"] is not None]
+    for f in persisted:
+        on_disk = r.meta_label_classifier_manifest_path.parent / f["path"]
+        assert on_disk.exists()
+        assert sha256_file(on_disk) == f["sha256"]
+        # Confirm joblib can load + the loaded object exposes predict_proba
+        clf = joblib.load(on_disk)
+        assert hasattr(clf, "predict_proba")
+        assert hasattr(clf, "get_params")
+
+
+def test_pipeline_meta_label_results_csv_columns(pipeline_run):
+    r = pipeline_run("run1")
+    df = pd.read_csv(r.meta_label_results_path)
+    expected_cols = {
+        "threshold", "precision", "recall", "f1",
+        "n_trades_kept", "n_trades_dropped",
+        "mean_r_kept_set", "mean_r_dropped_set", "edge_lift_r",
+        "target_n_pos", "target_n_neg", "target_positive_rate",
+        "aggregate_oof_auc_mean", "aggregate_oof_auc_std",
+        "n_folds_valid", "n_folds_total",
+    }
+    assert expected_cols <= set(df.columns)
+    assert len(df) == len(DEFAULT_THRESHOLD_SWEEP)
+    assert list(df["threshold"]) == list(DEFAULT_THRESHOLD_SWEEP)
+
+
+def test_pipeline_meta_label_edge_lift_on_learnable_target(pipeline_run):
+    """Sanity check: at threshold 0.5, kept-set mean R should exceed
+    dropped-set mean R on a learnable synthetic target."""
+    r = pipeline_run("run1")
+    df = pd.read_csv(r.meta_label_results_path)
+    # Pick the 0.5 row (it's deterministic across runs)
+    row = df[df["threshold"] == 0.5].iloc[0]
+    if row["n_trades_kept"] > 0 and row["n_trades_dropped"] > 0:
+        # The synthetic target is learnable; kept set should out-perform.
+        # Soft assertion — small synthetic pool can wobble, so just
+        # require positive edge lift, not a specific magnitude.
+        assert row["edge_lift_r"] > 0, (
+            f"expected positive edge lift on learnable synthetic; got "
+            f"kept={row['mean_r_kept_set']:.4f} vs dropped="
+            f"{row['mean_r_dropped_set']:.4f} (lift={row['edge_lift_r']:.4f})"
+        )
+
+
+# ── Determinism ──────────────────────────────────────────────────────
+
+
+def test_pipeline_meta_label_two_run_determinism(pipeline_run):
+    """All seven on-disk artefacts byte-identical across two runs;
+    classifier-manifest stable-payload sha256 matches."""
+    r1 = pipeline_run("run1")
+    r2 = pipeline_run("run2")
+    for path_attr in (
+        "stub_summary_path",
+        "automl_leaderboard_path", "automl_importance_path",
+        "compute_budget_path",
+        "meta_label_results_path",
+    ):
+        p1 = getattr(r1, path_attr)
+        p2 = getattr(r2, path_attr)
+        assert sha256_file(p1) == sha256_file(p2), f"{path_attr} differs across runs"
+
+    # Top-level manifest stable payload
+    assert stable_payload_sha256(r1.step4_manifest_path) == stable_payload_sha256(
+        r2.step4_manifest_path
+    )
+    # Classifier-manifest stable payload (timestamp + sha256s of pickles)
+    cm1 = stable_classifier_manifest_sha256(r1.meta_label_classifier_manifest_path)
+    cm2 = stable_classifier_manifest_sha256(r2.meta_label_classifier_manifest_path)
+    assert cm1 == cm2
+
+
+def _params_equal_nan_aware(p1: dict, p2: dict) -> bool:
+    """Compare two sklearn ``get_params()`` dicts with NaN-aware
+    equality. Required because XGBoost's params include
+    ``'missing': nan``, and Python's ``nan != nan``."""
+    if set(p1.keys()) != set(p2.keys()):
+        return False
+    for k in p1:
+        v1, v2 = p1[k], p2[k]
+        if isinstance(v1, float) and isinstance(v2, float):
+            if np.isnan(v1) and np.isnan(v2):
+                continue  # both NaN → treat as equal
+        if v1 != v2:
+            return False
+    return True
+
+
+def test_pipeline_classifier_pickle_params_match_across_runs(pipeline_run):
+    """Per dispatch §6 #7: joblib pickle bytes can vary across joblib
+    versions, but the get_params() snapshot of the loaded classifier
+    should be identical across two runs at the same joblib version.
+
+    NaN-aware comparison handles XGBoost's ``'missing': nan`` param
+    (Python's ``nan != nan`` would otherwise produce false negatives).
+    """
+    r1 = pipeline_run("run1")
+    r2 = pipeline_run("run2")
+    cm1 = json.loads(r1.meta_label_classifier_manifest_path.read_text(encoding="utf-8"))
+    cm2 = json.loads(r2.meta_label_classifier_manifest_path.read_text(encoding="utf-8"))
+    persisted1 = [f for f in cm1["folds"] if f["path"] is not None]
+    persisted2 = [f for f in cm2["folds"] if f["path"] is not None]
+    assert len(persisted1) == len(persisted2)
+    for f1, f2 in zip(persisted1, persisted2):
+        clf1 = joblib.load(r1.meta_label_classifier_manifest_path.parent / f1["path"])
+        clf2 = joblib.load(r2.meta_label_classifier_manifest_path.parent / f2["path"])
+        assert _params_equal_nan_aware(clf1.get_params(), clf2.get_params()), (
+            f"params differ for fold {f1['fold_id']} "
+            f"({f1['classifier_type']}): "
+            f"{clf1.get_params()!r} vs {clf2.get_params()!r}"
+        )
+
+
+# ── Skip-path tests ─────────────────────────────────────────────────
+
+
+def test_pipeline_skip_meta_label_when_pool_missing_columns(tmp_path):
+    """Pool without meta-label columns → AutoML runs, meta-labeling
+    skips with the right reason."""
+    # Same synthetic pool from test_automl.py: has entry_time + y but no
+    # meta-label columns.
+    rng = np.random.default_rng(2)
+    n = 200
+    df = pd.DataFrame({
+        "a": rng.standard_normal(n), "b": rng.standard_normal(n),
+        "c": rng.standard_normal(n), "d": rng.standard_normal(n),
+        "trade_id": np.arange(n),
+        "entry_time": pd.date_range(end="2020-12-15", periods=n, freq="h", tz="UTC"),
+    })
+    df["y"] = ((df["a"] + 0.5 * df["b"]) > 0).astype(int)
+    pool_path = tmp_path / "pool.parquet"
+    df.to_parquet(pool_path, compression="snappy", index=False)
+
+    cfg_path = _override_config(tmp_path)
+    lineage = pd.DataFrame([
+        {"name": "a", "causal_lineage": "clean", "feature_class": "x"},
+        {"name": "b", "causal_lineage": "clean", "feature_class": "x"},
+        {"name": "c", "causal_lineage": "clean", "feature_class": "x"},
+        {"name": "d", "causal_lineage": "clean", "feature_class": "x"},
+        {"name": "trade_id", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "entry_time", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "y", "causal_lineage": "suspect", "feature_class": "meta"},
+    ])
+    cfg = load_config(
+        cfg_path, arc_name="x", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    r = run_pipeline(cfg, lineage_df=lineage)
+    assert r.automl_skip_reason == "ok"
+    assert r.meta_label_skip_reason.startswith("missing_meta_label_columns")
+    assert r.meta_label_result is None
+    # Manifest reflects the skip
+    payload = json.loads(r.step4_manifest_path.read_text(encoding="utf-8"))
+    assert payload["meta_label"]["skip_reason"].startswith("missing_meta_label_columns")
+
+
+def test_pipeline_skip_meta_label_when_pool_missing_entry_time(tmp_path):
+    """Pool without entry_time → AutoML AND meta-labeling both skip
+    independently (meta-labeling does NOT cascade from AutoML — they're
+    parallel stages with independent preconditions)."""
+    rng = np.random.default_rng(3)
+    n = 50
+    df = pd.DataFrame({
+        "a": rng.standard_normal(n), "b": rng.standard_normal(n),
+        "trade_id": np.arange(n),
+    })
+    pool_path = tmp_path / "pool.parquet"
+    df.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    lineage = pd.DataFrame([
+        {"name": "a", "causal_lineage": "clean", "feature_class": "x"},
+        {"name": "b", "causal_lineage": "clean", "feature_class": "x"},
+        {"name": "trade_id", "causal_lineage": "suspect", "feature_class": "meta"},
+    ])
+    cfg = load_config(
+        cfg_path, arc_name="x", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    r = run_pipeline(cfg, lineage_df=lineage)
+    assert r.automl_skip_reason == "missing_entry_time"
+    # Meta-labeling skips for the same reason — pool lacks entry_time
+    # (which both stages need independently).
+    assert r.meta_label_skip_reason == "missing_entry_time"
+
+
+# ── run_meta_labeling direct unit tests (HALT loud) ─────────────────
+
+
+def test_run_meta_labeling_halts_loud_on_pool_schema(tmp_path):
+    pool = pd.DataFrame([
+        {"trade_id": i, "entry_time": pd.Timestamp("2020-01-01", tz="UTC")
+         + pd.Timedelta(hours=i),
+         "a": float(i), "b": float(-i)}
+        for i in range(50)
+    ])
+    with pytest.raises(PoolSchemaError, match="requires pool columns"):
+        run_meta_labeling(
+            pool=pool, used_features=("a", "b"),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            arc_name="x", cluster_id=0,
+            classifiers_dir=tmp_path / "clf",
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+        )
+
+
+def test_run_meta_labeling_halts_loud_on_missing_final_r(tmp_path):
+    pool = _meta_label_pool(n=120).drop(columns=["final_r"])
+    with pytest.raises(PoolSchemaError, match="final_r"):
+        run_meta_labeling(
+            pool=pool, used_features=("a", "b", "c", "d"),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            arc_name="x", cluster_id=0,
+            classifiers_dir=tmp_path / "clf",
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+        )
+
+
+def test_run_meta_labeling_end_to_end(tmp_path):
+    """Direct unit test (no pipeline orchestrator) for the
+    run_meta_labeling public API."""
+    pool = _meta_label_pool()
+    result = run_meta_labeling(
+        pool=pool, used_features=("a", "b", "c", "d"),
+        train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+        arc_name="test", cluster_id=0,
+        classifiers_dir=tmp_path / "clf",
+        n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+        permutation_repeats=TEST_PERMUTATION_REPEATS,
+    )
+    assert isinstance(result, MetaLabelResult)
+    assert result.skip_reason == "ok"
+    # OOF predictions span all trades (TimeSeriesSplit covers folds 2..N)
+    oof = result.automl_result.oof_predictions
+    assert not oof.empty
+    assert set(oof.columns) == {"trade_id", "fold", "y_true", "y_pred_proba"}
+    # Threshold sweep produced default-grid rows
+    assert len(result.threshold_sweep) == len(DEFAULT_THRESHOLD_SWEEP)
+    # Classifier manifest written
+    assert result.classifier_manifest_path.exists()
+
+
+# ── Single-class fold NaN propagation (PR-B pattern) ─────────────────
+
+
+def test_meta_label_nan_auc_on_single_class_folds(tmp_path):
+    """Build a meta-label pool whose target is mostly all-zero in
+    early folds → single-class training → meta-label AUC NaN for those
+    folds, aggregate uses nanmean."""
+    n = 400
+    rng = np.random.default_rng(7)
+    end = pd.Timestamp("2020-12-15", tz="UTC")
+    df = pd.DataFrame({
+        "a": rng.standard_normal(n), "b": rng.standard_normal(n),
+        "c": rng.standard_normal(n), "d": rng.standard_normal(n),
+        "trade_id": np.arange(n),
+        "entry_time": pd.date_range(end=end, periods=n, freq="h"),
+    })
+    # First 80% of trades never reach 1R; last 20% half do
+    bars_to_1r = np.full(n, np.nan)
+    cutoff = int(0.8 * n)
+    bars_to_1r[cutoff:] = np.where(
+        rng.random(n - cutoff) > 0.5,
+        rng.integers(low=1, high=10, size=n - cutoff),
+        np.nan,
+    )
+    bars_held = rng.integers(low=3, high=30, size=n)
+    df["bars_to_1r_mfe"] = bars_to_1r
+    df["bars_held"] = bars_held
+    df["exit_reason"] = "time_exit"
+    df["final_r"] = np.where(~np.isnan(bars_to_1r), 1.5, -0.5)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = run_meta_labeling(
+            pool=df, used_features=("a", "b", "c", "d"),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            arc_name="x", cluster_id=0,
+            classifiers_dir=tmp_path / "clf",
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+    ar = result.automl_result
+    nan_folds = [fr for fr in ar.fold_results if not np.isfinite(fr.auc_val)]
+    # At least one early fold should NaN out
+    assert len(nan_folds) >= 1
+    # n_folds_valid + n_folds_nan == n_folds_total
+    assert ar.n_folds_valid == ar.n_folds_total - len(nan_folds)
+
+
+# ── persist_fold_classifiers direct test ─────────────────────────────
+
+
+def test_persist_fold_classifiers_skips_none_fitted(tmp_path):
+    """Folds whose fitted_estimator is None still appear in the
+    manifest (with path: null) — full audit trail per dispatch §4."""
+    # Build a result with a mix of fitted + skipped folds via the public
+    # API on a target that produces ≥1 NaN fold.
+    pool = _meta_label_pool()
+    # Force a single-class early fold by clobbering target generation
+    pool.loc[: int(0.8 * len(pool)), "bars_to_1r_mfe"] = np.nan
+    pool.loc[: int(0.8 * len(pool)), "exit_reason"] = "sl"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = run_meta_labeling(
+            pool=pool, used_features=("a", "b", "c", "d"),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            arc_name="x", cluster_id=0,
+            classifiers_dir=tmp_path / "clf",
+            n_folds=TEST_N_FOLDS, max_iter_per_fold=TEST_MAX_ITER,
+            permutation_repeats=TEST_PERMUTATION_REPEATS,
+        )
+    cm = json.loads(result.classifier_manifest_path.read_text(encoding="utf-8"))
+    # All N folds present in manifest
+    assert len(cm["folds"]) == TEST_N_FOLDS
+    # joblib version captured
+    assert cm["joblib_version"] == joblib.__version__
+
+
+def test_persist_fold_classifiers_handles_empty_result(tmp_path):
+    """Directly persisting an empty AutoMLResult still writes a manifest."""
+    from core.heavy_ml_probe.automl import AutoMLResult
+    empty = AutoMLResult(
+        fold_results=(), leaderboard=pd.DataFrame(),
+        importance=pd.DataFrame(), used_features=(),
+        n_folds_total=0, n_folds_valid=0,
+        auc_mean=float("nan"), auc_std=float("nan"),
+        total_modelcount=0, total_fit_wall_seconds=0.0,
+        flaml_version="", metric="roc_auc",
+    )
+    path = persist_fold_classifiers(
+        empty, tmp_path / "clf", arc_name="x", cluster_id=0,
+    )
+    assert path.exists()
+    cm = json.loads(path.read_text(encoding="utf-8"))
+    assert cm["folds"] == []
+    assert cm["n_folds_persisted"] == 0
+
+
+# ── Pool-schema constants ────────────────────────────────────────────
+
+
+def test_required_pool_columns_constant_locked():
+    """Public constant matches the dispatch §1 schema requirement."""
+    assert REQUIRED_POOL_COLUMNS == (
+        "bars_to_1r_mfe", "bars_held", "exit_reason", "final_r",
+    )
+
+
+def test_meta_label_target_col_constant_locked():
+    assert META_LABEL_TARGET_COL == "y_meta_label"

--- a/tests/heavy_ml_probe/test_meta_labeling.py
+++ b/tests/heavy_ml_probe/test_meta_labeling.py
@@ -367,9 +367,12 @@ def test_pipeline_writes_meta_label_artefacts(pipeline_run):
         and r.meta_label_classifier_manifest_path.exists()
     )
 
-    # Manifest should list all six artefacts now (stub + 3 AutoML + 2 meta-label)
+    # Manifest should list at minimum the 6 meta-label / AutoML artefacts.
+    # PR-D adds survival_model_results + survival_classifier_manifest
+    # when the pool also carries the survival schema (which the
+    # test_meta_labeling fixture does — same MFE columns).
     payload = json.loads(r.step4_manifest_path.read_text(encoding="utf-8"))
-    assert set(payload["artefacts"].keys()) == {
+    required = {
         "stub_summary",
         "automl_leaderboard",
         "automl_feature_importance",
@@ -377,6 +380,7 @@ def test_pipeline_writes_meta_label_artefacts(pipeline_run):
         "meta_label_results",
         "meta_label_classifier_manifest",
     }
+    assert required <= set(payload["artefacts"].keys())
     # Meta-label extras block
     ml = payload["meta_label"]
     assert ml["skip_reason"] == "ok"

--- a/tests/heavy_ml_probe/test_survival.py
+++ b/tests/heavy_ml_probe/test_survival.py
@@ -1,0 +1,660 @@
+"""Tests for core.heavy_ml_probe.survival + PR-D pipeline integration.
+
+Per dispatch §10: covers target construction (event, duration,
+censoring), concordance index correctness, end-to-end PHReg fit + model
+persistence, two-run determinism, minimum-N warning (n < 200), and
+convergence-failure NaN propagation.
+
+Test pool scale matches PR-B/PR-C: n=400, n_folds=5. Cox PH fit cost is
+typically lower than FLAML AutoML so wall-clock should stay well under
+the dispatch §4 60s ceiling per-test.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+import joblib
+import numpy as np
+import pandas as pd
+import pytest
+
+# Import-guard statsmodels — heavy dep; if missing the test module is
+# skipped. Per dispatch §1: install verified to clean cp314 wheel.
+statsmodels = pytest.importorskip("statsmodels")  # noqa: F841
+
+from core.heavy_ml_probe.io import sha256_file  # noqa: E402
+from core.heavy_ml_probe.meta_labeling import PoolSchemaError  # noqa: E402
+from core.heavy_ml_probe.metrics import concordance  # noqa: E402
+from core.heavy_ml_probe.pipeline import (  # noqa: E402
+    load_config,
+    run_pipeline,
+    stable_payload_sha256,
+)
+from core.heavy_ml_probe.survival import (  # noqa: E402
+    MIN_N_WARN,
+    SURVIVAL_REQUIRED_POOL_COLUMNS,
+    SurvivalResult,
+    build_survival_target,
+    persist_fold_models,
+    run_survival,
+)
+
+DEFAULT_CONFIG_PATH = Path("configs/heavy_ml_probe/default.yaml")
+
+TEST_N_FOLDS = 5
+N_TRADES = 400
+
+
+# ── Target construction (dispatch §3 edge cases) ────────────────────
+
+
+def test_target_event_before_close():
+    """Reached +1R before close → event=1, duration=bars_to_1r."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 3.0, "bars_held": 10.0, "exit_reason": "tp",
+    }])
+    d, e = build_survival_target(pool)
+    assert d.tolist() == [3]
+    assert e.tolist() == [1]
+
+
+def test_target_never_reached_censored_at_time_exit():
+    """Never reached +1R, time-exited → event=0, duration=bars_held."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": np.nan, "bars_held": 30.0, "exit_reason": "time_exit",
+    }])
+    d, e = build_survival_target(pool)
+    assert d.tolist() == [30]
+    assert e.tolist() == [0]
+
+
+def test_target_sl_on_entry_bar_censored():
+    """SL on entry bar (MFE never reached +1R) → event=0, duration=1
+    (clipped from 0 to keep Cox PH happy)."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": np.nan, "bars_held": 1.0, "exit_reason": "sl",
+    }])
+    d, e = build_survival_target(pool)
+    assert d.tolist() == [1]
+    assert e.tolist() == [0]
+
+
+def test_target_same_bar_sl_tie_censored():
+    """+1R and SL on same bar → SL wins → event=0 (censored at that bar)."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 5.0, "bars_held": 5.0, "exit_reason": "sl",
+    }])
+    d, e = build_survival_target(pool)
+    assert d.tolist() == [5]
+    assert e.tolist() == [0]
+
+
+def test_target_same_bar_non_sl_event():
+    """+1R and time-exit on same bar (not SL) → event=1 (reached before
+    non-adverse close)."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 7.0, "bars_held": 7.0, "exit_reason": "time_exit",
+    }])
+    d, e = build_survival_target(pool)
+    assert d.tolist() == [7]
+    assert e.tolist() == [1]
+
+
+def test_target_zero_bars_clipped_to_one():
+    """Cox PH requires duration > 0; a 0-bar trade gets clipped to 1."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": np.nan, "bars_held": 0.0, "exit_reason": "sl",
+    }])
+    d, e = build_survival_target(pool)
+    assert d.tolist() == [1]
+    assert e.tolist() == [0]
+
+
+def test_target_vectorised_mixed():
+    pool = pd.DataFrame([
+        {"bars_to_1r_mfe": 2.0,   "bars_held": 5.0,  "exit_reason": "tp"},
+        {"bars_to_1r_mfe": np.nan,"bars_held": 10.0, "exit_reason": "sl"},
+        {"bars_to_1r_mfe": 5.0,   "bars_held": 5.0,  "exit_reason": "sl"},
+        {"bars_to_1r_mfe": 5.0,   "bars_held": 5.0,  "exit_reason": "time_exit"},
+        {"bars_to_1r_mfe": np.nan,"bars_held": 30.0, "exit_reason": "time_exit"},
+    ])
+    d, e = build_survival_target(pool)
+    assert d.tolist() == [2, 10, 5, 5, 30]
+    assert e.tolist() == [1, 0, 0, 1, 0]
+
+
+def test_target_halts_loud_on_missing_column():
+    pool = pd.DataFrame([{"bars_to_1r_mfe": 1.0, "bars_held": 2.0}])  # no exit_reason
+    with pytest.raises(PoolSchemaError, match="requires pool columns"):
+        build_survival_target(pool)
+
+
+def test_target_halts_loud_on_nan_bars_held():
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 1.0, "bars_held": np.nan, "exit_reason": "sl",
+    }])
+    with pytest.raises(ValueError, match="bars_held column has NaN"):
+        build_survival_target(pool)
+
+
+def test_target_sl_case_insensitive():
+    """SL tie-break is case-insensitive (matches PR-C convention)."""
+    for er in ("sl", "SL", "Sl", "sL"):
+        pool = pd.DataFrame([{
+            "bars_to_1r_mfe": 5.0, "bars_held": 5.0, "exit_reason": er,
+        }])
+        _, e = build_survival_target(pool)
+        assert e.tolist() == [0], f"exit_reason={er!r} should trigger SL tie-break"
+
+
+# ── Concordance from-scratch correctness (dispatch §4) ──────────────
+
+
+def test_concordance_perfectly_ranked():
+    """Higher predicted risk → smaller observed time → concordant
+    pairs only → C = 1.0."""
+    event = np.array([1, 1, 1, 1])
+    time = np.array([1.0, 2.0, 3.0, 4.0])
+    risk = np.array([4.0, 3.0, 2.0, 1.0])  # inverse rank to time
+    assert concordance(event, time, risk) == pytest.approx(1.0)
+
+
+def test_concordance_perfectly_reversed():
+    """Predicted risk inversely related to observed event order →
+    discordant pairs only → C = 0.0."""
+    event = np.array([1, 1, 1, 1])
+    time = np.array([1.0, 2.0, 3.0, 4.0])
+    risk = np.array([1.0, 2.0, 3.0, 4.0])  # same rank as time
+    assert concordance(event, time, risk) == pytest.approx(0.0)
+
+
+def test_concordance_random_close_to_half():
+    """Random risk vs random time should be ~0.5 over a reasonable
+    sample. Soft bound to absorb finite-sample wobble."""
+    rng = np.random.default_rng(42)
+    n = 200
+    event = (rng.random(n) > 0.3).astype(int)
+    time = rng.uniform(1, 100, size=n)
+    risk = rng.standard_normal(n)
+    c = concordance(event, time, risk)
+    assert 0.40 <= c <= 0.60, f"random concordance should be near 0.5, got {c:.4f}"
+
+
+def test_concordance_hand_computed_with_censoring():
+    """Hand-computed 3-trade case with one censored.
+
+    trades: (event=1, time=1, risk=10), (event=0, time=5, risk=8), (event=1, time=3, risk=5)
+    Comparable pairs (i with event=1 and time_i < time_j):
+      i=0, j=1: t=1 < t=5, risk_i=10 > risk_j=8 → concordant
+      i=0, j=2: t=1 < t=3, risk_i=10 > risk_j=5 → concordant
+      i=2, j=1: t=3 < t=5, risk_i=5  < risk_j=8 → discordant
+    concordance = (2 + 0) / 3 = 0.6667
+    """
+    event = np.array([1, 0, 1])
+    time = np.array([1.0, 5.0, 3.0])
+    risk = np.array([10.0, 8.0, 5.0])
+    assert concordance(event, time, risk) == pytest.approx(2.0 / 3.0)
+
+
+def test_concordance_with_ties():
+    """Tied predicted risks contribute 0.5 each.
+
+    trades: (event=1, time=1, risk=5), (event=1, time=2, risk=5), (event=1, time=3, risk=1)
+    Comparable pairs:
+      i=0, j=1: t=1 < t=2, risk_i=5 == risk_j=5 → tied
+      i=0, j=2: t=1 < t=3, risk_i=5 >  risk_j=1 → concordant
+      i=1, j=2: t=2 < t=3, risk_i=5 >  risk_j=1 → concordant
+    concordance = (2 + 0.5*1) / 3 = 2.5 / 3
+    """
+    event = np.array([1, 1, 1])
+    time = np.array([1.0, 2.0, 3.0])
+    risk = np.array([5.0, 5.0, 1.0])
+    assert concordance(event, time, risk) == pytest.approx(2.5 / 3.0)
+
+
+def test_concordance_no_comparable_pairs_returns_nan():
+    """All-censored validation slice → no comparable pairs → NaN."""
+    event = np.array([0, 0, 0])
+    time = np.array([1.0, 2.0, 3.0])
+    risk = np.array([1.0, 2.0, 3.0])
+    assert np.isnan(concordance(event, time, risk))
+
+
+def test_concordance_shape_mismatch_raises():
+    with pytest.raises(ValueError, match="shape mismatch"):
+        concordance(np.array([1, 0]), np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0, 3.0]))
+
+
+def test_concordance_non_finite_dropped():
+    """Trades with NaN risk/time are dropped before pair enumeration."""
+    event = np.array([1, 1, 1])
+    time = np.array([1.0, 2.0, np.nan])
+    risk = np.array([5.0, 1.0, 99.0])
+    # After dropping the NaN-time row: 2 trades, both events, t=1 < t=2,
+    # risk=5 > risk=1 → concordant. C = 1/1 = 1.0
+    assert concordance(event, time, risk) == pytest.approx(1.0)
+
+
+# ── End-to-end Cox PH (run_survival direct) ──────────────────────────
+
+
+def _survival_pool(
+    *,
+    n: int = N_TRADES,
+    seed: int = 1,
+    last_entry: pd.Timestamp = pd.Timestamp("2020-12-15", tz="UTC"),
+    target_strength: float = 0.7,
+) -> pd.DataFrame:
+    """Synthetic pool with a learnable Cox PH target.
+
+    The signal: trades with high `a + 0.5*b` reach +1R faster than
+    those with low values. Cox PH should recover positive coefficient
+    on `a` and a smaller positive coefficient on `b`.
+    """
+    rng = np.random.default_rng(seed)
+    feats = rng.standard_normal((n, 4))
+    df = pd.DataFrame({
+        "a": feats[:, 0], "b": feats[:, 1],
+        "c": feats[:, 2], "d": feats[:, 3],
+    })
+    end = pd.Timestamp(last_entry)
+    if end.tzinfo is None:
+        end = end.tz_localize("UTC")
+    df["entry_time"] = pd.date_range(end=end, periods=n, freq="h")
+    df["trade_id"] = np.arange(n)
+    noise = rng.standard_normal(n) * (1.0 - target_strength)
+    score = df["a"] + 0.5 * df["b"] + noise
+    reached = (score > 0).values
+    bars_held = rng.integers(low=3, high=30, size=n)
+    df["bars_to_1r_mfe"] = np.where(
+        reached, rng.integers(low=1, high=15, size=n), np.nan
+    )
+    df["bars_held"] = bars_held
+    df["exit_reason"] = np.where(reached, "tp", "sl")
+    return df
+
+
+def _used_features() -> tuple[str, ...]:
+    return ("a", "b", "c", "d")
+
+
+def test_run_survival_smoke(tmp_path):
+    """End-to-end Cox PH run produces valid concordance + non-empty
+    coefficient table + persisted manifest."""
+    pool = _survival_pool()
+    with pytest.warns(UserWarning):  # small-N warning fires on early folds
+        result = run_survival(
+            pool=pool, used_features=_used_features(),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            arc_name="smoke", cluster_id=0,
+            classifiers_dir=tmp_path / "clf",
+            n_folds=TEST_N_FOLDS,
+        )
+    assert isinstance(result, SurvivalResult)
+    assert result.n_folds_total == TEST_N_FOLDS
+    assert result.n_folds_valid >= 1
+    # Learnable target → concordance materially above 0.5
+    assert result.concordance_mean > 0.6, (
+        f"expected concordance > 0.6, got {result.concordance_mean:.4f}"
+    )
+    # Coefficient table populated
+    assert not result.coefficients_long.empty
+    assert {"fold", "feature", "coefficient", "p_value", "std_err",
+            "concordance", "n_train", "n_train_event",
+            "convergence_warning"} <= set(result.coefficients_long.columns)
+
+
+def test_run_survival_recovers_positive_a_coefficient(tmp_path):
+    """The synthetic generator builds the target as monotone-increasing
+    in `a`, so Cox PH should recover a positive coefficient for `a`
+    on at least one fold."""
+    pool = _survival_pool()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = run_survival(
+            pool=pool, used_features=_used_features(),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            arc_name="x", cluster_id=0,
+            classifiers_dir=tmp_path / "clf",
+            n_folds=TEST_N_FOLDS,
+        )
+    a_coefs = result.coefficients_long[
+        result.coefficients_long["feature"] == "a"
+    ]["coefficient"].dropna()
+    assert (a_coefs > 0).any(), (
+        f"expected at least one positive `a` coefficient; got {a_coefs.tolist()}"
+    )
+
+
+def test_run_survival_persists_baseline_hazard(tmp_path):
+    """Per dispatch §8: PR-E needs baseline hazard to recover absolute
+    survival probability. The per-fold pickle must include it."""
+    pool = _survival_pool()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = run_survival(
+            pool=pool, used_features=_used_features(),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            arc_name="x", cluster_id=0,
+            classifiers_dir=tmp_path / "clf",
+            n_folds=TEST_N_FOLDS,
+        )
+    cm = json.loads(result.classifier_manifest_path.read_text(encoding="utf-8"))
+    persisted = [f for f in cm["folds"] if f["path"] is not None]
+    assert persisted, "expected at least one persisted fold"
+    for f in persisted:
+        on_disk = result.classifier_manifest_path.parent / f["path"]
+        payload = joblib.load(on_disk)
+        assert set(payload.keys()) >= {
+            "results", "baseline_hazard", "used_features", "coefficients",
+        }
+        bh = payload["baseline_hazard"]
+        assert set(bh.keys()) == {
+            "stratum", "times", "cumulative_hazard", "survival_function",
+        }
+        # Non-empty (we had events in training)
+        assert len(bh["times"]) > 0
+        assert len(bh["cumulative_hazard"]) == len(bh["times"])
+        # Cumulative hazard is non-decreasing
+        ch = np.asarray(bh["cumulative_hazard"])
+        assert np.all(np.diff(ch) >= -1e-9), (
+            "cumulative hazard should be non-decreasing"
+        )
+        # Survival function is non-increasing and within [0, 1]
+        s = np.asarray(bh["survival_function"])
+        assert np.all((s >= -1e-9) & (s <= 1 + 1e-9))
+        assert np.all(np.diff(s) <= 1e-9)
+
+
+# ── Determinism (Cox PH is deterministic; no seed needed) ───────────
+
+
+def test_run_survival_two_run_determinism(tmp_path):
+    """Same input → byte-identical CSV + identical coefficient pickles.
+
+    Cox PH has no randomness; statsmodels' optimiser is deterministic
+    given the same starting point. Two consecutive runs should produce
+    coefficients that match to numerical precision.
+    """
+    pool = _survival_pool()
+    feats = _used_features()
+    end = pd.Timestamp("2021-01-01", tz="UTC")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        r1 = run_survival(
+            pool=pool.copy(), used_features=feats, train_end=end,
+            arc_name="x", cluster_id=0, classifiers_dir=tmp_path / "r1",
+            n_folds=TEST_N_FOLDS,
+        )
+        r2 = run_survival(
+            pool=pool.copy(), used_features=feats, train_end=end,
+            arc_name="x", cluster_id=0, classifiers_dir=tmp_path / "r2",
+            n_folds=TEST_N_FOLDS,
+        )
+    # Concordance + coefficient table match byte-for-byte
+    assert r1.concordance_mean == r2.concordance_mean
+    assert r1.concordance_std == r2.concordance_std
+    pd.testing.assert_frame_equal(
+        r1.coefficients_long.reset_index(drop=True),
+        r2.coefficients_long.reset_index(drop=True),
+    )
+    # Manifest stable payload (no timestamps in sidecar) matches
+    assert sha256_file(r1.classifier_manifest_path) == sha256_file(r2.classifier_manifest_path)
+    # Per-fold pickles match — Cox PH coefficients reproducible
+    cm1 = json.loads(r1.classifier_manifest_path.read_text(encoding="utf-8"))
+    cm2 = json.loads(r2.classifier_manifest_path.read_text(encoding="utf-8"))
+    persisted1 = [f for f in cm1["folds"] if f["path"] is not None]
+    persisted2 = [f for f in cm2["folds"] if f["path"] is not None]
+    assert len(persisted1) == len(persisted2)
+    for f1, f2 in zip(persisted1, persisted2):
+        p1 = joblib.load(r1.classifier_manifest_path.parent / f1["path"])
+        p2 = joblib.load(r2.classifier_manifest_path.parent / f2["path"])
+        # Pickle params should be numerically identical (Cox PH is
+        # deterministic; statsmodels uses analytic optimisation).
+        np.testing.assert_array_equal(p1["coefficients"], p2["coefficients"])
+        np.testing.assert_array_equal(
+            p1["baseline_hazard"]["cumulative_hazard"],
+            p2["baseline_hazard"]["cumulative_hazard"],
+        )
+
+
+# ── Minimum-N warning (dispatch §6) ─────────────────────────────────
+
+
+def test_run_survival_min_n_warning_fires_and_completes(tmp_path):
+    """n < 200 → UserWarning fires per fold, run completes with
+    convergence_warning=True on those folds."""
+    # Small pool: 80 trades, 3 folds → each train slice well below 200
+    pool = _survival_pool(n=80)
+    assert len(pool) < MIN_N_WARN
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", UserWarning)
+        result = run_survival(
+            pool=pool, used_features=_used_features(),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            arc_name="x", cluster_id=0,
+            classifiers_dir=tmp_path / "clf",
+            n_folds=3,
+        )
+    min_n_warnings = [
+        w for w in caught
+        if "MIN_N_WARN" in str(w.message) or "n_train=" in str(w.message)
+    ]
+    assert min_n_warnings, "expected at least one MIN_N_WARN UserWarning"
+    # Run completed; every fold flagged convergence_warning=True
+    # because n_train < MIN_N_WARN
+    rows = result.coefficients_long
+    if not rows.empty:
+        assert rows["convergence_warning"].all()
+
+
+def test_run_survival_no_events_fold_skipped(tmp_path):
+    """A fold whose training slice has zero events emits a
+    'skipped:no_events_in_training_slice' fit_message and NaN
+    concordance (no crash)."""
+    # Construct a pool where the first N trades all censored, last N all events
+    n = 300
+    rng = np.random.default_rng(11)
+    feats = rng.standard_normal((n, 3))
+    df = pd.DataFrame({"a": feats[:, 0], "b": feats[:, 1], "c": feats[:, 2]})
+    df["entry_time"] = pd.date_range(
+        end="2020-12-15", periods=n, freq="h", tz="UTC"
+    )
+    df["trade_id"] = np.arange(n)
+    df["bars_held"] = rng.integers(low=3, high=30, size=n)
+    # First 90% all censored (no +1R), last 10% all events
+    cutoff = int(0.9 * n)
+    bars_to_1r = np.full(n, np.nan)
+    bars_to_1r[cutoff:] = rng.integers(low=1, high=10, size=n - cutoff)
+    df["bars_to_1r_mfe"] = bars_to_1r
+    df["exit_reason"] = np.where(np.isnan(bars_to_1r), "time_exit", "tp")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        result = run_survival(
+            pool=df, used_features=("a", "b", "c"),
+            train_end=pd.Timestamp("2021-01-01", tz="UTC"),
+            arc_name="x", cluster_id=0,
+            classifiers_dir=tmp_path / "clf",
+            n_folds=5,
+        )
+    # At least one early fold should have been skipped
+    skipped = [
+        fr for fr in result.fold_results
+        if "no_events_in_training_slice" in fr.fit_message
+    ]
+    assert len(skipped) >= 1
+    for fr in skipped:
+        assert not fr.fit_succeeded
+        assert not np.isfinite(fr.concordance)
+
+
+# ── Pipeline integration ────────────────────────────────────────────
+
+
+def _override_config(tmp_path: Path) -> Path:
+    import yaml
+    with DEFAULT_CONFIG_PATH.open("r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    raw["automl"]["n_folds"] = TEST_N_FOLDS
+    raw["automl"]["max_iter_per_fold"] = 10
+    p = tmp_path / "test_config.yaml"
+    p.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return p
+
+
+def _full_pipeline_lineage_df() -> pd.DataFrame:
+    """Mark feature cols clean, metadata suspect."""
+    return pd.DataFrame([
+        {"name": "a", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "b", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "c", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "d", "causal_lineage": "clean", "feature_class": "price_geometry"},
+        {"name": "trade_id", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "entry_time", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "bars_to_1r_mfe", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "bars_held", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "exit_reason", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "y", "causal_lineage": "suspect", "feature_class": "meta"},
+    ])
+
+
+@pytest.fixture
+def pipeline_run(tmp_path):
+    """Pool carries survival schema (bars_to_1r_mfe + bars_held +
+    exit_reason). No final_r / y → meta-label + AutoML skip cleanly."""
+    pool = _survival_pool()
+    pool_path = tmp_path / "pool.parquet"
+    pool.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    lineage = _full_pipeline_lineage_df()
+
+    def _run(label: str):
+        out_root = tmp_path / label
+        cfg = load_config(
+            cfg_path, arc_name="test_arc", cluster_id=0,
+            pool_path=pool_path, output_root=out_root,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            return run_pipeline(cfg, lineage_df=lineage)
+
+    return _run
+
+
+def test_pipeline_writes_survival_artefacts(pipeline_run):
+    r = pipeline_run("run1")
+    assert r.survival_skip_reason == "ok"
+    assert r.survival_result is not None
+    assert r.survival_results_path is not None and r.survival_results_path.exists()
+    assert (
+        r.survival_classifier_manifest_path is not None
+        and r.survival_classifier_manifest_path.exists()
+    )
+
+    # Manifest must include survival artefacts
+    payload = json.loads(r.step4_manifest_path.read_text(encoding="utf-8"))
+    assert {"survival_model_results", "survival_classifier_manifest"} <= set(
+        payload["artefacts"].keys()
+    )
+    sb = payload["survival"]
+    assert sb["skip_reason"] == "ok"
+    assert sb["n_folds_total"] == TEST_N_FOLDS
+    assert sb["statsmodels_version"]
+    assert isinstance(sb["concordance_mean"], float)
+
+
+def test_pipeline_survival_csv_columns(pipeline_run):
+    r = pipeline_run("run1")
+    df = pd.read_csv(r.survival_results_path)
+    expected = {
+        "fold", "feature", "coefficient", "p_value", "std_err",
+        "concordance", "n_train", "n_train_event", "convergence_warning",
+    }
+    assert expected <= set(df.columns)
+    # One row per (fold, feature)
+    assert len(df) == TEST_N_FOLDS * 4  # 4 features
+
+
+def test_pipeline_survival_two_run_determinism(pipeline_run):
+    r1 = pipeline_run("run1")
+    r2 = pipeline_run("run2")
+    # Survival CSV + classifier manifest byte-identical
+    assert sha256_file(r1.survival_results_path) == sha256_file(r2.survival_results_path)
+    assert sha256_file(r1.survival_classifier_manifest_path) == sha256_file(
+        r2.survival_classifier_manifest_path
+    )
+    # Top-level manifest stable payload matches
+    assert stable_payload_sha256(r1.step4_manifest_path) == stable_payload_sha256(
+        r2.step4_manifest_path
+    )
+
+
+def test_pipeline_skip_survival_when_missing_columns(tmp_path):
+    """Pool with no survival columns → AutoML may still run; survival
+    skips with the right reason."""
+    rng = np.random.default_rng(3)
+    n = 100
+    df = pd.DataFrame({
+        "a": rng.standard_normal(n), "b": rng.standard_normal(n),
+        "trade_id": np.arange(n),
+        "entry_time": pd.date_range(
+            end="2020-12-15", periods=n, freq="h", tz="UTC"
+        ),
+    })
+    df["y"] = (df["a"] > 0).astype(int)
+    pool_path = tmp_path / "pool.parquet"
+    df.to_parquet(pool_path, compression="snappy", index=False)
+    cfg_path = _override_config(tmp_path)
+    lineage = pd.DataFrame([
+        {"name": "a", "causal_lineage": "clean", "feature_class": "x"},
+        {"name": "b", "causal_lineage": "clean", "feature_class": "x"},
+        {"name": "trade_id", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "entry_time", "causal_lineage": "suspect", "feature_class": "meta"},
+        {"name": "y", "causal_lineage": "suspect", "feature_class": "meta"},
+    ])
+    cfg = load_config(
+        cfg_path, arc_name="x", cluster_id=0,
+        pool_path=pool_path, output_root=tmp_path / "out",
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        r = run_pipeline(cfg, lineage_df=lineage)
+    assert r.survival_skip_reason.startswith("missing_survival_columns")
+    assert r.survival_result is None
+
+
+# ── persist_fold_models direct tests ────────────────────────────────
+
+
+def test_persist_fold_models_handles_empty(tmp_path):
+    """Empty SurvivalResult still writes a manifest."""
+    empty = SurvivalResult(
+        fold_results=(), coefficients_long=pd.DataFrame(),
+        used_features=(),
+        n_folds_total=0, n_folds_valid=0,
+        concordance_mean=float("nan"), concordance_std=float("nan"),
+        total_n_events=0, statsmodels_version="0.14.6",
+    )
+    path = persist_fold_models(empty, tmp_path / "clf", arc_name="x", cluster_id=0)
+    assert path.exists()
+    cm = json.loads(path.read_text(encoding="utf-8"))
+    assert cm["folds"] == []
+    assert cm["n_folds_persisted"] == 0
+    assert cm["stage"] == "survival"
+
+
+# ── Module constants locked ─────────────────────────────────────────
+
+
+def test_required_columns_constant_locked():
+    assert SURVIVAL_REQUIRED_POOL_COLUMNS == (
+        "bars_to_1r_mfe", "bars_held", "exit_reason",
+    )
+
+
+def test_min_n_warn_constant_locked():
+    assert MIN_N_WARN == 200


### PR DESCRIPTION
## Summary

**Gate PR** for the heavy_ml_probe sub-protocol build. Wires AutoML + meta-labeling + Cox PH survival into a single end-to-end invocation, emits the Step 5 augmentation manifest, and ships the A2/A4/A6 adapters that downstream consumers use to load heavy-ML components without retraining.

**Build sequence:** PR-A → PR-B → PR-C → PR-D → **PR-E (this, gate)** → PR-F (docs polish, final).

**Target:** `infra/heavy_ml_probe_build`. PR-E cut from PR-D locally; chat's A/B/C/D merges will collapse upstream portions of the diff.

## §5 Determinism gate — PASS

**10/10 artefacts byte-identical across two runs on identical input + seed.** No HALT. `test_determinism_gate_all_artefacts_byte_identical` in `test_integration.py` asserts:

| Artefact | sha256 stable? |
|---|---|
| `stub_summary.md` | ✓ |
| `compute_budget_used.md` (PR-E aggregate) | ✓ |
| `automl_leaderboard.csv` | ✓ |
| `automl_feature_importance.csv` | ✓ |
| `meta_label_results.csv` | ✓ |
| `meta_label_classifier_manifest` | ✓ |
| `survival_model_results.csv` | ✓ |
| `survival_classifier_manifest` | ✓ |
| `step_5/heavy_ml_augmented/heavy_ml_manifest.json` | ✓ |
| top-level `step_4/heavy_ml/manifest.json` (stable payload) | ✓ |

## §2 Adapter contract verification — confirmed

All three contracts match what `core/architectures/{A2,A4,A6}*.py` actually expects:

- **A2 / A6:** consume `predict_proba`-shaped classifier; FLAML's inner estimator drops in.
- **A4:** consumes `PathClassifierFit` via `predict_admit(fit, feature_row)`. `CoxPHAdapter` exposes both `hazard_predict(features, bars_survived) → P` (dispatch §2.2 primary) AND a `predict_proba(X)` shim that reads `bars_survived` from a named column (`BARS_SURVIVED_FEATURE = \"_bars_survived\"`).

The load-bearing test (`test_build_a4_predict_admit_handshake`) loads the emitted manifest, builds the A4 bundle, constructs a feature_row including BARS_SURVIVED_FEATURE, and calls `predict_admit(fit, feature_row) → (bool, float in [0, 1])`. PASS.

## Cox PH hazard math hand-computed check

`test_coxph_adapter_hazard_predict_hand_computed` traces dispatch §2.2 formula:

```
coefficients   = [0.5, -0.3]
features       = [1.0, 2.0] → linpred = -0.1 → relative_risk ≈ 0.9048
baseline H_0   = [0.10, 0.40, 0.90] at times [2, 5, 10]
bars_survived  = 2, k_horizon = 3 → integrated = (0.40 - 0.10) * 0.9048 = 0.2714
P              = 1 - exp(-0.2714) ≈ 0.2378
```

Adapter returns 0.2378 (matches to 1e-9). PASS. Plus 6 boundary tests.

## What's in this PR

| Area | Files | Purpose |
|---|---|---|
| Core | `core/heavy_ml_probe/adapters.py` (new) | `build_a{2,4,6}_from_heavy_ml`; `CoxPHAdapter`; `EnsembleMeanProbaClassifier`; `FoldSelectionStrategy`; manifest reader |
| Core | `core/heavy_ml_probe/pipeline.py` (extended) | `_compute_budget_aggregate_markdown`; `_emit_step5_manifest`; `_pipeline_overall_status` (drives exit code 3) |
| CLI | `scripts/heavy_ml_probe/run_probe.py` (extended) | `EXIT_PARTIAL_SUCCESS=3` per dispatch §4 |
| Spec | `docs/sub_protocols/heavy_ml_probe.md` (extended) | Invocation section + Step 5 manifest format + narrow-scope clarification |
| Tests | `tests/heavy_ml_probe/test_adapters.py` (new) | 29 tests — hand-computed Cox PH, schema validation, fold strategies, partial-success error handling |
| Tests | `tests/heavy_ml_probe/test_integration.py` (new) | 9 tests — end-to-end, **determinism gate**, adapter handshake, CLI exit codes (0/0/3/1) |
| Tests | `test_automl.py`, `test_io_manifest.py` (tweaked) | Artefact-set assertions updated to allow always-present `compute_budget_used.md` |
| Docs | `docs/dispatches/heavy_ml_probe_pr_e_log.md` (new) | Determinism + contract verification + scope decision + flags |

## Step 5 augmented scope decision: NARROW

Per dispatch §6 default. PR-E ships **adapters** + emits `step_5/heavy_ml_augmented/heavy_ml_manifest.json` describing what's adapter-buildable. PR-E does **NOT** invoke `core/architectures/{A2,A4,A6}*.py` — that's the overseer Step 5 loop's job when an arc declares `sub_protocol: heavy_ml_probe`. Dispatch §3 boundary (\"do not touch `core/architectures/**`\") respected.

## Verification

- `pytest tests/heavy_ml_probe -q`: **149/149 pass in 241s** (31 PR-A + 19 PR-B + 30 PR-C + 31 PR-D + 9 integration + 29 adapter)
- `pytest tests/discovery -q` (sibling): **42/42 pass**
- `ruff check`: clean
- CLI smoke: exit codes 0 / 0 / 3 / 1 verified (full success / all-skipped / partial / holdout-violation)
- Wall-clock: gate test (n=500, 5 folds, max_iter=10) completes in **5.47s** (well under §5's 30s target)

## Test plan

- [x] `pytest tests/heavy_ml_probe -q` (local)
- [x] `pytest tests/discovery -q` (sibling regression)
- [x] `ruff check` over new/modified modules
- [x] **Determinism gate** (10/10 artefacts byte-identical across two runs)
- [x] **Adapter contract verification** (all three A2/A4/A6 adapter outputs accepted by their respective Config classes; predict_admit handshake works)
- [x] CLI exit code 3 emission (partial success path)
- [x] Cox PH hand-computed math (1e-9 precision)
- [ ] CI green (will confirm after push)

## Deviations from dispatch (PR-E log §7)

- **A2 sources from PR-C's meta-label classifier**, not from a separate AutoML-output persistence (PR-B doesn't currently persist FLAML inner estimators for the `y` target). Documented in `build_a2_from_heavy_ml` docstring; one-line path lookup change to extend if chat wants vanilla-target A2.
- **`build_a4_from_heavy_ml` returns a tuple `(A4Config, CoxPHAdapter)`**, not a mutated A4Config. The dispatch §2.2 \"A4Config exposing hazard_predict\" wording is ambiguous; bundle pattern respects dispatch §3's no-core/architectures-touching boundary.
- **`compute_budget_used.md` writer moved from `_run_automl_stage` to pipeline end** so the artefact aggregates all 3 stages. PR-B test assertions updated to allow the file to land even when stages skip.

## Flags for chat (non-blocking)

- **Test wall-clock at 241s** total (up from PR-D's 138s — added 38 new tests including 9 integration tests that fit Cox PH twice per determinism check).
- **A2 contract gap** (above §7.1) — chat may want PR-F or post-merge to add PR-B-side AutoML inner-estimator persistence.
- **`FULL_REFIT` fold strategy** = `NotImplementedError` per dispatch §3 (\"NOT IMPLEMENTED IN PR-E\"). Tested.

Full log + per-section detail: [`docs/dispatches/heavy_ml_probe_pr_e_log.md`](https://github.com/kpanapabusiness-droid/Forex-Backtester/blob/infra/heavy_ml_probe_pr_e/docs/dispatches/heavy_ml_probe_pr_e_log.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)