### PR TITLE
[Sidecar] Add --quick-test flag to bypass H4 boundary wait

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -244,6 +244,7 @@ All 🔴 NOT STARTED — defer to Phase 2 trigger.
 - **5ers_eet cache build for 28 pairs × 7 TFs:** One-time workstation operation per PROTOCOL_RUNTIME.md §15.3.
 - **Cross-asset data (DXY / US10Y / SPX as features):** on hold per user. Revisit if Phase 1 doesn't produce deployable.
 - **KH-24 live VPS health:** confirmed running normally on 5ers MT5 broker feed. Independent of local data state. Untouched by Phase-1-engine-build sprint (legacy engine path preserved).
+- **KMeans cluster-label assumption in `core/steps/classifier_persistence.py`:** 🔴 OPEN (low priority). The A2 orchestrator path assumes Step-2 cluster IDs start at 0, but KMeans can return labels `[1,2,3,4]` in different environments → `test_a2_end_to_end.py` cross-environment CI flake (`ValueError: cluster_id 0 not present in Step4Result`). Fix: cluster-label → candidate lookup must iterate over the actual returned labels, not assume a 0-based range. Affects strategy research only (L_PROTOCOL Step 2 clustering); does NOT affect deployment, sidecar, EA, or live trading. Fix post-FundedNext deploy.
 - **OpenWebUI / OpenClaw:** evaluated and skipped — no immediate value.
 - **Obsidian:** skipped — user doesn't search docs themselves.
 - **`STATUS.md` and `CHANGELOG.md` and `SESSION_ZERO.md`:** untouched by reset and untouched by CC_22 per chat decision. Pre-v3.0 legacy; separate cleanup decision not in scope.

--- a/deployment/sidecar/__main__.py
+++ b/deployment/sidecar/__main__.py
@@ -41,6 +41,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Run N cycles then exit (default: run forever)",
     )
     p.add_argument(
+        "--quick-test",
+        action="store_true",
+        help=(
+            "Diagnostic: bypass the wait-for-next-H4-close sleep, run one "
+            "cycle immediately against the most-recently-closed H4 bar, then "
+            "exit. Implies --iterations 1. Anchor probe + heartbeat still run; "
+            "real production output path (no special filenames)."
+        ),
+    )
+    p.add_argument(
         "--log-level",
         default="INFO",
         choices=("DEBUG", "INFO", "WARNING", "ERROR"),
@@ -60,7 +70,10 @@ def main(argv: list[str] | None = None) -> int:
         sidecar_yaml_path=args.sidecar_config,
         sidecar_root=args.sidecar_root,
     )
-    initialize_and_run(cfg, iterations=args.iterations)
+    # --quick-test runs exactly one cycle; honour an explicit --iterations only
+    # to stay consistent, but a single immediate run is always implied.
+    iterations = 1 if args.quick_test else args.iterations
+    initialize_and_run(cfg, iterations=iterations, quick_test=args.quick_test)
     return 0
 
 

--- a/deployment/sidecar/boundary.py
+++ b/deployment/sidecar/boundary.py
@@ -117,6 +117,26 @@ def next_h4_close(now_utc: datetime, convention: str) -> datetime:
     raise RuntimeError("next_h4_close: no anchor found (unreachable)")
 
 
+def prev_h4_close(now_utc: datetime, convention: str) -> datetime:
+    """Return the most recent H4 boundary <= ``now_utc`` (UTC-aware).
+
+    The close instant of the most-recently-closed H4 bar — the downward
+    mirror of :func:`next_h4_close`. Used by ``--quick-test`` to log which
+    bar the immediate cycle targets; the cycle itself fetches the latest
+    bars from MT5, so this is advisory.
+    """
+    _validate_convention(convention)
+    now_utc = _ensure_aware_utc(now_utc)
+    local = now_utc.astimezone(_tz_for(convention))
+    # Today's then yesterday's anchors guarantee a hit (>= 6 anchors/day).
+    for day_offset in (0, -1):
+        local_date = (local + timedelta(days=day_offset)).date()
+        for inst in reversed(_anchor_instants_utc(local_date, convention)):
+            if inst <= now_utc:
+                return inst
+    raise RuntimeError("prev_h4_close: no anchor found (unreachable)")
+
+
 def _next_anchor_after(sig_utc: datetime, convention: str) -> datetime:
     """The first H4 anchor open-instant strictly after ``sig_utc`` (UTC),
     ignoring the weekend gap (pure grid successor)."""
