### PR TITLE
Fix W1 producer lookahead — canonical HTF alignment for _w1_close_slope_sign

### DIFF
--- a/core/features/multi_tf.py
+++ b/core/features/multi_tf.py
@@ -138,6 +138,13 @@ def _w1_close_slope_sign(pair_df: pd.DataFrame, panel=None) -> pd.Series:
     weekly bar (week N-1 visible during week N).
 
     Requires ``panel.aux["w1"]`` — a Panel keyed at W1.
+
+    Uses the canonical ``get_htf_value_at(..., require_fully_closed=True)``
+    pattern that the D1 producers in this module already follow. The slope
+    is pre-computed on the W1 series via ``shift(1)`` then looked up at
+    the most recently fully-closed W1 bar at each LTF timestamp — i.e. at
+    an H4 timestamp inside week N, the result is ``sign(W1_close[N-1] -
+    W1_close[N-2])``, never involving week N's own (not-yet-closed) close.
     """
     if panel is None or not hasattr(panel, "aux") or "w1" not in panel.aux:
         return pd.Series(np.nan, index=pair_df.index, name="w1_close_slope_sign")
@@ -145,16 +152,10 @@ def _w1_close_slope_sign(pair_df: pd.DataFrame, panel=None) -> pd.Series:
     w1_df = panel.aux["w1"].pair_dfs[pair]
     w1_close = (w1_df["close_bid"] + w1_df["close_ask"]) / 2.0
     slope = (w1_close - w1_close.shift(1)).rename("slope")
-    # Align by `merge_asof(direction='backward')` on week-start key, then enforce
-    # that the matched week's bar ended strictly before the signal bar.
-    df = pd.DataFrame({"_t": pair_df.index, "_idx": np.arange(len(pair_df))})
-    df = df.sort_values("_t")
-    w1_pos = slope.to_frame().reset_index().rename(columns={w1_df.index.name or "index": "_t"})
-    w1_pos.columns = ["_t", "slope"]
-    w1_pos = w1_pos.sort_values("_t")
-    merged = pd.merge_asof(df, w1_pos, on="_t", direction="backward", allow_exact_matches=False)
-    merged = merged.sort_values("_idx").reset_index(drop=True)
-    return np.sign(pd.Series(merged["slope"].values, index=pair_df.index)).astype("float64")
+    aligned = get_htf_value_at(
+        pair_df.index, slope.to_frame(), "slope", require_fully_closed=True
+    )
+    return np.sign(aligned).astype("float64")
 
 
 register(
@@ -164,11 +165,12 @@ register(
         lineage=CausalLineage.CLEAN,
         feature_class="multi_tf",
         description=(
-            "Sign of the prior-W1 close-on-close slope. -1 / 0 / +1. Strictly "
-            "prior W1 bar (no exact-match alignment — week N's bar isn't visible "
+            "Sign of the prior-W1 close-on-close slope. -1 / 0 / +1. Uses the "
+            "L_PROTOCOL §1 strict-prior rule (most recently fully-closed W1 "
+            "bar visible at the LTF timestamp; week N's W1 not visible "
             "until week N+1 starts)."
         ),
-        inputs={"reference_tf": "W1", "alignment": "strict_prior"},
+        inputs={"reference_tf": "W1", "alignment": "fully_closed_prior"},
         needs_panel=True,
     )
 )

--- a/docs/PROTOCOL_RUNTIME.md
+++ b/docs/PROTOCOL_RUNTIME.md
@@ -1027,12 +1027,21 @@ value (e.g. prior-day D1 close) at an LTF anchor timestamp (e.g. each H4 bar).
 Replaces the legacy UTC-anchored idioms that broke under the 5ers EET storage
 convention in §15.3:
 
-| Legacy idiom | Failure mode under EET | Canonical replacement |
+| Legacy idiom | Failure mode | Canonical replacement |
 |---|---|---|
-| `ltf_index.floor("4h").map(idx_h4)` | State **C** — `.map()` exact-match returns NaN → empty signal pool | `get_htf_index_at(..., require_fully_closed=True)` |
-| `ltf_index.normalize().map(idx_d1)` | State **C** | `get_htf_index_at(...)` or `get_htf_value_at(...)` |
-| `df.index.normalize() - pd.Timedelta(days=1)` + `merge_asof(backward)` | State **B** — silently picks same-EET-day HTF (lookahead) | `get_htf_value_at(..., require_fully_closed=True)` or `get_htf_row_at(...)` |
-| `d1_ts.normalize()` + `np.searchsorted` | State **B** — picks neighbouring EET-day HTF | `get_htf_index_at(...)` |
+| `ltf_index.floor("4h").map(idx_h4)` | EET-only: State **C** — `.map()` exact-match returns NaN → empty signal pool | `get_htf_index_at(..., require_fully_closed=True)` |
+| `ltf_index.normalize().map(idx_d1)` | EET-only: State **C** | `get_htf_index_at(...)` or `get_htf_value_at(...)` |
+| `df.index.normalize() - pd.Timedelta(days=1)` + `merge_asof(backward)` | EET-only: State **B** — silently picks same-EET-day HTF (lookahead) | `get_htf_value_at(..., require_fully_closed=True)` or `get_htf_row_at(...)` |
+| `d1_ts.normalize()` + `np.searchsorted` | EET-only: State **B** — picks neighbouring EET-day HTF | `get_htf_index_at(...)` |
+| `pd.merge_asof(direction='backward', allow_exact_matches=False)` against `label='left'` HTF bars | **Convention-independent** State **B** — at any LTF ts strictly inside HTF period N, picks N's own bar with its eventual end-of-period close (within-period lookahead) | `get_htf_value_at(..., require_fully_closed=True)` |
+
+The last row is a distinct fault class from the others: it is **not** a
+timezone-shift bug (it occurs identically under UTC and EET) but a
+**within-period** bug — `merge_asof(direction='backward')` against a
+left-labelled HTF bar matches the period's own label, and the bar's
+`close` column carries that period's eventual end-of-period close.
+Discovered cross-arc on `core/features/multi_tf.py::_w1_close_slope_sign`
+in 2026-05; fixed canonically via PR `engine/w1_producer_canonical_alignment`.
 
 **Public API:**
 

--- a/docs/audits/signal_module_eet_audit_2026_05.md
+++ b/docs/audits/signal_module_eet_audit_2026_05.md
@@ -209,3 +209,99 @@ tests/test_features_individual.py 23 passed
 ## Footer update: `engine_capability_audit_2026_05.md`
 
 Signal-level EET alignment gap: MISSING → **WIRED**. See this audit doc + canonical utility at `core/signals/htf_alignment.py`.
+
+---
+
+## 2026-05-25 — `_w1_close_slope_sign` State A classification SUPERSEDED
+
+The 2026-05 audit (this doc, row at line 113 of the per-module table)
+classified `core/features/multi_tf.py::_w1_close_slope_sign` as State A
+under both UTC and EET, with the note "Already uses `merge_asof` against
+actual W1 timestamps; tz-invariant by construction". This classification
+was incomplete: the audit checked for the **timezone-shift** lookahead
+fault class (UTC-anchored `.floor()`/`.normalize()` keys against
+EET-shifted HTF labels) but missed a separate **within-period**
+lookahead fault class.
+
+### The within-period lookahead bug
+
+W1 panels are produced by `core/data/aggregator.py` at `freq='W-MON'`
+with `label='left'`, `closed='left'` — so the W1 bar for week N has its
+index timestamp at the Monday 00:00 UTC of week N but its `close_bid` /
+`close_ask` columns hold the END-OF-WEEK close (Sunday 23:59 UTC of
+week N). The pre-fix producer used:
+
+```python
+merged = pd.merge_asof(df, w1_pos, on='_t', direction='backward',
+                       allow_exact_matches=False)
+```
+
+At any H4 timestamp **strictly after** Monday 00:00 of week N (i.e.
+every mid-week H4 bar from Monday 00:00:01 through Sunday 23:59:59),
+`merge_asof(direction='backward')` returns week N's W1 bar — whose
+`close` is the **eventual** Sunday close. The producer then computed
+`sign(close[N] - close[N-1])`, leaking the future Sunday close as a
+sign-of-slope feature on every mid-week H4 bar.
+
+Convention-independent: this happens identically under UTC and EET
+storage (the bug is in the producer's alignment to its own panel, not
+in any tz-shift) — which is why the 2026-05 audit's State-A
+classification (looking only for tz-shift) missed it.
+
+### Identification
+
+Bug identified by Arc 8 v3.0.2 + Arc 10 v3.0.2 CC chat audits. The
+three sibling D1 producers (`_d1_close_slope_sign`,
+`_d1_close_slope_magnitude`, `_d1_atr_percentile_100`) plus the shared
+helper `_build_d1_lag1_series` were already canonical
+(`get_htf_value_at(..., require_fully_closed=True)`); the W1 producer
+was the lone non-canonical case in this file.
+
+### Fix
+
+Replaced the `merge_asof` body with the canonical
+`get_htf_value_at(..., require_fully_closed=True)` pattern that mirrors
+the D1 producers in the same file. The fix is purely an HTF-alignment
+swap — the slope is still pre-computed on the W1 series via `shift(1)`,
+just looked up at the **most recently fully-closed W1 bar** (week N-1
+when mid-week N) instead of the `merge_asof`-resolved same-week bar.
+
+Landed via PR `engine/w1_producer_canonical_alignment` (2026-05-25):
+
+- `core/features/multi_tf.py::_w1_close_slope_sign` rewritten.
+- `tests/test_features_multi_tf.py` added: three regression tests
+  covering within-week lookahead, lag correctness at multiple H4
+  timestamps, and a static source guard against `merge_asof`
+  reintroduction.
+
+### Updated classification
+
+The State A classification for `_w1_close_slope_sign` (line 113 above)
+now stands accurately post-fix. The pre-fix state was **State B under
+both UTC and EET** (silent within-period lookahead, convention-
+independent), not State A as previously documented.
+
+### Cross-arc impact
+
+Affected v3.0 / v3.0.x runs whose feature pipelines consumed
+`w1_close_slope_sign` (any arc whose Step 1 builds the full feature
+matrix). KH-24 is **not** affected: KH-24's signal config does not
+consume this feature (verified by grep against
+`configs/replays_v2_1_1/kh24*.yaml` and `core/strategies/kh24/`).
+
+### Future audits
+
+Audits of feature/signal pipelines must include **within-period**
+lookahead checks in addition to **timezone-shift** checks. The two
+fault classes are independent:
+
+- *Timezone-shift* — `.floor()`/`.normalize()`-derived keys against
+  EET-shifted HTF labels (the 2026-05 audit's focus).
+- *Within-period* — `merge_asof(direction='backward')` (or equivalent
+  soft-prior lookup) against `label='left'` HTF bars: at any LTF
+  timestamp inside HTF period N strictly after N's label, the lookup
+  returns N's bar with N's eventual close — a leak independent of tz.
+
+The canonical utility `get_htf_value_at(..., require_fully_closed=True)`
+defends against both by construction (the `bar_end[k] <= ts` check is
+both tz-invariant AND strict-period-closure).

--- a/tests/test_features_multi_tf.py
+++ b/tests/test_features_multi_tf.py
@@ -1,0 +1,263 @@
+"""Regression tests for ``core/features/multi_tf.py::_w1_close_slope_sign``.
+
+Guards against the within-period W1 lookahead bug discovered by Arc 8 +
+Arc 10 v3.0.2 audits:
+
+The W1 panel is left-labelled (``label='left', closed='left'`` on ``W-MON``
+freq), so the W1 bar for week N has its index timestamp at the Monday
+00:00 UTC of week N, BUT its ``close_bid`` / ``close_ask`` columns hold
+the END-OF-WEEK close (Sunday 23:59 UTC of week N). The pre-fix producer
+used ``pd.merge_asof(direction='backward', allow_exact_matches=False)``
+which, at any H4 timestamp strictly after Monday 00:00 of week N, picks
+the SAME week's W1 bar — leaking the eventual Sunday close every
+mid-week H4 bar. Convention-independent (UTC and EET both affected;
+that's why the 2026-05 audit's State A classification missed it).
+
+The fix replaces ``merge_asof`` with the canonical
+``core.signals.htf_alignment.get_htf_value_at(..., require_fully_closed=True)``
+utility — semantics: at LTF timestamp t, pick the most recent W1 bar
+whose END (next W1 bar's start) is ``<= t``. Mid-week N, week N's bar
+is NOT fully closed; the lookup returns week N-1's W1 instead.
+
+Tests:
+  1. ``test_w1_close_slope_sign_no_lookahead_within_week`` — at a
+     mid-week H4 timestamp, the slope sign reflects only PRIOR weeks,
+     never the current week's eventual Sunday close. Pre-fix this test
+     fails; post-fix passes.
+  2. ``test_w1_close_slope_sign_lag_correctness`` — hand-computed
+     expected values at multiple H4 timestamps match the producer.
+  3. ``test_w1_close_slope_sign_canonical_alignment`` — static source
+     guard: the producer must use ``get_htf_value_at`` and must not use
+     ``merge_asof``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import numpy as np
+import pandas as pd
+
+from core.features.multi_tf import _w1_close_slope_sign
+from core.sim.panel import Panel
+
+# ── Synthetic W1 / H4 panel construction ─────────────────────────────
+
+
+def _build_w1_panel(weekly_closes: list[float], start_monday: str = "2024-01-01") -> Panel:
+    """Build a synthetic W1 Panel keyed at Monday 00:00 UTC.
+
+    ``weekly_closes[i]`` is the END-OF-WEEK close for week ``i`` — this
+    mirrors the production aggregator's ``label='left'`` schema where
+    the W1 bar at index ``Monday[i]`` carries week ``i``'s closing OHLC
+    in its columns.
+    """
+    monday = pd.Timestamp(start_monday, tz="UTC")
+    idx = pd.date_range(monday, periods=len(weekly_closes), freq="W-MON", tz="UTC")
+    idx.name = "timestamp_utc"
+    spread = 0.00010  # 1 pip half-width
+    closes = np.array(weekly_closes, dtype=float)
+    df = pd.DataFrame(
+        {
+            "open_bid": closes - spread,
+            "high_bid": closes - spread,
+            "low_bid": closes - spread,
+            "close_bid": closes - spread,
+            "open_ask": closes + spread,
+            "high_ask": closes + spread,
+            "low_ask": closes + spread,
+            "close_ask": closes + spread,
+            "volume": np.ones(len(closes), dtype=np.int64),
+            "spread_close": np.full(len(closes), 2 * spread, dtype=float),
+            "bid_ask_data_quality": ["ok"] * len(closes),
+        },
+        index=idx,
+    )
+    return Panel(pair_dfs={"EURUSD": df}, tf="W1")
+
+
+def _build_h4_frame(start_monday: str, n_weeks: int) -> pd.DataFrame:
+    """Build an H4 ``pair_df`` index spanning ``n_weeks`` from ``start_monday``."""
+    monday = pd.Timestamp(start_monday, tz="UTC")
+    n_bars = n_weeks * 7 * 6  # 7 days × 6 H4 bars/day
+    idx = pd.date_range(monday, periods=n_bars, freq="4h", tz="UTC")
+    idx.name = "timestamp_utc"
+    df = pd.DataFrame(index=idx)
+    df.attrs["pair"] = "EURUSD"
+    return df
+
+
+def _attach_w1_aux(h4_frame: pd.DataFrame, w1_panel: Panel) -> Panel:
+    """Build an H4 Panel and attach W1 to ``.aux`` (the convention used by
+    the engine — see ``scripts/arc_7/run_arc_7.py``).
+    """
+    h4_panel = Panel(pair_dfs={"EURUSD": _h4_bidask(h4_frame.index)}, tf="H4")
+    # Panel is a frozen dataclass; the engine uses object.__setattr__ to
+    # bolt on an ``aux`` dict. Mirror that pattern in tests.
+    object.__setattr__(h4_panel, "aux", {"w1": w1_panel})
+    return h4_panel
+
+
+def _h4_bidask(idx: pd.DatetimeIndex) -> pd.DataFrame:
+    """Trivial H4 OHLC frame matching the schema Panel expects."""
+    n = len(idx)
+    closes = np.full(n, 1.10, dtype=float)
+    spread = 0.00010
+    df = pd.DataFrame(
+        {
+            "open_bid": closes - spread,
+            "high_bid": closes - spread,
+            "low_bid": closes - spread,
+            "close_bid": closes - spread,
+            "open_ask": closes + spread,
+            "high_ask": closes + spread,
+            "low_ask": closes + spread,
+            "close_ask": closes + spread,
+            "volume": np.ones(n, dtype=np.int64),
+            "spread_close": np.full(n, 2 * spread, dtype=float),
+            "bid_ask_data_quality": ["ok"] * n,
+        },
+        index=idx,
+    )
+    return df
+
+
+# ── Test 1: no within-week lookahead ─────────────────────────────────
+
+
+def test_w1_close_slope_sign_no_lookahead_within_week() -> None:
+    """At any H4 timestamp mid-week N, w1_close_slope_sign must use only
+    fully-closed W1 bars (week N-1 + week N-2), never the eventual close
+    of week N itself.
+
+    Setup: weekly closes are chosen so the prior-vs-prior-prior slope
+    has the OPPOSITE sign to the current-vs-prior slope. Pre-fix
+    ``merge_asof(direction='backward', allow_exact_matches=False)`` at
+    a mid-week-N H4 timestamp picks week N's W1 bar (with its eventual
+    Sunday close), producing the wrong sign. Post-fix
+    ``get_htf_value_at(..., require_fully_closed=True)`` picks week
+    N-1's W1 bar, producing the correct sign.
+
+    Weekly closes:
+        week 0 = 1.10
+        week 1 = 1.20  → slope(1→2): +1, slope(0→1): +1
+        week 2 = 1.00  → slope(2→3): +1, slope(1→2): -1  ← divergent
+        week 3 = 1.25  → slope(3→4): -1, slope(2→3): +1  ← divergent
+        week 4 = 1.05  → slope(4→5): +1, slope(3→4): -1  ← divergent
+        week 5 = 1.30
+    """
+    weekly_closes = [1.10, 1.20, 1.00, 1.25, 1.05, 1.30]
+    w1_panel = _build_w1_panel(weekly_closes, start_monday="2024-01-01")
+    h4_frame = _build_h4_frame("2024-01-01", n_weeks=6)
+    panel = _attach_w1_aux(h4_frame, w1_panel)
+
+    out = _w1_close_slope_sign(h4_frame, panel=panel)
+    assert isinstance(out, pd.Series)
+    assert len(out) == len(h4_frame)
+
+    # H4 bars at Wednesday 12:00 UTC of weeks 2, 3, 4 — each mid-week,
+    # where the buggy merge_asof picks the same week's eventual close
+    # and the canonical lookup picks the prior week's close.
+    # Week N Monday-00:00 + 2 days 12 hours = Wednesday 12:00.
+    monday0 = pd.Timestamp("2024-01-01", tz="UTC")
+    wednesdays = {
+        n: monday0 + pd.Timedelta(weeks=n, days=2, hours=12) for n in range(2, 5)
+    }
+
+    # Expected (canonical) sign at mid-week N = sign(close[N-1] - close[N-2]):
+    #   wed week 2 → sign(1.20 - 1.10) = +1
+    #   wed week 3 → sign(1.00 - 1.20) = -1
+    #   wed week 4 → sign(1.25 - 1.00) = +1
+    expected_canonical = {2: +1.0, 3: -1.0, 4: +1.0}
+    # The buggy (pre-fix) sign at mid-week N = sign(close[N] - close[N-1]),
+    # i.e. leaking the current week's eventual close. Asserted to NOT
+    # equal the canonical sign — proves the test is non-vacuous.
+    buggy_signs = {2: -1.0, 3: +1.0, 4: -1.0}
+
+    for n, ts in wednesdays.items():
+        # ts must exist in the H4 index
+        assert ts in out.index, f"week {n} Wednesday {ts} missing from H4 index"
+        v = out.loc[ts]
+        assert v == expected_canonical[n], (
+            f"Week {n} Wed: expected sign {expected_canonical[n]:+.1f} "
+            f"(close[{n-1}]-close[{n-2}]); got {v:+.1f}. Within-week "
+            f"lookahead would have produced {buggy_signs[n]:+.1f}."
+        )
+        # Sanity: the buggy and canonical answers really do diverge for
+        # these timestamps. Otherwise the test would be vacuous.
+        assert expected_canonical[n] != buggy_signs[n]
+
+
+# ── Test 2: lag correctness at hand-computed timestamps ──────────────
+
+
+def test_w1_close_slope_sign_lag_correctness() -> None:
+    """Hand-computed expected values for multiple H4 timestamps match the
+    producer output. Covers Monday boundary, mid-week, and Friday close
+    timestamps to pin down the strict-prior semantics at edges.
+
+    Weekly closes (monotone-up to make slope sign trivial):
+        week 0 = 1.00 (warmup; lag-2 NaN at week 0/1)
+        week 1 = 1.10
+        week 2 = 1.20
+        week 3 = 1.30
+        week 4 = 1.40
+    """
+    weekly_closes = [1.00, 1.10, 1.20, 1.30, 1.40]
+    w1_panel = _build_w1_panel(weekly_closes, start_monday="2024-01-01")
+    h4_frame = _build_h4_frame("2024-01-01", n_weeks=5)
+    panel = _attach_w1_aux(h4_frame, w1_panel)
+    out = _w1_close_slope_sign(h4_frame, panel=panel)
+
+    monday0 = pd.Timestamp("2024-01-01", tz="UTC")
+
+    # During week N (N ≥ 2), the canonical fully-closed prior W1 is week
+    # N-1, whose pre-shifted slope value is close[N-1] - close[N-2].
+    # For monotone-up closes, all signs are +1.
+    cases = [
+        # (timestamp, expected_value, description)
+        # ── Monday 00:00 of week 1: only week 0 is fully closed; its
+        #    slope (close[0] - close[-1]) is NaN → np.sign(NaN) = NaN.
+        (monday0 + pd.Timedelta(weeks=1), float("nan"), "Mon 00 week 1 (warmup)"),
+        # ── Mid-week N: slope sign at that H4 reflects close[N-1] -
+        #    close[N-2]. All monotone-up → +1.
+        (monday0 + pd.Timedelta(weeks=2, days=2, hours=12), +1.0, "Wed 12 week 2"),
+        (monday0 + pd.Timedelta(weeks=3, days=4, hours=16), +1.0, "Fri 16 week 3"),
+        # ── Monday 00:00 of week 4 (exact boundary): the bar that
+        #    closes at this instant is week 3's W1. Per "fully closed at
+        #    ts iff bar_end[k] <= ts", week 3 (ending at Mon 00 of wk 4)
+        #    IS fully closed. Slope value = sign(close[3] - close[2]).
+        (monday0 + pd.Timedelta(weeks=4), +1.0, "Mon 00 week 4 (boundary)"),
+    ]
+
+    for ts, expected, desc in cases:
+        assert ts in out.index, f"{desc}: ts {ts} missing from H4 index"
+        actual = out.loc[ts]
+        if np.isnan(expected):
+            assert np.isnan(actual), (
+                f"{desc}: expected NaN (warmup), got {actual!r}"
+            )
+        else:
+            assert actual == expected, (
+                f"{desc}: expected sign {expected:+.1f}, got {actual:+.1f}"
+            )
+
+
+# ── Test 3: canonical alignment — source-level guard ─────────────────
+
+
+def test_w1_close_slope_sign_canonical_alignment() -> None:
+    """Static guard: the producer must use the canonical HTF utility
+    and must not use ``merge_asof`` (the pre-fix idiom that introduced
+    the within-week lookahead).
+    """
+    source = inspect.getsource(_w1_close_slope_sign)
+    assert "merge_asof" not in source, (
+        "Lookahead-prone merge_asof must not be used; canonical "
+        "get_htf_value_at(..., require_fully_closed=True) is the only "
+        "approved HTF lookup pattern in this module."
+    )
+    assert "get_htf_value_at" in source, (
+        "Producer must use the canonical core.signals.htf_alignment "
+        "utility for HTF lookups."
+    )


### PR DESCRIPTION
## Bug mechanism

`core/features/multi_tf.py::_w1_close_slope_sign` used `pd.merge_asof(direction='backward', allow_exact_matches=False)` against W1 bars labelled at week-start (aggregator `label='left', closed='left'` on `W-MON`).

At an H4 timestamp mid-week N, `merge_asof` picked the **same** week's W1 bar — whose `close_bid` / `close_ask` columns hold the eventual Sunday end-of-week close. The producer then computed `sign(close[N] - close[N-1])`, leaking the future Sunday close every H4 bar from Monday 00:00:01 through Sunday 23:59:59 of week N.

Convention-independent: this happens identically under UTC and EET storage. It is a **within-period** lookahead bug, distinct from the **timezone-shift** lookahead class the 2026-05 audit looked for — which is why the audit classified the producer as State A and missed it.

The three sibling D1 producers (`_d1_close_slope_sign`, `_d1_close_slope_magnitude`, `_d1_atr_percentile_100`) plus the shared helper `_build_d1_lag1_series` were already canonical (`get_htf_value_at(..., require_fully_closed=True)`). The W1 producer was the lone non-canonical case in this file.

## Fix

Replace the `merge_asof` body with the canonical `core.signals.htf_alignment.get_htf_value_at(..., require_fully_closed=True)` utility, mirroring the D1 producers in the same file. The slope is still pre-computed on the W1 series via `shift(1)`, just looked up at the **most recently fully-closed W1 bar** (week N-1 when mid-week N) instead of the `merge_asof`-resolved same-week bar.

## Cross-arc impact

Affected v3.0 / v3.0.x runs whose feature pipelines consumed `w1_close_slope_sign`:

- **Arc 5 v3.0.2** — currently HALTED on this bug
- **Arc 8 v3.0.2** — originator HALT; resumes post-merge
- **Arc 10 v3.0.2** — currently HALTED at W1 audit
- **Arc 11 v3.0.2** — currently running on contaminated pipeline; will be HALTED separately

**KH-24 is NOT affected.** KH-24's signal config does not consume `w1_close_slope_sign` (verified by grep against `configs/replays_v2_1_1/kh24*.yaml` + `core/strategies/kh24/`). Anchor preservation by construction.

## Test coverage

New file `tests/test_features_multi_tf.py` adds three tests:

1. **`test_w1_close_slope_sign_no_lookahead_within_week`** — at mid-week H4 timestamps (weeks 2, 3, 4 Wednesday 12:00 UTC) where the canonical and buggy answers diverge, asserts the canonical sign. Weekly closes chosen so `sign(close[N-1] - close[N-2])` has the opposite sign to `sign(close[N] - close[N-1])` — non-vacuous by construction.

2. **`test_w1_close_slope_sign_lag_correctness`** — hand-computed expected values at four H4 timestamps (Monday-boundary warmup NaN, mid-week, Friday afternoon, exact Monday 00:00 of next week).

3. **`test_w1_close_slope_sign_canonical_alignment`** — static source guard via `inspect.getsource`; fails on `merge_asof` reintroduction or `get_htf_value_at` removal.

All existing tests still green (full `pytest -q`: **1776 passed, 305 skipped, 0 failures** in 481s on Python 3.14 / pandas 3.0.2). The static guard in `tests/signals/test_htf_alignment_timezone_invariance.py::test_no_floor_or_normalize_in_fixed_module[core/features/multi_tf.py]` continues to pass since the fix doesn't introduce `.floor()` / `.normalize()`.

## KH-24 anchor verification

Per §4 of the dispatch:

```
grep -rn "w1_close_slope_sign|_w1_close_slope" configs/replays_v2_1_1/kh24*.yaml core/strategies/kh24/ → no matches
```

KH-24 does not consume `_w1_close_slope_sign`. **Anchor preserved by construction** — no anchor reproduction run needed per the dispatch's §4 branch ("If the feature is NOT in KH-24's pipeline: anchor is preserved by construction; merge proceeds").

## State A audit classification correction

`docs/audits/signal_module_eet_audit_2026_05.md` appended with a SUPERSEDED section correcting the prior `_w1_close_slope_sign` State A classification. The pre-fix state was actually **State B under both UTC and EET** (silent within-period lookahead). The post-fix classification is correctly State A under both conventions.

`docs/PROTOCOL_RUNTIME.md` §15.4 table extended with the within-period fault row (`merge_asof(direction='backward', allow_exact_matches=False)` against `label='left'` HTF bars), and a paragraph distinguishing the within-period from the timezone-shift fault class.

## Coordination

Unblocks the four Wave 1 v3.0.2 arcs listed above. The Step 6 framework patch is orthogonal and in flight in a different chat — both can land independently.