### PR TITLE
Step 6 ultimate audit — wire spread P&L + harden every category

### DIFF
--- a/core/arc/arc_orchestrator.py
+++ b/core/arc/arc_orchestrator.py
@@ -224,6 +224,16 @@ class CandidateAmendedResult:
     chained_dd_method: str   # "equity_stitching" | "full_window_sim"
     per_day_max_dd_artefact_path: Path | None
     amended_gate: AmendedGateResult
+    # Holdout trade counts at the three risk tiers (Amendment 4 §6.5
+    # risk-leak detection). All three are observed under IDENTICAL
+    # signal-evaluation logic — only the sizing scales — so they MUST
+    # match. Divergence is a critical engine bug (the 2026-05-25 Arc 7
+    # rerun at r=2% vs r=0.5% surfaced exactly this — 36-38% fewer
+    # trades under the higher risk). ``None`` when the corresponding
+    # holdout sim did not run (scaling not feasible, no holdout fold).
+    holdout_n_trades_at_r_base: int | None = None
+    holdout_n_trades_at_r_safe: int | None = None
+    holdout_n_trades_at_r_hard: int | None = None
 
 
 @dataclass(frozen=True)
@@ -652,6 +662,17 @@ class ArcOrchestrator:
                 r_base=self.cfg.risk_pct,
             )
 
+            # §6.5 risk-leak detection inputs: capture trade counts at
+            # each scaled-risk holdout tier (Amendment 4 §6.5). Equal
+            # counts → admit logic is risk-independent (correct);
+            # divergent counts surface engine bugs like the 2026-05-25
+            # Arc 7 r=2% vs r=0.5% incident.
+            base_holdout_match = holdout_by_cid.get(cid)
+            holdout_n_base = (
+                int(base_holdout_match.holdout_stats.n_trades)
+                if base_holdout_match is not None
+                else None
+            )
             amended_results.append(CandidateAmendedResult(
                 config_id=cid,
                 chained_max_dd_base_pct=chained_dd,
@@ -663,6 +684,13 @@ class ArcOrchestrator:
                 chained_dd_method="equity_stitching",
                 per_day_max_dd_artefact_path=parquet_path,
                 amended_gate=amended_gate,
+                holdout_n_trades_at_r_base=holdout_n_base,
+                holdout_n_trades_at_r_safe=(
+                    int(holdout_safe.n_trades) if holdout_safe is not None else None
+                ),
+                holdout_n_trades_at_r_hard=(
+                    int(holdout_hard.n_trades) if holdout_hard is not None else None
+                ),
             ))
 
         return AmendedWfoSearchResult(base=s5, amended_results=tuple(amended_results))
@@ -821,10 +849,18 @@ class ArcOrchestrator:
             arc_root.mkdir(parents=True, exist_ok=True)
             wfo_struct_amend = self.cfg.wfo_structure or build_v3_folds()
             holdout_start = None
+            holdout_fold_id = None
             if wfo_struct_amend.holdout is not None:
                 holdout_start = pd.Timestamp(wfo_struct_amend.holdout.oos_start)
                 if holdout_start.tzinfo is None:
                     holdout_start = holdout_start.tz_localize("UTC")
+                holdout_fold_id = int(wfo_struct_amend.holdout.fold_id)
+            # Panel boundary convention threaded through for §6.3
+            # propagation check (Amendment 6).
+            primary_tf_name = signal_eval.primary_tf
+            panel_boundary_convention = getattr(
+                self.panels.get(primary_tf_name), "boundary_convention", None,
+            )
             step_6_dispatch = maybe_dispatch_step_6(
                 arc_orchestrator_result=_LightOrchestratorView(
                     arc_name=self.cfg.arc_name,
@@ -839,8 +875,13 @@ class ArcOrchestrator:
                 feature_matrix=self.cfg.feature_matrix,
                 feature_lineage=self.cfg.feature_lineage,
                 signal_module_name=type(self.signal_module).__module__,
-                primary_tf=signal_eval.primary_tf,
+                primary_tf=primary_tf_name,
                 pair_set=tuple(self.cfg.pair_set),
+                strategy_results=getattr(self, "_last_strategy_results", None),
+                holdout_results=tuple(holdout or ()),
+                holdout_fold_id=holdout_fold_id,
+                r_base_pct=float(self.cfg.risk_pct),
+                panel_boundary_convention=panel_boundary_convention,
             )
             # Per Amendment 4 + chat Q1: if Step 6 critical-failed, downgrade
             # the Top-1 candidate by re-classifying its gate with

--- a/core/step_6/deployment_readiness.py
+++ b/core/step_6/deployment_readiness.py
@@ -6,7 +6,10 @@ is self-contained. Does not duplicate the parser's Section 4-L PASS
 validation (which the parser already enforces pre-merge) — the audit's
 job here is to surface DEPLOYABLE-READY issues to the closure reader.
 
-Five checks:
+Hardened in ``engine/step_6_ultimate_audit`` from 5 to 8 checks with
+broker/venue declaration, timezone declaration parity, and the EA
+parity check (flagging A6 meta-labeling architectures as
+research-only-not-currently-EA-deployable):
 
   1. ``deployment_spec_section_present`` (critical) — closure doc has
      a ``## §4 deployment_spec`` heading. Mirrors parser Section 4-L
@@ -17,11 +20,24 @@ Five checks:
   3. ``deployment_spec_subsections_present`` (critical) — every §4.X
      subsection heading (§4.1 through §4.11) is present in the closure
      doc.
-  4. ``features_live_computable`` (warning) — every feature in
+  4. ``ea_parity`` (critical) — winning architecture is reproducible in
+     MQL5. A1 / A2 / A6 with rule-based gates are EA-deployable; A3 /
+     A4 (per-fold retraining) and A6 with Python-only classifier are
+     research-only. Surfaces as critical fail when verdict is PASS-
+     DEPLOYABLE on a non-deployable architecture, warning otherwise.
+  5. ``broker_venue_declared`` (warning) — closure §4 declares which
+     broker spreads the verdict was computed against (5ers / IC Markets
+     / other). Cross-references the §6.3 spread P&L decomposition's
+     fragility classification.
+  6. ``timezone_declaration_parity`` (warning) — closure declares which
+     boundary convention was used (utc / 5ers_eet). Mismatch with the
+     declared deployment venue is a critical fail; mismatch with KH-24's
+     utc convention is informational.
+  7. ``features_live_computable`` (warning) — every feature in
      ``best_candidate_features`` has a non-empty Step 6.3
      equivalent: its FeatureSpec exists in the registry AND
      `needs_panel == False` OR a panel is realistically available live.
-  5. ``deployment_checklist_marked`` (info) — count of checked items
+  8. ``deployment_checklist_marked`` (info) — count of checked items
      in the §4.11 checklist.
 """
 
@@ -182,6 +198,182 @@ def _check_features_live_computable(inputs: Step6Inputs) -> CheckResult:
     )
 
 
+def _check_ea_parity(inputs: Step6Inputs) -> CheckResult:
+    """Winning architecture must be reproducible in MQL5.
+
+    A1 (rule-based system filter) — EA-deployable.
+    A2 (admit-classifier) — EA-deployable IF the classifier is
+        expressible as ONNX or a simple rule set; flag as warning
+        otherwise.
+    A3 / A4 (per-fold retraining) — NOT EA-deployable; research-only.
+    A6 (meta-labeling) — EA-deployable IF classifier is portable to
+        MQL5 inference (ONNX or simple rule set); else research-only.
+
+    Pass condition: winning architecture is A1, OR the closure
+    documents the EA-reproducibility path explicitly.
+    """
+    arch = (inputs.best_candidate_architecture or "").upper()
+    closure_text = _load_closure_text(inputs.arc_root) or ""
+    # Heuristic for explicit EA-reproducibility declaration.
+    mentions_ea = any(
+        tag in closure_text.lower()
+        for tag in ("mql5", "ea_deployable", "ea deployable", "ea parity",
+                    "research-only", "research_only")
+    )
+    research_only_archs = {"A3", "A4"}
+    review_required = {"A2", "A6"}
+    deployable = {"A1"}
+    if arch in deployable:
+        return CheckResult(
+            name="ea_parity",
+            passed=True,
+            severity=Severity.CRITICAL,
+            message=f"winning architecture {arch!r} is EA-deployable by construction (A1 rule-based)",
+            evidence={"architecture": arch, "ea_deployable": True},
+        )
+    if arch in research_only_archs:
+        # Critical fail if verdict is PASS-DEPLOYABLE (we'd be claiming
+        # deployability for a non-deployable architecture).
+        ba = (inputs.closure_payload or {}).get("best_architecture") or {}
+        verdict = str(ba.get("verdict") or "").upper()
+        is_deployable_verdict = verdict == "PASS_DEPLOYABLE"
+        passed = mentions_ea  # closure must acknowledge it
+        return CheckResult(
+            name="ea_parity",
+            passed=passed and not is_deployable_verdict,
+            severity=Severity.CRITICAL,
+            message=(
+                f"winning architecture {arch!r} requires per-fold retraining — "
+                "NOT EA-deployable. "
+                + (
+                    f"Verdict PASS-DEPLOYABLE on {arch} is contradictory; "
+                    "downgrade to research-only."
+                    if is_deployable_verdict
+                    else (
+                        "Closure acknowledges research-only status."
+                        if mentions_ea
+                        else "Closure does not mark research-only; review."
+                    )
+                )
+            ),
+            evidence={
+                "architecture": arch,
+                "verdict": verdict,
+                "closure_mentions_ea_or_research_only": mentions_ea,
+            },
+        )
+    if arch in review_required:
+        return CheckResult(
+            name="ea_parity",
+            passed=mentions_ea,
+            severity=Severity.WARNING,
+            message=(
+                f"winning architecture {arch!r} requires an EA-side ONNX/rules "
+                "inference path. Closure "
+                + (
+                    "documents the path." if mentions_ea
+                    else "MUST document the EA inference path before deployment."
+                )
+            ),
+            evidence={
+                "architecture": arch,
+                "closure_mentions_ea_or_research_only": mentions_ea,
+            },
+        )
+    # Unknown architecture — informational.
+    return CheckResult(
+        name="ea_parity",
+        passed=True,
+        severity=Severity.INFO,
+        message=f"architecture {arch!r} not recognised — manual EA-parity review required",
+        evidence={"architecture": arch},
+    )
+
+
+def _check_broker_venue_declared(inputs: Step6Inputs) -> CheckResult:
+    """Closure must declare which broker spreads the verdict was computed against.
+
+    Cross-refs the §6.3 spread P&L decomposition fragility: a
+    'fragile' classification (verdict downgrades at <1.5× spread
+    inflation) demands an explicit venue declaration so the deployment
+    decision can match the verdict's spread regime.
+    """
+    text = _load_closure_text(inputs.arc_root) or ""
+    declares = any(
+        tag in text
+        for tag in ("5ers", "IC Markets", "icmarkets", "Pepperstone",
+                    "broker:", "venue:", "Broker:", "Venue:")
+    )
+    return CheckResult(
+        name="broker_venue_declared",
+        passed=declares,
+        severity=Severity.WARNING,
+        message=(
+            "closure declares broker / venue context"
+            if declares
+            else "closure does not name the broker/venue context — "
+            "spread sensitivity (§6.3 spread P&L) is uninterpretable"
+        ),
+        evidence={"declared": declares},
+    )
+
+
+def _check_timezone_declaration_parity(inputs: Step6Inputs) -> CheckResult:
+    """Closure declares its boundary convention (utc / 5ers_eet).
+
+    Amendment 6: KH-24 runs at ``utc``; new arcs may use ``5ers_eet``
+    for daily-DD bucketing aligned to the broker trading day. Missing
+    declaration → cannot tell which calendar boundary was used → cannot
+    judge daily-DD claims against the 5ers hard 5% limit.
+
+    Pass: closure declares boundary convention AND it matches the
+    engine's panel convention (if Step 6 was supplied the panel value).
+    """
+    closure_payload = inputs.closure_payload or {}
+    pool_meta = closure_payload.get("pool_metadata") or {}
+    recorded = pool_meta.get("boundary_convention")
+    declared = inputs.panel_boundary_convention
+    if recorded is None and declared is None:
+        # Older closures — treat as informational; default UTC.
+        return CheckResult(
+            name="timezone_declaration_parity",
+            passed=True,
+            severity=Severity.INFO,
+            message="no boundary_convention declared (pre-Amendment-6); UTC assumed",
+            evidence={"recorded": None, "declared": None},
+        )
+    if recorded and not declared:
+        return CheckResult(
+            name="timezone_declaration_parity",
+            passed=True,
+            severity=Severity.INFO,
+            message=f"closure records {recorded!r}; engine value not supplied to Step 6",
+            evidence={"recorded": recorded, "declared": None},
+        )
+    if declared and not recorded:
+        return CheckResult(
+            name="timezone_declaration_parity",
+            passed=False,
+            severity=Severity.WARNING,
+            message=(
+                f"engine used {declared!r} but closure does not record "
+                "boundary_convention — closure §4 must declare it"
+            ),
+            evidence={"recorded": None, "declared": declared},
+        )
+    passed = declared == recorded
+    return CheckResult(
+        name="timezone_declaration_parity",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"closure={recorded!r}, engine={declared!r}: "
+            + ("match" if passed else "MISMATCH (deployment-blocking)")
+        ),
+        evidence={"recorded": recorded, "declared": declared, "match": passed},
+    )
+
+
 def _check_deployment_checklist(inputs: Step6Inputs) -> CheckResult:
     text = _load_closure_text(inputs.arc_root)
     if text is None:
@@ -209,6 +401,9 @@ def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult
         _check_deployment_spec_heading(inputs),
         _check_config_artefact_path(inputs),
         _check_subsections_present(inputs),
+        _check_ea_parity(inputs),
+        _check_broker_venue_declared(inputs),
+        _check_timezone_declaration_parity(inputs),
         _check_features_live_computable(inputs),
         _check_deployment_checklist(inputs),
     )

--- a/core/step_6/determinism.py
+++ b/core/step_6/determinism.py
@@ -5,7 +5,11 @@ two-run sha256 guarantee is provided by ``tests/test_determinism.py``
 in CI. Step 6's job is to confirm the on-disk artefacts match the
 recorded manifest, catching post-emission tampering / corruption.
 
-Four checks:
+Hardened in ``engine/step_6_ultimate_audit`` from 4 to 8 checks. The
+marquee addition is ``risk_independent_admit_decisions`` (critical) —
+catches the 2026-05-25 engine bug where Arc 7 at r=2% produced 36–38%
+fewer trades than at r=0.5%, indicating risk had leaked into the
+signal/admit path:
 
   1. ``step_4_manifest_sha256_match`` (critical) — every entry in
      ``step_4/classifiers/manifest.json`` matches the recomputed sha256
@@ -13,10 +17,24 @@ Four checks:
   2. ``arc_artefacts_present`` (critical) — required artefacts
      (ARC_CLOSURE.md, step_1/pool.parquet, step_5/wfo_results.csv if
      present, etc.) are on disk under arc_root.
-  3. ``seed_pinning_verified`` (warning) — grep producer source files
+  3. ``risk_independent_admit_decisions`` (critical) — holdout trade
+     counts at ``r_base`` vs ``r_safe`` vs ``r_hard`` must match. Same
+     admit logic; only sizing scales. Divergence = risk-leak.
+  4. ``ledger_schema_parity`` (critical) — Top-1 trade ledger carries
+     every column the downstream §6.3 spread P&L decomposition + the
+     §4 deployment_spec consume (bid+ask, sl_price, parent_position_id).
+     Catches the case where a producer regression silently strips a
+     column that later checks depend on.
+  5. ``classifier_version_pinning`` (warning) — sklearn / lightgbm /
+     joblib / pandas versions recorded in the classifier manifest so
+     deployment-time drift is detectable.
+  6. ``seed_pinning_verified`` (warning) — grep producer source files
      for ``random_state=`` references; flag any classifier builder that
      doesn't pin the seed.
-  4. ``line_terminator_lf`` (info) — sample text artefacts use LF line
+  7. ``two_run_byte_identity_recorded`` (info) — surfaces whether a
+     two-run sha256 reproduction manifest is on disk for the arc
+     (recorded by ``tests/test_determinism.py`` in CI).
+  8. ``line_terminator_lf`` (info) — sample text artefacts use LF line
      endings.
 """
 
@@ -165,6 +183,230 @@ def _check_seed_pinning() -> CheckResult:
     )
 
 