@@ -221,5 +241,6 @@ __all__ = (
     "expected_utc_offset_hours",
     "is_h4_anchor",
     "next_h4_close",
+    "prev_h4_close",
     "project_entry_bar_open",
 )

--- a/deployment/sidecar/sidecar.py
+++ b/deployment/sidecar/sidecar.py
@@ -38,6 +38,7 @@ from deployment.sidecar.boundary import (
     expected_utc_offset_hours,
     is_h4_anchor,
     next_h4_close,
+    prev_h4_close,
 )
 from deployment.sidecar.config import (
     SidecarConfig,
@@ -271,13 +272,17 @@ def main_loop(
     mt5_module: Mt5Module,
     *,
     iterations: int | None = None,
+    quick_test: bool = False,
     sleep_func=time.sleep,
     now_func=lambda: datetime.now(timezone.utc),
 ) -> None:
     """Run the sidecar main loop.
 
     ``iterations=None`` means run forever; integer values cap the loop
-    count (for tests).
+    count (for tests). ``quick_test=True`` bypasses the wait-for-next-H4
+    sleep entirely and runs exactly one cycle immediately against the
+    most-recently-closed H4 bar, then returns — for diagnostic iteration
+    without waiting up to 4h for the next live boundary.
     """
     state = load_state(cfg.state_path)
     state.restart_count += 1
@@ -288,6 +293,16 @@ def main_loop(
         state.restart_count,
         len(cfg.pairs),
     )
+
+    if quick_test:
+        last_close = prev_h4_close(now_func(), cfg.boundary_convention)
+        logger.info(
+            "quick-test mode: bypassing H4 boundary wait; running against "
+            "last closed bar at %s",
+            last_close.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+        _loop_iteration(cfg, mt5_module, state)
+        return
 
     count = 0
     while iterations is None or count < iterations:
@@ -309,8 +324,15 @@ def initialize_and_run(
     cfg: SidecarConfig,
     *,
     iterations: int | None = None,
+    quick_test: bool = False,
 ) -> None:
-    """Production entry: import MT5, initialize with backoff, verify anchors, run loop."""
+    """Production entry: import MT5, initialize with backoff, verify anchors, run loop.
+
+    ``quick_test=True`` skips the wait-for-next-H4 sleep in the loop. The
+    anchor probe (broker-grid correctness) and broker-offset sanity check
+    still run — they are convention correctness gates, independent of bar
+    freshness — so quick-test exercises the real production path.
+    """
     from deployment.sidecar.mt5_data_fetcher import import_mt5  # local import
 
     mt5 = import_mt5()
@@ -325,7 +347,7 @@ def initialize_and_run(
         verify_mt5_h4_alignment(
             mt5, probe_symbol=probe_symbol, convention=cfg.boundary_convention
         )
-        main_loop(cfg, mt5, iterations=iterations)
+        main_loop(cfg, mt5, iterations=iterations, quick_test=quick_test)
     finally:
         mt5.shutdown()
 

--- a/tests/sidecar/test_boundary.py
+++ b/tests/sidecar/test_boundary.py
@@ -26,12 +26,29 @@ from deployment.sidecar.boundary import (
     expected_utc_offset_hours,
     is_h4_anchor,
     next_h4_close,
+    prev_h4_close,
     project_entry_bar_open,
 )
 
 
 def _utc(y, m, d, h, mi=0, s=0):
     return datetime(y, m, d, h, mi, s, tzinfo=timezone.utc)
+
+
+def test_prev_h4_close_utc_grid():
+    # Between anchors → the most recent one at or before now.
+    assert prev_h4_close(_utc(2026, 5, 27, 12, 0, 1), CONVENTION_UTC) == _utc(2026, 5, 27, 12)
+    # Exactly on an anchor → that anchor (<= is inclusive).
+    assert prev_h4_close(_utc(2026, 5, 27, 12, 0, 0), CONVENTION_UTC) == _utc(2026, 5, 27, 12)
+    # Just past midnight rolls back to the prior day's 20:00 anchor.
+    assert prev_h4_close(_utc(2026, 5, 27, 0, 30), CONVENTION_UTC) == _utc(2026, 5, 27, 0)
+    assert prev_h4_close(_utc(2026, 5, 27, 3, 59), CONVENTION_UTC) == _utc(2026, 5, 27, 0)
+
+
+def test_prev_h4_close_eet_summer():
+    # EEST (UTC+3): local anchors 00/04/.../20 → UTC 21/01/05/09/13/17.
+    # now = 15:17 UTC summer → local 18:17 → most recent anchor local 16:00 = 13:00 UTC.
+    assert prev_h4_close(_utc(2026, 5, 27, 15, 17), CONVENTION_EET) == _utc(2026, 5, 27, 13)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/sidecar/test_quick_test_mode.py
+++ b/tests/sidecar/test_quick_test_mode.py
@@ -1,0 +1,196 @@
+"""Tests for the ``--quick-test`` diagnostic flag.
+
+Quick-test bypasses the wait-for-next-H4-close sleep and runs exactly one
+cycle immediately against the most-recently-closed H4 bar, so the staleness
+investigation can iterate without waiting up to 4h for the next live
+boundary. It must still exercise the real production path: anchor probe,
+heartbeat, identical output filenames.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import deployment.sidecar.mt5_data_fetcher as mt5_data_fetcher
+import deployment.sidecar.sidecar as sidecar_mod
+from deployment.sidecar.__main__ import main as cli_main
+from deployment.sidecar.config import load_sidecar_config
+from deployment.sidecar.sidecar import initialize_and_run, main_loop
+from deployment.sidecar.state_manager import load_state
+
+
+def test_quick_test_runs_one_iteration_without_sleeping(
+    fake_mt5, winning_config_path, sidecar_root
+):
+    cfg = load_sidecar_config(winning_config_path, None, sidecar_root)
+    sleeps: list[float] = []
+    main_loop(
+        cfg,
+        fake_mt5,
+        quick_test=True,
+        sleep_func=sleeps.append,
+        now_func=lambda: datetime(2026, 5, 27, 15, 17, tzinfo=timezone.utc),
+    )
+    # The defining property: no wait-for-next-H4 sleep at all.
+    assert sleeps == []
+    # One cycle actually ran: heartbeat + state were written.
+    hb = json.loads(cfg.heartbeat_path.read_text(encoding="utf-8"))
+    assert hb["last_loop_complete_utc"]
+    state = load_state(cfg.state_path)
+    for pair in cfg.pairs:
+        assert pair in state.last_processed_bar_utc
+
+
+def test_quick_test_exits_after_one_iteration(
+    fake_mt5, winning_config_path, sidecar_root, monkeypatch
+):
+    cfg = load_sidecar_config(winning_config_path, None, sidecar_root)
+    calls: list[int] = []
+
+    real_iter = sidecar_mod._loop_iteration
+
+    def _counting_iter(*args, **kwargs):
+        calls.append(1)
+        return real_iter(*args, **kwargs)
+
+    monkeypatch.setattr(sidecar_mod, "_loop_iteration", _counting_iter)
+    main_loop(
+        cfg,
+        fake_mt5,
+        quick_test=True,
+        sleep_func=lambda _s: None,
+        now_func=lambda: datetime(2026, 5, 27, 15, 17, tzinfo=timezone.utc),
+    )
+    assert sum(calls) == 1
+
+
+def test_quick_test_runs_anchor_probe_and_heartbeat(
+    fake_mt5, winning_config_path, sidecar_root, monkeypatch
+):
+    """Through the real entry point: anchor probe still fires, heartbeat
+    still written. (conftest's fake panel is UTC-anchored so the probe
+    passes.)"""
+    cfg = load_sidecar_config(winning_config_path, None, sidecar_root)
+
+    # Inject the fake MT5 instead of importing the Windows-only library.
+    monkeypatch.setattr(mt5_data_fetcher, "import_mt5", lambda: fake_mt5)
+
+    probe_calls: list[str] = []
+    real_probe = sidecar_mod.verify_mt5_h4_alignment
+
+    def _spy_probe(*args, **kwargs):
+        probe_calls.append(kwargs.get("convention", "utc"))
+        return real_probe(*args, **kwargs)
+
+    monkeypatch.setattr(sidecar_mod, "verify_mt5_h4_alignment", _spy_probe)
+
+    initialize_and_run(cfg, quick_test=True)
+
+    # Anchor probe ran (broker-grid correctness gate is never skipped).
+    assert len(probe_calls) == 1
+    # Heartbeat written by the single cycle.
+    hb = json.loads(cfg.heartbeat_path.read_text(encoding="utf-8"))
+    assert hb["last_loop_complete_utc"]
+    # MT5 was cleanly shut down.
+    assert fake_mt5.shutdown_calls == 1
+
+
+def test_quick_test_cli_implies_single_iteration(
+    fake_mt5, winning_config_path, sidecar_root, monkeypatch
+):
+    """``--quick-test`` with no ``--iterations`` must still run exactly one
+    cycle. Verified at the CLI wiring: iterations=1 + quick_test=True reach
+    initialize_and_run."""
+    captured: dict[str, object] = {}
+
+    def _fake_run(cfg, *, iterations=None, quick_test=False):
+        captured["iterations"] = iterations
+        captured["quick_test"] = quick_test
+
+    monkeypatch.setattr("deployment.sidecar.__main__.initialize_and_run", _fake_run)
+
+    rc = cli_main(
+        [
+            "--winning-config",
+            str(winning_config_path),
+            "--sidecar-root",
+            str(sidecar_root),
+            "--quick-test",
+        ]
+    )
+    assert rc == 0
+    assert captured["quick_test"] is True
+    assert captured["iterations"] == 1
+
+
+def test_quick_test_works_under_eet_convention(
+    fake_mt5, tmp_path, sidecar_root, monkeypatch
+):
+    """Both boundary conventions must work with --quick-test. EET path: the
+    prev-close log helper and loop run without error."""
+    content = (winning_eet_config := tmp_path / "winning_config.yaml")
+    content.write_text(
+        """
+arc_name: l_arc_10_v3.0.2_eet
+verdict: PASS-DEPLOYABLE
+boundary_convention: 5ers_eet
+
+signal:
+  name: dlr_d1_swing_low_rejection_long
+  module: signals.lchar_dlr_long
+  version: v0.1
+
+direction: long
+
+architecture:
+  name: A1
+  variant: system_level_filter
+
+stop_loss:
+  type: atr_multiple
+  atr_period: 14
+  multiplier: 3.5
+  anchor: mid
+  reference: entry_price
+
+exit_policy:
+  name: sl_partial_close_1r_runner_trail
+  partial_close_at: 1.0
+  partial_close_fraction: 0.5
+  runner_trail_atr_below_peak: 1.0
+  update_frequency: bar_close
+
+time_exit:
+  max_bars: 240
+
+timeframes:
+  primary: H4
+  anchor: D1
+
+pairs:
+  - EURUSD
+  - GBPUSD
+
+risk:
+  r_safe_pct: 0.004336
+
+fills:
+  entry_long: open_ask
+  spread_source: histdata_m1_bid_ask
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    cfg = load_sidecar_config(winning_eet_config, None, sidecar_root)
+    sleeps: list[float] = []
+    main_loop(
+        cfg,
+        fake_mt5,
+        quick_test=True,
+        sleep_func=sleeps.append,
+        now_func=lambda: datetime(2026, 5, 27, 15, 17, tzinfo=timezone.utc),
+    )
+    assert sleeps == []
+    hb = json.loads(cfg.heartbeat_path.read_text(encoding="utf-8"))
+    assert hb["last_loop_complete_utc"]


### PR DESCRIPTION
## Summary
- Adds a `--quick-test` CLI flag to the Arc 10 sidecar that **bypasses the wait-for-next-H4-close sleep**, runs exactly one cycle immediately against the most-recently-closed H4 bar, then exits (implies `--iterations 1`).
- Unblocks the `sidecar_state.json` staleness investigation, which otherwise has to wait up to 4h for the next live UTC H4 boundary to iterate.
- Adds `prev_h4_close()` to `deployment/sidecar/boundary.py` for the advisory startup log line.

## Behaviour
- **Production path unchanged**: without `--quick-test`, the loop sleeps until the next H4 close + buffer exactly as before.
- **Gates still run**: the MT5 anchor probe (`verify_mt5_h4_alignment`) and broker-offset sanity check still fire — these are broker/convention correctness gates, independent of bar freshness. Nothing in the sidecar rejects on bar age, so quick-test exercises the real verification path.
- **No new config mode**: pure CLI flag; no `sidecar.yaml` / `winning_config.yaml` changes.
- **Output unchanged**: identical filenames, paths, and JSON format (no quick-test prefix) — we test the real production path.
- **Both conventions**: works under `utc` and `5ers_eet`.
- Startup log: `quick-test mode: bypassing H4 boundary wait; running against last closed bar at <utc>`.

## Test plan
- [x] `tests/sidecar/test_quick_test_mode.py` — runs one iteration with no sleep; exits after one iteration; still runs anchor probe + writes heartbeat (via `initialize_and_run`); CLI implies single iteration without `--iterations`; works under EET convention.
- [x] `tests/sidecar/test_boundary.py` — `prev_h4_close` unit tests (UTC grid + EEST summer).
- [x] Full sidecar suite green (84 passed, 1 skipped); ruff clean.
- [x] **Live MT5 smoke** (EET broker): full 28-pair cycle, heartbeat + state written, clean single-shot exit; `prev_h4_close` correctly logged the most-recently-closed bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)