### PR TITLE
Per-position H4 bar-rollover dispatch (single-chart-multi-pair)

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -188,8 +188,12 @@ The watchdog fires every 30s; restarts the NSSM service if
 1. Open MetaEditor (F4 inside MT5).
 2. Copy `deployment/ea/Arc10_DLR_Sidecar_EA.mq5` and the `deployment/ea/include/` directory into `MQL5/Experts/Arc10_Sidecar/` (preserving structure).
 3. Compile. Resolve any include-path errors by editing the `#include "include/*.mqh"` directives if you placed the includes elsewhere.
-4. Attach to one chart per traded pair (28 charts, one per pair, all H4). The EA polls `signals_out/` regardless of attached symbol but lot-size + intra-tick TP1 checks reference the chart's symbol — attach to each pair you trade.
-5. In each chart's EA input dialog, set:
+4. **Attach to exactly ONE chart — single-chart-multi-pair topology.**
+   - Attach the EA to a **single H4 chart**. Recommended symbol: **EURUSD** — the most actively-ticking pair on 5ers, so `OnTick` fires frequently and position management stays responsive across all pairs.
+   - **Subscribe all 28 traded pairs in Market Watch** (right-click Market Watch → "Show All", or add each pair). The EA reads every position's pair via `SymbolInfoDouble(pair, …)` and `iTime(pair, PERIOD_H4, 0)` for intra-tick TP1, lot sizing, and per-position bar-rollover handling (trail ratchet / time exit / peak update). An **unsubscribed** pair returns zero/stale prices and a zero `iTime`, so its position would be **silently skipped** by the rollover dispatch — every traded pair MUST be in Market Watch.
+   - **Do NOT attach one chart per pair.** Each attached instance polls the shared `signals_out/` inbox independently and would place **duplicate entries** for the same signal (the per-pair concurrency cap is per-EA-instance, not cross-instance). The prior "28 charts, one per pair" instruction was incorrect and is removed.
+   - The EA polls `signals_out/` and manages every position regardless of the chart's own symbol; bar-rollover updates are driven per-position off each position's own pair (not the chart symbol), so non-chart pairs are managed correctly.
+5. In the EA input dialog, set:
    - `Risk_Per_Trade` = `0.0043` (default; UTC r_safe)
    - `Sidecar_Inbox_Dir` = `Arc10\signals_out` (default — resolves to
      `<APPDATA>\MetaQuotes\Terminal\Common\Files\Arc10\signals_out\`

--- a/deployment/ea/Arc10_DLR_Sidecar_EA.mq5
+++ b/deployment/ea/Arc10_DLR_Sidecar_EA.mq5
@@ -57,7 +57,6 @@ input int     Signal_Poll_Min_Interval_Sec = 5;
 // ─── Globals ──────────────────────────────────────────────────────
 CTrade           g_trade;
 datetime         g_last_poll = 0;
-datetime         g_last_bar_time = 0;
 
 // Pending news-delayed signals (held until delay_until_utc passes).
 struct ArcDeferredSignal
@@ -387,13 +386,33 @@ void ArcManagePositions()
      }
   }
 
-void ArcOnNewH4Bar()
+// ─── Per-position H4-bar-rollover dispatch ───────────────────────
+// Single-chart-multi-pair safe. Each in-use position tracks its own
+// pair's last-processed H4 bar; bar-rollover handling (peak ratchet,
+// trail-hit + SL ratchet, time exit, trail_modify logging) fires when
+// THAT pair's iTime(pair, H4, 0) advances — not when the chart symbol's
+// bar rolls over. The chart-gated predecessor (ArcIsNewH4Bar) starved
+// non-chart pairs of these updates under single-chart deployment.
+//
+// iTime(pair, H4, 0) returns 0 for a pair not subscribed in Market
+// Watch; we skip those slots so an unsubscribed pair never spuriously
+// "advances" against last_processed_h4_bar==0 (deployment requires all
+// traded pairs subscribed — see deployment/README.md §5).
+void ArcOnNewH4BarPerPosition()
   {
+   bool any_advanced = false;
    for(int slot = 0; slot < ARC10_MAX_POSITIONS; slot++)
      {
       if(!g_arc_positions[slot].in_use)
          continue;
-      bool should_close = ArcExitOnNewBar(slot, Time_Exit_Bars, g_trade);
+      datetime cur_bar = iTime(g_arc_positions[slot].pair, PERIOD_H4, 0);
+      if(cur_bar == 0)
+         continue;  // pair not subscribed / data not yet available
+      if(cur_bar == g_arc_positions[slot].last_processed_h4_bar)
+         continue;
+      g_arc_positions[slot].last_processed_h4_bar = cur_bar;
+      any_advanced = true;
+      ArcExitOnNewBar(slot, Time_Exit_Bars, g_trade);
       if(g_arc_positions[slot].trail_sl_current > 0
          && g_arc_positions[slot].peak_high_bid > 0)
         {
@@ -417,18 +436,8 @@ void ArcOnNewH4Bar()
                           0, 0, AccountInfoDouble(ACCOUNT_EQUITY), "");
         }
      }
-   ArcPositionsSave(Ea_Positions_Path);
-  }
-
-bool ArcIsNewH4Bar()
-  {
-   datetime cur = iTime(_Symbol, PERIOD_H4, 0);
-   if(cur != g_last_bar_time)
-     {
-      g_last_bar_time = cur;
-      return true;
-     }
-   return false;
+   if(any_advanced)
+      ArcPositionsSave(Ea_Positions_Path);
   }
 
 // ─── MT5 callbacks ────────────────────────────────────────────────
@@ -449,7 +458,6 @@ int OnInit()
    ArcNewsEnsureInit();
    ArcRecoveryRun(Magic_Number, SL_ATR_Multiplier_Expected, Trade_Log_Path);
    ArcPositionsSave(Ea_Positions_Path);
-   g_last_bar_time = iTime(_Symbol, PERIOD_H4, 0);
    return INIT_SUCCEEDED;
   }
 
@@ -488,8 +496,7 @@ void OnTick()
      }
 
    ArcManagePositions();
-   if(ArcIsNewH4Bar())
-      ArcOnNewH4Bar();
+   ArcOnNewH4BarPerPosition();
    ArcEaHeartbeatWrite(Ea_Heartbeat_Path);
    // Clear single-tick equity-force-closed flag at end of OnTick so it
    // only labels closes detected THIS tick (set in

--- a/deployment/ea/include/PositionManager.mqh
+++ b/deployment/ea/include/PositionManager.mqh
@@ -62,6 +62,7 @@ struct ArcPosition
    bool              tp1_fired;
    int               tp1_bar_ordinal;        // -1 until fired
    int               bar_ordinal;            // increments on every new H4 bar
+   datetime          last_processed_h4_bar;  // this pair's last H4 bar processed by the rollover dispatch (single-chart-multi-pair)
    double            partial_close_price;    // -1 until fired
    datetime          partial_close_time;
    bool              partial_close_logged;   // true once partial_close row written
@@ -93,6 +94,7 @@ void ArcPositionReset(int i)
    g_arc_positions[i].tp1_fired = false;
    g_arc_positions[i].tp1_bar_ordinal = -1;
    g_arc_positions[i].bar_ordinal = 0;
+   g_arc_positions[i].last_processed_h4_bar = 0;
    g_arc_positions[i].partial_close_price = 0.0;
    g_arc_positions[i].partial_close_time = 0;
    g_arc_positions[i].partial_close_logged = false;
@@ -228,6 +230,10 @@ ulong ArcPlaceEntry(
    g_arc_positions[slot].r_atr = sig.sl_distance_price;
    g_arc_positions[slot].initial_lots = lots;
    g_arc_positions[slot].current_lots = lots;
+   // Anchor the rollover dispatch to this pair's current H4 bar so the
+   // first per-position bar-rollover handling fires at the NEXT H4 close
+   // on this pair (not the chart symbol's).
+   g_arc_positions[slot].last_processed_h4_bar = iTime(symbol, PERIOD_H4, 0);
    slot_out = slot;
    g_arc_pos_count++;
    return t;

--- a/deployment/ea/include/RecoveryManager.mqh
+++ b/deployment/ea/include/RecoveryManager.mqh
@@ -81,6 +81,10 @@ void ArcReconstructPosition(int slot, ulong ticket, double sl_atr_multiplier,
      }
    g_arc_positions[slot].peak_high_bid = peak;
    g_arc_positions[slot].bar_ordinal = n_bars;
+   // Anchor rollover dispatch to this pair's current H4 bar — the held
+   // bars up to now are already folded into peak/bar_ordinal above, so
+   // the next handled rollover is this pair's next H4 close.
+   g_arc_positions[slot].last_processed_h4_bar = iTime(symbol, PERIOD_H4, 0);
 
    // Check for partial-close in deal history.
    HistorySelect(entry_time - 60, now + 60);


### PR DESCRIPTION
## Summary

Fixes the per-position bar-rollover bug for single-chart-multi-pair live deployment of the Arc 10 DLR Sidecar EA.

`ArcIsNewH4Bar()` gated bar-rollover handling on `iTime(_Symbol, PERIOD_H4, 0)` — the **chart** symbol's bar. Under single-chart-multi-pair deployment, positions on non-chart pairs got stale/skipped bar-rollover updates (trail ratchet, time exit, peak-high update, `trail_modify` logging), because those only fired when the chart symbol's H4 bar rolled over.

### Changes
- **`PositionManager.mqh`** — new `datetime last_processed_h4_bar` field on `ArcPosition`; reset to 0 in `ArcPositionReset`; anchored to `iTime(pair, H4, 0)` in `ArcPlaceEntry`.
- **`RecoveryManager.mqh`** — anchor `last_processed_h4_bar` to `iTime(pair, H4, 0)` in `ArcReconstructPosition` (recovery path).
- **`Arc10_DLR_Sidecar_EA.mq5`** — new `ArcOnNewH4BarPerPosition()` iterates slots, advancing each position when its own pair's `iTime(pair, H4, 0)` changes; unsubscribed pairs (`iTime==0`) are skipped. `OnTick` now calls it unconditionally in place of `if(ArcIsNewH4Bar()) ArcOnNewH4Bar();`. Deleted now-unused `ArcIsNewH4Bar` and `g_last_bar_time` (global + OnInit init).
- **`deployment/README.md`** — single-chart (EURUSD) topology with all 28 pairs subscribed in Market Watch; removed the incorrect "28 charts, one per pair" instruction (would cause duplicate entries).

### Parity / safety
- `last_processed_h4_bar` anchored at entry reproduces the prior `g_last_bar_time` first-rollover timing, so single-pair behavior is unchanged.
- The only behavioral change beyond per-pair dispatch is `ArcPositionsSave` now runs only when a position advances — that touches `ea_positions.json`, not `trade_log.csv`.

## Test plan

- [x] `py -m pytest tests/ea/test_fake_sidecar.py` — 16 passed (envelope path intact)
- [ ] **Reviewer:** re-run s1 ST scenario (EURUSD chart + EURUSD position) and confirm `trade_log.csv` matches pre-fix: entry → partial_close → trail_modify chain → exit `trail_stop @ 1.15925`, net **+\$327.77**. (MT5 Strategy Tester is GUI-driven; not runnable in CI.)
- [ ] Compile in MetaEditor and confirm no warnings for the removed symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)