+def _check_risk_independent_admit(inputs: Step6Inputs) -> CheckResult:
+    """Catches the 2026-05-25 Arc 7 r=2% vs r=0.5% engine bug.
+
+    Premise: the holdout sim at ``r_base``, ``r_safe``, and ``r_hard``
+    runs the *same architecture* against the *same panels* with the
+    *same signal evaluation* — only the sizing scales. Trade timestamps
+    and counts MUST be identical; only the realised P&L per trade
+    (and therefore final balance / DD) differs.
+
+    A divergence means risk has leaked into the signal/admit path —
+    either the rescale changed a non-sizing field, or the architecture
+    reads ``risk_pct`` inside signal evaluation (which is a contract
+    violation). Critical severity; would have caught the recent bug.
+
+    Pass conditions:
+      * top1 amended candidate has all three holdout trade counts and
+        they match exactly, OR
+      * scaling was not feasible (``scalable_to_safe == False`` etc.) AND
+        the missing tier's count is None (not a divergence, just absent).
+    """
+    res = inputs.arc_orchestrator_result
+    amended_wfo = getattr(res, "amended_wfo", None) if res is not None else None
+    if amended_wfo is None or not getattr(amended_wfo, "amended_results", ()):
+        return CheckResult(
+            name="risk_independent_admit_decisions",
+            passed=True,
+            severity=Severity.INFO,
+            message="no amended results available — skipping (manual CLI on a fresh closure)",
+            evidence={},
+        )
+    # Top-1 ranking mirrors core.step_6.dispatch._select_top1_amended.
+    ranked = sorted(
+        amended_wfo.amended_results,
+        key=lambda r: (
+            2 if r.amended_gate.verdict.name == "PASS_DEPLOYABLE"
+            else 1 if r.amended_gate.verdict.name == "PASS_VIABLE" else 0
+        ),
+        reverse=True,
+    )
+    top1 = ranked[0]
+    n_base = getattr(top1, "holdout_n_trades_at_r_base", None)
+    n_safe = getattr(top1, "holdout_n_trades_at_r_safe", None)
+    n_hard = getattr(top1, "holdout_n_trades_at_r_hard", None)
+    observations = {
+        "base": n_base, "r_safe": n_safe, "r_hard": n_hard,
+    }
+    observed = {k: v for k, v in observations.items() if v is not None}
+    if len(observed) < 2:
+        return CheckResult(
+            name="risk_independent_admit_decisions",
+            passed=True,
+            severity=Severity.INFO,
+            message=(
+                f"only {len(observed)} risk tier(s) ran on holdout "
+                f"({list(observed.keys())}) — cannot compare for risk-leak"
+            ),
+            evidence={"observed": observations},
+        )
+    values = list(observed.values())
+    all_match = all(v == values[0] for v in values)
+    spread_pct = (
+        (max(values) - min(values)) / max(1, max(values)) * 100.0
+        if not all_match else 0.0
+    )
+    return CheckResult(
+        name="risk_independent_admit_decisions",
+        passed=all_match,
+        severity=Severity.CRITICAL,
+        message=(
+            f"holdout trade counts at base/safe/hard = "
+            f"{observations} — "
+            + (
+                "identical (admit logic is risk-independent)" if all_match
+                else f"DIVERGE by {spread_pct:.1f}% — RISK-LEAK detected "
+                "(2026-05-25 Arc 7 mechanism); rescale path is touching "
+                "non-sizing fields OR architecture reads risk_pct in admit"
+            )
+        ),
+        evidence={
+            "trade_counts_per_tier": observations,
+            "all_match": all_match,
+            "spread_pct": spread_pct,
+            "top_1_config_id": top1.config_id,
+        },
+    )
+
+
+def _check_ledger_schema_parity(inputs: Step6Inputs) -> CheckResult:
+    """Top-1 ledger must carry every column downstream consumers read.
+
+    The §6.3 spread P&L decomposition expects
+    ``entry_bid / entry_ask / exit_bid / exit_ask / sl_price``;
+    multi-leg consumers expect ``parent_position_id``. A producer
+    regression that silently strips one of these would manifest as a
+    silently-skipped diagnostic (still records "info: skipped" — not a
+    FAIL). This check elevates the silent-skip into an explicit
+    critical when the ledger IS present but missing a load-bearing
+    column.
+    """
+    ledger = inputs.top_1_trade_ledger
+    if ledger is None:
+        return CheckResult(
+            name="ledger_schema_parity",
+            passed=True,
+            severity=Severity.INFO,
+            message="no top-1 ledger supplied — skipping (no schema to verify)",
+            evidence={"ledger_present": False},
+        )
+    required = (
+        "entry_price", "exit_price",
+        "entry_bid", "entry_ask", "exit_bid", "exit_ask",
+        "sl_price",
+        "parent_position_id",
+    )
+    missing = [c for c in required if c not in ledger.columns]
+    # NaN-only columns are silently broken — flag them too.
+    nan_only: list[str] = []
+    for c in required:
+        if c in ledger.columns and ledger[c].isna().all():
+            nan_only.append(c)
+    passed = (not missing) and (not nan_only)
+    return CheckResult(
+        name="ledger_schema_parity",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"ledger has {len(ledger.columns)} column(s); "
+            f"{len(missing)} required column(s) missing, "
+            f"{len(nan_only)} required column(s) all-NaN"
+        ),
+        evidence={
+            "n_columns": int(len(ledger.columns)),
+            "missing_columns": missing,
+            "all_nan_columns": nan_only,
+            "n_rows": int(len(ledger)),
+        },
+    )
+
+
+def _check_classifier_version_pinning(inputs: Step6Inputs) -> CheckResult:
+    """sklearn/lightgbm/joblib/pandas versions recorded in manifest.
+
+    Deployment-time version drift can shift classifier outputs even
+    when the saved artefact byte-matches. The classifier manifest must
+    record the versions present at training time so a deployment check
+    can compare them.
+    """
+    manifest_path = inputs.arc_root / "step_4" / "classifiers" / "manifest.json"
+    if not manifest_path.exists():
+        return CheckResult(
+            name="classifier_version_pinning",
+            passed=True,
+            severity=Severity.INFO,
+            message="no Step 4 classifier manifest — arc is rule-based",
+            evidence={"manifest_path": str(manifest_path)},
+        )
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    versions = data.get("versions") or data.get("environment") or {}
+    required_libs = ("sklearn", "lightgbm", "joblib", "pandas")
+    missing = [lib for lib in required_libs if lib not in versions]
+    passed = not missing
+    return CheckResult(
+        name="classifier_version_pinning",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"classifier manifest records {len(versions) - len(missing)} of "
+            f"{len(required_libs)} required version pin(s); missing: "
+            f"{missing if missing else 'none'}"
+        ),
+        evidence={
+            "versions_recorded": list(versions.keys()),
+            "missing": missing,
+        },
+    )
+
+
+def _check_two_run_byte_identity_recorded(inputs: Step6Inputs) -> CheckResult:
+    """Surfaces whether a two-run reproduction manifest is on disk.
+
+    Step 6 does NOT re-run the sim (that's CI's job per existing
+    scope) but does verify the manifest claim of byte-identity.
+    Looks for ``two_run_sha256.json`` or similar under the arc.
+    """
+    candidates = (
+        inputs.arc_root / "two_run_sha256.json",
+        inputs.arc_root / "step_5" / "two_run_sha256.json",
+        inputs.arc_root / "ci" / "two_run_sha256.json",
+    )
+    found = next((p for p in candidates if p.exists()), None)
+    if found is None:
+        return CheckResult(
+            name="two_run_byte_identity_recorded",
+            passed=True,
+            severity=Severity.INFO,
+            message=(
+                "no two-run byte-identity manifest on disk — CI-side "
+                "determinism gate may live elsewhere"
+            ),
+            evidence={"checked_paths": [str(p) for p in candidates]},
+        )
+    try:
+        data = json.loads(found.read_text(encoding="utf-8"))
+        n_files = len(data.get("files") or {})
+        return CheckResult(
+            name="two_run_byte_identity_recorded",
+            passed=True,
+            severity=Severity.INFO,
+            message=(
+                f"two-run byte-identity manifest present: {found.name} "
+                f"({n_files} file(s) tracked)"
+            ),
+            evidence={"path": str(found), "n_files": n_files},
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        return CheckResult(
+            name="two_run_byte_identity_recorded",
+            passed=False,
+            severity=Severity.INFO,
+            message=f"could not parse two-run manifest: {exc}",
+            evidence={"path": str(found), "error": str(exc)},
+        )
+
+
 def _check_line_terminator(inputs: Step6Inputs) -> CheckResult:
     # Sample ARC_CLOSURE.md + capturability summary if present.
     samples = (
@@ -203,7 +445,11 @@ def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult
     checks = (
         _check_step_4_manifest(inputs),
         _check_arc_artefacts_present(inputs),
+        _check_risk_independent_admit(inputs),
+        _check_ledger_schema_parity(inputs),
+        _check_classifier_version_pinning(inputs),
         _check_seed_pinning(),
+        _check_two_run_byte_identity_recorded(inputs),
         _check_line_terminator(inputs),
     )
     diagnostic: dict[str, Any] = {"arc_root": str(inputs.arc_root)}

--- a/core/step_6/dispatch.py
+++ b/core/step_6/dispatch.py
@@ -116,6 +116,12 @@ def maybe_dispatch_step_6(
     signal_module_name: str | None = None,
     primary_tf: str | None = None,
     pair_set: tuple[str, ...] = (),
+    strategy_results: Mapping[str, Mapping[int, Any]] | None = None,
+    holdout_results: tuple = (),
+    holdout_fold_id: int | None = None,
+    r_base_pct: float | None = None,
+    panel_boundary_convention: str | None = None,
+    extras: Mapping[str, Any] | None = None,
 ) -> DispatchOutcome:
     """If the Top-1 amended candidate is PASS-tier, run Step 6 and return
     the outcome bundle. Otherwise return a no-op outcome.
@@ -129,6 +135,21 @@ def maybe_dispatch_step_6(
 
     cfg = audit_config or AuditConfig()
 
+    # Per Amendment 4 + §6.3 spread P&L wiring: extract Top-1's
+    # closed-trade ledger + fold assignments from the orchestrator's
+    # strategy-results side-channel so the diagnostic runs end-to-end.
+    # Returns (None, None, holdout_fold_id) when reconstruction fails;
+    # the diagnostic then skips gracefully (info-severity).
+    from core.step_6.ledger_extraction import extract_top_1_ledger_bundle
+    top_1_trade_ledger, top_1_fold_assignments, _hfid = (
+        extract_top_1_ledger_bundle(
+            top_1_config_id=top1.config_id,
+            strategy_results=strategy_results,
+            holdout_results=holdout_results,
+            holdout_fold_id=holdout_fold_id,
+        )
+    )
+
     # Build Step6Inputs from the live result. Pass through any extras the
     # auto-dispatch path can supply.
     inputs = from_arc_orchestrator_result(
@@ -140,6 +161,12 @@ def maybe_dispatch_step_6(
         primary_tf=primary_tf,
         pair_set=pair_set,
         holdout_start=holdout_start,
+        top_1_trade_ledger=top_1_trade_ledger,
+        top_1_fold_assignments=top_1_fold_assignments,
+        holdout_fold_id=holdout_fold_id,
+        r_base_pct=r_base_pct,
+        panel_boundary_convention=panel_boundary_convention,
+        extras=extras,
     )
 
     result = run_step_6(inputs, trigger=TriggerSource.AUTO_PASS, audit_config=cfg)

--- a/core/step_6/execution_realism.py
+++ b/core/step_6/execution_realism.py
@@ -6,7 +6,15 @@ re-computation — these checks read recorded artefacts (HistData M1
 bid+ask under `data/histdata/`, pool spread regime samples) and the
 deployment_spec; they do not re-run the simulator.
 
-Six checks + one info-severity diagnostic:
+Hardened in ``engine/step_6_ultimate_audit`` from the original six to
+twelve checks + the post-sim spread P&L diagnostic. New checks:
+``post_fill_sl_anchor`` (Arc 10 EA collapse mechanism),
+``boundary_convention_propagation`` (Amendment 6 — folded from the
+proposed §6.7), ``histdata_vs_venue_spread_differential``,
+``news_filter_assumption_declared``, ``zero_spread_bar_fraction``,
+``weekend_gap_handling_declared``.
+
+Twelve checks + one info-severity diagnostic:
 
   1. ``real_spread_source_present`` (critical) — HistData M1 bid+ask
      directory exists per L_PROTOCOL §1 "Real bid/ask spreads. HistData
@@ -311,6 +319,374 @@ def _check_utc_bar_boundary(inputs: Step6Inputs) -> CheckResult:
     )
 
 
+def _check_post_fill_sl_anchor() -> CheckResult:
+    """SL must be anchored to the realised fill, not the signal close.
+
+    Arc 10 EA collapse mechanism: a strategy that computes SL from the
+    signal bar close before the next-bar fill silently mis-prices its
+    risk on news/gaps where the realised fill diverges materially from
+    the signal close. The engine path verified here is
+    ``core.architectures.a1._next_bar_open_fill`` (and its peers) —
+    they must compute SL distance from the realised entry price.
+
+    Static check on the source module — surface-level grep verifies
+    the helper call signature includes the realised entry price, not a
+    pre-fill close. Manual review required if the helper name changes.
+    """
+    try:
+        from core.architectures import a1_system_level_filter as _a1  # type: ignore
+    except ImportError as exc:
+        return CheckResult(
+            name="post_fill_sl_anchor",
+            passed=False,
+            severity=Severity.WARNING,
+            message=f"could not import a1 module: {exc}",
+            evidence={"error": str(exc)},
+        )
+    try:
+        source = inspect.getsource(_a1)
+    except OSError as exc:
+        return CheckResult(
+            name="post_fill_sl_anchor",
+            passed=False,
+            severity=Severity.WARNING,
+            message=f"could not read a1 source: {exc}",
+            evidence={"error": str(exc)},
+        )
+    # The canonical engine path uses the realised fill (``entry_price``
+    # or ``entry_proxy`` — the next-bar open) as the SL anchor. If the
+    # source still mentions ``signal_close`` in SL calc, that's the
+    # Arc 10 mechanism. Heuristic — surface as critical only when the
+    # suspicious pattern is BOTH present AND no fill-price anchor
+    # exists.
+    sl_uses_entry = (
+        "sl_price" in source
+        and ("entry_price" in source or "entry_proxy" in source)
+    )
+    sl_uses_signal_close = ("signal_close" in source and "sl" in source.lower())
+    passed = sl_uses_entry and not (
+        sl_uses_signal_close and not sl_uses_entry
+    )
+    return CheckResult(
+        name="post_fill_sl_anchor",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            "SL anchor uses realised fill price (entry_price)" if passed
+            else "SL anchor may use signal_close — Arc 10 collapse mechanism smell"
+        ),
+        evidence={
+            "sl_uses_entry_price": sl_uses_entry,
+            "sl_uses_signal_close": sl_uses_signal_close,
+        },
+    )
+
+
+def _check_news_filter_not_assumed(inputs: Step6Inputs) -> CheckResult:
+    """Surface whether the strategy trades through high-impact news windows.
+
+    The EA on 5ers will typically block entries within a configured
+    window around high-impact NFP / FOMC / CPI events. If the backtest
+    didn't filter those out but the live EA does, the deployed system
+    will produce materially fewer fills than the backtest. Surface this
+    as a deployment-readiness flag.
+
+    Heuristic: look for an explicit news-filter manifest under
+    ``configs/news_calendar*`` AND check whether closure §4 records a
+    matching news-filter declaration.
+    """
+    from pathlib import Path
+
+    repo_root = (
+        inputs.arc_root.resolve().parents[1]
+        if len(inputs.arc_root.resolve().parents) >= 2
+        else inputs.arc_root.resolve()
+    )
+    news_calendar = list((repo_root / "configs").glob("news_calendar*")) \
+        if (repo_root / "configs").exists() else []
+    closure = inputs.arc_root / "ARC_CLOSURE.md"
+    closure_mentions_news = False
+    if closure.exists():
+        try:
+            text = closure.read_text(encoding="utf-8").lower()
+            closure_mentions_news = (
+                "news_filter" in text
+                or "news filter" in text
+                or "nfp" in text
+                or "fomc" in text
+            )
+        except OSError:
+            pass
+    # Pass condition: either the strategy declares it does NOT filter
+    # news AND the closure says so explicitly, OR a news calendar
+    # config exists AND the closure references it.
+    return CheckResult(
+        name="news_filter_assumption_declared",
+        passed=closure_mentions_news,
+        severity=Severity.WARNING,
+        message=(
+            f"news calendar config present: {bool(news_calendar)}; "
+            f"closure references news filter: {closure_mentions_news} — "
+            + (
+                "deployment-readiness OK"
+                if closure_mentions_news
+                else "closure must declare whether the EA filters news "
+                "(silent divergence is the Arc 10 mechanism)"
+            )
+        ),
+        evidence={
+            "news_calendar_files": [str(p.name) for p in news_calendar],
+            "closure_mentions_news": closure_mentions_news,
+        },
+    )
+
+
+def _check_weekend_gap_handling(inputs: Step6Inputs) -> CheckResult:
+    """Flag positions held over the weekend and check exit time semantics.
+
+    Pool exit_time distribution — count of positions whose entry_time
+    is Friday and exit_time is Monday-or-later. These positions
+    experience the weekend gap; if no SL gap handling is documented,
+    deployment carries gap risk.
+    """
+    import pandas as pd
+
+    trades = inputs.pool_trades
+    if trades is None or len(trades) == 0:
+        return CheckResult(
+            name="weekend_gap_handling_declared",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool_trades absent — cannot evaluate gap exposure",
+            evidence={},
+        )
+    if "entry_time" not in trades.columns or "exit_time" not in trades.columns:
+        return CheckResult(
+            name="weekend_gap_handling_declared",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool lacks entry_time/exit_time — skipping",
+            evidence={"columns": list(trades.columns)},
+        )
+    ent = pd.to_datetime(trades["entry_time"], utc=True, errors="coerce")
+    exi = pd.to_datetime(trades["exit_time"], utc=True, errors="coerce")
+    # Friday entry: dayofweek=4. Monday exit (or later in next ISO week).
+    fri_entry = ent.dt.dayofweek == 4
+    mon_or_later_exit = exi.dt.dayofweek <= 3  # Mon..Thu = next-week resume
+    weekend_held = bool((fri_entry & (exi - ent > pd.Timedelta(days=1))).any())
+    n_weekend = int((fri_entry & (exi - ent > pd.Timedelta(days=1))).sum())
+    return CheckResult(
+        name="weekend_gap_handling_declared",
+        passed=True,  # informational; cannot fail without explicit declaration
+        severity=Severity.INFO,
+        message=(
+            f"{n_weekend} of {len(trades)} trade(s) held over weekend "
+            f"(Fri entry, post-weekend exit)"
+        ),
+        evidence={
+            "n_total_trades": int(len(trades)),
+            "n_weekend_held": n_weekend,
+            "has_weekend_exposure": weekend_held,
+        },
+    )
+
+
+def _check_zero_spread_bar_fraction(inputs: Step6Inputs) -> CheckResult:
+    """Fraction of trades whose entry bar carried a zero-spread data flag.
+
+    HistData M1 occasionally records bars with bid == ask (data-quality
+    artefact, not real market). The L_PROTOCOL §1 directive is to flag
+    these rather than silently backfill. If a non-trivial fraction of
+    trades fired on zero-spread bars, the strategy is trading through
+    data-quality issues — verdict-correctness degrades.
+    """
+    trades = inputs.pool_trades
+    if trades is None or len(trades) == 0:
+        return CheckResult(
+            name="zero_spread_bar_fraction",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool_trades absent — skipping",
+            evidence={},
+        )
+    # Look for a recognised zero-spread marker column.
+    flag_col = None
+    for cand in (
+        "bid_ask_data_quality",
+        "spread_zero_flag",
+        "is_zero_spread",
+    ):
+        if cand in trades.columns:
+            flag_col = cand
+            break
+    if flag_col is None:
+        # Infer from spread column if available.
+        for cand in ("spread_pips", "spread", "entry_spread"):
+            if cand in trades.columns:
+                n_zero = int((trades[cand] <= 0).sum())
+                frac = n_zero / max(1, len(trades))
+                passed = frac < 0.05  # <5% is acceptable noise floor
+                return CheckResult(
+                    name="zero_spread_bar_fraction",
+                    passed=passed,
+                    severity=Severity.WARNING,
+                    message=(
+                        f"{n_zero}/{len(trades)} trade(s) ({frac:.1%}) fired "
+                        f"on bars with spread<=0 (data-quality flag)"
+                    ),
+                    evidence={
+                        "n_trades": int(len(trades)),
+                        "n_zero_spread": n_zero,
+                        "fraction": frac,
+                        "source_column": cand,
+                    },
+                )
+        return CheckResult(
+            name="zero_spread_bar_fraction",
+            passed=True,
+            severity=Severity.INFO,
+            message="no spread / data-quality column in pool — skipping",
+            evidence={},
+        )
+    # Explicit marker column path
+    marker = trades[flag_col].astype(str).str.lower()
+    n_zero = int(marker.isin(("zero_spread", "1", "true")).sum())
+    frac = n_zero / max(1, len(trades))
+    passed = frac < 0.05
+    return CheckResult(
+        name="zero_spread_bar_fraction",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"{n_zero}/{len(trades)} ({frac:.1%}) trade(s) fired on "
+            f"zero-spread bars per column '{flag_col}'"
+        ),
+        evidence={
+            "n_zero_spread": n_zero,
+            "fraction": frac,
+            "source_column": flag_col,
+        },
+    )
+
+
+def _check_histdata_vs_5ers_spread_differential(inputs: Step6Inputs) -> CheckResult:
+    """HistData spread baseline vs 5ers MT5 published spread differential.
+
+    HistData spreads typically run below 5ers MT5 published spreads
+    (HistData is composite quoting, 5ers is a single venue). If the
+    arc's median spread is materially below a recorded 5ers baseline,
+    the strategy may be trading on edge that doesn't survive at the
+    live venue. The §6.3 spread P&L decomposition diagnostic (PR #205)
+    quantifies this; this check surfaces whether a baseline-file
+    exists for comparison.
+
+    Pass condition: either a venue-spread baseline file exists for
+    cross-reference, or the closure documents that spread sensitivity
+    has been evaluated.
+    """
+    from pathlib import Path
+
+    repo_root = (
+        inputs.arc_root.resolve().parents[1]
+        if len(inputs.arc_root.resolve().parents) >= 2
+        else inputs.arc_root.resolve()
+    )
+    candidates = [
+        repo_root / "configs" / "broker_spread_5ers.yaml",
+        repo_root / "configs" / "spread_floors_5ers.yaml",
+        repo_root / "data" / "venue_spreads" / "5ers.csv",
+    ]
+    present = [p for p in candidates if p.exists()]
+    # Also accept if Step 6's spread P&L decomposition artefact is on
+    # disk — that's a stronger guarantee that spread sensitivity has
+    # been quantified.
+    decomposition_artefact = (
+        inputs.arc_root / "step_6" / "spread_pnl_verdict_flip_summary.csv"
+    )
+    decomposition_present = decomposition_artefact.exists()
+    passed = bool(present) or decomposition_present
+    return CheckResult(
+        name="histdata_vs_venue_spread_differential",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            "HistData↔5ers spread comparison "
+            + (
+                "available" if passed
+                else "MISSING — recommend live spread sample on 5ers MT5 "
+                "before deployment go/no-go"
+            )
+            + f" (baseline files: {[str(p.relative_to(repo_root)) for p in present]}; "
+            f"spread P&L decomp artefact: {decomposition_present})"
+        ),
+        evidence={
+            "venue_baseline_files": [str(p.relative_to(repo_root)) for p in present],
+            "spread_decomposition_present": decomposition_present,
+        },
+    )
+
+
+def _check_boundary_convention_propagation(inputs: Step6Inputs) -> CheckResult:
+    """Boundary convention declared at arc open must reach every consumer.
+
+    Per §6.7 (folded into §6.3): if the closure declares
+    ``boundary_convention = "5ers_eet"`` (Amendment 6) but the engine
+    used UTC for daily-DD bucketing (or vice versa), the verdict is
+    measured on the wrong calendar boundary. The
+    ``Panel.boundary_convention`` attribute is the canonical source;
+    it must match the closure's recorded value.
+    """
+    declared = inputs.panel_boundary_convention
+    closure_payload = inputs.closure_payload or {}
+    pool_meta = closure_payload.get("pool_metadata") or {}
+    recorded = pool_meta.get("boundary_convention")
+    if declared is None and recorded is None:
+        # Older closures (pre-Amendment-6) — default to UTC; informational
+        return CheckResult(
+            name="boundary_convention_propagation",
+            passed=True,
+            severity=Severity.INFO,
+            message="no explicit boundary_convention declaration (pre-Amendment-6 arc)",
+            evidence={"declared": None, "recorded": None},
+        )
+    # If one side declares and the other doesn't, that's a propagation
+    # gap — surface as critical.
+    if declared and not recorded:
+        return CheckResult(
+            name="boundary_convention_propagation",
+            passed=True,
+            severity=Severity.INFO,
+            message=(
+                f"panel boundary_convention={declared!r}; closure pool_metadata "
+                "does not record it (informational; engine value authoritative)"
+            ),
+            evidence={"declared": declared, "recorded": recorded},
+        )
+    if recorded and not declared:
+        return CheckResult(
+            name="boundary_convention_propagation",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=(
+                f"closure declares boundary_convention={recorded!r} but "
+                "engine panel did not propagate it — verdict measured on "
+                "wrong calendar"
+            ),
+            evidence={"declared": None, "recorded": recorded},
+        )
+    passed = declared == recorded
+    return CheckResult(
+        name="boundary_convention_propagation",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"panel convention={declared!r}, closure recorded={recorded!r}: "
+            + ("match" if passed else "MISMATCH (Amendment 6 violation)")
+        ),
+        evidence={"declared": declared, "recorded": recorded},
+    )
+
+
 def _run_spread_pnl_diagnostic(
     inputs: Step6Inputs,
 ) -> tuple[CheckResult, SpreadDecompositionResult | None, str | None, dict | None]:
@@ -419,7 +795,13 @@ def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult
         _check_spread_regime(inputs, audit_config),
         _check_next_bar_open_fill(inputs),
         _check_lot_rounding_at_r_safe(inputs),
+        _check_post_fill_sl_anchor(),
+        _check_boundary_convention_propagation(inputs),
         _check_mid_price_refactor(),
+        _check_histdata_vs_5ers_spread_differential(inputs),
+        _check_news_filter_not_assumed(inputs),
+        _check_zero_spread_bar_fraction(inputs),
+        _check_weekend_gap_handling(inputs),
         _check_utc_bar_boundary(inputs),
     )
     diag_check, diag_result, diag_md, diag_manifest = _run_spread_pnl_diagnostic(inputs)

--- a/core/step_6/execution_realism.py
+++ b/core/step_6/execution_realism.py
@@ -395,8 +395,6 @@ def _check_news_filter_not_assumed(inputs: Step6Inputs) -> CheckResult:
     ``configs/news_calendar*`` AND check whether closure §4 records a
     matching news-filter declaration.
     """
-    from pathlib import Path
-
     repo_root = (
         inputs.arc_root.resolve().parents[1]
         if len(inputs.arc_root.resolve().parents) >= 2
@@ -470,9 +468,9 @@ def _check_weekend_gap_handling(inputs: Step6Inputs) -> CheckResult:
         )
     ent = pd.to_datetime(trades["entry_time"], utc=True, errors="coerce")
     exi = pd.to_datetime(trades["exit_time"], utc=True, errors="coerce")
-    # Friday entry: dayofweek=4. Monday exit (or later in next ISO week).
+    # Friday entry: dayofweek=4. A position held > 1 day from a Friday
+    # entry crosses the weekend.
     fri_entry = ent.dt.dayofweek == 4
-    mon_or_later_exit = exi.dt.dayofweek <= 3  # Mon..Thu = next-week resume
     weekend_held = bool((fri_entry & (exi - ent > pd.Timedelta(days=1))).any())
     n_weekend = int((fri_entry & (exi - ent > pd.Timedelta(days=1))).sum())
     return CheckResult(
@@ -584,8 +582,6 @@ def _check_histdata_vs_5ers_spread_differential(inputs: Step6Inputs) -> CheckRes
     cross-reference, or the closure documents that spread sensitivity
     has been evaluated.
     """
-    from pathlib import Path
-
     repo_root = (
         inputs.arc_root.resolve().parents[1]
         if len(inputs.arc_root.resolve().parents) >= 2

--- a/core/step_6/inputs.py
+++ b/core/step_6/inputs.py
@@ -96,6 +96,13 @@ class Step6Inputs:
     # diagnostic when None.
     r_base_pct: float | None = None
 
+    # Boundary convention threaded through the primary panel — "utc" |
+    # "5ers_eet". Consumed by the §6.3 boundary-propagation check (catches
+    # the case where a closure declares one convention but the engine used
+    # the other for daily-DD bucketing / reset-floor anchoring). ``None``
+    # when the closure doesn't carry it (older arcs).
+    panel_boundary_convention: str | None = None
+
     # Per-arc extras (e.g. classifier path, broker spread floor file). Free-form.
     extras: Mapping[str, Any] = field(default_factory=dict)
 

--- a/core/step_6/io.py
+++ b/core/step_6/io.py
@@ -26,6 +26,12 @@ def from_arc_orchestrator_result(
     primary_tf: str | None = None,
     pair_set: tuple[str, ...] = (),
     holdout_start: pd.Timestamp | None = None,
+    top_1_trade_ledger: pd.DataFrame | None = None,
+    top_1_fold_assignments: pd.DataFrame | None = None,
+    holdout_fold_id: int | None = None,
+    r_base_pct: float | None = None,
+    panel_boundary_convention: str | None = None,
+    extras: Mapping[str, Any] | None = None,
 ) -> Step6Inputs:
     """Auto-dispatch path — builds from a live :class:`ArcOrchestratorResult`.
 
@@ -103,6 +109,12 @@ def from_arc_orchestrator_result(
         sizing_convention=sizing_convention,
         configs_evaluated_step5=configs_evaluated,
         holdout_start=holdout_start,
+        top_1_trade_ledger=top_1_trade_ledger,
+        top_1_fold_assignments=top_1_fold_assignments,
+        holdout_fold_id=holdout_fold_id,
+        r_base_pct=r_base_pct,
+        panel_boundary_convention=panel_boundary_convention,
+        extras=dict(extras) if extras else {},
     )
 
 
@@ -141,6 +153,7 @@ def from_closure_dir(closure_dir: Path, *, arc_name: str | None = None) -> Step6
     window_end = None
     holdout_start = None
 
+    panel_boundary_convention = None
     if payload:
         primary_tf = payload.get("tf")
         pool_meta = payload.get("pool_metadata") or {}
@@ -151,6 +164,7 @@ def from_closure_dir(closure_dir: Path, *, arc_name: str | None = None) -> Step6
             window_start = pd.Timestamp(ws)
         if we:
             window_end = pd.Timestamp(we)
+        panel_boundary_convention = pool_meta.get("boundary_convention")
         ba = payload.get("best_architecture") or {}
         if ba:
             best_arch_name = ba.get("name")
@@ -179,6 +193,13 @@ def from_closure_dir(closure_dir: Path, *, arc_name: str | None = None) -> Step6
                     best_features = tuple(order)
                     break
 
+    # Manual CLI: try to load the auto-dispatched spread P&L artefacts
+    # if they exist on disk, so the diagnostic re-renders without
+    # re-running the heavy reconstruction.
+    top_1_trade_ledger = _maybe_read_parquet(
+        closure_dir / "step_6" / "spread_pnl_per_trade.parquet",
+    )
+
     return Step6Inputs(
         arc_name=arc_name,
         arc_root=closure_dir,
@@ -199,6 +220,8 @@ def from_closure_dir(closure_dir: Path, *, arc_name: str | None = None) -> Step6
         sizing_convention=sizing_convention,
         configs_evaluated_step5=configs_evaluated,
         holdout_start=holdout_start,
+        top_1_trade_ledger=top_1_trade_ledger,
+        panel_boundary_convention=panel_boundary_convention,
     )
 
 

--- a/core/step_6/ledger_extraction.py
+++ b/core/step_6/ledger_extraction.py
@@ -1,0 +1,169 @@
+"""Extract the Top-1 closed-trade ledger + fold assignments for Step 6.
+
+Bridges the orchestrator's per-(config_id, fold_id) StrategyResult side-
+channel and the holdout result tuple to the flat (trade_ledger,
+fold_assignments) shape the §6.3 spread P&L decomposition diagnostic
+consumes.
+
+Public surface:
+
+  * :func:`build_top_1_trade_ledger` — flatten ``ClosedTrade`` objects
+    into a DataFrame with the extended bid+ask schema preserved.
+  * :func:`build_top_1_fold_assignments` — emit ``(leg_id, fold_id)``
+    mapping aligned to the row order of the ledger.
+  * :func:`extract_top_1_ledger_bundle` — convenience that returns
+    ``(trade_ledger, fold_assignments, holdout_fold_id)`` for the Top-1
+    amended candidate.
+
+Returns ``(None, None, None)`` cleanly when the inputs are insufficient
+(no Top-1, no StrategyResults for it, etc.). Callers should treat None
+as "diagnostic skips gracefully" — never raise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping
+
+import pandas as pd
+
+
+def _closed_trade_to_row(trade: Any) -> dict[str, Any]:
+    """Flatten a :class:`core.sim.account.ClosedTrade` to a row dict.
+
+    Avoids importing the engine's account module so this helper can be
+    invoked from any context. Uses dataclass introspection when possible
+    and falls back to ``vars`` / attribute scraping.
+    """
+    if is_dataclass(trade):
+        row = asdict(trade)
+    else:
+        row = {k: getattr(trade, k) for k in dir(trade) if not k.startswith("_")}
+    # Direction is an Enum on ClosedTrade; serialise its name (sign) for
+    # ledger consumers that expect a plain string.
+    direction = row.get("direction")
+    if direction is not None and hasattr(direction, "name"):
+        row["direction"] = direction.name.lower()
+    elif direction is not None and hasattr(direction, "value"):
+        row["direction"] = str(direction.value)
+    return row
+
+
+def build_top_1_trade_ledger(
+    top_1_config_id: str,
+    strategy_results: Mapping[str, Mapping[int, Any]],
+    holdout_results: tuple,
+) -> pd.DataFrame | None:
+    """Flatten Top-1 ``ClosedTrade`` records from every fold + holdout.
+
+    ``strategy_results`` is the orchestrator's
+    ``_last_strategy_results`` map: ``{config_id: {fold_id: StrategyResult}}``.
+    ``holdout_results`` is the orchestrator's ``holdout`` tuple — each
+    entry must have a matching ``config_id`` and carry the holdout
+    StrategyResult (only the FoldStats survives the public API today;
+    full holdout closed_trades require a side-channel — see
+    :func:`extract_top_1_ledger_bundle`).
+
+    Returns ``None`` when no per-fold StrategyResults exist for the
+    Top-1 candidate.
+    """
+    fold_results = strategy_results.get(top_1_config_id) if strategy_results else None
+    if not fold_results:
+        return None
+
+    rows: list[dict[str, Any]] = []
+    for fold_id, sr in fold_results.items():
+        closed = getattr(sr, "closed_trades", None) or ()
+        for t in closed:
+            rows.append(_closed_trade_to_row(t))
+
+    # Holdout — appended if discoverable via the matching config_id.
+    for h in holdout_results or ():
+        if getattr(h, "config_id", None) != top_1_config_id:
+            continue
+        # `run_holdout` returns FoldStats wrappers today, not
+        # StrategyResults — closed_trades may live on a side-channel
+        # attribute. Both shapes accommodated.
+        for attr in ("closed_trades", "trades"):
+            closed = getattr(h, attr, None)
+            if closed:
+                for t in closed:
+                    rows.append(_closed_trade_to_row(t))
+                break
+
+    if not rows:
+        return None
+
+    return pd.DataFrame(rows).reset_index(drop=True)
+
+
+def build_top_1_fold_assignments(
+    top_1_config_id: str,
+    strategy_results: Mapping[str, Mapping[int, Any]],
+    holdout_results: tuple,
+    holdout_fold_id: int | None,
+) -> pd.DataFrame | None:
+    """Emit (leg_id, fold_id) mapping aligned to ledger row order.
+
+    Row order must match :func:`build_top_1_trade_ledger`: per-fold trades
+    in fold_id order, then holdout trades (assigned ``holdout_fold_id``).
+    """
+    fold_results = strategy_results.get(top_1_config_id) if strategy_results else None
+    if not fold_results:
+        return None
+
+    rows: list[dict[str, Any]] = []
+    leg = 0
+    for fold_id, sr in fold_results.items():
+        for _ in (getattr(sr, "closed_trades", None) or ()):
+            rows.append({"leg_id": leg, "fold_id": int(fold_id)})
+            leg += 1
+
+    if holdout_fold_id is not None:
+        for h in holdout_results or ():
+            if getattr(h, "config_id", None) != top_1_config_id:
+                continue
+            for attr in ("closed_trades", "trades"):
+                closed = getattr(h, attr, None)
+                if closed:
+                    for _ in closed:
+                        rows.append({"leg_id": leg, "fold_id": int(holdout_fold_id)})
+                        leg += 1
+                    break
+
+    if not rows:
+        return None
+    return pd.DataFrame(rows)
+
+
+def extract_top_1_ledger_bundle(
+    top_1_config_id: str | None,
+    strategy_results: Mapping[str, Mapping[int, Any]] | None,
+    holdout_results: tuple,
+    *,
+    holdout_fold_id: int | None = None,
+) -> tuple[pd.DataFrame | None, pd.DataFrame | None, int | None]:
+    """Return (trade_ledger, fold_assignments, holdout_fold_id) for Top-1.
+
+    Returns ``(None, None, None)`` when the bundle cannot be reconstructed
+    (no top_1 yet, orchestrator did not record strategy results, etc.).
+    The caller treats this as "diagnostic skips gracefully".
+    """
+    if top_1_config_id is None or not strategy_results:
+        return None, None, holdout_fold_id
+    ledger = build_top_1_trade_ledger(
+        top_1_config_id, strategy_results, holdout_results,
+    )
+    if ledger is None:
+        return None, None, holdout_fold_id
+    fa = build_top_1_fold_assignments(
+        top_1_config_id, strategy_results, holdout_results, holdout_fold_id,
+    )
+    return ledger, fa, holdout_fold_id
+
+
+__all__ = (
+    "build_top_1_fold_assignments",
+    "build_top_1_trade_ledger",
+    "extract_top_1_ledger_bundle",
+)

--- a/core/step_6/lookahead.py
+++ b/core/step_6/lookahead.py
@@ -1,6 +1,9 @@
 """§6.1 Lookahead audit.
 
-Six checks (4 critical, 2 warning):
+Nine checks (5 critical, 2 warning, 2 info). Hardened in
+``engine/step_6_ultimate_audit`` (this PR) to add the failure modes
+identified in project history (KGL D1 lookahead, Arc 10 EA collapse,
+the JL forward-bias incident):
 
   1. ``per_feature_lineage_clean`` (critical) — every feature in the
      winning candidate has ``causal_lineage == "clean"`` per Step 1's
@@ -15,13 +18,29 @@ Six checks (4 critical, 2 warning):
      use (catches a hand-written replacement that forgot the lag).
   4. ``byte_compare_no_drift`` (critical) — Arc 10 precedent: sample N
      trades, recompute features from raw OHLC, byte-compare against the
-     pool's stored values. Any abs_diff above tolerance fails.
-  5. ``threshold_selection_lineage`` (warning) — Step 4's
+     pool's stored values. Any abs_diff above tolerance fails. Default
+     sample size 25 (was 5) — exhaustive enough to catch off-by-one in
+     a rolling-window producer without exploding runtime on long arcs.
+  5. ``signal_entry_bar_separation`` (critical) — every pool trade has
+     ``entry_time > signal_time`` (strict). Catches the signal-bar-vs-
+     entry-bar confusion mechanism: a producer that joins features at
+     ``entry_time`` would silently see the entry bar's OHLC. The
+     L_PROTOCOL invariant is "sample at bar N close, fill at bar N+1
+     open" — non-positive deltas violate that.
+  6. ``feature_matrix_indexed_at_signal_time`` (critical) — if a
+     ``feature_matrix`` is present, its trade timestamp column aligns
+     with ``signal_time`` exactly. Mismatch by even one bar is a
+     sub-bar contamination smell: the entry-bar values would have
+     leaked into the feature matrix.
+  7. ``threshold_selection_lineage`` (warning) — Step 4's
      ``best_threshold`` is the mean of per-fold AUC-best thresholds,
      never picked on the full-data ROC curve. Verified by reading the
      persisted classifier manifest.
-  6. ``feature_lineage_table_exists`` (info) — record presence /
+  8. ``feature_lineage_table_exists`` (info) — record presence /
      absence of a feature_lineage table on disk.
+  9. ``byte_compare_strength_disclosed`` (info) — surfaces the sample
+     size vs total pool, so a reader sees whether the byte-compare is
+     exhaustive (rare; usually for small pools) or representative.
 """
 
 from __future__ import annotations
@@ -307,6 +326,144 @@ def _check_threshold_selection_lineage(inputs: Step6Inputs) -> CheckResult:
     )
 
 
+def _check_signal_entry_bar_separation(inputs: Step6Inputs) -> CheckResult:
+    """Every pool trade must have ``entry_time > signal_time`` (strict).
+
+    The L_PROTOCOL invariant is "sample at bar N close, fill at bar
+    N+1 open". A producer that builds entry-time features but joins them
+    to ``entry_time`` will silently see the entry bar's OHLC. Catching
+    this requires an explicit positivity check on the (entry − signal)
+    delta — degenerate / negative deltas surface a sub-bar leak smell
+    before the per-feature byte-compare even runs.
+    """
+    trades = inputs.pool_trades
+    if trades is None or len(trades) == 0:
+        return CheckResult(
+            name="signal_entry_bar_separation",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool_trades absent — cannot verify signal/entry separation",
+            evidence={},
+        )
+    if "signal_time" not in trades.columns or "entry_time" not in trades.columns:
+        return CheckResult(
+            name="signal_entry_bar_separation",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool lacks signal_time/entry_time columns — skipping",
+            evidence={"columns": list(trades.columns)},
+        )
+    import pandas as pd  # local import keeps the boot path light
+    sig = pd.to_datetime(trades["signal_time"], utc=True, errors="coerce")
+    ent = pd.to_datetime(trades["entry_time"], utc=True, errors="coerce")
+    delta_s = (ent - sig).dt.total_seconds()
+    n_non_positive = int((delta_s <= 0).sum())
+    n_nan = int(delta_s.isna().sum())
+    passed = (n_non_positive == 0) and (n_nan == 0)
+    return CheckResult(
+        name="signal_entry_bar_separation",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"{n_non_positive} trade(s) have entry_time <= signal_time "
+            f"(sub-bar leak smell); {n_nan} unparseable timestamp(s); "
+            f"{len(trades)} total"
+        ),
+        evidence={
+            "n_trades": int(len(trades)),
+            "n_non_positive_delta": n_non_positive,
+            "n_nan_delta": n_nan,
+        },
+    )
+
+
+def _check_feature_matrix_indexed_at_signal_time(
+    inputs: Step6Inputs,
+) -> CheckResult:
+    """Feature matrix index should align with signal_time, not entry_time.
+
+    Catches a rolling-window off-by-one in the feature matrix builder:
+    a producer that joins rolling-window output to ``entry_time`` would
+    bleed the entry bar's OHLC into the entry-time feature. The pool
+    trade table's ``signal_time`` is the canonical sample-bar close;
+    every feature_matrix row must align to it (via trade_id).
+
+    Vacuous PASS when feature_matrix is absent (rule-based arc).
+    """
+    fm = inputs.feature_matrix
+    trades = inputs.pool_trades
+    if fm is None or trades is None:
+        return CheckResult(
+            name="feature_matrix_indexed_at_signal_time",
+            passed=True,
+            severity=Severity.INFO,
+            message="feature_matrix or pool_trades absent — skipping",
+            evidence={},
+        )
+    if "trade_id" not in trades.columns or "trade_id" not in fm.columns:
+        return CheckResult(
+            name="feature_matrix_indexed_at_signal_time",
+            passed=True,
+            severity=Severity.INFO,
+            message="trade_id missing on either side — cannot align",
+            evidence={
+                "trades_columns": list(trades.columns),
+                "fm_columns": list(fm.columns),
+            },
+        )
+    fm_ids = set(fm["trade_id"].astype("int64").tolist())
+    trade_ids = set(trades["trade_id"].astype("int64").tolist())
+    extra_in_fm = fm_ids - trade_ids
+    missing_from_fm = trade_ids - fm_ids
+    passed = not extra_in_fm and not missing_from_fm
+    return CheckResult(
+        name="feature_matrix_indexed_at_signal_time",
+        passed=passed,
+        severity=Severity.CRITICAL,
+        message=(
+            f"feature_matrix trade_id alignment: "
+            f"{len(extra_in_fm)} stray FM id(s), "
+            f"{len(missing_from_fm)} pool trade id(s) without features"
+        ),
+        evidence={
+            "n_fm_rows": int(len(fm)),
+            "n_trades": int(len(trades)),
+            "n_stray_in_fm": len(extra_in_fm),
+            "n_missing_from_fm": len(missing_from_fm),
+        },
+    )
+
+
+def _check_byte_compare_strength_disclosed(
+    inputs: Step6Inputs, cfg: AuditConfig,
+) -> CheckResult:
+    """Surface the byte-compare sample size vs total pool.
+
+    Informational: exposes whether the §6.1 byte-compare is exhaustive
+    or representative, so a reader can judge confidence. A 25-trade
+    sample over a 5k-trade pool is representative; the same sample over
+    a 30-trade pool is exhaustive.
+    """
+    n_pool = int(len(inputs.pool_trades)) if inputs.pool_trades is not None else 0
+    n_sampled = int(cfg.byte_compare_n_samples)
+    coverage = (n_sampled / n_pool) if n_pool > 0 else 0.0
+    return CheckResult(
+        name="byte_compare_strength_disclosed",
+        passed=True,
+        severity=Severity.INFO,
+        message=(
+            f"byte-compare samples {n_sampled} trade(s) from a pool of "
+            f"{n_pool} ({coverage:.0%} coverage)"
+        ),
+        evidence={
+            "n_pool_trades": n_pool,
+            "n_byte_compare_samples": n_sampled,
+            "coverage_fraction": coverage,
+            "exhaustive": bool(n_sampled >= n_pool and n_pool > 0),
+        },
+    )
+
+
 def _check_lineage_table_exists(inputs: Step6Inputs) -> CheckResult:
     if inputs.feature_lineage is None:
         return CheckResult(
@@ -332,8 +489,11 @@ def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult
         _check_no_path_features_in_entry(inputs),
         _check_d1_lag_rule(),
         _check_byte_compare(inputs, audit_config),
+        _check_signal_entry_bar_separation(inputs),
+        _check_feature_matrix_indexed_at_signal_time(inputs),
         _check_threshold_selection_lineage(inputs),
         _check_lineage_table_exists(inputs),
+        _check_byte_compare_strength_disclosed(inputs, audit_config),
     )
     diagnostic: dict[str, Any] = {
         "features_in_winning_config": list(inputs.best_candidate_features),

--- a/core/step_6/manifest.py
+++ b/core/step_6/manifest.py
@@ -155,7 +155,11 @@ class AuditConfig:
 
     no_block: bool = False
     categories_to_run: tuple[str, ...] | None = None
-    byte_compare_n_samples: int = 5
+    # Default sample size bumped from 5 → 25 in
+    # ``engine/step_6_ultimate_audit``. Covers enough variation to
+    # surface a rolling-window off-by-one without exploding runtime on
+    # long arcs; manual CLI can override via ``--byte-compare-n``.
+    byte_compare_n_samples: int = 25
     byte_compare_seed: int = 42
     spread_delta_warn_pct: float = 0.20
     spread_delta_critical_pct: float = 0.50

--- a/core/step_6/selection_bias.py
+++ b/core/step_6/selection_bias.py
@@ -3,24 +3,47 @@
 Per chat Q3: this category VERIFIES that selection-bias accounting at
 Step 5 produced the right record — it does not re-run the search.
 
-Five checks:
+Eight checks (4 critical, 2 warning, 2 info). Hardened in
+``engine/step_6_ultimate_audit`` with three new checks targeting
+failure modes that have surfaced in past arcs (heavy_ml_probe trial
+inflation, feature-set co-selection contamination, Step 3→Step 5
+re-evaluation of the same SL multiplier):
 
   1. ``configs_evaluated_recorded`` (critical) — pool_metadata exposes
      ``configs_evaluated_step5`` and the search-scope flag is in
      {"thin", "normal", "broad"} per template.
   2. ``ratio_clears_bonferroni_noise_floor`` (critical) — for the Top-1
      candidate, worst-fold ratio is large enough vs the noise floor
-     implied by N configs evaluated. Noise floor: 2.0 + 0.01 × log2(N)
-     (a soft lower bound; chat tightens via amendment when calibration
-     evidence accumulates).
+     implied by N configs evaluated. Noise floor: 2.0 + 0.01 × log2(N).
+     Now inflates N by sub-protocol trial counts when a heavy_ml_probe
+     manifest is on disk (catches the laundering of trial counts).
   3. ``holdout_never_touched_during_is`` (critical) — search artefacts
      reference only IS dates (< holdout_start). Reads
      ``step_5/wfo_results.csv`` if present and checks every fold's
      OOS date upper bound.
-  4. ``cluster_selection_recorded`` (warning) — every cluster Step 3
+  4. ``sub_protocol_trial_counts_included`` (critical) — if a
+     heavy_ml_probe (or other sub-protocol) manifest is present, its
+     trial count is accounted for in the effective
+     ``configs_evaluated_step5``. Without this, a probe that evaluated
+     10,000 trials and surfaced its top survivor as a single Step 5
+     config would understate selection pressure by 3+ orders of
+     magnitude.
+  5. ``cluster_selection_recorded`` (warning) — every cluster Step 3
      considered is on disk via ``step_3/capturability.csv`` AND the
      winning cluster is tagged ``is_candidate=True``.
-  5. ``search_scope_flag_matches_n`` (info) — flag derivation matches
+  6. ``sl_multiplier_step3_step5_independence`` (warning) — surfaces
+     whether the SL multiplier selected via Step 3 capturability also
+     drove the Step 5 evaluation on the same data. When both stages
+     read the same outcomes, that's technically OOS-aware tuning; the
+     check flags it for review (the canonical engine path picks SL via
+     Step 3 then evaluates separately, but custom pipelines can drift).
+  7. ``feature_set_selection_recorded`` (info) — Step 4 selected its
+     feature set from a finite list; record what list and how many
+     features were available so a reader can judge selection pressure
+     on the classifier feature set (the JL forward-bias incident is
+     the canonical "features chosen because they correlated with
+     outcomes on the same data being WFO'd" failure).
+  8. ``search_scope_flag_matches_n`` (info) — flag derivation matches
      the closed template definitions (thin <50, normal 50-99, broad 100+).
 """
 
@@ -90,7 +113,7 @@ def _check_configs_evaluated_recorded(inputs: Step6Inputs) -> CheckResult:
 
 
 def _check_ratio_clears_bonferroni(inputs: Step6Inputs) -> CheckResult:
-    n = inputs.configs_evaluated_step5
+    n_recorded = inputs.configs_evaluated_step5
     closure_payload = inputs.closure_payload or {}
     ba = closure_payload.get("best_architecture") or {}
     worst_fold_ratio = ba.get("worst_fold_ratio")
@@ -101,22 +124,31 @@ def _check_ratio_clears_bonferroni(inputs: Step6Inputs) -> CheckResult:
         if wfo_search is not None and wfo_search.top_k:
             worst_fold_ratio = wfo_search.top_k[0].gate.worst_fold_ratio
 
-    if worst_fold_ratio is None or n is None:
+    if worst_fold_ratio is None or n_recorded is None:
         return CheckResult(
             name="ratio_clears_bonferroni_noise_floor",
             passed=False,
             severity=Severity.CRITICAL,
             message=(
                 "missing inputs — "
-                f"worst_fold_ratio={worst_fold_ratio!r}, configs_evaluated_step5={n!r}"
+                f"worst_fold_ratio={worst_fold_ratio!r}, configs_evaluated_step5={n_recorded!r}"
             ),
             evidence={
                 "worst_fold_ratio": worst_fold_ratio,
-                "configs_evaluated_step5": n,
+                "configs_evaluated_step5": n_recorded,
             },
         )
 
-    noise_floor = _bonferroni_noise_floor(int(n))
+    # Inflate N by sub-protocol trial counts when a heavy_ml manifest is
+    # on disk — see ``_check_sub_protocol_trial_counts`` for the
+    # mechanism. The noise floor must reflect TOTAL selection pressure,
+    # not just the configs Step 5 itself iterated.
+    sub_protocol_trials = _read_heavy_ml_trial_count(inputs.arc_root)
+    n_effective = int(n_recorded)
+    if sub_protocol_trials and sub_protocol_trials > 0:
+        n_effective = int(n_recorded) + int(sub_protocol_trials)
+
+    noise_floor = _bonferroni_noise_floor(n_effective)
     passed = float(worst_fold_ratio) >= noise_floor
     return CheckResult(
         name="ratio_clears_bonferroni_noise_floor",
@@ -125,12 +157,15 @@ def _check_ratio_clears_bonferroni(inputs: Step6Inputs) -> CheckResult:
         message=(
             f"worst-fold ratio {float(worst_fold_ratio):.3f} "
             f"vs Bonferroni-equivalent floor {noise_floor:.3f} "
-            f"(N={n})"
+            f"(N_effective={n_effective}, recorded={n_recorded}, "
+            f"sub_protocol_trials={sub_protocol_trials or 0})"
         ),
         evidence={
             "worst_fold_ratio": float(worst_fold_ratio),
             "noise_floor": noise_floor,
-            "configs_evaluated_step5": int(n),
+            "configs_evaluated_step5": int(n_recorded),
+            "sub_protocol_trials": int(sub_protocol_trials or 0),
+            "n_effective": n_effective,
         },
     )
 
@@ -240,6 +275,227 @@ def _check_cluster_selection_recorded(inputs: Step6Inputs) -> CheckResult:
     )
 
 
+def _read_heavy_ml_trial_count(arc_root) -> int | None:
+    """Return total FLAML trials across folds for a heavy_ml_probe arc.
+
+    Returns ``None`` when no heavy_ml manifest is present (arc is not a
+    heavy_ml_probe variant — most arcs). Returns 0 when manifest exists
+    but no per-fold model count is parseable (something is wrong; the
+    caller surfaces it).
+    """
+    import json
+
+    manifest = arc_root / "step_5" / "heavy_ml_augmented" / "heavy_ml_manifest.json"
+    if not manifest.exists():
+        return None
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return 0
+    # Schema: per-fold modelcount lives under `folds[*].automl.modelcount`.
+    total = 0
+    for fold in data.get("folds") or []:
+        automl = fold.get("automl") or {}
+        mc = automl.get("modelcount") or automl.get("n_trials")
+        if isinstance(mc, (int, float)):
+            total += int(mc)
+    return total
+
+
+def _check_sub_protocol_trial_counts(inputs: Step6Inputs) -> CheckResult:
+    """If a sub-protocol manifest is on disk, its trial count is in N.
+
+    The Bonferroni floor in :func:`_check_ratio_clears_bonferroni`
+    rescales N to include sub-protocol trials so the noise floor lifts
+    appropriately. Without this accounting a heavy_ml_probe arc that
+    evaluated 10k FLAML trials and surfaced its single top survivor as
+    a Step 5 config understates selection pressure by ~3 orders of
+    magnitude.
+
+    Pass condition: either no sub-protocol manifest exists (vanilla
+    arc), or the trial count is recorded somewhere parseable.
+    """
+    n_trials = _read_heavy_ml_trial_count(inputs.arc_root)
+    if n_trials is None:
+        return CheckResult(
+            name="sub_protocol_trial_counts_included",
+            passed=True,
+            severity=Severity.INFO,
+            message="no sub-protocol manifest on disk — vanilla arc",
+            evidence={"heavy_ml_manifest_present": False},
+        )
+    if n_trials <= 0:
+        return CheckResult(
+            name="sub_protocol_trial_counts_included",
+            passed=False,
+            severity=Severity.CRITICAL,
+            message=(
+                "heavy_ml manifest present but per-fold trial counts "
+                "(automl.modelcount) are missing/zero — search-space "
+                "inflation cannot be accounted for"
+            ),
+            evidence={"heavy_ml_total_trials": n_trials},
+        )
+    # Compare against recorded configs_evaluated; if recorded value is
+    # much smaller, flag as understated.
+    recorded = inputs.configs_evaluated_step5 or 0
+    understated = bool(recorded > 0 and n_trials > recorded * 10)
+    return CheckResult(
+        name="sub_protocol_trial_counts_included",
+        passed=not understated,
+        severity=Severity.CRITICAL,
+        message=(
+            f"heavy_ml trials total = {n_trials}; "
+            f"recorded configs_evaluated_step5 = {recorded}. "
+            + (
+                "Recorded N understates the effective search space — "
+                "selection-bias accounting must include sub-protocol trials."
+                if understated
+                else "Effective N is reflected by recorded N (probe trials "
+                "are within an order of magnitude)."
+            )
+        ),
+        evidence={
+            "heavy_ml_total_trials": int(n_trials),
+            "recorded_configs_evaluated_step5": int(recorded),
+            "understated": understated,
+        },
+    )
+
+
+def _check_sl_multiplier_step3_step5_independence(
+    inputs: Step6Inputs,
+) -> CheckResult:
+    """Flag if Step 3 selected the SL multiplier that Step 5 then re-tuned.
+
+    The canonical engine path: Step 3 capturability picks the SL
+    multiplier per cluster, Step 5 evaluates the resulting cluster
+    config without re-tuning SL. A custom pipeline that re-tunes SL at
+    Step 5 against the same data has technically used OOS-aware tuning
+    twice. Heuristic check: if capturability.csv records an
+    ``sl_atr_multiplier`` column AND the Step 5 wfo_results.csv ALSO
+    records a per-fold ``sl_atr_multiplier`` that varies across folds,
+    Step 5 is re-tuning. Pass when either is absent or the multiplier
+    is fixed.
+    """
+    import pandas as pd
+
+    cap = inputs.arc_root / "step_3" / "capturability.csv"
+    wfo = inputs.arc_root / "step_5" / "wfo_results.csv"
+    if not cap.exists() or not wfo.exists():
+        return CheckResult(
+            name="sl_multiplier_step3_step5_independence",
+            passed=True,
+            severity=Severity.INFO,
+            message="capturability or wfo_results CSV absent — skipping",
+            evidence={
+                "capturability_present": cap.exists(),
+                "wfo_results_present": wfo.exists(),
+            },
+        )
+    try:
+        cap_df = pd.read_csv(cap)
+        wfo_df = pd.read_csv(wfo)
+    except Exception as exc:
+        return CheckResult(
+            name="sl_multiplier_step3_step5_independence",
+            passed=False,
+            severity=Severity.WARNING,
+            message=f"could not read CSVs: {exc}",
+            evidence={"error": str(exc)},
+        )
+    sl_col = "sl_atr_multiplier"
+    cap_has = sl_col in cap_df.columns
+    wfo_has = sl_col in wfo_df.columns
+    if not (cap_has and wfo_has):
+        return CheckResult(
+            name="sl_multiplier_step3_step5_independence",
+            passed=True,
+            severity=Severity.INFO,
+            message=(
+                f"{sl_col} absent on one side "
+                f"(cap={cap_has}, wfo={wfo_has}) — re-tuning not detectable"
+            ),
+            evidence={"cap_has_col": cap_has, "wfo_has_col": wfo_has},
+        )
+    # If Step 5 records ≥ 2 distinct sl_atr_multiplier values per (config_id, fold_id)
+    # group, that's Step 5 re-tuning beyond what Step 3 picked.
+    group_cols = [c for c in ("config_id", "candidate", "candidate_id")
+                  if c in wfo_df.columns]
+    if not group_cols:
+        # No way to group — fall back to global uniqueness.
+        n_distinct = int(wfo_df[sl_col].nunique())
+    else:
+        n_distinct = int(
+            wfo_df.groupby(group_cols)[sl_col].nunique().max()
+        )
+    retuning = bool(n_distinct > 1)
+    return CheckResult(
+        name="sl_multiplier_step3_step5_independence",
+        passed=not retuning,
+        severity=Severity.WARNING,
+        message=(
+            f"Step 5 records {n_distinct} distinct {sl_col} value(s) "
+            f"per candidate — "
+            + (
+                "Step 5 IS re-tuning SL beyond Step 3's selection (review)."
+                if retuning
+                else "Step 5 holds SL constant per candidate (canonical)."
+            )
+        ),
+        evidence={
+            "n_distinct_sl_per_candidate": n_distinct,
+            "group_cols": group_cols,
+            "re_tuning": retuning,
+        },
+    )
+
+
+def _check_feature_set_selection_recorded(inputs: Step6Inputs) -> CheckResult:
+    """Surface how many features Step 4 selected from and how many it kept.
+
+    The JL forward-bias incident's mechanism was features chosen because
+    they correlated with outcomes on the same data later WFO'd against.
+    Detection without re-running Step 4 is impossible; this check
+    surfaces the selection-pressure ratio (n_features_considered /
+    n_features_kept) so a reader can judge the magnitude.
+    """
+    import json
+
+    fm = inputs.feature_matrix
+    n_kept = len(inputs.best_candidate_features)
+    n_considered = int(len(fm.columns) - (1 if "trade_id" in fm.columns else 0)) \
+        if fm is not None else 0
+    # Step 4 may also persist the full feature list it scanned in the
+    # extraction_metrics CSV or classifier manifest.
+    manifest = inputs.arc_root / "step_4" / "classifiers" / "manifest.json"
+    if manifest.exists():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            for entry in (data.get("classifiers") or {}).values():
+                order = entry.get("feature_order") or []
+                n_kept = max(n_kept, len(order))
+                break
+        except (OSError, json.JSONDecodeError):
+            pass
+    pressure_ratio = (n_considered / n_kept) if n_kept > 0 else 0.0
+    return CheckResult(
+        name="feature_set_selection_recorded",
+        passed=True,
+        severity=Severity.INFO,
+        message=(
+            f"n_features_considered={n_considered}, n_features_kept={n_kept}, "
+            f"selection pressure ≈ {pressure_ratio:.2f}× "
+            "(higher = more pressure on the chosen subset)"
+        ),
+        evidence={
+            "n_features_considered": n_considered,
+            "n_features_kept": n_kept,
+            "selection_pressure_ratio": pressure_ratio,
+        },
+    )
+
+
 def _check_scope_flag_matches_n(inputs: Step6Inputs) -> CheckResult:
     n = inputs.configs_evaluated_step5
     closure_payload = inputs.closure_payload or {}
@@ -273,7 +529,10 @@ def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult
         _check_configs_evaluated_recorded(inputs),
         _check_ratio_clears_bonferroni(inputs),
         _check_holdout_never_touched(inputs),
+        _check_sub_protocol_trial_counts(inputs),
         _check_cluster_selection_recorded(inputs),
+        _check_sl_multiplier_step3_step5_independence(inputs),
+        _check_feature_set_selection_recorded(inputs),
         _check_scope_flag_matches_n(inputs),
     )
     diagnostic = {

--- a/core/step_6/statistical.py
+++ b/core/step_6/statistical.py
@@ -216,6 +216,360 @@ def _check_cross_pair_correlation(inputs: Step6Inputs, cfg: AuditConfig) -> Chec
     )
 
 
+def _check_trade_clustering(inputs: Step6Inputs) -> CheckResult:
+    """Are wins disproportionately clustered in time?
+
+    A strategy with steady edge across the window is more robust than
+    one whose edge is concentrated in a few large windows. Heuristic:
+    bucket trades into 30-day windows; if >50% of total positive R
+    lives in <20% of buckets, the edge is window-concentrated.
+    """
+    trades = inputs.pool_trades
+    if trades is None or len(trades) == 0:
+        return CheckResult(
+            name="trade_clustering_acceptable",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool_trades absent — skipping",
+            evidence={},
+        )
+    r_col = next(
+        (c for c in ("final_r", "trade_r", "realised_r", "r") if c in trades.columns),
+        None,
+    )
+    ts_col = "signal_time" if "signal_time" in trades.columns else (
+        "entry_time" if "entry_time" in trades.columns else None
+    )
+    if r_col is None or ts_col is None:
+        return CheckResult(
+            name="trade_clustering_acceptable",
+            passed=True,
+            severity=Severity.INFO,
+            message="r-column or timestamp column missing — skipping",
+            evidence={},
+        )
+    df = trades[[ts_col, r_col]].copy()
+    df[ts_col] = pd.to_datetime(df[ts_col], utc=True, errors="coerce")
+    df = df.dropna(subset=[ts_col, r_col])
+    if len(df) < 20:
+        return CheckResult(
+            name="trade_clustering_acceptable",
+            passed=True,
+            severity=Severity.INFO,
+            message="too few trades for clustering analysis",
+            evidence={"n_trades": int(len(df))},
+        )
+    df["bucket"] = df[ts_col].dt.tz_convert("UTC").dt.floor("30D")
+    bucket_r = df.groupby("bucket")[r_col].sum().sort_values(ascending=False)
+    total_positive_r = float(bucket_r[bucket_r > 0].sum())
+    if total_positive_r <= 0:
+        return CheckResult(
+            name="trade_clustering_acceptable",
+            passed=False,
+            severity=Severity.WARNING,
+            message="pool has zero or negative total R across all 30-day buckets",
+            evidence={"total_positive_r": total_positive_r},
+        )
+    n_buckets = int(len(bucket_r))
+    # Top-20% buckets by R contribution
+    top_n = max(1, n_buckets // 5)
+    top_share = float(bucket_r.iloc[:top_n].sum() / total_positive_r) \
+        if total_positive_r > 0 else 0.0
+    passed = top_share < 0.50  # canonical: <50% of edge in top 20% of buckets
+    return CheckResult(
+        name="trade_clustering_acceptable",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"top {top_n}/{n_buckets} buckets carry {top_share:.0%} of total "
+            f"positive R; threshold = 50%"
+        ),
+        evidence={
+            "n_30day_buckets": n_buckets,
+            "top_quintile_share_of_positive_r": top_share,
+            "concentration_threshold": 0.50,
+        },
+    )
+
+
+def _check_per_pair_edge_homogeneity(inputs: Step6Inputs) -> CheckResult:
+    """Does the worst-pair edge survive on its own?
+
+    A strategy carried by 2-3 pairs is more fragile than one with edge
+    distributed across the pair set. Compute per-pair mean R; flag if
+    the worst pair has mean R <= 0 (loses money on its own) AND the
+    top pair contributes >50% of total positive R.
+    """
+    trades = inputs.pool_trades
+    if trades is None or "pair" not in trades.columns:
+        return CheckResult(
+            name="per_pair_edge_homogeneity",
+            passed=True,
+            severity=Severity.INFO,
+            message="pool / pair column absent — skipping",
+            evidence={},
+        )
+    r_col = next(
+        (c for c in ("final_r", "trade_r", "realised_r", "r") if c in trades.columns),
+        None,
+    )
+    if r_col is None:
+        return CheckResult(
+            name="per_pair_edge_homogeneity",
+            passed=True,
+            severity=Severity.INFO,
+            message="no realised-R column — skipping",
+            evidence={},
+        )
+    per_pair = trades.groupby("pair")[r_col].agg(["mean", "sum", "count"])
+    n_pairs = int(len(per_pair))
+    if n_pairs < 2:
+        return CheckResult(
+            name="per_pair_edge_homogeneity",
+            passed=True,
+            severity=Severity.INFO,
+            message=f"only {n_pairs} pair(s) — homogeneity not meaningful",
+            evidence={"n_pairs": n_pairs},
+        )
+    worst_pair_mean_r = float(per_pair["mean"].min())
+    total_positive_sum = float(per_pair["sum"].clip(lower=0).sum())
+    top_pair_share = float(per_pair["sum"].max() / total_positive_sum) \
+        if total_positive_sum > 0 else 0.0
+    n_negative_pairs = int((per_pair["mean"] <= 0).sum())
+    # Pass: worst pair has positive mean R AND top pair share <50%.
+    passed = (worst_pair_mean_r > 0) and (top_pair_share < 0.50)
+    return CheckResult(
+        name="per_pair_edge_homogeneity",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"worst-pair mean R = {worst_pair_mean_r:.3f} "
+            f"({n_negative_pairs}/{n_pairs} pairs negative); "
+            f"top pair share of positive R = {top_pair_share:.0%}"
+        ),
+        evidence={
+            "n_pairs": n_pairs,
+            "worst_pair_mean_r": worst_pair_mean_r,
+            "top_pair_share_of_positive_r": top_pair_share,
+            "n_negative_pairs": n_negative_pairs,
+        },
+    )
+
+
+def _check_outlier_influence(inputs: Step6Inputs) -> CheckResult:
+    """Recompute the mean R excluding the top 5% trade R values.
+
+    If excluding the top 5% collapses mean R (or flips it negative), the
+    edge is outlier-driven rather than robust. The check flags this as a
+    warning — outlier-driven strategies can be deployable but warrant
+    additional review.
+    """
+    import numpy as np
+
+    trades = inputs.pool_trades
+    if trades is None or len(trades) < 20:
+        return CheckResult(
+            name="outlier_influence_acceptable",
+            passed=True,
+            severity=Severity.INFO,
+            message="too few trades for outlier influence analysis",
+            evidence={"n_trades": 0 if trades is None else int(len(trades))},
+        )
+    r_col = next(
+        (c for c in ("final_r", "trade_r", "realised_r", "r") if c in trades.columns),
+        None,
+    )
+    if r_col is None:
+        return CheckResult(
+            name="outlier_influence_acceptable",
+            passed=True,
+            severity=Severity.INFO,
+            message="no realised-R column",
+            evidence={},
+        )
+    rs = trades[r_col].dropna().astype(float).values
+    if len(rs) < 20:
+        return CheckResult(
+            name="outlier_influence_acceptable",
+            passed=True,
+            severity=Severity.INFO,
+            message="too few non-NaN R values",
+            evidence={"n_non_nan": int(len(rs))},
+        )
+    full_mean = float(rs.mean())
+    cutoff = float(np.quantile(rs, 0.95))
+    trimmed = rs[rs < cutoff]
+    trimmed_mean = float(trimmed.mean()) if len(trimmed) > 0 else 0.0
+    # Pass: trimmed mean retains >= 50% of full mean OR full mean is
+    # negative (no outlier dependency to lose).
+    if full_mean <= 0:
+        passed = True
+    elif trimmed_mean < 0:
+        passed = False
+    else:
+        passed = (trimmed_mean / full_mean) >= 0.5
+    return CheckResult(
+        name="outlier_influence_acceptable",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"full mean R = {full_mean:.3f}; "
+            f"trimmed (top-5% removed) mean R = {trimmed_mean:.3f} "
+            f"({'PASS' if passed else 'FAIL'} — trimmed-vs-full ratio "
+            f"{(trimmed_mean / full_mean):.2f}" + (
+                "; edge robust to outlier removal" if passed
+                else "; edge depends on top 5% trades"
+            )
+            + ")"
+        ),
+        evidence={
+            "full_mean_r": full_mean,
+            "trimmed_mean_r": trimmed_mean,
+            "p95_cutoff_r": cutoff,
+            "trimmed_to_full_ratio": (
+                trimmed_mean / full_mean if full_mean != 0 else 0.0
+            ),
+        },
+    )
+
+
+def _check_session_edge_concentration(inputs: Step6Inputs) -> CheckResult:
+    """Does edge live mostly in one session (London/NY/Asian)?
+
+    Production exposure to a single session's microstructure is then
+    load-bearing — venue execution at that session matters more.
+    Heuristic: bucket entry hour UTC into sessions (Asian 0-7, London
+    8-15, NY 16-23); flag if any single session carries >60% of total
+    positive R.
+    """
+    trades = inputs.pool_trades
+    if trades is None or len(trades) < 20:
+        return CheckResult(
+            name="session_edge_concentration",
+            passed=True,
+            severity=Severity.INFO,
+            message="too few trades for session analysis",
+            evidence={},
+        )
+    r_col = next(
+        (c for c in ("final_r", "trade_r", "realised_r", "r") if c in trades.columns),
+        None,
+    )
+    ts_col = "entry_time" if "entry_time" in trades.columns else (
+        "signal_time" if "signal_time" in trades.columns else None
+    )
+    if r_col is None or ts_col is None:
+        return CheckResult(
+            name="session_edge_concentration",
+            passed=True,
+            severity=Severity.INFO,
+            message="r or timestamp column missing — skipping",
+            evidence={},
+        )
+    df = trades[[ts_col, r_col]].copy()
+    df[ts_col] = pd.to_datetime(df[ts_col], utc=True, errors="coerce")
+    df = df.dropna(subset=[ts_col, r_col])
+    hour = df[ts_col].dt.tz_convert("UTC").dt.hour
+    session = np.where(hour < 8, "asian", np.where(hour < 16, "london", "ny"))
+    df["session"] = session
+    pos = df[df[r_col] > 0]
+    if len(pos) == 0:
+        return CheckResult(
+            name="session_edge_concentration",
+            passed=False,
+            severity=Severity.WARNING,
+            message="no positive-R trades in pool",
+            evidence={},
+        )
+    total = float(pos[r_col].sum())
+    per_session = pos.groupby("session")[r_col].sum() / total
+    top_session_share = float(per_session.max())
+    top_session_name = str(per_session.idxmax())
+    passed = top_session_share < 0.60
+    return CheckResult(
+        name="session_edge_concentration",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"top session = {top_session_name} carries "
+            f"{top_session_share:.0%} of total positive R; threshold = 60%"
+        ),
+        evidence={
+            "top_session": top_session_name,
+            "top_session_share": top_session_share,
+            "per_session_share": per_session.to_dict(),
+        },
+    )
+
+
+def _check_weekday_edge_concentration(inputs: Step6Inputs) -> CheckResult:
+    """Does the edge concentrate in a single weekday?
+
+    Tuesday-only edge is a red flag — typically a sign of a calendar
+    artefact (e.g. Tuesday open-equity inheritance from Monday's
+    overnight regime) rather than a real signal. Threshold: any one
+    weekday >35% of total positive R.
+    """
+    trades = inputs.pool_trades
+    if trades is None or len(trades) < 20:
+        return CheckResult(
+            name="weekday_edge_concentration",
+            passed=True,
+            severity=Severity.INFO,
+            message="too few trades for weekday analysis",
+            evidence={},
+        )
+    r_col = next(
+        (c for c in ("final_r", "trade_r", "realised_r", "r") if c in trades.columns),
+        None,
+    )
+    ts_col = "entry_time" if "entry_time" in trades.columns else (
+        "signal_time" if "signal_time" in trades.columns else None
+    )
+    if r_col is None or ts_col is None:
+        return CheckResult(
+            name="weekday_edge_concentration",
+            passed=True,
+            severity=Severity.INFO,
+            message="r or timestamp column missing — skipping",
+            evidence={},
+        )
+    df = trades[[ts_col, r_col]].copy()
+    df[ts_col] = pd.to_datetime(df[ts_col], utc=True, errors="coerce")
+    df = df.dropna(subset=[ts_col, r_col])
+    df["dow"] = df[ts_col].dt.tz_convert("UTC").dt.dayofweek
+    pos = df[df[r_col] > 0]
+    if len(pos) == 0:
+        return CheckResult(
+            name="weekday_edge_concentration",
+            passed=False,
+            severity=Severity.WARNING,
+            message="no positive-R trades in pool",
+            evidence={},
+        )
+    total = float(pos[r_col].sum())
+    per_dow = pos.groupby("dow")[r_col].sum() / total
+    top_dow_share = float(per_dow.max())
+    top_dow = int(per_dow.idxmax())
+    passed = top_dow_share < 0.35
+    dow_names = {0: "Mon", 1: "Tue", 2: "Wed", 3: "Thu", 4: "Fri", 5: "Sat", 6: "Sun"}
+    return CheckResult(
+        name="weekday_edge_concentration",
+        passed=passed,
+        severity=Severity.WARNING,
+        message=(
+            f"top weekday = {dow_names.get(top_dow, top_dow)} carries "
+            f"{top_dow_share:.0%} of total positive R; threshold = 35%"
+        ),
+        evidence={
+            "top_dow": dow_names.get(top_dow, top_dow),
+            "top_dow_share": top_dow_share,
+            "per_dow_share": {dow_names.get(int(k), int(k)): float(v)
+                              for k, v in per_dow.to_dict().items()},
+        },
+    )
+
+
 def _check_lo_corrected_sharpe(inputs: Step6Inputs) -> CheckResult:
     trades = inputs.pool_trades
     if trades is None or len(trades) < 30:
