### PR TITLE
Step 6 lookahead — vacuous-pass for A1 features_in_winning_config: []

### DIFF
--- a/core/step_6/lookahead.py
+++ b/core/step_6/lookahead.py
@@ -58,12 +58,23 @@ def _check_per_feature_lineage(inputs: Step6Inputs) -> CheckResult:
     features = inputs.best_candidate_features
     lineage = inputs.feature_lineage
 
+    # Vacuous-pass: rule-based architectures (A1 system_level_filter) by
+    # design carry no classifier features. The universal quantifier "every
+    # feature in the winning config has clean lineage" is vacuously True
+    # over an empty set — no features means no opportunity for lineage
+    # contamination. Treating empty as "cannot verify → CRITICAL" is the
+    # inverse of intent (see engine/step_6_a1_vacuous_pass, 2026-05-25).
     if not features:
         return CheckResult(
             name="per_feature_lineage_clean",
-            passed=False,
-            severity=Severity.CRITICAL,
-            message="best_candidate_features is empty — cannot enforce lineage",
+            passed=True,
+            severity=Severity.INFO,
+            message=(
+                "best_candidate_features is empty (by-design for rule-based "
+                "architectures like A1 system_level_filter). No classifier "
+                "features means no opportunity for feature lineage contamination — "
+                "vacuous PASS per universal-quantifier-over-empty-set."
+            ),
             evidence={"features_in_winning_config": []},
         )
     if lineage is None:
@@ -118,12 +129,20 @@ def _check_per_feature_lineage(inputs: Step6Inputs) -> CheckResult:
 
 def _check_no_path_features_in_entry(inputs: Step6Inputs) -> CheckResult:
     features = inputs.best_candidate_features
+    # Vacuous-pass: same semantics as _check_per_feature_lineage above.
+    # No entry features means no opportunity for path-feature contamination
+    # in entry decisions (see engine/step_6_a1_vacuous_pass, 2026-05-25).
     if not features:
         return CheckResult(
             name="no_path_features_in_entry",
-            passed=False,
-            severity=Severity.CRITICAL,
-            message="best_candidate_features is empty — cannot enforce no-path-in-entry",
+            passed=True,
+            severity=Severity.INFO,
+            message=(
+                "best_candidate_features is empty (by-design for rule-based "
+                "architectures like A1 system_level_filter). No entry features "
+                "means no opportunity for path-feature contamination in entry — "
+                "vacuous PASS per universal-quantifier-over-empty-set."
+            ),
             evidence={"features_in_winning_config": []},
         )
     leaks: list[str] = []

--- a/docs/PROTOCOL_RUNTIME.md
+++ b/docs/PROTOCOL_RUNTIME.md
@@ -740,6 +740,8 @@ core/step_6/
 
 `CategoryAuditResult.passed = AND over critical-severity checks only`.
 
