### PR TITLE
Arc 10 Sidecar EA: topology fix — single-chart-multi-pair (per-position bar gate)

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -188,8 +188,9 @@ The watchdog fires every 30s; restarts the NSSM service if
 1. Open MetaEditor (F4 inside MT5).
 2. Copy `deployment/ea/Arc10_DLR_Sidecar_EA.mq5` and the `deployment/ea/include/` directory into `MQL5/Experts/Arc10_Sidecar/` (preserving structure).
 3. Compile. Resolve any include-path errors by editing the `#include "include/*.mqh"` directives if you placed the includes elsewhere.
-4. Attach to one chart per traded pair (28 charts, one per pair, all H4). The EA polls `signals_out/` regardless of attached symbol but lot-size + intra-tick TP1 checks reference the chart's symbol — attach to each pair you trade.
-5. In each chart's EA input dialog, set:
+4. **Subscribe all 28 traded pairs in Market Watch** (right-click Market Watch → "Show All" or add each pair manually). The EA needs SymbolInfo access + iTime/iHigh/iClose data for every pair it trades. `ArcPlaceEntry` calls `SymbolSelect(pair, true)` defensively, but pre-subscribing avoids first-entry latency. The 28 pairs are listed in `configs/l_arc_10_v3.0.2_utc_rerun/winning_config.yaml`.
+5. **Attach the EA to a SINGLE chart** — recommended EURUSD H4 (highest tick frequency = most responsive intra-tick TP1 polling for all positions). The EA is symbol-agnostic: it processes envelopes for any pair the sidecar emits, places trades on `envelope.pair` via broker routing, and tracks per-position H4 bar rollover independently per pair (single-chart-multi-pair topology, matching KH-24 ops model). The chart symbol is irrelevant to position management beyond OnTick wake-up frequency.
+6. In the EA input dialog, set:
    - `Risk_Per_Trade` = `0.0043` (default; UTC r_safe)
    - `Sidecar_Inbox_Dir` = `Arc10\signals_out` (default — resolves to
      `<APPDATA>\MetaQuotes\Terminal\Common\Files\Arc10\signals_out\`
@@ -197,6 +198,8 @@ The watchdog fires every 30s; restarts the NSSM service if
    - `Expected_Config_Hash` = the sha256 from step 2
    - `Magic_Number` = `1010202601` (or chosen value not already in use)
    - `Enable_News_Filter` = `true` (only if you've whitelisted the FF URL)
+
+> **Topology note:** the EA previously documented "28 charts, one per pair" deployment. That was incorrect — the code is pair-agnostic and 28 parallel instances would each try to enter every signal, producing duplicate orders. Single-chart-EURUSD is the canonical topology.
 
 ### 6. Verify
 

--- a/deployment/ea/Arc10_DLR_Sidecar_EA.mq5
+++ b/deployment/ea/Arc10_DLR_Sidecar_EA.mq5
@@ -57,7 +57,10 @@ input int     Signal_Poll_Min_Interval_Sec = 5;
 // ─── Globals ──────────────────────────────────────────────────────
 CTrade           g_trade;
 datetime         g_last_poll = 0;
-datetime         g_last_bar_time = 0;
+// Note: the chart-symbol-bound g_last_bar_time global was removed in the
+// single-chart-multi-pair topology fix. Per-position bar tracking via
+// ArcPosition.last_processed_h4_bar replaces it; see
+// ArcOnNewH4BarPerPosition below.
 
 // Pending news-delayed signals (held until delay_until_utc passes).
 struct ArcDeferredSignal
@@ -387,12 +390,38 @@ void ArcManagePositions()
      }
   }
 
-void ArcOnNewH4Bar()
+// ─── Per-position H4-bar-rollover handler (topology fix) ──────────
+// Single-chart-multi-pair safe: each in-use position self-gates on its
+// OWN pair's H4 bar advancement (via per-position last_processed_h4_bar)
+// rather than on the chart symbol's bar (the old ArcIsNewH4Bar approach).
+//
+// Called every OnTick. For each position, checks whether iTime(slot.pair,
+// PERIOD_H4, 0) has advanced past the stored last_processed_h4_bar. If
+// yes, runs the new-bar logic for THAT pair specifically (ArcExitOnNewBar
+// reads iHigh/iClose at shift=1 = the just-closed bar, safely available
+// once the per-pair shift=0 has rolled).
+//
+// Skips pairs that haven't ticked yet for the new bar (iTime returns 0
+// or the prior bar's open time — gate condition prevents stale-data
+// processing). Also skips pairs not yet in Market Watch (iTime returns
+// 0; SymbolSelect call in ArcPlaceEntry / ArcReconstructPosition ensures
+// subscription, but this is defensive).
+void ArcOnNewH4BarPerPosition()
   {
+   bool any_processed = false;
    for(int slot = 0; slot < ARC10_MAX_POSITIONS; slot++)
      {
       if(!g_arc_positions[slot].in_use)
          continue;
+      datetime cur_bar = iTime(g_arc_positions[slot].pair, PERIOD_H4, 0);
+      if(cur_bar == 0)
+         continue;  // pair not yet ticking; iTime not yet authoritative
+      if(cur_bar == g_arc_positions[slot].last_processed_h4_bar)
+         continue;  // this pair's H4 hasn't rolled since last processing
+      g_arc_positions[slot].last_processed_h4_bar = cur_bar;
+      // Run the new-bar logic for THIS pair. ArcExitOnNewBar internally
+      // reads iHigh/iClose at shift=1 = the just-closed bar for this
+      // pair, now safely available since shift=0 has advanced.
       bool should_close = ArcExitOnNewBar(slot, Time_Exit_Bars, g_trade);
       if(g_arc_positions[slot].trail_sl_current > 0
          && g_arc_positions[slot].peak_high_bid > 0)
@@ -416,19 +445,10 @@ void ArcOnNewH4Bar()
                           0, "",
                           0, 0, AccountInfoDouble(ACCOUNT_EQUITY), "");
         }
+      any_processed = true;
      }
-   ArcPositionsSave(Ea_Positions_Path);
-  }
-
-bool ArcIsNewH4Bar()
-  {
-   datetime cur = iTime(_Symbol, PERIOD_H4, 0);
-   if(cur != g_last_bar_time)
-     {
-      g_last_bar_time = cur;
-      return true;
-     }
-   return false;
+   if(any_processed)
+      ArcPositionsSave(Ea_Positions_Path);
   }
 
 // ─── MT5 callbacks ────────────────────────────────────────────────
@@ -449,7 +469,9 @@ int OnInit()
    ArcNewsEnsureInit();
    ArcRecoveryRun(Magic_Number, SL_ATR_Multiplier_Expected, Trade_Log_Path);
    ArcPositionsSave(Ea_Positions_Path);
-   g_last_bar_time = iTime(_Symbol, PERIOD_H4, 0);
+   // No chart-symbol bar init needed — per-position bar tracking via
+   // ArcPosition.last_processed_h4_bar (set in ArcPlaceEntry +
+   // ArcReconstructPosition) replaces the prior chart-symbol gate.
    return INIT_SUCCEEDED;
   }
 
@@ -488,8 +510,12 @@ void OnTick()
      }
 
    ArcManagePositions();
-   if(ArcIsNewH4Bar())
-      ArcOnNewH4Bar();
+   // Per-position bar-rollover handler — self-gates by checking each
+   // pair's own iTime(PERIOD_H4, 0) against the slot's
+   // last_processed_h4_bar. Replaces the prior chart-symbol-gated
+   // ArcIsNewH4Bar + ArcOnNewH4Bar pair for single-chart-multi-pair
+   // deployment compatibility.
+   ArcOnNewH4BarPerPosition();
    ArcEaHeartbeatWrite(Ea_Heartbeat_Path);
    // Clear single-tick equity-force-closed flag at end of OnTick so it
    // only labels closes detected THIS tick (set in

--- a/deployment/ea/include/PositionManager.mqh
+++ b/deployment/ea/include/PositionManager.mqh
@@ -65,6 +65,7 @@ struct ArcPosition
    double            partial_close_price;    // -1 until fired
    datetime          partial_close_time;
    bool              partial_close_logged;   // true once partial_close row written
+   datetime          last_processed_h4_bar;  // per-position bar-rollover gate (single-chart-multi-pair topology fix)
    bool              pending_close;
    ENUM_ARC_EXIT_REASON pending_close_reason;
   };
@@ -96,6 +97,7 @@ void ArcPositionReset(int i)
    g_arc_positions[i].partial_close_price = 0.0;
    g_arc_positions[i].partial_close_time = 0;
    g_arc_positions[i].partial_close_logged = false;
+   g_arc_positions[i].last_processed_h4_bar = 0;
    g_arc_positions[i].pending_close = false;
    g_arc_positions[i].pending_close_reason = ARC_EXIT_NONE;
   }
@@ -178,6 +180,16 @@ ulong ArcPlaceEntry(
    err_out = "";
    slot_out = -1;
    string symbol = sig.pair;
+   // Auto-subscribe the symbol to Market Watch defensively. Required for
+   // single-chart-multi-pair deployment — the EA is attached to a chart
+   // for one symbol (e.g. EURUSD) but trades any envelope.pair the
+   // sidecar emits. Without Market Watch subscription, SymbolInfoDouble
+   // and iTime/iHigh/iClose return 0/stale data for non-chart pairs.
+   if(!SymbolSelect(symbol, true))
+     {
+      err_out = StringFormat("symbol_select_failed:%s", symbol);
+      return 0;
+     }
    double lots = ArcComputeLots(symbol, risk_pct, sig.sl_distance_price);
    if(lots <= 0.0)
      {
@@ -226,6 +238,11 @@ ulong ArcPlaceEntry(
    // 1×ATR rather than 1R, causing TP1 / trail to fire 3.5× too tight
    // and Phase 2 parity would have diverged systematically.
    g_arc_positions[slot].r_atr = sig.sl_distance_price;
+   // Per-position bar-rollover gate — anchored at entry-bar open so the
+   // first new-bar event for this pair correctly triggers ArcExitOnNewBar.
+   // Required for the single-chart-multi-pair topology fix (replaces the
+   // chart-symbol-bound ArcIsNewH4Bar global gate).
+   g_arc_positions[slot].last_processed_h4_bar = iTime(symbol, PERIOD_H4, 0);
    g_arc_positions[slot].initial_lots = lots;
    g_arc_positions[slot].current_lots = lots;
    slot_out = slot;

--- a/deployment/ea/include/RecoveryManager.mqh
+++ b/deployment/ea/include/RecoveryManager.mqh
@@ -81,6 +81,12 @@ void ArcReconstructPosition(int slot, ulong ticket, double sl_atr_multiplier,
      }
    g_arc_positions[slot].peak_high_bid = peak;
    g_arc_positions[slot].bar_ordinal = n_bars;
+   // Per-position bar-rollover gate (topology fix). Anchored at the
+   // CURRENT bar so the first NEW bar after recovery triggers
+   // ArcOnNewH4BarPerPosition's per-pair logic. Auto-subscribe symbol
+   // defensively in case the EA was reattached without Market Watch.
+   SymbolSelect(symbol, true);
+   g_arc_positions[slot].last_processed_h4_bar = iTime(symbol, PERIOD_H4, 0);
 
    // Check for partial-close in deal history.
    HistorySelect(entry_time - 60, now + 60);


### PR DESCRIPTION
Follow-up to PR #223 (merged). Closes the topology pre-deploy gate flagged in [PR #223 comment §(a)](https://github.com/kpanapabusiness-droid/Forex-Backtester/pull/223#issuecomment-4569281495).

## Problem

Prior EA used `ArcIsNewH4Bar()` which read `iTime(_Symbol, PERIOD_H4, 0)` — chart-symbol-bound. Under single-chart-multi-pair deployment (1 chart, 28 pairs — matching KH-24 ops model), per-pair bar-close logic for non-chart pairs fires at the wrong time (using stale `shift=1` bar data) or gets missed entirely if the chart symbol doesn't tick at the UTC anchor.

For majors-watching-majors (EURUSD chart, GBPUSD/USDJPY positions) the tick-gap is sub-second and the bug is rarely visible. For exotic pairs the gap can be seconds-to-minutes — real correctness issue for 28-pair coverage.

The README also incorrectly documented "28 charts, one per pair" deployment — that would produce duplicate orders since the code is pair-agnostic (28 EA instances would each try to enter every signal).

## Fix

Replaces the chart-symbol-bound bar gate with **per-position bar tracking**:

1. **`PositionManager.mqh`**:
   - Added `datetime last_processed_h4_bar` to `ArcPosition` struct
   - Initialized in `ArcPositionReset` (0) and `ArcPlaceEntry` (`iTime(sig.pair, PERIOD_H4, 0)` at entry)
   - `ArcPlaceEntry` calls `SymbolSelect(symbol, true)` defensively to auto-subscribe pairs to Market Watch

2. **`RecoveryManager.mqh`**:
   - `ArcReconstructPosition` sets `last_processed_h4_bar` from `iTime(symbol, ...)` at recovery
   - Also calls `SymbolSelect` defensively

3. **`Arc10_DLR_Sidecar_EA.mq5`**:
   - Removed `ArcIsNewH4Bar()` function
   - Removed `g_last_bar_time` global + OnInit init
   - Replaced `ArcOnNewH4Bar()` with `ArcOnNewH4BarPerPosition()` — iterates slots, self-gates per position via `iTime(slot.pair, PERIOD_H4, 0) != slot.last_processed_h4_bar`, processes new-bar logic only when each pair's H4 has actually rolled
   - OnTick calls `ArcOnNewH4BarPerPosition()` unconditionally (function self-gates per position) instead of the prior `if(ArcIsNewH4Bar()) ArcOnNewH4Bar()` chart gate

4. **`deployment/README.md`** §5:
   - Replaced "Attach to one chart per traded pair (28 charts)" with single-chart-EURUSD + Market Watch subscription requirement
   - Added explicit topology note explaining the prior instruction was incorrect

## Behavioral equivalence — single-pair ST scenarios unchanged

For single-pair ST scenarios (chart_symbol == position_symbol):
- `iTime(chart_sym)` == `iTime(slot.pair)` → per-position gate fires at exactly the same instant the chart gate used to fire
- Same shift=1 data accessed; same trail/peak logic; same outputs
- Identical trade_log expected vs prior implementation

For multi-pair single-chart LIVE deployment (post-merge):
- Each pair's bar-close logic fires when THAT pair's H4 bar rolls
- No stale-shift=1 reads; no missed bar events
- `SymbolSelect` ensures Market Watch subscription for any sidecar-emitted pair (operator no longer needs to pre-subscribe, though pre-subscribing avoids first-entry latency)

## Policy-level unchanged

This is structurally a refactor of the bar-rollover gate. Decision logic, exit policy mechanics, position management, recovery, equity guards, news filter, signal poller — all unchanged. Only the gate that DRIVES the per-bar handler is fixed.

## Verification

- `tests/sidecar/` + `tests/ea/` — 64 passed, 1 expected skip
- Zero remaining `_Symbol` / `ArcIsNewH4Bar` / `g_last_bar_time` references in executable code (only in comments documenting the refactor)
- All new symbols present in compiled-target files:
  - `ArcOnNewH4BarPerPosition` (definition + OnTick call)
  - `last_processed_h4_bar` (struct decl + reset + ArcPlaceEntry init + ArcReconstruct init + 2× per-position use)
  - `SymbolSelect` (2× — entry and recovery)

## Pre-deploy gate status (per PR #223 comment §(a))

| Gate | Status |
|---|---|
| EA compile + ST scaffold | PASS (PR #223 merged) |
| ST scenario validation (6/12 PASS, 6 deferred) | PASS (PR #223 merged) |
| Single-chart-multi-pair topology fix | **PASS ← this PR** |
| Phase 2 parity validation (Dispatch C v2) | NOT STARTED |

Merging this closes the topology gate. Only Phase 2 parity remains before live deploy.

## Suggested operator post-merge step

Recompile EA in MetaEditor (F7). Re-run s1 once to confirm structural equivalence (identical trade_log expected — proves the refactor didn't regress). Then deploy to live by attaching to single EURUSD H4 chart with all 28 pairs in Market Watch.

KH-24 unaffected.