### PR TITLE
[Sidecar] Remove broker server-clock offset check (PR #227 regression)

### DIFF
--- a/deployment/sidecar/sidecar.py
+++ b/deployment/sidecar/sidecar.py
@@ -35,7 +35,6 @@ from datetime import datetime, timedelta, timezone
 
 from deployment.sidecar.boundary import (
     CONVENTION_UTC,
-    expected_utc_offset_hours,
     is_h4_anchor,
     next_h4_close,
     prev_h4_close,
@@ -83,7 +82,6 @@ def verify_mt5_h4_alignment(
     probe_symbol: str = "EURUSD",
     probe_count: int = 24,
     convention: str = CONVENTION_UTC,
-    now_func=lambda: datetime.now(timezone.utc),
 ) -> None:
     """Assert that MT5 returns bars on the expected H4 grid for ``convention``.
 
@@ -94,11 +92,14 @@ def verify_mt5_h4_alignment(
     Raises :class:`Mt5FetchError` on mismatch — the sidecar must NOT proceed if
     the broker is emitting bars off the grid the WFO lab validated.
 
-    Additionally (EET only) cross-checks the broker server's UTC offset against
-    the IANA-expected EET/EEST offset for "now" via ``symbol_info_tick``: a
-    server that fails to apply EU DST would still emit on-grid bars but with a
-    wrong absolute offset, which the anchor check alone cannot catch. The offset
-    check is best-effort — skipped if the module exposes no ``symbol_info_tick``.
+    This bar-anchor probe is the authoritative startup gate. The broker's
+    server *wall-clock* offset is a separate, operationally irrelevant axis:
+    a broker may run an EET server clock while publishing UTC-anchored bars
+    (5ers) or EET-anchored bars (FundedNext). What matters is that the data
+    fetcher converts the broker's bar timestamps to the correct UTC grid for
+    the configured convention — which this probe verifies directly. A broker
+    that mishandles DST in its *bars* is caught here; DST handling in its
+    *clock* alone does not affect us, so the server clock is not checked.
 
     Per dispatch §1.4 + intent §11.6.
     """
@@ -120,53 +121,6 @@ def verify_mt5_h4_alignment(
         raise Mt5FetchError(
             f"H4 anchor probe failed — broker is emitting bars off the {convention!r} "
             f"grid. Examples: {bad[:5]}. Sidecar refuses to start under this convention."
-        )
-
-    _verify_broker_offset(
-        mt5_module,
-        probe_symbol=probe_symbol,
-        convention=convention,
-        now_func=now_func,
-    )
-
-
-def _verify_broker_offset(
-    mt5_module: Mt5Module,
-    *,
-    probe_symbol: str,
-    convention: str,
-    now_func,
-) -> None:
-    """Cross-check the broker server's UTC offset against the calendar expectation.
-
-    Best-effort: returns silently if the module exposes no ``symbol_info_tick``.
-    MT5's ``symbol_info_tick(symbol).time`` is the last-tick instant in the
-    broker server wall clock encoded as a UTC-epoch; the gap between it and the
-    real "now" is the broker's UTC offset. We tolerate ±1h of clock skew /
-    tick-staleness around the IANA-expected offset.
-    """
-    if convention == CONVENTION_UTC:
-        expected = 0.0
-    else:
-        now = now_func()
-        expected = expected_utc_offset_hours(convention, now)
-
-    tick_fn = getattr(mt5_module, "symbol_info_tick", None)
-    if tick_fn is None:
-        return  # offset sanity check unavailable on this module
-    tick = tick_fn(probe_symbol)
-    tick_epoch = getattr(tick, "time", None)
-    if tick_epoch is None:
-        return
-    now = now_func()
-    broker_wall = datetime.fromtimestamp(int(tick_epoch), tz=timezone.utc)
-    observed_offset = (broker_wall - now).total_seconds() / 3600.0
-    if abs(observed_offset - expected) > 1.0:
-        raise Mt5FetchError(
-            f"Broker UTC-offset sanity check failed for {convention!r}: observed "
-            f"~{observed_offset:+.1f}h, expected ~{expected:+.1f}h. A server that "
-            "fails to apply EU DST emits on-grid bars at the wrong absolute time. "
-            "Sidecar refuses to start."
         )
 
 

--- a/tests/sidecar/test_sidecar_loop.py
+++ b/tests/sidecar/test_sidecar_loop.py
@@ -93,33 +93,13 @@ def test_verify_mt5_h4_alignment_eet_rejects_drifted_bars(fake_mt5):
         )
 
 
-def test_verify_broker_offset_eet_winter_pass(fake_mt5):
-    """EET winter: a server correctly applying +2 passes the offset sanity check."""
-    now = datetime(2024, 1, 15, 12, 0, tzinfo=timezone.utc)
+def test_verify_mt5_h4_alignment_utc_accepts_eet_server_clock(fake_mt5):
+    """Regression (PR #227 bug): 5ers runs an EET server clock (+3 summer) while
+    publishing UTC-anchored bars. The UTC-convention probe must accept it — the
+    server wall-clock offset is irrelevant once bars convert to the correct UTC
+    grid. The old _verify_broker_offset check wrongly rejected this."""
     fake_mt5.symbol_info_tick = lambda sym: SimpleNamespace(
-        time=_broker_epoch(2024, 1, 15, 14)  # broker wall clock = now + 2h
+        time=_broker_epoch(2024, 7, 15, 15)  # broker wall clock = real-now + 3h (EEST)
     )
-    verify_mt5_h4_alignment(
-        fake_mt5,
-        probe_symbol="EURUSD",
-        probe_count=6,
-        convention="5ers_eet",
-        now_func=lambda: now,
-    )
-
-
-def test_verify_broker_offset_eet_rejects_server_stuck_on_utc(fake_mt5):
-    """A misconfigured server that fails to apply EU DST still emits on-grid
-    bars but at the wrong absolute offset (here 0h vs expected +2h) → refuse."""
-    now = datetime(2024, 1, 15, 12, 0, tzinfo=timezone.utc)
-    fake_mt5.symbol_info_tick = lambda sym: SimpleNamespace(
-        time=_broker_epoch(2024, 1, 15, 12)  # broker wall clock = now (no offset)
-    )
-    with pytest.raises(Exception, match="offset sanity check failed"):
-        verify_mt5_h4_alignment(
-            fake_mt5,
-            probe_symbol="EURUSD",
-            probe_count=6,
-            convention="5ers_eet",
-            now_func=lambda: now,
-        )
+    # Bars are UTC-anchored (conftest default); convention="utc" must pass.
+    verify_mt5_h4_alignment(fake_mt5, probe_symbol="EURUSD", probe_count=6)


### PR DESCRIPTION
## Problem
PR #227's `_verify_broker_offset` sanity check **conflates two independent broker attributes**: the server *wall-clock* timezone and the *bar anchor* convention. It blocked the live 5ers UTC deployment leg:

```
python -m deployment.sidecar --winning-config configs/l_arc_10_v3.0.2_utc_rerun/winning_config.yaml \
  --sidecar-root <root> --quick-test    # 5ers MT5 attached
→ Mt5FetchError: Broker UTC-offset sanity check failed for 'utc': observed ~+3.0h, expected ~+0.0h
```

These are independent axes:
- **5ers**: EET server clock (+3 summer) + **UTC** bar anchors → bars at UTC 00/04/08/12/16/20
- **FundedNext**: EET server clock (+3 summer) + **EET** bar anchors → bars at UTC 21/01/05/09/13/17 (summer)

Both brokers have EET server clocks; they differ only in bar anchor convention. The offset check assumed `utc` convention ⇒ UTC server clock, which is not how 5ers operates.

## Fix (approach (a))
Remove `_verify_broker_offset` entirely. `verify_mt5_h4_alignment`'s bar-anchor probe is the authoritative gate — it verifies the broker's bar timestamps convert to the correct UTC grid for the configured convention. The server clock offset is operationally irrelevant once bars convert correctly. A broker mishandling DST in its **bars** is still caught by the anchor probe; DST handling in its **clock** alone does not affect us.

Removed: `_verify_broker_offset`, its call, the now-dead `now_func` param on `verify_mt5_h4_alignment`, and the `expected_utc_offset_hours` import in `sidecar.py`. The `expected_utc_offset_hours` boundary utility itself is kept (independently exported + unit-tested).

## Test plan
- [x] Removed the two `_verify_broker_offset` tests; added a regression test: UTC-convention probe **accepts** a broker whose `symbol_info_tick` reports +3h (EET server clock) with UTC-anchored bars.
- [x] Sidecar suite: 90 passed, 1 skipped; ruff clean.
- [x] **Live 5ers (EET clock)**: original repro (UTC config) now exits 0, processes all 28 pairs. EET config also still passes — all 28 pairs.

## Flag (substantial, no action requested)
With the offset check gone, the anchor probe **cannot distinguish UTC-bar from EET-bar brokers** in either DST regime — because the EET-anchored UTC grid is exactly the UTC grid shifted by the EET offset, a UTC-bar broker viewed under EET convention re-aligns onto EET anchors (and vice-versa). So convention selection is now purely the operator's responsibility (matched offline by the parity harness at 0.00 pip P95). This matches the intended deployment model (5ers→`utc`, FundedNext→`5ers_eet`), but means a wrong-convention *operator* error would not be caught at startup. Documented here so it's a deliberate, known tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)