### PR TITLE
Backfill AMENDMENT_5 + AMENDMENT_5_1 cutoff ISOs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -225,8 +225,6 @@ All 🔴 NOT STARTED — defer to Phase 2 trigger.
 | Closure-writer YAML auto-emission | 🔴 | Currently hand-written; defer until orchestrator gains closure-emit capability |
 | Legacy engine retirement (migrate `live/run_daily.py` + 32 importers off `core/backtester.py` + `core/signal_logic.py`) | 🔴 | Gate: KH-24 anchor preservation (±0.5pp ROI / ±1pp DD). Out of scope for current PRs; separate dispatch needed. |
 | EA mid-trail update (live MT5 EA still uses bid-side `CopyClose`) | 🔴 | To restore backtest↔EA parity post-PR-#189; separate deployment PR |
-| Backfill `AMENDMENT_5_CUTOFF_ISO` in `scripts/tracker_parser/schema.py` with PR #194 merge timestamp | 🔴 | Placeholder pinned at `2026-05-23T00:00:00Z`. Mirror PR-186 / Amendment 3 backfill pattern. Trivial one-line follow-up PR. |
-| Backfill `AMENDMENT_5_1_CUTOFF_ISO` in `scripts/tracker_parser/schema.py` with PR Amendment-5.1 merge timestamp | 🔴 | Placeholder pinned at `2026-05-25T00:00:00Z`. Mirror `AMENDMENT_5_CUTOFF_ISO` backfill pattern. Trivial one-line follow-up PR. |
 | KH-24 anchor F2/F3 fold-2 anchor-drift bisect investigation | 🔴 | Pre-existing on main; F2/F3 divergence between legacy `KH24FoldRunner` (warmup_days=30) and A1 path (full-history warmup). Documented; queued investigation. |
 | Triple-spread sensitivity diagnostic (Step 6 §6.3 enhancement) | 🔴 | Optional Step 6 framework enhancement |
 | HistData ↔ 5ers MT5 spread comparison (calibration task) | 🔴 | User-side; procedure at [docs/calibration/histdata_mt5_aggregation_parity_2026_05.md §5](docs/calibration/histdata_mt5_aggregation_parity_2026_05.md) |

--- a/scripts/tracker_parser/schema.py
+++ b/scripts/tracker_parser/schema.py
@@ -44,22 +44,15 @@ PHASE_2_CUTOFF_ISO: str = "2026-05-23T06:20:59Z"
 
 # L_PROTOCOL Amendment 5 cutoff for Phase 2 tightening on
 # `architectures_skipped_by_amendment_5`. After this timestamp, PASS verdicts
-# MUST carry the field (may be `[]`). PLACEHOLDER pinned at ratification date;
-# backfill with the Amendment-5 PR's actual merge timestamp post-merge. The
-# placeholder is functionally equivalent for all practical purposes — the PR
-# cannot merge before this instant, and no PASS closure will have a
-# `closed_timestamp` between the placeholder and the actual merge timestamp.
-AMENDMENT_5_CUTOFF_ISO: str = "2026-05-23T00:00:00Z"
+# MUST carry the field (may be `[]`). Backfilled with PR #194 merge timestamp
+# (mirrors PHASE_2_CUTOFF_ISO / Amendment 3 backfill pattern).
+AMENDMENT_5_CUTOFF_ISO: str = "2026-05-25T02:03:13Z"
 