+**Empty `features_in_winning_config` (vacuous pass):** rule-based architectures (A1 system_level_filter) by design have no classifier features. The `per_feature_lineage_clean` and `no_path_features_in_entry` checks treat `features_in_winning_config: []` as a vacuous pass per universal-quantifier-over-empty-set semantics: no features to check means no opportunity for lineage/path contamination, not a missing-check failure. Patch landed 2026-05-25 (`engine/step_6_a1_vacuous_pass`).
+
 **Manual CLI** — `scripts/run_step_6.py`:
 
 ```bash

--- a/tests/step_6/test_lookahead.py
+++ b/tests/step_6/test_lookahead.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
-from core.step_6.lookahead import audit
+from core.step_6.lookahead import (
+    _check_no_path_features_in_entry,
+    _check_per_feature_lineage,
+    audit,
+)
 from core.step_6.manifest import AuditConfig, Severity
 from tests.step_6._fixtures import build_clean_inputs, build_leaky_inputs
 
@@ -54,3 +59,31 @@ def test_category_is_lookahead(tmp_path: Path):
     inputs = build_clean_inputs(tmp_path)
     result = audit(inputs, AuditConfig())
     assert result.category == "lookahead"
+
+
+def test_per_feature_lineage_empty_features_vacuous_pass(tmp_path: Path):
+    """A1 winning config with features_in_winning_config: [] passes vacuously.
+
+    Rule-based architectures (A1 system_level_filter) by design have no
+    classifier features. The universal-quantifier "every feature is clean"
+    is vacuously True over an empty set — no features means no lineage
+    contamination opportunity, not a missing-check failure.
+    """
+    inputs = replace(build_clean_inputs(tmp_path), best_candidate_features=())
+    result = _check_per_feature_lineage(inputs)
+    assert result.passed is True
+    assert result.severity == Severity.INFO
+    assert "vacuous PASS" in result.message
+
+
+def test_no_path_features_in_entry_empty_features_vacuous_pass(tmp_path: Path):
+    """A1 winning config with features_in_winning_config: [] passes vacuously.
+
+    Same semantics as per_feature_lineage_clean — no entry features means
+    no opportunity for path-feature contamination in entry.
+    """
+    inputs = replace(build_clean_inputs(tmp_path), best_candidate_features=())
+    result = _check_no_path_features_in_entry(inputs)
+    assert result.passed is True
+    assert result.severity == Severity.INFO
+    assert "vacuous PASS" in result.message


### PR DESCRIPTION
## Context

Phase 1 escalation `MASTERMIND_step6_a1_false_positive.md`, **Option C ratified**. Unblocks corrected dispatches for Arc 5 / Arc 8 / Arc 10 v3.0.2 and benefits all future arcs with A1 winning configs (Arc 11 in flight + downstream).

## The bug

`core/step_6/lookahead.py` had two checkers that fail-hard CRITICAL on empty `best_candidate_features`:

- `_check_per_feature_lineage` → `"best_candidate_features is empty — cannot enforce lineage"`
- `_check_no_path_features_in_entry` → `"best_candidate_features is empty — cannot enforce no-path-in-entry"`

A1 (`system_level_filter`) by design carries `features_in_winning_config: []` — no classifier, no entry features. Per closure template v1.3.1 + Arc 10 v3.0 original's grandfathered hand-written Step 6 (which PASSed A1 with empty features: *"no classifier; raw signal pool"*), empty is the correct A1 contract, not a degenerate state.

The intent of both checks is universally quantified over the feature set:
- "every feature in the winning config has clean lineage"
- "no entry feature matches a forward-path pattern"

Universal quantification over the empty set is vacuously True (standard predicate logic). Zero classifier features = zero opportunities for entry-time lookahead in the classifier — because there *is* no classifier. The framework was inverting the intent: treating "no features to check" as "cannot verify → CRITICAL".

## The fix

Both `if not features:` early-returns flipped from `passed=False, severity=CRITICAL` to `passed=True, severity=INFO` with an explanatory message citing the universal-quantifier-over-empty-set semantics. Inline comments added near both checkers. All other code paths (lineage table present + features non-empty, path-pattern detection on non-empty features, etc.) untouched.

## Files touched

- [core/step_6/lookahead.py](core/step_6/lookahead.py) — two early-return blocks flipped + inline comments
- [tests/step_6/test_lookahead.py](tests/step_6/test_lookahead.py) — two new tests:
  - `test_per_feature_lineage_empty_features_vacuous_pass`
  - `test_no_path_features_in_entry_empty_features_vacuous_pass`
- [docs/PROTOCOL_RUNTIME.md](docs/PROTOCOL_RUNTIME.md) §10b — paragraph on vacuous-pass semantics

## Test coverage

- `py -m pytest tests/step_6/ -v` → **46 passed** (includes the two new vacuous-pass tests)
- `py -m pytest -q` → **1606 passed, 305 skipped, 0 failures** in 388s

No existing tests required modification; no regressions.

## Why this is a framework bug-fix, not a methodology change

- **L_PROTOCOL Amendment 4** (`§2 Step 6`) specifies the six-category framework as runnable engine code with `critical / warning / info` severities. The amendment intent is to verify *the entry classifier has no lookahead*, NOT to forbid rule-based architectures from clearing Step 6.
- **Closure template v1.3.1** already permits `features_in_winning_config: []` as a valid winning-config payload. No schema change required.
- **Arc 10 v3.0 original** Step 6 (hand-written, grandfathered) explicitly PASSed A1 with the empty-features contract — the design contract for A1 was always vacuous-pass; the auto-checkers just had the polarity wrong.
- No `L_PROTOCOL.md` change. No closure template change. No closure doc change (Arc 10 v3.0.2 prior HALT artefact retained as-is per dispatch §3).

## What was deliberately NOT touched

Per dispatch §3:
- Other Step 6 categories (`selection_bias.py`, `execution_realism.py`, `statistical.py`, `determinism.py`, `deployment_readiness.py`) — out of scope.
- `core/step_6/dispatch.py` / `maybe_dispatch_step_6` — correct as-is.
- Closure template schema — already valid.
- `L_PROTOCOL.md` Amendment 4 — no sub-amendment needed; checker logic bug only.
- Any arc closure docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)