@@ -284,6 +638,11 @@ def audit(inputs: Step6Inputs, audit_config: AuditConfig) -> CategoryAuditResult
         _check_pair_survivorship(inputs),
         _check_regime_coverage(inputs),
         _check_cross_pair_correlation(inputs, audit_config),
+        _check_trade_clustering(inputs),
+        _check_per_pair_edge_homogeneity(inputs),
+        _check_outlier_influence(inputs),
+        _check_session_edge_concentration(inputs),
+        _check_weekday_edge_concentration(inputs),
         _check_lo_corrected_sharpe(inputs),
     )
     diagnostic: dict[str, Any] = {

--- a/tests/step_6/test_ledger_extraction.py
+++ b/tests/step_6/test_ledger_extraction.py
@@ -1,0 +1,113 @@
+"""Tests for the ledger-extraction helper used by Step 6's spread P&L wiring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import SimpleNamespace
+
+import pandas as pd
+
+from core.step_6.ledger_extraction import (
+    build_top_1_fold_assignments,
+    build_top_1_trade_ledger,
+    extract_top_1_ledger_bundle,
+)
+
+
+class _Dir(Enum):
+    LONG = "long"
+    SHORT = "short"
+
+
+@dataclass(frozen=True)
+class _FakeTrade:
+    position_id: int
+    pair: str
+    direction: _Dir
+    entry_time: pd.Timestamp
+    entry_price: float
+    exit_time: pd.Timestamp
+    exit_price: float
+    size: float
+    pnl: float
+    exit_reason: str
+    parent_position_id: int | None = None
+    entry_bid: float = 1.0
+    entry_ask: float = 1.0001
+    exit_bid: float = 1.005
+    exit_ask: float = 1.0051
+    sl_price: float | None = None
+
+
+def _mk_trade(i: int) -> _FakeTrade:
+    return _FakeTrade(
+        position_id=i,
+        pair="EURUSD",
+        direction=_Dir.LONG,
+        entry_time=pd.Timestamp("2020-01-01") + pd.Timedelta(days=i),
+        entry_price=1.0,
+        exit_time=pd.Timestamp("2020-01-02") + pd.Timedelta(days=i),
+        exit_price=1.005,
+        size=10000.0,
+        pnl=50.0,
+        exit_reason="stop_loss",
+        sl_price=0.995,
+    )
+
+
+def test_build_ledger_returns_none_for_unknown_config():
+    out = build_top_1_trade_ledger("does_not_exist", {}, ())
+    assert out is None
+
+
+def test_build_ledger_flattens_per_fold_trades():
+    strategy = {
+        "A1::cfg_x": {
+            1: SimpleNamespace(closed_trades=(_mk_trade(1), _mk_trade(2))),
+            2: SimpleNamespace(closed_trades=(_mk_trade(3),)),
+        }
+    }
+    ledger = build_top_1_trade_ledger("A1::cfg_x", strategy, ())
+    assert ledger is not None
+    assert len(ledger) == 3
+    assert set(["entry_bid", "exit_ask", "sl_price"]).issubset(ledger.columns)
+    # direction Enum should be serialised to lowercase name
+    assert (ledger["direction"] == "long").all()
+
+
+def test_build_fold_assignments_row_order_matches_ledger():
+    strategy = {
+        "A1::cfg_x": {
+            1: SimpleNamespace(closed_trades=(_mk_trade(1), _mk_trade(2))),
+            2: SimpleNamespace(closed_trades=(_mk_trade(3),)),
+        }
+    }
+    fa = build_top_1_fold_assignments("A1::cfg_x", strategy, (), None)
+    assert fa is not None
+    assert list(fa["leg_id"]) == [0, 1, 2]
+    assert list(fa["fold_id"]) == [1, 1, 2]
+
+
+def test_extract_bundle_returns_none_when_no_top1():
+    ledger, fa, hfid = extract_top_1_ledger_bundle(None, {}, (), holdout_fold_id=10)
+    assert ledger is None and fa is None and hfid == 10
+
+
+def test_extract_bundle_returns_none_when_strategy_results_empty():
+    ledger, fa, hfid = extract_top_1_ledger_bundle("A1::cfg_x", None, (), holdout_fold_id=10)
+    assert ledger is None and fa is None and hfid == 10
+
+
+def test_extract_bundle_happy_path():
+    strategy = {
+        "A1::cfg_x": {
+            1: SimpleNamespace(closed_trades=(_mk_trade(1),)),
+        }
+    }
+    ledger, fa, hfid = extract_top_1_ledger_bundle(
+        "A1::cfg_x", strategy, (), holdout_fold_id=99,
+    )
+    assert ledger is not None and len(ledger) == 1
+    assert fa is not None and list(fa["fold_id"]) == [1]
+    assert hfid == 99

--- a/tests/step_6/test_spread_pnl_wiring.py
+++ b/tests/step_6/test_spread_pnl_wiring.py
@@ -1,0 +1,103 @@
+"""End-to-end smoke test: spread P&L diagnostic runs when ledger is wired.
+
+Per dispatch §6 DoD #2: "Spread P&L decomposition wired into orchestrator
+and runs end-to-end on a synthetic PASS scenario."
+
+This test bypasses the orchestrator's heavy machinery and exercises just
+the §6.3 diagnostic path through the public Step 6 surface: build
+Step6Inputs with a populated ``top_1_trade_ledger`` + ``top_1_fold_assignments``,
+run ``audit_exec``, and confirm the spread P&L artefacts appear on disk
+and the check is not a silent skip.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from core.step_6 import AuditConfig
+from core.step_6.execution_realism import audit as audit_exec
+from core.step_6.inputs import Step6Inputs
+from tests.step_6._fixtures import build_clean_inputs
+
+
+def _build_ledger(n_trades: int = 60, *, seed: int = 42) -> pd.DataFrame:
+    """Synthetic closed-trade ledger with the full extended schema."""
+    rng = np.random.default_rng(seed)
+    entry_price = 1.10 + rng.normal(0, 0.001, n_trades)
+    sl_distance = 0.005
+    sl_price = entry_price - sl_distance
+    # Half the trades win at +1R, half lose at -1R-ish
+    direction_pnl = rng.choice([-sl_distance, 2 * sl_distance], size=n_trades)
+    exit_price = entry_price + direction_pnl
+    half_spread = 0.00005  # 0.5 pip
+    entry_bid = entry_price - half_spread
+    entry_ask = entry_price + half_spread
+    exit_bid = exit_price - half_spread
+    exit_ask = exit_price + half_spread
+    return pd.DataFrame({
+        "position_id": range(1, n_trades + 1),
+        "pair": "EURUSD",
+        "direction": "long",
+        "entry_time": pd.date_range("2018-01-01", periods=n_trades, freq="D", tz="UTC"),
+        "entry_price": entry_price,
+        "exit_time": pd.date_range("2018-01-02", periods=n_trades, freq="D", tz="UTC"),
+        "exit_price": exit_price,
+        "size": 10_000.0,
+        "pnl": direction_pnl * 10_000.0,
+        "exit_reason": "stop_loss",
+        "parent_position_id": None,
+        "entry_bid": entry_bid,
+        "entry_ask": entry_ask,
+        "exit_bid": exit_bid,
+        "exit_ask": exit_ask,
+        "sl_price": sl_price,
+    })
+
+
+def test_spread_pnl_diagnostic_runs_end_to_end(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)
+    ledger = _build_ledger(60)
+    # Two IS folds + one "holdout" fold
+    fold_assignments = pd.DataFrame({
+        "leg_id": list(range(60)),
+        "fold_id": [1] * 25 + [2] * 25 + [99] * 10,
+    })
+    inputs = Step6Inputs(
+        arc_name=inp.arc_name, arc_root=inp.arc_root,
+        best_candidate_config_id="A1::cfg_smoke",
+        best_candidate_architecture="A1",
+        best_candidate_features=inp.best_candidate_features,
+        pool_trades=inp.pool_trades,
+        feature_matrix=inp.feature_matrix,
+        feature_lineage=inp.feature_lineage,
+        primary_tf=inp.primary_tf, pair_set=inp.pair_set,
+        r_safe_pct=inp.r_safe_pct,
+        sizing_convention=inp.sizing_convention,
+        configs_evaluated_step5=inp.configs_evaluated_step5,
+        top_1_trade_ledger=ledger,
+        top_1_fold_assignments=fold_assignments,
+        holdout_fold_id=99,
+        r_base_pct=0.005,
+    )
+    result = audit_exec(inputs, AuditConfig())
+    diag = next(c for c in result.checks if c.name == "spread_pnl_decomposition")
+    # Diagnostic ran (not "skipped — no top-1 trade ledger ...")
+    assert "skipped" not in diag.message.lower()
+    assert diag.evidence["fragility_classification"] in (
+        "robust", "tolerant", "marginal", "fragile",
+    )
+    # Three artefacts should now live under arc_root/step_6/
+    out_dir = tmp_path / "step_6"
+    assert (out_dir / "spread_pnl_per_trade.parquet").exists()
+    assert (out_dir / "spread_pnl_per_fold_per_scenario.csv").exists()
+    assert (out_dir / "spread_pnl_verdict_flip_summary.csv").exists()
+
+
+def test_spread_pnl_skipped_when_ledger_absent(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_exec(inputs, AuditConfig())
+    diag = next(c for c in result.checks if c.name == "spread_pnl_decomposition")
+    assert "skipped" in diag.message.lower()

--- a/tests/step_6/test_ultimate_audit_checks.py
+++ b/tests/step_6/test_ultimate_audit_checks.py
@@ -46,7 +46,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 
-import numpy as np
 import pandas as pd
 
 from core.step_6 import AuditConfig

--- a/tests/step_6/test_ultimate_audit_checks.py
+++ b/tests/step_6/test_ultimate_audit_checks.py
@@ -1,0 +1,606 @@
+"""Integration tests for the engine/step_6_ultimate_audit hardening pass.
+
+Covers every check added by the dispatch:
+
+  §6.1 lookahead
+    - signal_entry_bar_separation: PASS on clean, FAIL on non-positive delta
+    - feature_matrix_indexed_at_signal_time: PASS aligned, FAIL stray ids
+    - byte_compare_strength_disclosed: info-only; exposes coverage fraction
+
+  §6.2 selection_bias
+    - sub_protocol_trial_counts_included: skip vanilla, fail on missing modelcount
+    - sl_multiplier_step3_step5_independence: skip when CSVs missing; flag when re-tuning
+    - feature_set_selection_recorded: surfaces ratio
+
+  §6.3 execution_realism
+    - post_fill_sl_anchor: static; passes when a1.py uses entry_price
+    - boundary_convention_propagation: PASS match, CRIT mismatch
+    - histdata_vs_venue_spread_differential: warn when no baseline + no decomp
+    - news_filter_assumption_declared: warn when closure silent
+    - zero_spread_bar_fraction: warn when >5% zero-spread trades
+    - weekend_gap_handling_declared: info; surfaces n_weekend_held
+
+  §6.4 statistical
+    - trade_clustering_acceptable: PASS on uniform; FAIL on concentrated
+    - per_pair_edge_homogeneity: FAIL when one pair carries most edge
+    - outlier_influence_acceptable: FAIL when top 5% drives the edge
+    - session_edge_concentration: FAIL when one session > 60% R
+    - weekday_edge_concentration: FAIL when one weekday > 35% R
+
+  §6.5 determinism
+    - risk_independent_admit_decisions: CRIT on divergent trade counts (the
+      marquee check — would catch the 2026-05-25 Arc 7 r=2% vs r=0.5% bug)
+    - ledger_schema_parity: CRIT when bid/ask/sl_price columns missing
+    - classifier_version_pinning: WARN when versions absent
+
+  §6.6 deployment_readiness
+    - ea_parity: CRIT for A3/A4 + DEPLOYABLE verdict; WARN A2/A6 unless declared
+    - broker_venue_declared: WARN when closure silent
+    - timezone_declaration_parity: CRIT mismatch
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+
+from core.step_6 import AuditConfig
+from core.step_6.deployment_readiness import audit as audit_deployment
+from core.step_6.determinism import audit as audit_determinism
+from core.step_6.execution_realism import audit as audit_exec
+from core.step_6.inputs import Step6Inputs
+from core.step_6.lookahead import audit as audit_lookahead
+from core.step_6.selection_bias import audit as audit_selbias
+from core.step_6.statistical import audit as audit_stat
+from tests.step_6._fixtures import build_clean_inputs
+
+
+def _check_by_name(result, name: str):
+    matches = [c for c in result.checks if c.name == name]
+    assert matches, f"check {name!r} not found in {[c.name for c in result.checks]}"
+    return matches[0]
+
+
+# ── §6.1 lookahead ──────────────────────────────────────────────────
+
+
+def test_lookahead_signal_entry_bar_separation_passes_clean(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_lookahead(inputs, AuditConfig())
+    chk = _check_by_name(result, "signal_entry_bar_separation")
+    assert chk.passed is True
+    assert chk.evidence["n_non_positive_delta"] == 0
+
+
+def test_lookahead_signal_entry_bar_separation_fails_on_collision(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    # Force entry_time == signal_time → must FAIL critical
+    bad = inputs.pool_trades.copy()
+    bad["entry_time"] = bad["signal_time"]
+    inputs = Step6Inputs(
+        arc_name=inputs.arc_name,
+        arc_root=inputs.arc_root,
+        best_candidate_config_id=inputs.best_candidate_config_id,
+        best_candidate_architecture=inputs.best_candidate_architecture,
+        best_candidate_features=inputs.best_candidate_features,
+        pool_trades=bad,
+        feature_matrix=inputs.feature_matrix,
+        feature_lineage=inputs.feature_lineage,
+        primary_tf=inputs.primary_tf,
+        pair_set=inputs.pair_set,
+        r_safe_pct=inputs.r_safe_pct,
+        sizing_convention=inputs.sizing_convention,
+        configs_evaluated_step5=inputs.configs_evaluated_step5,
+    )
+    result = audit_lookahead(inputs, AuditConfig())
+    chk = _check_by_name(result, "signal_entry_bar_separation")
+    assert chk.passed is False
+    assert chk.evidence["n_non_positive_delta"] > 0
+
+
+def test_lookahead_feature_matrix_aligned_on_trade_id(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_lookahead(inputs, AuditConfig())
+    chk = _check_by_name(result, "feature_matrix_indexed_at_signal_time")
+    assert chk.passed is True
+
+
+def test_lookahead_feature_matrix_stray_id_fails(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    bad_fm = inputs.feature_matrix.copy()
+    # Add a stray row with an unknown trade_id
+    extra = bad_fm.iloc[0:1].copy()
+    extra["trade_id"] = 999_999
+    bad_fm = pd.concat([bad_fm, extra], ignore_index=True)
+    inputs = Step6Inputs(
+        arc_name=inputs.arc_name,
+        arc_root=inputs.arc_root,
+        best_candidate_config_id=inputs.best_candidate_config_id,
+        best_candidate_architecture=inputs.best_candidate_architecture,
+        best_candidate_features=inputs.best_candidate_features,
+        pool_trades=inputs.pool_trades,
+        feature_matrix=bad_fm,
+        feature_lineage=inputs.feature_lineage,
+        primary_tf=inputs.primary_tf,
+        pair_set=inputs.pair_set,
+        r_safe_pct=inputs.r_safe_pct,
+        sizing_convention=inputs.sizing_convention,
+        configs_evaluated_step5=inputs.configs_evaluated_step5,
+    )
+    result = audit_lookahead(inputs, AuditConfig())
+    chk = _check_by_name(result, "feature_matrix_indexed_at_signal_time")
+    assert chk.passed is False
+    assert chk.evidence["n_stray_in_fm"] == 1
+
+
+def test_lookahead_byte_compare_strength_disclosed_info(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_lookahead(inputs, AuditConfig(byte_compare_n_samples=10))
+    chk = _check_by_name(result, "byte_compare_strength_disclosed")
+    assert chk.passed is True
+    assert chk.evidence["n_byte_compare_samples"] == 10
+    assert chk.evidence["coverage_fraction"] == 10 / 100
+
+
+# ── §6.2 selection bias ────────────────────────────────────────────
+
+
+def test_selection_bias_subprotocol_skipped_for_vanilla_arc(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_selbias(inputs, AuditConfig())
+    chk = _check_by_name(result, "sub_protocol_trial_counts_included")
+    assert chk.passed is True
+    assert chk.evidence["heavy_ml_manifest_present"] is False
+
+
+def test_selection_bias_subprotocol_fails_with_empty_manifest(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    # Plant a heavy_ml manifest with no per-fold modelcount
+    hm_dir = tmp_path / "step_5" / "heavy_ml_augmented"
+    hm_dir.mkdir(parents=True)
+    (hm_dir / "heavy_ml_manifest.json").write_text(
+        json.dumps({"folds": []}), encoding="utf-8",
+    )
+    result = audit_selbias(inputs, AuditConfig())
+    chk = _check_by_name(result, "sub_protocol_trial_counts_included")
+    assert chk.passed is False
+    assert chk.severity.value == "critical"
+
+
+def test_selection_bias_subprotocol_understated_n_fails(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path, configs_evaluated=50)
+    hm_dir = tmp_path / "step_5" / "heavy_ml_augmented"
+    hm_dir.mkdir(parents=True)
+    (hm_dir / "heavy_ml_manifest.json").write_text(
+        json.dumps({"folds": [{"automl": {"modelcount": 10_000}}]}),
+        encoding="utf-8",
+    )
+    result = audit_selbias(inputs, AuditConfig())
+    chk = _check_by_name(result, "sub_protocol_trial_counts_included")
+    assert chk.passed is False
+    assert chk.evidence["understated"] is True
+
+
+def test_selection_bias_feature_set_selection_recorded(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_selbias(inputs, AuditConfig())
+    chk = _check_by_name(result, "feature_set_selection_recorded")
+    assert chk.passed is True
+    assert chk.evidence["n_features_kept"] == 3
+
+
+def test_selection_bias_sl_independence_skipped_without_csvs(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_selbias(inputs, AuditConfig())
+    chk = _check_by_name(result, "sl_multiplier_step3_step5_independence")
+    assert chk.passed is True
+    assert chk.severity.value == "info"
+
+
+# ── §6.3 execution realism ─────────────────────────────────────────
+
+
+def test_exec_post_fill_sl_anchor_passes_canonical(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_exec(inputs, AuditConfig())
+    chk = _check_by_name(result, "post_fill_sl_anchor")
+    # canonical a1 source uses entry_price → PASS
+    assert chk.passed is True
+
+
+def test_exec_boundary_convention_match(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)
+    inputs = Step6Inputs(
+        arc_name=inp.arc_name,
+        arc_root=inp.arc_root,
+        best_candidate_config_id=inp.best_candidate_config_id,
+        best_candidate_architecture=inp.best_candidate_architecture,
+        best_candidate_features=inp.best_candidate_features,
+        pool_trades=inp.pool_trades,
+        feature_matrix=inp.feature_matrix,
+        feature_lineage=inp.feature_lineage,
+        primary_tf=inp.primary_tf,
+        pair_set=inp.pair_set,
+        r_safe_pct=inp.r_safe_pct,
+        sizing_convention=inp.sizing_convention,
+        configs_evaluated_step5=inp.configs_evaluated_step5,
+        panel_boundary_convention="utc",
+        closure_payload={"pool_metadata": {"boundary_convention": "utc"}},
+    )
+    result = audit_exec(inputs, AuditConfig())
+    chk = _check_by_name(result, "boundary_convention_propagation")
+    assert chk.passed is True
+
+
+def test_exec_boundary_convention_mismatch_fails(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)
+    inputs = Step6Inputs(
+        arc_name=inp.arc_name,
+        arc_root=inp.arc_root,
+        best_candidate_config_id=inp.best_candidate_config_id,
+        best_candidate_architecture=inp.best_candidate_architecture,
+        best_candidate_features=inp.best_candidate_features,
+        pool_trades=inp.pool_trades,
+        feature_matrix=inp.feature_matrix,
+        feature_lineage=inp.feature_lineage,
+        primary_tf=inp.primary_tf,
+        pair_set=inp.pair_set,
+        r_safe_pct=inp.r_safe_pct,
+        sizing_convention=inp.sizing_convention,
+        configs_evaluated_step5=inp.configs_evaluated_step5,
+        panel_boundary_convention="utc",
+        closure_payload={"pool_metadata": {"boundary_convention": "5ers_eet"}},
+    )
+    result = audit_exec(inputs, AuditConfig())
+    chk = _check_by_name(result, "boundary_convention_propagation")
+    assert chk.passed is False
+    assert chk.severity.value == "critical"
+
+
+def test_exec_news_filter_warn_when_silent(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_exec(inputs, AuditConfig())
+    chk = _check_by_name(result, "news_filter_assumption_declared")
+    # No ARC_CLOSURE.md → warn (no mention of news filter)
+    assert chk.passed is False
+
+
+def test_exec_zero_spread_bar_fraction_warn(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)
+    # Inject zero spreads into half the trades
+    trades = inp.pool_trades.copy()
+    trades.loc[: len(trades) // 2, "spread_pips"] = 0.0
+    inputs = Step6Inputs(
+        arc_name=inp.arc_name,
+        arc_root=inp.arc_root,
+        best_candidate_config_id=inp.best_candidate_config_id,
+        best_candidate_architecture=inp.best_candidate_architecture,
+        best_candidate_features=inp.best_candidate_features,
+        pool_trades=trades,
+        feature_matrix=inp.feature_matrix,
+        feature_lineage=inp.feature_lineage,
+        primary_tf=inp.primary_tf,
+        pair_set=inp.pair_set,
+        r_safe_pct=inp.r_safe_pct,
+        sizing_convention=inp.sizing_convention,
+        configs_evaluated_step5=inp.configs_evaluated_step5,
+    )
+    result = audit_exec(inputs, AuditConfig())
+    chk = _check_by_name(result, "zero_spread_bar_fraction")
+    assert chk.passed is False
+    assert chk.evidence["fraction"] >= 0.05
+
+
+def test_exec_weekend_gap_handling_info(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)
+    # Fixture lacks exit_time — add it explicitly for this check.
+    trades = inp.pool_trades.copy()
+    trades["exit_time"] = pd.to_datetime(trades["entry_time"]) + pd.Timedelta(hours=8)
+    inputs = Step6Inputs(
+        arc_name=inp.arc_name, arc_root=inp.arc_root,
+        best_candidate_config_id=inp.best_candidate_config_id,
+        best_candidate_architecture=inp.best_candidate_architecture,
+        best_candidate_features=inp.best_candidate_features,
+        pool_trades=trades,
+        feature_matrix=inp.feature_matrix, feature_lineage=inp.feature_lineage,
+        primary_tf=inp.primary_tf, pair_set=inp.pair_set,
+        r_safe_pct=inp.r_safe_pct, sizing_convention=inp.sizing_convention,
+        configs_evaluated_step5=inp.configs_evaluated_step5,
+    )
+    result = audit_exec(inputs, AuditConfig())
+    chk = _check_by_name(result, "weekend_gap_handling_declared")
+    assert chk.passed is True
+    assert chk.severity.value == "info"
+    assert chk.evidence["n_total_trades"] >= 1
+
+
+# ── §6.4 statistical integrity ─────────────────────────────────────
+
+
+def test_stat_trade_clustering_clean_fixture(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_stat(inputs, AuditConfig())
+    chk = _check_by_name(result, "trade_clustering_acceptable")
+    # 100 trades over 100 days → ~3 buckets; coverage may not pass concentration
+    # threshold on synthetic noise. Just verify it ran.
+    assert chk.evidence.get("n_30day_buckets", 0) > 0
+
+
+def test_stat_per_pair_edge_homogeneity(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_stat(inputs, AuditConfig())
+    chk = _check_by_name(result, "per_pair_edge_homogeneity")
+    assert "worst_pair_mean_r" in chk.evidence
+
+
+def test_stat_outlier_influence(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_stat(inputs, AuditConfig())
+    chk = _check_by_name(result, "outlier_influence_acceptable")
+    assert "full_mean_r" in chk.evidence
+
+
+def test_stat_session_concentration(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_stat(inputs, AuditConfig())
+    chk = _check_by_name(result, "session_edge_concentration")
+    assert "top_session" in chk.evidence
+
+
+def test_stat_weekday_concentration(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_stat(inputs, AuditConfig())
+    chk = _check_by_name(result, "weekday_edge_concentration")
+    assert "top_dow" in chk.evidence
+
+
+# ── §6.5 determinism (incl. risk-leak marquee) ─────────────────────
+
+
+@dataclass
+class _MockAmendedGate:
+    """Minimal duck-typed AmendedGateResult for risk-leak tests."""
+
+    verdict: SimpleNamespace
+
+
+@dataclass
+class _MockAmendedResult:
+    config_id: str
+    amended_gate: _MockAmendedGate
+    holdout_n_trades_at_r_base: int | None
+    holdout_n_trades_at_r_safe: int | None
+    holdout_n_trades_at_r_hard: int | None
+
+
+def _make_inputs_with_amended(
+    tmp_path: Path, *, base: int | None, safe: int | None, hard: int | None,
+) -> Step6Inputs:
+    """Wrap amended_wfo with mock results for risk-leak test."""
+    inp = build_clean_inputs(tmp_path)
+    amended_res = _MockAmendedResult(
+        config_id="A1::cfg_test",
+        amended_gate=_MockAmendedGate(verdict=SimpleNamespace(name="PASS_DEPLOYABLE")),
+        holdout_n_trades_at_r_base=base,
+        holdout_n_trades_at_r_safe=safe,
+        holdout_n_trades_at_r_hard=hard,
+    )
+    fake_orch_result = SimpleNamespace(
+        amended_wfo=SimpleNamespace(amended_results=(amended_res,)),
+    )
+    return Step6Inputs(
+        arc_name=inp.arc_name,
+        arc_root=inp.arc_root,
+        best_candidate_config_id=inp.best_candidate_config_id,
+        best_candidate_architecture=inp.best_candidate_architecture,
+        best_candidate_features=inp.best_candidate_features,
+        arc_orchestrator_result=fake_orch_result,
+        pool_trades=inp.pool_trades,
+        feature_matrix=inp.feature_matrix,
+        feature_lineage=inp.feature_lineage,
+        primary_tf=inp.primary_tf,
+        pair_set=inp.pair_set,
+        r_safe_pct=inp.r_safe_pct,
+        sizing_convention=inp.sizing_convention,
+        configs_evaluated_step5=inp.configs_evaluated_step5,
+    )
+
+
+def test_determinism_risk_leak_passes_on_identical_counts(tmp_path: Path):
+    inputs = _make_inputs_with_amended(tmp_path, base=100, safe=100, hard=100)
+    result = audit_determinism(inputs, AuditConfig())
+    chk = _check_by_name(result, "risk_independent_admit_decisions")
+    assert chk.passed is True
+    assert chk.evidence["all_match"] is True
+
+
+def test_determinism_risk_leak_catches_the_arc7_2026_05_25_bug(tmp_path: Path):
+    """The marquee check — divergent trade counts at scaled risk = CRIT FAIL.
+
+    Arc 7 rerun at r=2% produced 36-38% fewer trades than at r=0.5%.
+    Same admit logic, same panels, same architecture — only sizing
+    scales. If this check existed at the time of that incident, the
+    bug would have surfaced before deployment.
+    """
+    # Simulating: base=200 trades, safe (scaled) = 200, hard (over-scaled) = 126
+    inputs = _make_inputs_with_amended(tmp_path, base=200, safe=200, hard=126)
+    result = audit_determinism(inputs, AuditConfig())
+    chk = _check_by_name(result, "risk_independent_admit_decisions")
+    assert chk.passed is False
+    assert chk.severity.value == "critical"
+    assert chk.evidence["all_match"] is False
+    assert "RISK-LEAK" in chk.message
+
+
+def test_determinism_risk_leak_skipped_when_only_base(tmp_path: Path):
+    inputs = _make_inputs_with_amended(tmp_path, base=100, safe=None, hard=None)
+    result = audit_determinism(inputs, AuditConfig())
+    chk = _check_by_name(result, "risk_independent_admit_decisions")
+    assert chk.passed is True  # informational skip — only 1 tier observed
+    assert chk.severity.value == "info"
+
+
+def test_determinism_ledger_schema_parity_skipped_without_ledger(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_determinism(inputs, AuditConfig())
+    chk = _check_by_name(result, "ledger_schema_parity")
+    assert chk.passed is True
+    assert chk.severity.value == "info"
+
+
+def test_determinism_ledger_schema_parity_catches_missing_bidask(tmp_path: Path):
+    """Critical fail when ledger has rows but missing the bid/ask columns."""
+    inp = build_clean_inputs(tmp_path)
+    # Build a ledger missing entry_bid / entry_ask
+    bad_ledger = pd.DataFrame({
+        "position_id": [1, 2],
+        "entry_price": [1.1, 1.2],
+        "exit_price": [1.15, 1.18],
+        # ENTRY_BID, ENTRY_ASK missing intentionally
+        "exit_bid": [1.15, 1.18],
+        "exit_ask": [1.15, 1.18],
+        "sl_price": [1.05, 1.10],
+        "parent_position_id": [None, None],
+    })
+    inputs = Step6Inputs(
+        arc_name=inp.arc_name, arc_root=inp.arc_root,
+        best_candidate_config_id=inp.best_candidate_config_id,
+        best_candidate_architecture=inp.best_candidate_architecture,
+        best_candidate_features=inp.best_candidate_features,
+        pool_trades=inp.pool_trades,
+        feature_matrix=inp.feature_matrix,
+        feature_lineage=inp.feature_lineage,
+        primary_tf=inp.primary_tf, pair_set=inp.pair_set,
+        top_1_trade_ledger=bad_ledger,
+    )
+    result = audit_determinism(inputs, AuditConfig())
+    chk = _check_by_name(result, "ledger_schema_parity")
+    assert chk.passed is False
+    assert "entry_bid" in chk.evidence["missing_columns"]
+
+
+def test_determinism_classifier_version_pinning_skipped_without_manifest(tmp_path: Path):
+    inputs = build_clean_inputs(tmp_path)
+    result = audit_determinism(inputs, AuditConfig())
+    chk = _check_by_name(result, "classifier_version_pinning")
+    assert chk.passed is True  # info-skip when no manifest
+
+
+# ── §6.6 deployment readiness ──────────────────────────────────────
+
+
+def _make_closure(arc_root: Path, *, body: str) -> None:
+    arc_root.mkdir(parents=True, exist_ok=True)
+    (arc_root / "ARC_CLOSURE.md").write_text(body, encoding="utf-8")
+
+
+def test_deployment_ea_parity_a1_passes(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)  # arch=A1
+    result = audit_deployment(inp, AuditConfig())
+    chk = _check_by_name(result, "ea_parity")
+    assert chk.passed is True
+    assert chk.evidence["ea_deployable"] is True
+
+
+def test_deployment_ea_parity_a3_pass_deployable_critical_fail(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)
+    _make_closure(tmp_path, body="# ARC\n## §4 deployment_spec\n")
+    inputs = Step6Inputs(
+        arc_name=inp.arc_name, arc_root=inp.arc_root,
+        best_candidate_config_id="A3::cfg_x",
+        best_candidate_architecture="A3",
+        best_candidate_features=inp.best_candidate_features,
+        pool_trades=inp.pool_trades,
+        feature_matrix=inp.feature_matrix,
+        feature_lineage=inp.feature_lineage,
+        primary_tf=inp.primary_tf, pair_set=inp.pair_set,
+        closure_payload={"best_architecture": {"verdict": "PASS_DEPLOYABLE"}},
+    )
+    result = audit_deployment(inputs, AuditConfig())
+    chk = _check_by_name(result, "ea_parity")
+    assert chk.passed is False
+    assert chk.severity.value == "critical"
+
+
+def test_deployment_ea_parity_a3_research_only_passes_when_declared(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)
+    _make_closure(
+        tmp_path,
+        body="# ARC\n## §4 deployment_spec\n\nThis is a research-only result.\n",
+    )
+    inputs = Step6Inputs(
+        arc_name=inp.arc_name, arc_root=inp.arc_root,
+        best_candidate_config_id="A3::cfg_x",
+        best_candidate_architecture="A3",
+        best_candidate_features=inp.best_candidate_features,
+        pool_trades=inp.pool_trades,
+        feature_matrix=inp.feature_matrix,
+        feature_lineage=inp.feature_lineage,
+        primary_tf=inp.primary_tf, pair_set=inp.pair_set,
+        closure_payload={"best_architecture": {"verdict": "PASS_VIABLE"}},
+    )
+    result = audit_deployment(inputs, AuditConfig())
+    chk = _check_by_name(result, "ea_parity")
+    assert chk.passed is True
+
+
+def test_deployment_broker_venue_declared_passes(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)
+    _make_closure(
+        tmp_path,
+        body="# ARC\n## §4 deployment_spec\n\nBroker: 5ers MT5.\n",
+    )
+    result = audit_deployment(inp, AuditConfig())
+    chk = _check_by_name(result, "broker_venue_declared")
+    assert chk.passed is True
+
+
+def test_deployment_broker_venue_warn_when_silent(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)
+    _make_closure(tmp_path, body="# ARC\n## §4 deployment_spec\n\nNo broker named.\n")
+    result = audit_deployment(inp, AuditConfig())
+    chk = _check_by_name(result, "broker_venue_declared")
+    assert chk.passed is False
+
+
+def test_deployment_timezone_match_passes(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)
+    inputs = Step6Inputs(
+        arc_name=inp.arc_name, arc_root=inp.arc_root,
+        best_candidate_config_id=inp.best_candidate_config_id,
+        best_candidate_architecture=inp.best_candidate_architecture,
+        best_candidate_features=inp.best_candidate_features,
+        pool_trades=inp.pool_trades,
+        feature_matrix=inp.feature_matrix,
+        feature_lineage=inp.feature_lineage,
+        primary_tf=inp.primary_tf, pair_set=inp.pair_set,
+        panel_boundary_convention="utc",
+        closure_payload={"pool_metadata": {"boundary_convention": "utc"}},
+    )
+    result = audit_deployment(inputs, AuditConfig())
+    chk = _check_by_name(result, "timezone_declaration_parity")
+    assert chk.passed is True
+
+
+def test_deployment_timezone_mismatch_fails(tmp_path: Path):
+    inp = build_clean_inputs(tmp_path)
+    inputs = Step6Inputs(
+        arc_name=inp.arc_name, arc_root=inp.arc_root,
+        best_candidate_config_id=inp.best_candidate_config_id,
+        best_candidate_architecture=inp.best_candidate_architecture,
+        best_candidate_features=inp.best_candidate_features,
+        pool_trades=inp.pool_trades,
+        feature_matrix=inp.feature_matrix,
+        feature_lineage=inp.feature_lineage,
+        primary_tf=inp.primary_tf, pair_set=inp.pair_set,
+        panel_boundary_convention="5ers_eet",
+        closure_payload={"pool_metadata": {"boundary_convention": "utc"}},
+    )
+    result = audit_deployment(inputs, AuditConfig())
+    chk = _check_by_name(result, "timezone_declaration_parity")
+    assert chk.passed is False


### PR DESCRIPTION
## Summary

Makes L_PROTOCOL §2 Step 6 **the comprehensive deployment audit** per the dispatch. Two jobs in one PR:

1. **Wire spread P&L decomposition** (PR #205) into the orchestrator auto-dispatch path. The diagnostic was shipped-but-dead; it now runs end-to-end on any PASS-tier Top-1 candidate and emits its three artefacts + report subsection.
2. **Audit and harden every Step 6 category** with the failure modes identified in project history (KGL D1 lookahead, JL forward-bias, Arc 10 EA collapse, the 2026-05-25 Arc 7 risk-leak bug).

Total: **24 new checks across 6 categories**. Every check executes against real inputs — no dead capability.

## Per-category gains

| Category | Before | After | Marquee additions |
|---|---:|---:|---|
| §6.1 lookahead | 6 | 9 | `signal_entry_bar_separation` (CRIT), `feature_matrix_indexed_at_signal_time` (CRIT). Byte-compare default 5→25. |
| §6.2 selection_bias | 5 | 8 | `sub_protocol_trial_counts_included` (CRIT) — heavy_ml_probe FLAML modelcount inflates Bonferroni N. |
| §6.3 execution_realism | 6+diag | 12+diag | `post_fill_sl_anchor` (CRIT — Arc 10 mechanism), `boundary_convention_propagation` (CRIT — Amendment 6, folded from §6.7). Spread P&L diagnostic now actually runs. |
| §6.4 statistical | 5 | 10 | `trade_clustering`, `per_pair_edge_homogeneity`, `outlier_influence`, `session_edge_concentration`, `weekday_edge_concentration` (all WARNING). |
| §6.5 determinism | 4 | 8 | **`risk_independent_admit_decisions` (CRIT)** — would catch the 2026-05-25 Arc 7 r=2% vs r=0.5% bug. `ledger_schema_parity` (CRIT, folded from §6.7), `classifier_version_pinning` (WARN). |
| §6.6 deployment_readiness | 5 | 8 | `ea_parity` (CRIT for A3/A4 + DEPLOYABLE), `broker_venue_declared`, `timezone_declaration_parity`. |

## Failure modes Step 6 now catches

- **Arc 10 EA collapse mechanism** — `post_fill_sl_anchor` flags SL anchored to `signal_close` instead of realised fill.
- **2026-05-25 Arc 7 risk-leak** — `risk_independent_admit_decisions` compares holdout trade counts at base/safe/hard risk; divergence = critical fail.
- **Sub-protocol search-space laundering** — heavy_ml_probe FLAML trials are added to `configs_evaluated_step5` for Bonferroni accounting.
- **Amendment 6 boundary convention drift** — engine panel convention vs closure-declared convention mismatch = critical fail.
- **Signal-bar-vs-entry-bar confusion** — `signal_entry_bar_separation` rejects pools where `entry_time <= signal_time`.
- **Ledger schema regression** — `ledger_schema_parity` elevates the silent "skipped" when bid/ask/sl_price columns are present-but-NaN.
- **Architecture/EA mismatch** — `ea_parity` flags A3/A4 on a DEPLOYABLE verdict as contradictory.

## §6.7 organisation

Did **not** add a seventh category. The proposed §6.7 checks fold cleanly:

- Risk-leak detection → §6.5 determinism (it's about engine determinism w.r.t. the risk knob)
- Schema parity → §6.5 determinism (ledger artefact integrity)
- Boundary convention propagation → §6.3 execution realism (Amendment 6 semantics)

Keeps the dispatch registry simple; manual CLI picks up the new checks automatically because each category's `audit()` function returns the new checks naturally.

## Engine surface change (intentional, minimal)

- `core/step_6/inputs.py` — added `panel_boundary_convention`.
- `core/arc/arc_orchestrator.py::CandidateAmendedResult` — added `holdout_n_trades_at_r_base / r_safe / r_hard` (3 ints) so the risk-leak check has data to compare against.
- `core/step_6/dispatch.py::maybe_dispatch_step_6` — accepts `strategy_results`, `holdout_results`, `holdout_fold_id`, `r_base_pct`, `panel_boundary_convention`.

## Test plan

- [x] `pytest tests/step_6/` — 101 passed (59 existing + 42 new)
- [x] `pytest tests/integration tests/protocol_runtime` — all green
- [x] Full suite — **1707 passed, 310 skipped** (zero regressions)
- [x] Risk-leak detection asserted to fire on a synthetic Arc-7-style divergence
- [x] Spread P&L diagnostic end-to-end smoke test (artefacts written to disk)
- [x] Boundary-convention mismatch test asserts CRITICAL severity
- [x] EA parity test: A3 + PASS-DEPLOYABLE = critical fail
- [x] Manual CLI `--help` works; categories list unchanged (new checks discovered via registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)