-AMENDMENT_5_1_CUTOFF_ISO: str = "2026-05-25T00:00:00Z"
-# Placeholder. Backfill with PR merge timestamp post-merge (mirror
-# AMENDMENT_5_CUTOFF_ISO and AMENDMENT_3_CUTOFF_ISO patterns).
-# Cutoff: closures with closed_timestamp >= AMENDMENT_5_1_CUTOFF_ISO
-# and verdict in {PASS-DEPLOYABLE, PASS-VIABLE, *_PROVISIONAL}
-# and ≥2 candidate clusters surviving Step 3 in the closure body
-# MUST list either a constituent cluster's PASS-tier verdict OR
-# the string "a5_gate_4_admission_blocked_by_no_pass_tier_constituent"
-# in architectures_skipped_by_amendment_5.
+# L_PROTOCOL Amendment 5.1 cutoff. After this timestamp, PASS closures with
+# ≥2 candidate clusters surviving Step 3 MUST either run A5 or cite
+# "a5_gate_4_admission_blocked_by_no_pass_tier_constituent" in
+# architectures_skipped_by_amendment_5. Backfilled with PR #201 merge timestamp.
+AMENDMENT_5_1_CUTOFF_ISO: str = "2026-05-25T05:29:01Z"
 
 V11_EXCLUSIVE_FIELDS = {
     "worst_fold_dd_base_pct",

--- a/tests/tracker_parser/test_amendment_5_1_gate_4_qualifier.py
+++ b/tests/tracker_parser/test_amendment_5_1_gate_4_qualifier.py
@@ -1,7 +1,7 @@
 """L_PROTOCOL Amendment 5.1 (2026-05-25) — Gate 4 PASS-tier-constituent qualifier.
 
 Coverage:
-- ``AMENDMENT_5_1_CUTOFF_ISO`` constant pinned at the ratification-date placeholder
+- ``AMENDMENT_5_1_CUTOFF_ISO`` constant pinned at PR #201 merge timestamp
 - Schema accepts the reason string ``a5_gate_4_admission_blocked_by_no_pass_tier_constituent``
   as an entry in ``architectures_skipped_by_amendment_5`` (alongside architecture IDs)
 - Unknown reason strings still rejected
@@ -95,9 +95,9 @@ def _non_candidate_cluster() -> dict:
 # ── Schema vocabulary tests ────────────────────────────────────────────────
 
 
-def test_amendment_5_1_cutoff_placeholder_locked():
-    """Cutoff is pinned at ratification-date placeholder pending PR-merge backfill."""
-    assert AMENDMENT_5_1_CUTOFF_ISO == "2026-05-25T00:00:00Z"
+def test_amendment_5_1_cutoff_locked():
+    """Cutoff backfilled with PR #201 merge timestamp."""
+    assert AMENDMENT_5_1_CUTOFF_ISO == "2026-05-25T05:29:01Z"
 
 
 def test_schema_accepts_amendment_5_1_reason_string():
@@ -145,8 +145,8 @@ def test_is_post_amendment_5_1_cutoff_true_when_after():
 
 def test_is_post_amendment_5_1_cutoff_false_when_at_or_before():
     """Equality and strictly-before are pre-cutoff (grandfathered)."""
-    assert _is_post_amendment_5_1_cutoff("2026-05-25T00:00:00Z") is False
-    assert _is_post_amendment_5_1_cutoff("2026-05-24T23:59:59Z") is False
+    assert _is_post_amendment_5_1_cutoff("2026-05-25T05:29:01Z") is False
+    assert _is_post_amendment_5_1_cutoff("2026-05-25T05:29:00Z") is False
 
 
 def test_is_post_amendment_5_1_cutoff_missing_timestamp_grandfathered():

--- a/tests/tracker_parser/test_amendment_5_field.py
+++ b/tests/tracker_parser/test_amendment_5_field.py
@@ -1,7 +1,7 @@
 """L_PROTOCOL Amendment 5 (v1.3.1) — `architectures_skipped_by_amendment_5` field.
 
 Coverage:
-- ``AMENDMENT_5_CUTOFF_ISO`` constant pinned at the ratification-date placeholder
+- ``AMENDMENT_5_CUTOFF_ISO`` constant pinned at PR #194 merge timestamp
 - Schema accepts the field as optional (presence or absence)
 - Schema accepts ``[]`` (Amendment-5 set ⊇ Amendment-1 set)
 - Schema enum-validates entries against ``{A1..A6}``
@@ -45,9 +45,9 @@ _BASE_PAYLOAD: dict = {
 }
 
 
-def test_amendment_5_cutoff_placeholder_locked():
-    """Cutoff is pinned at ratification-date placeholder pending PR-merge backfill."""
-    assert AMENDMENT_5_CUTOFF_ISO == "2026-05-23T00:00:00Z"
+def test_amendment_5_cutoff_locked():
+    """Cutoff backfilled with PR #194 merge timestamp."""
+    assert AMENDMENT_5_CUTOFF_ISO == "2026-05-25T02:03:13Z"
 
 
 def test_schema_accepts_field_absent():
@@ -82,14 +82,14 @@ def test_schema_rejects_invalid_architecture_in_field():
 
 def test_is_post_amendment_5_cutoff_true_when_after():
     """Closures strictly after the cutoff are post-cutoff."""
-    assert _is_post_amendment_5_cutoff("2026-05-24T00:00:00Z") is True
-    assert _is_post_amendment_5_cutoff("2026-05-23T12:00:00Z") is True
+    assert _is_post_amendment_5_cutoff("2026-05-26T00:00:00Z") is True
+    assert _is_post_amendment_5_cutoff("2026-05-25T06:00:00Z") is True
 
 
 def test_is_post_amendment_5_cutoff_false_when_at_or_before():
     """Equality and strictly-before are pre-cutoff (grandfathered)."""
-    assert _is_post_amendment_5_cutoff("2026-05-23T00:00:00Z") is False
-    assert _is_post_amendment_5_cutoff("2026-05-22T23:59:59Z") is False
+    assert _is_post_amendment_5_cutoff("2026-05-25T02:03:13Z") is False
+    assert _is_post_amendment_5_cutoff("2026-05-25T02:03:12Z") is False
 
 
 def test_is_post_amendment_5_cutoff_missing_timestamp_grandfathered():


### PR DESCRIPTION
## Summary

- Backfills `AMENDMENT_5_CUTOFF_ISO` with the actual [PR #194](https://github.com/kpanapabusiness-droid/Forex-Backtester/pull/194) merge timestamp (`2026-05-25T02:03:13Z`).
- Backfills `AMENDMENT_5_1_CUTOFF_ISO` with the actual [PR #201](https://github.com/kpanapabusiness-droid/Forex-Backtester/pull/201) merge timestamp (`2026-05-25T05:29:01Z`).
- Removes both standing-item TODO rows; tightens cutoff comments; updates four test assertions whose old values would otherwise straddle the new cutoffs.

## Why bundled

Both placeholders were pinned at ratification-date midnight UTC. Doing them in one PR avoids two trivial follow-ups and closes both grandfather windows before any Phase 1 v3.0.2 PASS closure could exploit them. Mastermind authorised the bundle.

## Files touched

- [scripts/tracker_parser/schema.py](scripts/tracker_parser/schema.py) — two constants updated; placeholder-language comments rewritten.
- [tests/tracker_parser/test_amendment_5_field.py](tests/tracker_parser/test_amendment_5_field.py) — `test_amendment_5_cutoff_locked` value; `*_true_when_after` / `*_false_when_at_or_before` test values adjusted around the new cutoff (old `2026-05-24` values would now be PRE-cutoff and would invert the assertion).
- [tests/tracker_parser/test_amendment_5_1_gate_4_qualifier.py](tests/tracker_parser/test_amendment_5_1_gate_4_qualifier.py) — `test_amendment_5_1_cutoff_locked` value; `*_false_when_at_or_before` boundary values shifted to new cutoff (the `*_true_when_after` values were `2026-05-26` and `2026-05-25T12:00` and are still post-cutoff — left untouched).
- [TODO.md](TODO.md) — two backfill standing-item rows deleted.

## Test plan

- [x] `py -m pytest tests/tracker_parser/` — 84 passed