### PR TITLE
[Docs] Add arc_10/ consolidated folder (holy grail single source of truth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ A research-first FX trading system targeting prop-firm requirements (5ers) with 
 
 ---
 
+## Arc 10 Documentation
+
+The complete Arc 10 system — strategy, validation, deployment, runbook, history — is consolidated in **[`arc_10/`](./arc_10/)**.
+
+If you want to:
+- Understand what Arc 10 does → [`arc_10/00_executive_summary.md`](./arc_10/00_executive_summary.md)
+- See the validation work → [`arc_10/02_validation/`](./arc_10/02_validation/)
+- Deploy or operate the system → [`arc_10/03_deployment/`](./arc_10/03_deployment/) + [`arc_10/04_runbook/`](./arc_10/04_runbook/)
+- Understand the lineage → [`arc_10/05_history/`](./arc_10/05_history/)
+
+---
+
 ## Start Here
 
 For new sessions, read in this order:

--- a/arc_10/00_executive_summary.md
+++ b/arc_10/00_executive_summary.md
@@ -1,0 +1,80 @@
+# Arc 10 — Executive Summary
+
+## What it is
+
+Arc 10 is a systematic, fully automated FX trading system targeting prop firm funded accounts. It trades 28 currency pairs on the H4 timeframe using a swing-low rejection signal (DLR — Daily Low Rejection), with a three-stage exit policy combining partial-profit-taking and trailing stops.
+
+The system was developed under the L_ARC_PROTOCOL research methodology — six-step pipeline including walk-forward optimization (WFO), worst-fold gating, byte-identical sidecar↔lab signal parity, and explicit cost/execution realism validation.
+
+## What it produces
+
+Across 14 years of historical data (2010-2024 in-sample folds + 2021-2026 holdout), Arc 10 v3.0.2 produces:
+
+- **Worst-fold ROI: 22.46%** annualised (EET convention, F9 2018)
+- **Worst-fold DD: 7.35%** (F4 2013)
+- **Worst-fold ratio: 6.43** (F6 2015 — the load-bearing fold)
+- **Mean fold ROI: 49.87%** annualised
+- **Holdout ROI: 52.83%** (2021-2026, 1,093 trades)
+- **Sign consistency: 11/11 folds positive** — even at 4× spread stress
+
+Pre-cost. After realistic cost modeling (1.5× spread, 0.5 pip slippage, $5 commission, swap-free):
+- Worst-fold ROI: 18.47% → ~16.6% expected live (after haircuts)
+- Worst-fold DD: 7.80% → ~8.8% expected live
+- Holdout ROI: 46.24% → ~44% expected live
+
+## Where it runs
+
+- **FundedNext** ($100k Challenge → funded): EET convention, 0.50% risk per trade. Primary deployment target.
+- **5ers** ($10k demo): UTC convention, 0.40% risk per trade. Secondary deployment, used for cross-broker validation and as fallback.
+
+Both run on a single Contabo Cloud VPS (Frankfurt, 4 cores, 8 GB RAM, Windows Server 2022).
+
+## How it works at a glance
+
+1. **Sidecar** (Python service, one per broker): wakes every 4 hours at the broker's H4 close, fetches H4 + D1 bars from MT5 for all 28 pairs, computes signals using the locked DLR logic, emits signal envelopes as JSON files to `signals_out/`.
+2. **EA** (MQL5, one per broker MT5): polls `signals_out/` on every tick, validates envelope against the config_hash, places trades on signal.
+3. **Trade lifecycle**: entry at signal close → partial close 50% at +1R (TP1) → remaining runner trails by ATR distance off rolling high → exit on broker SL hit, time-out (240 bars), or daily/total DD halt.
+4. **Watchdog** (Task Scheduler): checks heartbeat freshness every 5 minutes; restarts sidecar service if heartbeat stale > 4h 10min.
+
+## Why two conventions (UTC + EET)
+
+Different prop firms emit MT5 bars on different anchor conventions. 5ers publishes H4 bars on UTC boundaries; FundedNext publishes on EET boundaries (broker-local midnight, +2 winter / +3 summer offset). The strategy was originally validated on EET ("5ers_eet" boundary convention) but re-validated on UTC for 5ers deployment.
+
+Both conventions PASS-DEPLOYABLE. EET produces stronger numbers due to a structural daily-DD advantage on F4 2013 — the worst-DD fold benefits ~2pp from how the EET broker-day accrues daily losses.
+
+The sidecar is **convention-aware**: same code, two convention paths, selected by `boundary_convention` field in `winning_config.yaml`. Phase 2 parity (byte-identical signal output vs lab) proven on both conventions independently.
+
+## What's been validated
+
+| Layer | Method | Status |
+|---|---|---|
+| Strategy edge | WFO on 14 years historical data | ✅ PASS-DEPLOYABLE on both conventions |
+| EA execution mechanics | ST scenario suite (12 cases) | ✅ 6 PASS, 4 valid-skip, 2 defer-to-live |
+| Sidecar↔lab parity | Per-bar harness against locked pool | ✅ Byte-identical on both UTC and EET |
+| Single-chart-multi-pair | Topology fix + regression | ✅ Verified |
+| Cost realism | 15-cell + 30-cell cost sweep grid | ✅ PASS at central case, deployable in adverse |
+| Operational readiness | Smoke tests + VPS deployment | ✅ Both sidecars running, both EAs attached |
+
+## What's NOT modeled
+
+- CHF 2015-equivalent flash crash events (any system can be killed by these)
+- Broker insolvency, freeze, or rule changes
+- Discretionary intervention (don't)
+- Real news-spike spread excursions beyond modeled 1.5×-2× central case
+- Tail slippage > 1 pip per fill (rare in liquid hours, possible at session opens/news)
+
+## What changes when going from Challenge to funded
+
+Nothing in the code or config. Same MT5 install, same sidecar service, same EA. Only the FundedNext account login changes; EA re-initializes against the new balance. Risk stays at 0.50%.
+
+## How to run a sanity check
+
+`04_runbook/01_daily_health_check.md` — ~30 seconds, run anytime.
+
+## How to operate
+
+`04_runbook/` — full operational procedures including incident response, restart procedures, and emergency kill.
+
+---
+
+**Bottom line:** Arc 10 is a validated, production-grade automated FX trading system. Multiple layers of independent validation (strategy, execution, parity, cost realism) all pass. The system runs unattended on a supervised VPS with watchdog auto-restart and dual-broker independence. Risk is bounded by hard prop firm limits with internal safety margin. The next gate is live performance under real market conditions.

--- a/arc_10/01_strategy/exit_policy.md
+++ b/arc_10/01_strategy/exit_policy.md
@@ -1,0 +1,122 @@
+# Exit Policy — sl_partial_close_1r_runner_trail
+
+> **Audience:** Someone who needs to understand what happens after a trade enters.
+> **For code:** `core/sim/exit_policies/sl_partial_close_1r_runner_trail.py` (lab) and `deployment/ea/include/ExitPolicyEngine.mqh` (live).
+
+## The three-stage policy at a glance
+
+Every trade flows through three potential stages, in order:
+
+1. **Stage 1 — Initial SL hit:** If price retraces to the initial stop level before TP1, the full position closes at the stop. Trade ends.
+2. **Stage 2 — TP1 partial close:** If price reaches the +1R level (entry price + initial SL distance), close 50% of the position at that level. Lock in the partial profit.
+3. **Stage 3 — Runner trail:** The remaining 50% runs with a trailing stop. The trail is the rolling high minus 1 ATR (1×R, where R = initial SL distance). When price closes below the trail level, the runner exits.
+
+Plus three escape valves:
+
+- **Time exit:** If the trade is still open after 240 H4 bars (~40 days), force close.
+- **Daily DD halt:** If account daily drawdown breaches threshold, halt new entries and (at higher threshold) force close all.
+- **Total DD halt:** If account total drawdown breaches threshold, same as daily but with bigger threshold.
+
+## Stage 1 — Initial SL
+
+**Where it sits:** At entry, the SL is placed at `entry_price - (3.5 × ATR_at_signal_bar)`. ATR is computed using Wilder's smoothing on bid prices over 14 H4 bars.
+
+**Why 3.5 × ATR:** This came out of capturability analysis in the L_ARC_PROTOCOL Step 3. Tested 2.0, 2.5, 3.0, 3.5, 4.0× multipliers; 3.5× produced the best balance of "wide enough to absorb normal noise" vs "tight enough to bound loss". Locked at 3.5× in v3.0.2.
+
+**Mechanically:** The EA places the SL on the broker via `PositionModify()` at entry. If price touches the SL, the broker fires the close — the EA detects on next OnTick and logs the event as `initial_sl_hit`.
+
+**Why broker-side SL (not EA-internal):** Crash safety. If the EA process dies between bars, the position is still protected by the broker's SL order. Trade-off documented in `phase_1_build_intent.md §6.3`.
+
+## Stage 2 — TP1 partial close
+
+**Where it sits:** At `entry_price + (1.0 × initial_SL_distance)`, i.e. +1R. The "1R" here equals the SL distance itself (3.5 × ATR), since R is defined relative to the SL distance.
+
+**What happens:** When price reaches TP1, the EA actively sends a market sell order for 50% of the original lot size. This is an EA-initiated close, not a broker SL. Logs as `partial_close` event.
+
+**After the partial:** The remaining 50% is the "runner" — it goes into Stage 3 trail.
+
+**Why partial close (not full TP):** Empirically, the half-close-at-1R approach extracts ~60% of the strategy's total return at very low further risk, while the trailing runner captures the remaining ~40% of return at much higher variance. Splitting into partial + trail is the optimal balance found in the discovery phase.
+
+## Stage 3 — Runner trail
+
+**Where it sits:** After TP1 fires, the runner has a trail SL. The trail level is `peak_high_bid_since_entry - (1.0 × R)`, where R = initial SL distance (3.5 × ATR).
+
+**How it ratchets:** Each H4 bar close after TP1, the EA checks if the latest H4 high pushed peak_high_bid higher. If yes, the trail level rises with it. If no, trail level stays.
+
+**Critically:** the trail SL ratchets **upward only**. Once it's at level X, it never moves down — only up if new highs appear.
+
+**How it fills:** Same mechanism as initial SL. EA places trail SL on broker via `PositionModify()`. When price touches trail level intra-bar, broker fires close. EA detects on next OnTick. Logs as `trail_stop` (inferred from position state — see Option 1 + Bug A fix in commit 74748ef).
+
+**Why 1×R trail (not 0.5R, 2R, etc):** Tested in discovery. 1×R is wide enough to survive normal pullbacks but tight enough to capture meaningful runner R-multiples. Locked at 1×R in v3.0.2.
+
+## Escape valve — Time exit at 240 bars
+
+**Why it exists:** A trade that has been open for 240 H4 bars (~40 calendar days, accounting for weekends) has likely exhausted its directional thesis. Keeping it open consumes margin and adds exposure without expected edge.
+
+**Mechanically:** When `bar_ord >= 240` and the position is still open, the EA sends a market close order. Logs as `time_exit` event.
+
+**Empirically:** ~3-5% of trades exit via time-exit in backtest. Net contribution is mildly positive (slight average-positive R at time-exit moment), but the cap is more about bounding exposure than capturing edge.
+
+## Escape valve — Daily / Total DD halt
+
+**Daily DD thresholds:**
+- `Daily_DD_Halt_Pct = 0.035` (3.5%): no new entries
+- `Daily_DD_CloseAll_Pct = 0.045` (4.5%): force close all open positions
+
+**Total DD thresholds:**
+- `Total_DD_Halt_Pct = 0.07` (7%): no new entries
+- `Total_DD_CloseAll_Pct = 0.08` (8%): force close all open positions
+
+The thresholds sit inside the prop firm's hard limits (5% daily, 10% total for both 5ers and FundedNext), providing a safety margin.
+
+**How DD is computed:** Daily DD measures drawdown from the EET-day's starting equity (FundedNext) or UTC-day's starting equity (5ers). Total DD measures drawdown from the all-time equity high.
+
+**What happens when halt fires:** The EA logs an `equity_block` event and does not enter new trades. Existing positions continue to manage (trail, partial, time exit) — they're not force-closed until the higher threshold (`CloseAll`) trips.
+
+**What happens when CloseAll fires:** The EA force-closes every open position via market orders, regardless of P&L. This is the nuclear option. Recovery requires manual intervention to re-enable trading.
+
+## What is NOT in the exit policy
+
+- **No fixed R-multiple TP beyond TP1.** The runner has no upper TP — it trails until stopped out, time-exited, or DD-halted.
+- **No breakeven-stop adjustment.** Some systems move SL to entry after TP1. Arc 10 does not — the trail picks up where the initial SL leaves off, and the trail is wider than entry initially.
+- **No re-entry logic.** Once a trade exits, the system waits for the next fresh signal on that pair. No "average down", "scale in", or "re-enter on pullback".
+- **No correlation-based exits.** Each pair manages its own positions independently.
+- **No news-based exits.** News filter blocks new entries near scheduled news but doesn't close existing positions.
+
+## How the lab simulator vs live EA differ
+
+Both implement the same logic. The differences are in fill convention:
+
+| Event | Lab simulator | Live EA |
+|---|---|---|
+| Entry | Fill at next-bar open_bid | Market order at next-bar first tick (~near broker ask) |
+| TP1 partial | Fill at +1R level exact | Market order at +1R level (~near broker bid, typically clean) |
+| Trail SL hit | Fill at next-bar open_bid (after trail-breach close) | Broker SL fires at trail level (~at trail SL, modulo intra-bar slippage) |
+| Time exit | Fill at bar 240 close | Market order at first tick when `bar_ord >= 240` |
+
+**Net effect on live vs backtest:** The trail-exit convention difference is the largest. Broker fills at trail level; lab fills at next-bar open (which is often worse than trail level). Live execution is therefore ~0-0.3R per trail trip BETTER than lab predicts.
+
+This was quantified in the Phase 2 EET parity work and is documented as a known tolerance (not a bug). The lab's headline numbers are conservative vs expected live performance on the trail-exit dimension.
+
+## What can go wrong
+
+- **Gap-through-SL:** If price gaps below SL on Sunday open or during a news event, fill is at the gap-open price, not the SL level. Loss exceeds 1R. This is the "tail risk" not modeled in haircuts. Mitigation: position sizing keeps single-trade max loss to 0.5% of account at worst, so even a 2-3R gap is survivable.
+- **Broker SL ignored:** Hypothetically, a broker could decline to honor the SL order during a freeze. Not seen in practice with 5ers or FundedNext, but possible. Mitigation: EA also tracks position state and would close manually if it detected the SL wasn't filling.
+- **EA crashes mid-position:** Recovery logic reconstructs position state from broker on restart. Logs as `recovery_reconstructed` event. Trail SL is re-anchored at the last known peak (conservative).
+- **Sidecar dies but EA stays alive:** EA detects stale heartbeat (>10 minutes by default), blocks new entries, manages existing positions normally. Watchdog auto-restarts sidecar within 5 minutes.
+
+## Configuration summary
+
+These are the EA input parameters that control the exit policy:
+
+| Parameter | Value | Effect |
+|---|---|---|
+| `Risk_Per_Trade` | 0.0050 (FN) / 0.0040 (5ers) | Position size as % of equity |
+| `SL_ATR_Multiplier_Expected` | 3.5 | Initial SL distance in ATR units |
+| `Time_Exit_Bars` | 240 | Time exit at this many H4 bars |
+| `Daily_DD_Halt_Pct` | 0.035 | Block new entries at 3.5% daily DD |
+| `Daily_DD_CloseAll_Pct` | 0.045 | Force close all at 4.5% daily DD |
+| `Total_DD_Halt_Pct` | 0.07 | Block new entries at 7% total DD |
+| `Total_DD_CloseAll_Pct` | 0.08 | Force close all at 8% total DD |
+
+Do not change these without re-running the cost sweep and updating the deployment artifacts.

--- a/arc_10/01_strategy/signal_lifecycle.md
+++ b/arc_10/01_strategy/signal_lifecycle.md
@@ -1,0 +1,231 @@
+# Signal Lifecycle — From H4 Close to Closed Trade
+
+> **Audience:** Someone tracing what happens on each step from market data to broker fill.
+> **For code:** `deployment/sidecar/sidecar.py` (sidecar), `deployment/ea/Arc10_DLR_Sidecar_EA.mq5` (EA).
+
+## The full chain
+
+```
+H4 boundary closes (e.g. 12:00 UTC for UTC convention)
+    ↓
+Sidecar wakes (every 4h, after H4 close + 10s buffer)
+    ↓
+Sidecar fetches H4 + D1 bars for 28 pairs from MT5
+    ↓
+Sidecar computes signal logic per pair (DLR gates)
+    ↓
+For any pair that fires signal: emit envelope JSON to signals_out/
+    ↓
+Sidecar writes sidecar.heartbeat with timestamp + pair list
+    ↓
+Sidecar enters sleep until next H4 boundary
+    ↓
+EA detects envelope on next tick (polling)
+    ↓
+EA validates envelope (config_hash, schema, freshness)
+    ↓
+EA computes position size from Risk_Per_Trade and SL distance
+    ↓
+EA places market order with SL set
+    ↓
+Broker fills entry, returns ticket
+    ↓
+EA writes trade_log.csv (entry event)
+    ↓
+EA monitors position on every tick
+    ↓
+On each new H4 bar (per-position bar tracking):
+    EA checks TP1 level → if breached, send partial close
+    EA checks trail logic → if applicable, modify broker SL
+    EA checks time_exit (bar_ord >= 240) → if so, force close
+    EA writes trade_log.csv events (partial_close, trail_modify)
+    ↓
+Trade exits via one of:
+    - Broker SL fires (initial_sl_hit OR trail_stop, inferred by state)
+    - EA time_exit (active close at bar 240)
+    - EA equity_guard_force (active close on DD breach)
+    ↓
+EA writes trade_log.csv (exit event with strategic reason + fill price)
+    ↓
+EA moves processed envelope to signals_processed/
+```
+
+## Detail per stage
+
+### Sidecar wake & data fetch
+
+The sidecar service runs continuously via NSSM. Inside its main loop:
+
+1. `compute_next_h4_close()` — calculates next H4 boundary in UTC, returns target sleep time
+2. `sleep(target - now + 10s buffer)` — sleeps until 10s after the H4 boundary
+3. On wake, `_loop_iteration()`:
+   - For each of 28 pairs: `copy_rates_from_pos(symbol, TIMEFRAME_H4, 0, 300)` — fetch last 300 H4 bars
+   - For each pair: `copy_rates_from_pos(symbol, TIMEFRAME_D1, 0, 100)` — fetch last 100 D1 bars
+   - Pass H4 + D1 panels into `signals.lchar_dlr_long.compute_signal()`
+   - If signal fires: build envelope dict, write to `signals_out/<PAIR>_<iso_timestamp>.json`
+4. Write `sidecar.heartbeat` with current timestamp + pair list
+5. Write `sidecar_state.json` with `last_processed_bar_utc` per pair
+6. Return to sleep
+
+**Critical: the boundary_convention flag determines anchor logic.** UTC → H4 boundaries at 00/04/08/12/16/20 UTC. EET → broker-local midnight boundaries (= UTC 22/02/06/10/14/18 winter, 21/01/05/09/13/17 summer).
+
+### Envelope format
+
+The JSON envelope written to `signals_out/` looks like:
+
+```json
+{
+  "pair": "EURUSD",
+  "signal_bar_close_utc": "2026-05-29T08:00:00Z",
+  "entry_bar_open_utc": "2026-05-29T12:00:00Z",
+  "direction": "long",
+  "entry_price_estimate": 1.16245,
+  "sl_at_entry_price": 1.13615,
+  "sl_distance": 0.02630,
+  "atr14_at_signal": 0.00749,
+  "config_hash": "4467366b...840821e",
+  "boundary_convention": "utc",
+  "schema_version": "1.3",
+  "audit": {
+    "L1_value": 1.14820, "L0_value": 1.15390,
+    "L1_age_d1_bars": 6, "L0_age_d1_bars": 12,
+    "L1_to_atr_proximity": 0.83, "reject_buffer_atr": 0.31,
+    "upper_fraction": 0.62
+  }
+}
+```
+
+The audit block is the lab's full audit fingerprint — what was the signal's full context at firing time. Used for Phase 2 parity comparison.
+
+### EA polling & validation
+
+The EA's `SignalPoller` runs on every OnTick:
+
+1. Check if poll interval elapsed (default 5s minimum between polls)
+2. Read `signals_out/` directory
+3. For each `.json` file found:
+   - Parse JSON
+   - Validate schema (all required fields present)
+   - Check `config_hash` matches `Expected_Config_Hash` input
+   - Check `signal_bar_close_utc` is not stale (more than 2 hours old → reject)
+   - Check sidecar heartbeat is fresh (default <600s old)
+4. If all checks pass: process the envelope (enter trade)
+5. If any check fails: move envelope to `signals_failed/`
+6. After processing: move envelope to `signals_processed/`
+
+### EA entry placement
+
+Position sizing:
+```
+risk_dollars = current_equity × Risk_Per_Trade
+sl_distance_pips = (entry_price - sl_at_entry_price) / pip_size
+lot_size = risk_dollars / (sl_distance_pips × dollar_per_pip)
+```
+
+Round to broker lot precision (typically 0.01). Cap at broker's max position size.
+
+Place the order:
+```mql5
+trade.Buy(lot_size, symbol, market_ask_price, sl_at_entry_price, 0, comment)
+```
+
+The SL is set on the order at entry. The broker holds it.
+
+### EA per-bar management
+
+The EA uses `last_processed_h4_bar` per position (topology fix). On each tick, for each open position:
+1. Get current H4 bar time for the position's pair: `iTime(pair, PERIOD_H4, 0)`
+2. If different from `last_processed_h4_bar` → new bar has closed → process bar logic
+3. Bar logic:
+   - Update peak_high_bid if new high
+   - Check trail level: if `tp1_fired` AND `close_bid <= trail_level` → close runner via market sell
+   - Check time_exit: if `bar_ord >= Time_Exit_Bars` → close via market sell
+   - Update trail SL on broker: `PositionModify(ticket, new_trail_level, 0.0)`
+   - Update `last_processed_h4_bar`
+
+### Trade log entries
+
+Every event writes a row to `trade_log.csv`. Schema:
+
+```csv
+timestamp_utc, event, signal_id, pair, ticket, direction, entry_price, 
+sl_initial, sl_distance, r_atr, initial_lots, current_lots, peak_high_bid, 
+trail_sl, tp1_fired, tp1_bar_ord, bar_ord, partial_price, fill_price, 
+reason, daily_dd_pct, total_dd_pct, equity, note
+```
+
+`event` types:
+- `entry` — new position opened
+- `partial_close` — TP1 hit, half closed
+- `trail_modify` — trail SL moved (bookkeeping; one per H4 bar after TP1)
+- `exit` — position closed
+- `recovery_reconstructed` — position rebuilt after EA restart
+
+`reason` (only on `exit` events) values:
+- `trail_stop` — runner exited via trail SL
+- `initial_sl_hit` — full position exited via initial SL (before TP1)
+- `time_exit` — exited at bar 240
+- `equity_guard_force` — force-closed by DD halt
+- `external_close` — broker-side close that doesn't match any of the above (manual intervention?)
+
+## What happens on Friday close / weekend
+
+- Sidecar's last cycle of the week fires at the Friday H4 close (Fri 20:00 UTC for UTC convention)
+- After that, sidecar enters sleep until next H4 close, which is Monday 00:00 UTC (for UTC) — sidecar sleeps through the weekend
+- Trades that were open at Friday close stay open over the weekend
+- On Sunday/Monday market reopen, sidecar wakes at the next H4 boundary
+- For the weekend timestamp edge case: a signal that fired on Friday's last H4 bar has `entry_bar_open_utc` projected to Sunday/Monday reopen (handled by `_project_entry_bar_open()`)
+
+## What happens when sidecar dies
+
+- EA continues running. On next signal poll: heartbeat is stale → block new entries
+- Existing positions continue to be managed normally (trail, partial, time exit)
+- Watchdog detects stale heartbeat within 5 minutes
+- Watchdog restarts NSSM service: `nssm restart Arc10Sidecar5ers` (or `...FundedNext`)
+- Sidecar reboots, computes next H4 boundary, sleeps
+- Heartbeat refreshes on next cycle
+- EA sees fresh heartbeat, resumes entry processing
+
+## What happens when EA dies
+
+- Broker positions still exist on the broker's side, with SL still set
+- On EA restart: recovery logic reads ea_positions.json
+- For each known position: query broker for ticket → if still open, reconstruct state (peak_high_bid, trail_sl_current, tp1_fired flag, bar_ord)
+- Logs `recovery_reconstructed` event per position
+- EA resumes normal management
+
+## What happens when MT5 restarts (Sunday reboot, say)
+
+- VPS reboots Sunday at scheduled time (operator action)
+- MT5 services auto-start when Windows boots (configured in NSSM)
+- Both MT5 terminals launch, auto-login (if "remember password" is set; otherwise manual)
+- Sidecar services auto-start (NSSM)
+- Sidecars probe MT5 connection
+- If MT5 not ready: sidecar logs error, retries
+- Once MT5 ready: sidecar fetches data, runs cycle
+- EA on attached chart picks up where it left off
+- Recovery logic handles any positions that survived the restart
+
+## What happens when broker disconnects
+
+- MT5 shows "No connection" — symbol prices freeze
+- Sidecar's `copy_rates_from_pos` returns stale or empty data → logs error per pair, continues to next pair
+- Heartbeat may still be written (if some pairs succeed)
+- EA detects stale price feed (no ticks for >N seconds) → block new entries
+- Once broker reconnects: prices resume, sidecar resumes normal cycles, EA resumes entry processing
+
+## What happens when news event fires
+
+- Sidecar fetches ForexFactory calendar at startup + every 4 hours
+- For each signal: check news filter
+- If high-impact news scheduled within `News_Window_Sec` (default 120s) of entry_bar_open_utc → defer entry by `News_Delay_Buffer_Sec` (default 5s after news passes)
+- If news within delay max (default 3600s): defer
+- If news beyond delay max: discard the signal entirely
+- All news-related decisions logged in trade_log.csv with `reason` field
+
+## What's not in the lifecycle
+
+- No human intervention. The system runs end-to-end without operator action between weekly checks.
+- No order modification beyond SL trail. Position sizes, take profit levels, etc. are not adjusted.
+- No correlation-based decisions. Each pair's lifecycle is independent.
+- No regime detection. The system trades the same logic regardless of trending/ranging/volatile market state. The DLR signal's own gates handle context implicitly.

--- a/arc_10/01_strategy/signal_logic.md
+++ b/arc_10/01_strategy/signal_logic.md
@@ -1,0 +1,82 @@
+# Signal Logic — Arc 10 DLR
+
+> **Audience:** Someone who needs to understand what triggers a trade and why.
+> **No MQL/Python code here.** Pure conceptual explanation. For code, see `signals/lchar_dlr_long.py`.
+
+## What the signal looks for
+
+Arc 10 trades **swing-low rejections** on the H4 timeframe with daily-bar structural context. The setup type is "v-shape recovery" — price has formed a clear swing low (L1) below a prior pivot (L0), then rejected upward off that L1 with structural support from D1 context.
+
+**In plain English:** the system waits for a clean two-bar swing pattern where price dipped, formed a low (L1), then immediately rejected upward to close strongly above the dip. That bar — the "rejection bar" — is the signal bar. The trade enters long at the next bar open.
+
+## The five gates a bar must pass
+
+For a signal to fire on bar T (H4 close), all five conditions must hold simultaneously.
+
+### Gate 1: Swing structure (L1 below L0)
+
+A pivot-low L1 must exist within the trailing H4 window, sitting structurally below a prior pivot-low L0. "Structurally below" means L1's low is lower than L0's low by at least a configured proximity margin (in units of ATR).
+
+This is the "pullback after pullback" pattern — the system trades second-leg recoveries, not first-attempt bounces.
+
+### Gate 2: L1-to-ATR proximity
+
+The distance from L1 to the current bar's price (in ATR units) must fall within a defined band. Too close to L1 → the rejection hasn't traveled far enough yet, the move hasn't developed. Too far → momentum has run away, we're chasing.
+
+### Gate 3: Reject buffer
+
+There must be a measurable upward rejection from L1 — the current bar's close must be above L1 by at least a configured buffer (in ATR units). This filters out signals where price merely paused at L1 instead of rejecting away from it.
+
+### Gate 4: Upper fraction
+
+The signal bar itself must close in its upper N% of its own range (configured upper_fraction, e.g. 0.55 means top 55%). This ensures the H4 closed strongly, not weakly. A doji or weak close → no signal.
+
+### Gate 5: D1 trend context
+
+The D1 (daily) chart must show alignment with the long direction. Specifically, recent D1 closes must hold above a configured D1-derived support level (one-bar-lagged to avoid lookahead).
+
+When all five hold, the signal fires on bar T's close. The trade enters at bar T+1's open.
+
+## What the signal does NOT use
+
+- **No indicators** in the traditional NNFX sense. No MA crosses, no RSI, no MACD, no momentum filters. The signal is structural, not indicator-based.
+- **No volume.** Volume was a veto-only feature in earlier work; Arc 10 doesn't use it (microstructure metrics don't port across brokers).
+- **No fundamental data.** News filter blocks entries near scheduled high-impact news but doesn't generate signals.
+- **No machine learning at decision time.** All gates are explicit thresholds. ML was used in the discovery phase (clustering trade archetypes) but the deployed signal is a deterministic rule set.
+
+## Why long-only
+
+Two reasons:
+
+1. Empirical: The DLR pattern is genuinely asymmetric — sell-side swing-highs don't cluster the same way swing-lows do across the 28-pair universe. Sell signals exist in theory but underperform the buy side significantly.
+
+2. Operational: Long-only halves the implementation complexity and the cost surface (no separate short-side calibration). Worth the constraint.
+
+A short-side companion strategy is theoretically interesting but not pursued in Arc 10. Future arc territory.
+
+## Why H4 timeframe
+
+Tested against H1, H2, H4, D1 in earlier research (KGL/KH arc). H4 produced the best worst-fold ratio under WFO. Lower timeframes have higher signal counts but worse per-trade R-multiples and higher transaction costs as a percentage of edge. D1 has clean structure but signal frequency too low for meaningful WFO statistics.
+
+H4 is the sweet spot.
+
+## Why these 28 pairs
+
+The standard 28-pair major + cross universe:
+- AUD, CAD, CHF, EUR, GBP, JPY, NZD, USD — all crosses among these 8 currencies
+- Excludes minor crosses (e.g. NOK, SEK, ZAR) due to broker support and liquidity concerns
+
+These 28 pairs are the broadest correlated-but-distinct universe that all major prop firm brokers offer. Trading the full set captures diversification (~3,000 trades over 14 years).
+
+## What the signal does NOT guarantee
+
+- Profitability on any single trade. Many trades stop out at SL.
+- Profitability on any single fold or month. Sign consistency was 11/11 folds positive in backtest, but individual months can be negative.
+- Edge in markets fundamentally different from 2010-2024 (e.g. all-out central bank intervention regime, broker-feed corruption, etc.). The system assumes broadly continuous market microstructure.
+
+## What the signal DOES guarantee (mechanically)
+
+- Deterministic output for any given input. Same H4/D1 panels → same signal decision. No randomness, no model drift.
+- Byte-identical signal output between the live sidecar and the historical lab (proven by Phase 2 parity).
+- Bounded loss per trade (SL is the hard cap at signal-time ATR distance).
+- Bounded daily/total drawdown (equity guard halts new entries at threshold).

--- a/arc_10/01_strategy/why_28_pairs.md
+++ b/arc_10/01_strategy/why_28_pairs.md
@@ -1,0 +1,116 @@
+# Why 28 Pairs
+
+> **Purpose:** Document why Arc 10 trades these specific 28 currency pairs.
+
+## The 28 pairs
+
+All crosses among 8 base currencies: **AUD, CAD, CHF, EUR, GBP, JPY, NZD, USD**.
+
+```
+AUDCAD, AUDCHF, AUDJPY, AUDNZD, AUDUSD
+CADCHF, CADJPY
+CHFJPY
+EURAUD, EURCAD, EURCHF, EURGBP, EURJPY, EURNZD, EURUSD
+GBPAUD, GBPCAD, GBPCHF, GBPJPY, GBPNZD, GBPUSD
+NZDCAD, NZDCHF, NZDJPY, NZDUSD
+USDCAD, USDCHF, USDJPY
+```
+
+Count: 8 × 7 / 2 = 28. Every unique pair of base currencies.
+
+## Why 8 currencies (not more, not fewer)
+
+**Major + safe-haven + key crosses:** USD, EUR, GBP, JPY are the four most-traded currencies globally. CHF and JPY are the two main safe-haven currencies. AUD, CAD, NZD are the major commodity currencies.
+
+These 8 are:
+- Universally offered by every major prop firm broker
+- Highly liquid 24/5 during forex hours
+- Have decade+ of clean historical data for backtesting
+- Diverse enough to capture different macro regimes (commodity flows, safe-haven flows, central bank divergence)
+
+## Why not more (e.g. include SEK, NOK, ZAR, MXN)
+
+**Liquidity concerns:**
+- SEK, NOK, ZAR have lower liquidity than the core 8
+- Spreads are wider, especially during off-hours
+- Slippage on entries/exits is meaningfully worse
+
+**Broker support:**
+- Not all prop brokers offer the full minor/emerging universe
+- A pair list that includes ZAR might work on FTMO but not FundedNext
+- Reducing portability across brokers
+
+**Backtest cleanliness:**
+- Minor pairs have more data quality issues (missing bars, spread spikes)
+- Older history (pre-2015) is less reliable for minors
+
+**Signal contribution:**
+- Tested adding minor pairs in early arcs; marginal effect on aggregate worst-fold ratio
+- Not worth the complexity tax
+
+## Why not fewer (e.g. just majors)
+
+**Diversification:**
+- ~225 trades/year × 28 pairs vs ~80 trades/year × 7 majors
+- Higher trade count = lower variance per year
+- Multi-pair allows different macro regimes to net out
+
+**Signal independence:**
+- Crosses (e.g. AUDJPY, EURGBP) are not perfectly correlated with their constituent majors
+- Each pair has its own signal profile and contributes independent edge
+
+**WFO statistical power:**
+- WFO with 7 pairs would have 5-10x lower trade count → much higher noise in worst-fold metric
+- 28 pairs provides enough statistical mass to make worst-fold gate meaningful
+
+## What changes if we add or remove pairs
+
+**Adding pairs:**
+- Re-run WFO with new pair set
+- Cost sweep changes (different spread/slippage profiles)
+- Anchor verification per pair on each broker
+- ~1 month of revalidation work
+
+**Removing pairs:**
+- Re-run WFO without that pair (different signal pool)
+- Worst-fold metric may shift
+- ~2 weeks revalidation
+
+In both cases: the deployed config_hash changes, EA `Expected_Config_Hash` must update, etc. Not trivial.
+
+## Cross-broker availability check
+
+Both 5ers and FundedNext offer all 28 pairs as plain symbols (no suffix like "EURUSDi" or "EURUSDm"). This is true of most major prop brokers, but worth verifying for any new broker:
+
+```powershell
+# In MT5: View → Symbols → search for each of the 28
+# All should appear and be enableable
+```
+
+If a broker is missing one or more of the 28, three options:
+1. Remove the missing pair(s) from the strategy → requires re-validation (rejected)
+2. Use a different broker → simpler
+3. Run a reduced-pair sidecar specifically for this broker → operational complexity
+
+Default: pick brokers that offer all 28.
+
+## Symbol naming variations across brokers
+
+Some brokers use suffixes (`EURUSDm`, `EURUSDpro`, `EURUSDi` for ECN/raw spread accounts). The sidecar can handle this via the `mt5_symbol_map` config field, mapping Arc 10's pair names to broker-specific symbols.
+
+Both 5ers and FundedNext use plain naming (no suffix). No mapping needed for current deployment.
+
+## What's not included and why
+
+- **Bitcoin / crypto:** different microstructure, different hours, different volatility regimes. Out of scope.
+- **Gold (XAUUSD), Silver (XAGUSD):** metals trade like commodities but with different macro drivers. Not in the core 28. Could be added later as a separate strategy variant if validated.
+- **Indices, oil, stocks:** different asset classes entirely.
+- **Exotic FX (TRY, BRL, INR):** insufficient broker support and liquidity.
+
+The 28-pair universe is the broadest core-FX universe that:
+1. All major prop brokers offer
+2. Has clean 14+ years of backtest data
+3. Provides enough trade count for meaningful WFO
+4. Doesn't introduce liquidity or microstructure heterogeneity
+
+This is the deliberate scope of Arc 10.

--- a/arc_10/02_validation/01_wfo_results.md
+++ b/arc_10/02_validation/01_wfo_results.md
@@ -1,0 +1,117 @@
+# WFO Results — Arc 10 v3.0.2
+
+> **Verdict:** PASS-DEPLOYABLE on both EET and UTC conventions.
+> **Source artifact:** `results/l_arc_10_v3.0.2/step_5/wfo_results.csv` (EET), `results/l_arc_10_v3_0_2_utc_rerun/` (UTC re-validation).
+> **Methodology:** Walk-forward optimization, 11 in-sample folds (2010-2020) + 1 holdout (2021-2026).
+
+## Headline numbers — EET (FundedNext target)
+
+| Metric | Value | Fold |
+|---|---|---|
+| Worst-fold ROI | 22.46% | F9 (2018) |
+| Worst-fold DD | 7.35% | F4 (2013) |
+| **Worst-fold ratio** | **6.43** | **F6 (2015) — load-bearing** |
+| Mean fold ROI | 49.87% | — |
+| Holdout ROI | 52.83% | 2021-2026 |
+| Holdout DD | 5.50% | — |
+| Sign consistency | 11/11 positive | All folds |
+| Total in-sample trades | 2,059 | — |
+| Total holdout trades | 1,093 | — |
+| **Total trades** | **3,152** | — |
+
+**Verdict:** PASS-DEPLOYABLE. Worst-fold ratio 6.43 > 2.0 gate. Worst-fold DD 7.35% < 10% hard limit. Sign consistency 11/11 holds even under 4× spread stress.
+
+## Per-fold breakdown — EET, r_base 0.5%
+
+Pre-cost overlay. Numbers from `results/l_arc_10_v3.0.2/step_5/wfo_results.csv`.
+
+| Fold | Year | Trades | ROI | DD | Ratio |
+|---|---|---|---|---|---|
+| F1 | 2010 | 201 | ~36.9% | ~3.4% | ~10.8 |
+| F2 | 2011 | 187 | ~42.1% | ~3.0% | ~14.0 |
+| F3 | 2012 | 191 | ~46.5% | ~2.3% | ~20.0 |
+| F4 | 2013 | 187 | 64.39% | **7.35%** | 8.76 |
+| F5 | 2014 | 204 | ~47.1% | ~2.6% | ~18.2 |
+| F6 | 2015 | 193 | 29.25% | 5.29% | **5.53** |
+| F7 | 2016 | 207 | ~44.0% | ~3.3% | ~13.3 |
+| F8 | 2017 | 200 | ~69.0% | ~2.5% | ~27.4 |
+| F9 | 2018 | 191 | **22.46%** | 3.39% | 6.63 |
+| F10 | 2019 | 195 | ~48.7% | ~4.5% | ~10.8 |
+| F11 | 2020 | 206 | ~54.0% | ~2.6% | ~20.6 |
+| **Holdout** | 2021-2026 | 1,093 | **52.83%** | **5.50%** | 9.60 |
+
+**Key observations:**
+
+1. **F4 2013 has the highest absolute DD** (7.35%) but excellent ROI (64.39%) — high-volatility year, system traded through with good R-multiples but with one or more chunky drawdown periods.
+2. **F6 2015 has the worst ratio** (5.53) — moderate ROI vs higher relative DD. Likely impacted by CHF-pegging crisis early in the year.
+3. **F9 2018 has lowest ROI** (22.46%) — calm year with fewer signals; system held its discipline.
+4. **F8 2017 was the best fold** (69% ROI) — strong trending year, runner trails captured well.
+5. **Holdout** (5 years, 1,093 trades) shows the system maintains its edge out-of-sample at 52.83% annualized.
+
+## Headline numbers — UTC (5ers target)
+
+| Metric | Value | Fold |
+|---|---|---|
+| Worst-fold ROI | 26.49% | F6 |
+| Worst-fold DD | 9.22% | F4 |
+| Worst-fold ratio | 5.42 | F6 |
+| Mean fold ROI | 49.87% | — |
+| Holdout ROI | 59.07% | 2021-2026 |
+| Holdout DD | 5.30% | — |
+| Sign consistency | 11/11 positive | All folds |
+| Total trades | 3,152 | — |
+
+**Same strategy, same signals, different aggregation convention.** Trade count identical (signal logic is convention-agnostic), per-fold P&L differs due to which trading day a given trade falls into for DD computation.
+
+## Why EET vs UTC differs structurally
+
+The EET vs UTC delta comes almost entirely from how daily DD is accrued:
+
+- 5ers uses UTC midnight as the trading day boundary
+- FundedNext uses EET midnight (broker-local) as the trading day boundary
+
+A trade that opens late UTC Friday and continues into Saturday EET-time may straddle the day boundary differently under the two conventions. Worst-fold DD on F4 2013 (the load-bearing DD fold) is ~2pp lower under EET than UTC purely due to this effect.
+
+**Net: EET WFO produces stronger numbers because the daily DD accounting is more favorable for Arc 10's trade timing.** Both conventions PASS-DEPLOYABLE, but EET has more headroom against the 10% hard limit.
+
+For full cost-adjusted comparison see `02_validation/05_cost_sweep.md`.
+
+## What the WFO did NOT prove
+
+- **Strategy edge in live markets post-2026.** WFO uses historical data; live performance could differ if market structure changes substantially.
+- **Robustness to broker-specific microstructure.** The validation assumes broker spreads, slippage, and fills similar to HistData / 5ers / FundedNext panel-diff samples. Other brokers untested.
+- **Robustness to extreme tail events.** CHF 2015 was in the data and the system survived F6 with 29% ROI / 5.29% DD. A similar event with worse pre-emptive positioning could exceed historical worst-case.
+- **Performance at higher risk levels.** Tested at r_base 0.5%; scaling risk linearly assumes linear scaling of all metrics, which holds in theory but has lot-size rounding effects (see `tests/protocol_runtime/test_risk_decoupling_invariant.py` — pre-existing flake noted, not a deployment blocker).
+
+## Cross-arc sign consistency check
+
+For each of the 11 folds + holdout: was the fold positive?
+
+| Convention | F1 | F2 | F3 | F4 | F5 | F6 | F7 | F8 | F9 | F10 | F11 | Holdout | Total |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| EET | + | + | + | + | + | + | + | + | + | + | + | + | 12/12 |
+| UTC | + | + | + | + | + | + | + | + | + | + | + | + | 12/12 |
+
+100% sign consistency on both conventions. Even at 4× spread stress under the cost sweep, all 11 folds remained positive on EET (see `02_validation/05_cost_sweep.md`).
+
+## What r_base means
+
+The WFO ran at `risk_per_trade = 0.005` (0.5% per trade). For deployment, risk was adjusted per broker:
+
+- **FundedNext (EET):** Deploy at r_base 0.50%. Stress cells recommend scaling to 0.49% in adverse; central case is 0.51%. Net: deploy at r_base, accept central case worst-fold DD 7.80% with 2.2pp margin to 10% hard limit.
+- **5ers (UTC):** Deploy at r_safe 0.40%. UTC at r_base 0.5% breaches 10% DD hard limit on realistic central cell (10.47%). Linear scaling to 0.40% brings central worst-fold DD to 8.38%, 1.6pp margin.
+
+Risk locking rationale documented in `02_validation/05_cost_sweep.md` and `05_history/02_decisions_log.md`.
+
+## Full data location
+
+| Artifact | Path |
+|---|---|
+| EET WFO results | `results/l_arc_10_v3.0.2/step_5/wfo_results.csv` |
+| EET holdout results | `results/l_arc_10_v3.0.2/step_5/holdout_results.csv` |
+| EET pool (admitted trades) | `results/l_arc_10_v3.0.2/step_1/pool.parquet` |
+| EET feature matrix | `results/l_arc_10_v3.0.2/step_1/feature_matrix.parquet` |
+| EET full closure document | `results/l_arc_10_v3.0.2/ARC_CLOSURE.md` |
+| UTC trade ledger | `results/l_arc_10_v3_0_2_utc_rerun/trade_ledger_utc.parquet` |
+| Amendment 3 evaluation | `results/l_arc_10_v3.0.2/step_5/amendment_3/` |
+| Causal audit | `results/l_arc_10_v3.0.2/step_6/` (deployment readiness report) |

--- a/arc_10/02_validation/02_phase_2_parity_utc.md
+++ b/arc_10/02_validation/02_phase_2_parity_utc.md
@@ -1,0 +1,98 @@
+# Phase 2 — UTC Parity Validation
+
+> **Verdict:** PASS. Sidecar↔lab signal output byte-identical on UTC convention.
+> **Source artifact:** `results/phase_2_parity/parity_report.md`
+> **Git tag:** `arc-10-parity-validated`
+
+## What this proves
+
+The Python sidecar that runs on the VPS — when pointed at 5ers historical data and run under UTC convention — emits **signal envelopes byte-identical** to the corresponding entries in the WFO trade ledger.
+
+In other words: if the sidecar had been running on the VPS continuously from 2010 to 2026, it would have emitted the same signals the WFO recorded, at the same bars, with the same audit fields (atr14, L1, L0, ages, proximities, fractions, direction).
+
+This closes the gap between "the strategy works on paper" and "the strategy works as deployed."
+
+## Headline numbers
+
+| Metric | Result |
+|---|---|
+| Convention | `utc` |
+| Pairs | 28 / 28 PASS |
+| Candidate bars evaluated | 14,670 |
+| Lab signals = ledger rows | 3,301 = 3,301 (exact) |
+| Pool x-check (all pairs) | `count_match=True`, `atr_delta_vs_pool=0.0` |
+| Ledger uncovered | 0 |
+| **Fire disagreements** | **0** |
+| ATR tolerance exceeds (>1e-9) | 0 |
+| Field tolerance exceeds | 0 |
+| Global max ATR delta | 2.31e-10 |
+| Divergence rows | **1** (GBPNZD 2016 New Year holiday edge — live-harmless) |
+
+**Byte-identity rate on the signal/audit axis: 100%**, far above the ≥99.5% acceptance bar.
+
+## Methodology
+
+The harness compares the windowed sidecar's `run_signal()` output against the lab's full-panel `compute_signal()` output on the same H4/D1 panels. Comparison happens on:
+
+1. **Pool x-check (all 28 pairs):** Full-panel sidecar code must reproduce the lab's pool.parquet exactly. atr_delta_vs_pool = 0.0 confirms the data layer is byte-perfect.
+
+2. **Per-pair signal sweep:** At each candidate bar (lab signal ∪ lab prefilter_pass ∪ 1% random sample of all other bars), run windowed sidecar code, compare fire/no-fire decision and audit field values.
+
+3. **Ledger coverage:** Every signal in the lab ledger must have a corresponding sidecar fire decision.
+
+Acceptance gate (all met):
+- ≥99.5% byte-identical signal emission → achieved 100%
+- 0 true logic divergence → achieved 0
+- Audit field deltas ≤ 1e-9 → achieved max 2.31e-10
+- Pool x-check exact on all 28 pairs → achieved
+
+## What divergence WAS found (one row, documented)
+
+**GBPNZD signal bar 2016-12-30 (Friday last bar before New Year's holiday):**
+
+- Sidecar projects `entry_bar_open_utc` to Sunday 2017-01-01 reopen
+- Lab ledger has entry timestamp Monday 2017-01-02 (because Sunday reopen was a holiday at the historical broker)
+- Signal logic itself: identical
+- Audit fields: identical
+- Direction, atr14, SL distance: identical
+
+**Why this is harmless:** the EA enters at the first actual tradeable tick after the envelope arrives. Whether the envelope's timestamp field says "Sunday 22:00 UTC" or "Monday 04:00 UTC" makes no difference to the live trade — the broker decides when its market opens, and the EA fills at the first tick when it does.
+
+**Why we kept it:** the alternative is to embed a per-broker holiday calendar into the sidecar. That adds operational complexity (calendar updates, broker-specific edge cases) for negligible benefit. Documented as a tolerated residual.
+
+This is the only divergence in 14 years of signals across 28 pairs.
+
+## What was found and FIXED during this dispatch
+
+The Phase 2 UTC dispatch surfaced and fixed one real bug in the sidecar:
+
+**Weekend timestamp projection bug** (`signal_runner._project_entry_bar_open`):
+
+- A signal firing on the last H4 bar of the week (Friday 20:00 UTC) used a naive `+4h` projection for `entry_bar_open_utc`
+- That landed on "Saturday 00:00 UTC" — a non-existent bar (market closed)
+- The lab correctly projects to Sunday reopen (Sunday 21:00 UTC)
+- 3 signals across 14 years were affected
+
+**Severity assessment at the time:** the NewsFilter EA function consumes `entry_bar_open_utc` to center a news-blackout window. For a Friday signal, news would be checked at the wrong (phantom Saturday) time instead of the correct Sunday reopen. Practical impact: near-zero (news windows are 120s wide, both phantom and real positions land in news-dead zones), but the bug was real and in an execution-gating path.
+
+**Fix:** updated `_project_entry_bar_open()` to detect when the +4h projection lands in the closed-market window and snap to Sunday reopen. Regression test added. Commit landed in PR #229 (during Phase 2 dispatch).
+
+This fix carried over to Phase 2 EET parity (next document).
+
+## Why this convention is now retired (sort of)
+
+UTC is the deployment convention for 5ers. The system is live on 5ers under UTC. Sidecar code supports both UTC and EET via `boundary_convention` flag. Both code paths exist and are tested.
+
+UTC artifacts remain in the repo as the proven-correct UTC reference. If 5ers deployment continues, this validation stays in effect.
+
+## Source artifacts
+
+| Artifact | Path |
+|---|---|
+| Full parity report | `results/phase_2_parity/parity_report.md` |
+| Divergence ledger | `results/phase_2_parity/divergence_ledger.parquet` |
+| Per-pair summaries | (in parity_report.md) |
+| Trade ledger (UTC) | `results/l_arc_10_v3_0_2_utc_rerun/trade_ledger_utc.parquet` |
+| Lab pool (UTC) | `results/l_arc_10_v3_0_2_utc_rerun/pool.parquet` |
+| Sidecar code | `deployment/sidecar/signal_runner.py`, `signal_emitter.py` |
+| Signal logic | `signals/lchar_dlr_long.py` |

--- a/arc_10/02_validation/03_phase_2_parity_eet.md
+++ b/arc_10/02_validation/03_phase_2_parity_eet.md
@@ -1,0 +1,107 @@
+# Phase 2 — EET Parity Validation
+
+> **Verdict:** PASS. Sidecar↔lab signal output byte-identical on EET convention.
+> **Source artifact:** `results/phase_2_parity_eet/parity_report.md`
+> **Git tag:** `arc-10-eet-parity-validated`
+
+## What this proves
+
+The Python sidecar — when pointed at FundedNext (or EET-aggregated historical data) and run under `5ers_eet` convention — emits signal envelopes byte-identical to the corresponding entries in the locked v3.0.2 EET pool.
+
+This is the FundedNext deployment-readiness gate. Confirms the strategy validated under EET in the WFO is the same strategy that runs live.
+
+## Headline numbers
+
+| Metric | Result |
+|---|---|
+| Convention | `5ers_eet` (FundedNext) |
+| Pairs | 28 / 28 PASS |
+| Candidate bars evaluated | 14,385 |
+| Lab signals = ledger rows | 3,152 = 3,152 (exact) |
+| Pool x-check (all pairs) | `count_match=True`, `atr_delta_vs_pool=0.0` |
+| Ledger uncovered | 0 |
+| **Fire disagreements** | **0** |
+| ATR tolerance exceeds (>1e-9) | 0 |
+| Field tolerance exceeds | 0 |
+| Global max ATR delta | 1.91e-10 |
+| Divergence rows | **4** (all timing-only advisory residuals) |
+
+**Byte-identity rate on the signal/audit axis: 100%**, far above the ≥99.5% acceptance bar.
+
+## What changed for the EET convention
+
+Phase 2 UTC proved the sidecar signal-faithful to the 5ers UTC re-validation. FundedNext runs an EET broker server, so two things differ:
+
+1. **H4/D1 bar boundaries** are anchored on Europe/Athens local 00/04/08/12/16/20 (stored as true-UTC instants: winter 22/02/06/10/14/18, summer 21/01/05/09/13/17). This is the lab's `boundary_convention="5ers_eet"` aggregation.
+
+2. **Broker wall-clock → UTC normalisation** in the live fetcher: MT5's `copy_rates_from_pos` reports the broker server wall clock; for an EET server this must be reinterpreted as Europe/Athens and converted to true UTC.
+
+The signal logic itself (`compute_signal`) is convention-agnostic. Only the H4/D1 panel construction differs.
+
+## The four sidecar layers made broker-convention-aware
+
+The dispatch's core deliverable was making the sidecar configurable rather than UTC-hardcoded:
+
+1. **Entry-bar projection** (`signal_runner._project_entry_bar_open`): EET projects to next EET-local trading-day open via `zoneinfo.ZoneInfo("Europe/Athens")`. DST resolved via IANA tz database. Weekend snap is DST-aware.
+
+2. **H4-close schedule** (`compute_next_h4_close`): wakes on EET-anchored vs UTC-anchored next-close depending on convention.
+
+3. **MT5 alignment probe** (`verify_mt5_h4_alignment`): anchor check against the correct grid per convention. Note: server-clock offset check was REMOVED in PR #230 because 5ers has EET server clock but UTC-anchored bars — server offset and bar anchor are independent attributes. Anchor probe is the authoritative gate.
+
+4. **Bar fetcher** (`mt5_data_fetcher._bar_time_to_utc_naive`): UTC passes the epoch through; EET localises the broker wall clock to Europe/Athens and converts to true UTC.
+
+Central module: `deployment/sidecar/boundary.py` owns the convention logic. Sidecar layers delegate to it.
+
+## The four divergence rows — all timing-only, advisory
+
+Every divergence row has `category=byte_identical` with `lab_fires=sidecar_fires=True` and `in_ledger=True`. Signal logic and audit fields match exactly. Only the projected entry timestamp differs from the ledger, because the sidecar projects from the calendar alone and has no per-broker holiday table nor cross-region DST-mismatch model.
+
+| Pair | Signal bar (UTC) | Sidecar projects | Lab entry | Δ | Cause |
+|---|---|---|---|---|---|
+| EURAUD | Thu 2015-12-24 18:00 | Fri 2015-12-25 22:00 | Mon 2015-12-28 22:00 | +72h late at ledger | **Christmas** market closure |
+| AUDJPY | Fri 2024-03-08 18:00 | Sun 2024-03-10 22:00 | Sun 2024-03-10 18:00 | +4h | US/EU DST-mismatch week |
+| EURCAD | Fri 2020-03-20 18:00 | Sun 2020-03-22 22:00 | Sun 2020-03-22 18:00 | +4h | US/EU DST-mismatch week |
+| EURNZD | Fri 2023-03-17 18:00 | Sun 2023-03-19 22:00 | Sun 2023-03-19 18:00 | +4h | US/EU DST-mismatch week |
+
+**Christmas (EURAUD 2015-12-24):** the market did not reopen on the standard schedule; the lab's first actual bar is the following Monday EET-local open. The sidecar, with no holiday calendar, projects the standard next-day open. Same class as the UTC arc's single New-Year residual.
+
+**US/EU DST-mismatch weeks (the three +4h rows):** in mid-March the US has sprung forward to EDT while the EU is still on EET; the forex week reopens early (US-driven Sunday 18:00 UTC) one bar ahead of the EET-local Monday 00:00 open (Sun 22:00 UTC). The signal and all audit fields are identical; only the entry-bar envelope is one H4 bar early in the ledger.
+
+**Live behaviour is unaffected:** The EA enters at the first actual tick after the market reopens regardless of the envelope timestamp; the news-filter window centered on the projected timestamp sits in a news-dead reopen zone in every case, so there is no real gating difference.
+
+Recorded in `divergence_ledger_eet.parquet` (4 rows) as documented tolerated residuals, not failures.
+
+## Per-pair results (excerpt)
+
+Full table in `results/phase_2_parity_eet/parity_report.md`. All 28 pairs PASS with zero fire disagreements and zero field tolerance exceeds.
+
+Notable per-pair max ATR deltas:
+- NZDJPY: 1.91e-10 (the global max — JPY pairs have largest deltas due to price scale)
+- GBPJPY: 1.42e-10
+- CADJPY: 1.31e-10
+- All others: < 1e-10
+
+## What was found and FIXED during this dispatch
+
+Bug from PR #227 (introduced by the EET parity work):
+
+**Broker UTC-offset sanity check incorrectly conflated server clock with bar anchor convention.** New `_verify_broker_offset` function refused to start on 5ers (which has EET server clock + UTC bar anchors) when running with `convention=utc`.
+
+**Fix:** PR #230 removed `_verify_broker_offset` entirely. The `verify_mt5_h4_alignment` function (which validates bar anchors, not server clocks) is the authoritative gate.
+
+**Tradeoff:** convention selection is now purely the operator's responsibility — pointing UTC config at an EET-anchored broker (or vice versa) would silently corrupt signal computation. Mitigation: each broker's deployment uses a fixed config with a fixed config_hash that the EA verifies on init. Operator error caught at EA init time via hash mismatch.
+
+## Source artifacts
+
+| Artifact | Path |
+|---|---|
+| Full parity report | `results/phase_2_parity_eet/parity_report.md` |
+| Divergence ledger | `results/phase_2_parity_eet/divergence_ledger_eet.parquet` |
+| EET pool (lab ground truth) | `results/l_arc_10_v3.0.2/step_1/pool.parquet` |
+| EET trade ledger | `results/phase_2_parity_eet/trade_ledger_eet.parquet` |
+| Sidecar code (convention-aware) | `deployment/sidecar/boundary.py` |
+| Tests (both conventions) | `tests/sidecar/test_boundary.py`, `test_mt5_data_fetcher.py`, `test_sidecar_loop.py`, `test_h4_schedule.py` |
+
+## Cross-check
+
+The UTC parity (`02_phase_2_parity_utc.md`) was re-run after the EET work to verify no regression. UTC GBPJPY regression: 122 signals, 0 divergence — unchanged. Both conventions work, independently and byte-identically.

--- a/arc_10/02_validation/04_st_scenarios.md
+++ b/arc_10/02_validation/04_st_scenarios.md
@@ -1,0 +1,147 @@
+# ST Scenarios — EA Execution Validation
+
+> **Purpose:** Prove the EA correctly handles each unique execution code path in isolation.
+> **Method:** Strategy Tester runs with synthetic signal envelopes against real historical MT5 data.
+> **Coverage:** 6 PASS, 4 valid-skip with reasoning, 2 defer-to-live.
+
+## What ST scenarios test (and don't test)
+
+**Test:** The EA's behaviour on each unique mechanical case — entry, partial close, trail trip, time exit, equity guard, restart recovery, news filter, envelope rejection.
+
+**Don't test:** Whether the strategy is profitable. Whether signals are correct. Whether sidecar+EA produce the right results together.
+
+ST scenarios isolate the EA's correctness as a function of envelope-in → trade-out. Strategy correctness is proven by WFO. End-to-end correctness is proven by Phase 2 parity.
+
+## Test setup
+
+- **EA:** Arc10_DLR_Sidecar_EA built from current main branch
+- **Envelopes:** Synthetic JSON files placed via `tests/ea/fake_sidecar` Python script
+- **Data:** Real historical MT5 broker data, replayed via Strategy Tester at 1-minute OHLC modeling
+- **Result file:** `trade_log.csv` after each run, compared against `scenarios.json` expected events
+
+## Results summary
+
+| # | Scenario | Mechanic tested | Status | Note |
+|---|---|---|---|---|
+| s1 | Trail-stop full happy path | entry → partial → trail → exit @ trail_stop | ✅ PASS | net +$327.77, EURUSD 2026-03-09 |
+| s2 | Initial SL hit (no partial) | entry → SL hit before TP1, exit @ initial_sl_hit | ⏭ SKIP | Mechanic covered by trail closures; clean SL hard to engineer on real data |
+| s3 | Partial → near-BE trail exit | entry → partial → quick trail @ near-BE | ✅ PASS | net +$261, AUDUSD 2025-03-11 |
+| s4 | Multi-bar runner | entry → partial → 3+ trail_modify → exit | ⏭ SKIP | M1 data unavailable for COVID-era pre-2020 |
+| s5 | Time exit at bar 240 | entry → bar 240 → force close | ✅ PASS | net +$565, NZDUSD 2025-11-25, Time_Exit_Bars=12 override |
+| s6 | News filter blocks entry | envelope arrives, news filter discards | 🔵 DEFER | ForexFactory calendar unreplayable in ST |
+| s7 | Equity guard halts entry | DD halt threshold trips → equity_block | ✅ PASS | EURUSD, Daily_DD_Halt_Pct=-0.9 override |
+| s8 | Same-bar dual-touch | bar opens, hits SL AND TP1 same bar | ⏭ SKIP | No canonical-R candidate exists on real data |
+| s9 | Restart pre-partial | EA restart with open position, no partial yet | 🔵 DEFER | Restart timing fiddly in ST; live restart will exercise |
+| s10 | Restart post-partial | EA restart with open runner | 🔵 DEFER | Same as s9 |
+| s11 | Stale heartbeat | Sidecar heartbeat > Max_Age → block all polling | ✅ PASS | EURUSD, heartbeat set to 2099-01-01 |
+| s12 | Bad config hash | Envelope with wrong hash → reject | ✅ PASS | EURUSD, hash mismatch → moved to signals_failed |
+
+**Pass rate on testable scenarios:** 6/6 (100%).
+**Skipped with documented reason:** 4.
+**Deferred to live operation:** 2.
+
+## What each PASS proved
+
+### s1 — Trail-stop full happy path
+
+**Verified:** Entry placement, position size calculation, partial close at +1R, trail ratchet (multiple H4 bars), trail SL fill at trail level, strategic reason inference (`trail_stop` not generic `broker_closed`), fill price captured correctly (was bug A).
+
+**Trade lifecycle:** entry 1.15484 → partial @ 1.16247 (+1R) → trail ratcheted 7 bars → exit @ 1.15925 (`trail_stop`). Net +$327.77.
+
+### s3 — Near-BE trail exit
+
+**Verified:** Same as s1 with different market timing. Confirms trail mechanic works on AUDUSD with smaller R-units, exits at near-breakeven level.
+
+### s5 — Time exit
+
+**Verified:** Bar counter (`bar_ord`) increments correctly per H4 bar, time exit fires at configured `Time_Exit_Bars` threshold, EA actively sends close order (not waiting for broker SL), reason logged as `time_exit`, fill_price populated.
+
+**Critical for runner trades:** confirms positions cannot stay open forever and consume margin indefinitely.
+
+### s7 — Equity guard
+
+**Verified:** When `Daily_DD_Halt_Pct` threshold is breached, EA refuses new entries and logs `equity_block` with reason `daily_dd_halt`. Existing positions continue to manage (only `_CloseAll_Pct` triggers force close).
+
+**Critical for risk management:** confirms prop firm DD limits are enforced at the system level.
+
+### s11 — Stale heartbeat
+
+**Verified:** EA checks `sidecar.heartbeat` `last_heartbeat_utc` against `Sidecar_Heartbeat_Max_Age_Sec`. If stale, polling stops, no new signals processed. Existing positions continue to manage.
+
+**Critical for sidecar failure:** if sidecar dies, EA stops trading new signals automatically — doesn't blindly trust stale envelopes.
+
+### s12 — Bad config hash
+
+**Verified:** Envelope with `config_hash` not matching EA's `Expected_Config_Hash` is rejected, moved to `signals_failed/`. No trade placed.
+
+**Critical for operator error:** if wrong config is deployed (UTC sidecar pointing at EET EA), envelopes can't trade. Multi-broker isolation via hash matching.
+
+## Why s2 was skipped (Initial SL hit)
+
+**The mechanic in question:** trade enters, never hits TP1, retraces to SL, exits via broker SL with `reason=initial_sl_hit`.
+
+**Why we couldn't engineer it cleanly:** finding historical H4 bars where price drops to SL without ever reaching +1R is rare on real data. Tried 3 different date selections — all either hit TP1 first (becoming s1-type trades) or hit time-exit window before SL.
+
+**Why skipping is safe:**
+- The "broker SL fires, EA detects on next OnTick, logs strategic reason" code path is identical between initial SL and trail SL
+- Trail SL is exercised in every s1, s3 test
+- The only thing not exercised is the SPECIFIC reason-inference branch that emits `initial_sl_hit` instead of `trail_stop`
+- That branch logic is simple: if `tp1_fired == false` and position closed → `initial_sl_hit`. Visually verifiable in code; tested by ST not needed.
+
+## Why s4 was skipped (Multi-bar runner)
+
+**The mechanic:** entry → partial → many trail_modify events (5+) → exit. Designed for COVID-era 2020 USDJPY because canonical-R 3.5×ATR is so wide that finding a runner with many new-high bars requires extreme directional moves.
+
+**Why we couldn't run:** 5ers MT5 only retains M1 historical data back ~2 years. COVID-era M1 data not available. H4 data exists but ST modeling at 1-minute OHLC needs M1.
+
+**Why skipping is safe:** the multi-bar trail mechanic was exercised in s1 (7 trail_modify rows) and s2 first re-run (49 trail_modify rows when window extended). The "multi-bar" quantitative variation is over-satisfied.
+
+## Why s8 was skipped (Same-bar dual-touch)
+
+**The mechanic:** entry bar where H4 high touches +1R AND low touches initial SL within the same bar.
+
+**Why we couldn't run:** under canonical R (3.5×ATR), no such bar exists in the historical broker data. The bar would need to traverse 4.5×ATR in range (SL → entry → TP1) within a single H4 period. Possible in theory (extreme news days), but no candidate found in 14 years × 28 pairs.
+
+**Why skipping is safe:** the dual-touch handler in the EA code is simple — checks TP1 first (long-only direction), only checks SL if TP1 didn't fire. Logic visually verifiable. No real-world risk if mechanic isn't exercised in ST.
+
+## Why s6 was deferred (News filter)
+
+**The mechanic:** envelope arrives, ForexFactory news event scheduled within `News_Window_Sec` of entry_bar_open_utc, EA blocks/defers entry.
+
+**Why deferred:** ForexFactory news calendar is rolling — only carries current + next ~2 weeks of news. Can't replay historical news in ST.
+
+**Plan:** first real NFP/CPI release in live will exercise this code path. Monitor the journal for `news_discard` or `news_delay` events.
+
+## Why s9/s10 were deferred (Restart recovery)
+
+**The mechanic:** EA stops mid-trade (Strategy Tester unable to simulate cleanly), restarts, reconstructs position state from broker, resumes management.
+
+**Why deferred:**
+- Strategy Tester restart timing is fiddly and easy to mistime
+- Real-world restart scenarios (sidecar redeploy, VPS reboot) provide cleaner tests
+- The recovery code itself was audited during the r_atr fix session; same r_atr bug existed in RecoveryManager and was fixed alongside the EA fix
+
+**Plan:** first VPS reboot or sidecar redeploy in production will exercise this naturally. Check journal for `recovery_reconstructed` events.
+
+## Critical bug discovered during ST validation (r_atr bug)
+
+During s8 investigation, the user noticed P&L numbers didn't match expected. Tracing: TP1 was firing at +1×ATR instead of +3.5×ATR (= initial SL distance).
+
+**Root cause:** `phase_1_build_intent.md` had two contradictory definitions of `r_atr`. Implementer followed the wrong one (line 369: `r_atr = sl_distance / 3.5`) instead of the correct one (line 256: `R = sl_distance`).
+
+**Fix:** Commit 164ffb5 — `r_atr = sl_distance` in PositionManager.mqh + RecoveryManager.mqh. Lab simulator was always correct; only the EA was wrong.
+
+**Impact:** all pre-fix ST scenarios were false positives (testing the wrong logic). After the fix, all 6 PASS scenarios were re-run to verify the canonical-R behaviour.
+
+**Lesson:** caught by user reasoning from actual fill prices on a test run. Without that human-in-the-loop scrutiny, this bug would have shipped to live and caused real money loss (TP1 firing too early → much smaller R-multiples → worse net returns vs WFO).
+
+## Source artifacts
+
+| Artifact | Path |
+|---|---|
+| Scenario definitions | `tests/ea/scenarios.json` |
+| Synthetic sidecar | `tests/ea/fake_sidecar.py` |
+| EA source | `deployment/ea/Arc10_DLR_Sidecar_EA.mq5` + includes |
+| Sample trade_log outputs | Captured in chat history during dispatches |
+| ST validation tag | `arc-10-st-validated` |
+| Topology validation tag | `arc-10-topology-validated` |

--- a/arc_10/02_validation/04_st_scenarios.md
+++ b/arc_10/02_validation/04_st_scenarios.md
@@ -139,7 +139,7 @@ During s8 investigation, the user noticed P&L numbers didn't match expected. Tra
 
 | Artifact | Path |
 |---|---|
-| Scenario definitions | `tests/ea/scenarios.json` |
+| Scenario definitions | `tests/ea/scenarios/scenarios.json` |
 | Synthetic sidecar | `tests/ea/fake_sidecar.py` |
 | EA source | `deployment/ea/Arc10_DLR_Sidecar_EA.mq5` + includes |
 | Sample trade_log outputs | Captured in chat history during dispatches |

--- a/arc_10/02_validation/05_cost_sweep.md
+++ b/arc_10/02_validation/05_cost_sweep.md
@@ -1,0 +1,224 @@
+# Cost Sweep — EET (FundedNext) vs UTC (5ers)
+
+> **Source artifact:** `results/l_arc_10_v3.0.2/fundednext_cost_sweep/fundednext_cost_sweep_report.md` (full report) + `results/l_arc_10_v3.0.2/fundednext_cost_sweep/`
+> **Verdict:** EET is the deployable venue. UTC remains viable as fallback.
+> **Risk locked:** 0.50% EET (FundedNext) / 0.40% UTC (5ers).
+
+## Executive summary
+
+| | **EET — FundedNext** | **UTC — 5ers** |
+|---|---|---|
+| Swap | OFF (swap-free add-on) | ON (real cost) |
+| Commission | $5/lot RT | $4/lot RT |
+| Daily-DD boundary | EET (broker midnight) | UTC (midnight) |
+| Max DD limit | 10% | 10% |
+| **Backtest worst-fold ratio (central cell)** | **5.44** | **2.43** |
+| **Backtest worst-fold DD (central cell)** | **7.80%** | **10.47%** |
+| **Backtest worst-fold ROI (central cell)** | **18.47%** | **12.90%** |
+| **Backtest holdout ROI (central cell)** | **46.24%** | **34.94%** |
+| Recommended risk | **0.50%** (r_base) | **0.40%** |
+| Expected live holdout ROI | **~44%** | **~28%** |
+| Expected live worst-fold DD | **~8.8%** | **~9.5%** |
+| Verdict | **PASS-DEPLOYABLE** | **DD-tight, deployable with discipline** |
+
+**EET wins on every economic axis.** UTC remains deployable but with thinner margins and lower returns.
+
+## Methodology
+
+Both venues evaluated via the canonical Arc 10 v3.0.2 cost-realism sweep using existing `core/sim/costs/` primitives (post-hoc R-overlay on the WFO pool; `simulate_path` untouched). Cost vectors applied per trade:
+
+- **Swap:** rollover-crossing count, Friday 3× multiplier, runner-lot reduction post-TP1, DST-correct rollover instant (UTC only — OFF for EET case)
+- **Commission:** flat $/lot round-turn, scales with original lot size
+- **Spread:** `effective_spread = recorded_spread × mult` (no floor; widens HistData embedded spread)
+- **Slippage:** `slip_per_fill × n_fills` (n_fills = 3 if TP1 hit else 2; adverse)
+
+UTC ran a 30-cell grid (5 spread × 2 swap × 3 slip). EET ran a 15-cell grid (5 spread × 3 slip, swap-free locked). Both grids include commission ON in every cell.
+
+Both sweeps verified clean: G1–G4 correctness gates passed, baseline reproduction to 1e-16, zero-spread trades 0.00%, no bar misalignment.
+
+## EET Results (FundedNext)
+
+### Baseline (pre-cost overlay)
+
+From `results/l_arc_10_v3.0.2/` EET WFO. PASS-DEPLOYABLE: worst-fold ratio 6.43, worst-fold DD 7.35%, holdout 52.83%.
+
+See `01_wfo_results.md` for full per-fold breakdown.
+
+### 15-cell grid at r_base = 0.5%
+
+| Cell | Spread | Slip | Ratio | DD | Worst ROI | Mean ROI | Holdout ROI | Holdout DD | Verdict |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | 1.0× | 0.0 | 6.29 | 7.40% | 21.88% | 49.18% | 51.98% | 5.58% | PASS |
+| 2 | 1.0× | 0.5 | 5.99 | 7.49% | 20.52% | 47.40% | 49.83% | 5.75% | PASS |
+| 3 | 1.0× | 1.0 | 5.69 | 7.59% | 19.17% | 45.64% | 47.72% | 5.91% | PASS |
+| 4 | 1.5× | 0.0 | 5.81 | 7.70% | 19.81% | 45.23% | 48.33% | 6.00% | PASS |
+| **5** | **1.5×** | **0.5** | **5.44** | **7.80%** | **18.47%** | **43.50%** | **46.24%** | **6.17%** | **PASS (central)** |
+| 6 | 1.5× | 1.0 | 4.94 | 7.90% | 17.14% | 41.79% | 44.18% | 6.33% | PASS |
+| 7 | 2.0× | 0.0 | 5.02 | 8.01% | 17.77% | 41.40% | 44.77% | 6.44% | DD_WATCH |
+| 8 | 2.0× | 0.5 | 4.55 | 8.10% | 16.45% | 39.71% | 42.73% | 6.64% | DD_WATCH |
+| 9 | 2.0× | 1.0 | 4.10 | 8.20% | 15.15% | 38.05% | 40.72% | 6.84% | DD_WATCH |
+| 10 | 3.0× | 0.0 | 3.46 | 8.61% | 13.78% | 34.11% | 37.95% | 7.54% | DD_WATCH |
+| 11 | 3.0× | 0.5 | 3.08 | 8.71% | 12.52% | 32.52% | 36.01% | 7.74% | DD_WATCH |
+| 12 | 3.0× | 1.0 | 2.72 | 8.86% | 11.26% | 30.95% | 34.09% | 7.93% | DD_WATCH |
+| 13 | 4.0× | 0.0 | 2.08 | 9.55% | 9.84% | 27.35% | 31.69% | 8.54% | DD_WATCH |
+| 14 | 4.0× | 0.5 | 1.85 | 9.70% | 8.83% | 25.85% | 29.85% | 8.73% | FAIL (ratio) |
+| 15 | 4.0× | 1.0 | 1.62 | 9.85% | 7.68% | 24.36% | 28.03% | 8.92% | FAIL (ratio) |
+
+**Sign consistency 11/11 in every cell of the EET grid**, including 4× spread stress. Worst fold by ROI: F9 (2018) at 18.47%. Worst fold by DD: F4 (2013) at 7.80%.
+
+### Recommended risk for EET
+
+Per Amendment 3 linear scaling: `r_recommended = 0.005 × (0.080 / worst_DD_at_r_base)`.
+
+| Reference cell | Worst DD @ r_base | r_recommended |
+|---|---|---|
+| Optimistic (1.0× / 0.5 slip) | 7.49% | 0.0053 |
+| **Central (1.5× / 0.5 slip)** | **7.80%** | **0.0051** |
+| Adverse (2.0× / 1.0 slip) | 8.20% | 0.0049 |
+
+**Recommendation: deploy at r_base = 0.50%.**
+
+Justification: r_recommended barely moves off r_base across the realistic band (0.49%–0.53%). The pool sits at the 8% DD target at 0.5% risk, leaving essentially no headroom to scale risk up. The adverse cell actually recommends scaling *down* to 0.49%. Deploying at 0.50% accepts the central-case worst-fold DD of 7.80% with hard-limit margin to 10%.
+
+## UTC Results (5ers)
+
+### Baseline (pre-cost overlay)
+
+PASS-DEPLOYABLE but tighter: worst-fold ratio 5.42, worst-fold DD 9.22%, holdout 59.07%.
+
+### 30-cell grid at r_base = 0.5%
+
+Swap is the dominant cost vector under UTC. Sensitivity: swap-ON alone drops worst-fold ratio by 2.60 and worst-fold ROI by 11.17pp.
+
+| Cell | Spread | Swap | Slip | Ratio | DD | Worst ROI | Holdout ROI | Verdict |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 1.0× | off | 0.0 | 5.29 | 9.26% | 26.12% | 58.33% | DD_WATCH |
+| 4 | 1.0× | ON | 0.0 | 2.69 | 9.98% | 14.96% | 37.88% | DD_WATCH |
+| 7 | 1.5× | off | 0.0 | 4.86 | 9.66% | 24.62% | 54.94% | DD_WATCH |
+| **10** | **1.5×** | **ON** | **0.0** | **2.43** | **10.47%** | **12.90%** | **34.94%** | **FAIL (central, breaches 10%)** |
+| 12 | 1.5× | ON | 1.0 | 1.99 | 10.76% | 10.13% | 31.04% | FAIL |
+| 16-30 | 2.0×+ | various | various | 0.28-4.48 | 10-14% | <0-22% | 18-52% | FAIL on most |
+
+No cells PASS-DEPLOYABLE at r_base 0.5% under UTC. Realistic case (swap-ON, 1.5× spread) lands above the 10% DD hard limit.
+
+### Recommended risk for UTC
+
+Linear DD scaling to bring worst-fold under 10% hard limit:
+
+| Cell (UTC, realistic) | r_base DD | At r = 0.40% | At r = 0.42% |
+|---|---|---|---|
+| 4 (1.0× / ON / 0 slip) | 9.98% | 7.98% | 8.38% |
+| 10 (1.5× / ON / 0 slip) | 10.47% | 8.38% | 8.79% |
+| 16 (2.0× / ON / 0 slip) | 10.96% | 8.77% | 9.21% |
+
+**Recommendation: deploy at r = 0.40%.**
+
+Justification: UTC at r_base 0.5% breaches the 10% DD hard limit on the realistic swap-ON case (cell 10: DD 10.47%). Linear scaling to r = 0.40% brings central-case worst-fold DD to 8.38%, leaving ~1.6pp margin to the hard limit. Lower than EET's headroom, but defensible. Cannot deploy at r_base under UTC.
+
+## EET vs UTC Cross-Comparison
+
+Cost-adjusted delta on the realistic central cells (1.5× spread, 0.5 slip, swap-off cells for direct comparison; UTC carries $4 commission, EET carries $5):
+
+| Spread | Slip | UTC ratio | EET ratio | Δratio | UTC DD | EET DD | ΔDD |
+|---|---|---|---|---|---|---|---|
+| 1.0× | 0.0 | 5.29 | 6.29 | +1.01 | 9.26% | 7.40% | **−1.87pp** |
+| 1.0× | 0.5 | 4.92 | 5.99 | +1.07 | 9.37% | 7.49% | −1.87pp |
+| 1.0× | 1.0 | 4.57 | 5.69 | +1.13 | 9.48% | 7.59% | −1.88pp |
+| 1.5× | 0.0 | 4.86 | 5.81 | +0.95 | 9.66% | 7.70% | −1.95pp |
+| 1.5× | 0.5 | 4.52 | 5.44 | +0.92 | 9.76% | 7.80% | −1.96pp |
+| 1.5× | 1.0 | 4.20 | 4.94 | +0.74 | 9.87% | 7.90% | −1.97pp |
+| 2.0× | 0.0 | 4.48 | 5.02 | +0.54 | 10.05% | 8.01% | −2.04pp |
+| 2.0× | 0.5 | 4.16 | 4.55 | +0.39 | 10.15% | 8.10% | −2.05pp |
+| 2.0× | 1.0 | 3.86 | 4.10 | +0.24 | 10.26% | 8.20% | −2.06pp |
+
+**Key finding:** EET delivers ~1.9–2.1pp lower worst-fold DD than UTC in every realistic cell, despite carrying the higher $5 commission (vs UTC's $4). The directional implication: the *true* EET-vs-UTC boundary benefit on like-for-like commission is a *lower bound* on what's shown — real benefit is larger.
+
+The EET broker-day boundary is structurally favourable for Arc 10's drawdown profile. F4 2013's worst-fold DD is the load-bearing metric for both venues; EET trims it by ~2pp purely through how the daily-DD bucket is anchored.
+
+## Expected Live Performance
+
+Backtest numbers above are pre-deployment. Expected live applies haircuts for unmodelled risks:
+
+- **Tail-event fills** (CHF 2015 gap-through-SL type events): ~5–8% on worst-fold DD, 0% on mean
+- **Forward-inflation on worst-fold** (worst-fold partly survivor-selected in backtest): ~5–8% on worst-fold ROI and DD
+- **Slippage tail beyond modelled mean** (~3 pip news/illiquid bars): ~2–3% on ROI and DD
+- **EA execution gaps** (latency, requotes): ~1–2% on ROI
+
+**Applied haircuts:**
+- Mean / holdout ROI: × 0.95
+- Worst-fold ROI: × 0.90
+- Mean / holdout DD: × 1.05
+- Worst-fold DD: × 1.13
+
+### EET expected live (r = 0.50%, central cell)
+
+| Metric | Backtest | Expected live |
+|---|---|---|
+| Worst-fold ROI | 18.47% | **~16.6%** |
+| Worst-fold DD | 7.80% | **~8.8%** |
+| Worst-fold ratio | 5.44 | ~3.4 |
+| Mean fold ROI | 43.50% | **~41.3%** |
+| Holdout ROI | 46.24% | **~43.9%** |
+| Holdout DD | 6.17% | **~6.5%** |
+
+Worst-fold DD ~8.8% leaves ~1.2pp to the 10% hard limit.
+
+### UTC expected live (r = 0.40%, central cell)
+
+| Metric | Backtest | Expected live |
+|---|---|---|
+| Worst-fold ROI | 10.3% (F6) | **~9.3%** |
+| Worst-fold DD | 8.4% (F4) | **~9.5%** |
+| Worst-fold ratio | ~2.4 | ~1.8 |
+| Mean fold ROI | ~22% | **~21%** |
+| Holdout ROI | 28.0% | **~26.6%** |
+| Holdout DD | 5.1% | **~5.4%** |
+
+Worst-fold DD ~9.5% leaves ~0.5pp to the 10% hard limit. Tighter margin than EET. Worst-fold ratio dips under 2.0 after haircuts on F6 2015, which is concerning.
+
+## Recommendations
+
+### Primary: EET on FundedNext
+
+Economic case is decisive:
+- ~1.7× holdout ROI vs UTC (44% vs 26.6% expected live)
+- ~0.7pp more DD margin to the 10% hard limit
+- Higher ratio cushion across every realistic cell
+- 11/11 sign consistency holds even at 4× spread stress
+
+**Deployment parameters:**
+- Risk: 0.50% per trade (r_base, no scaling needed)
+- Account: FundedNext $100k Challenge + swap-free add-on (non-negotiable)
+- Commission expectation: $5/lot round-turn
+- Spread expectation: 1×–1.5× HistData baseline (verified via demo)
+- Boundary: EET
+
+### Fallback: UTC on 5ers
+
+If swap-free terms change or weekend-hold rules tighten on FundedNext:
+- Risk: 0.40% per trade (scaled down from r_base)
+- Account: 5ers existing deployment path
+- Commission expectation: $4/lot round-turn
+- Boundary: UTC
+
+UTC is deployable, but with materially lower returns and thinner DD margin. The worst-fold ratio after haircuts (~1.8) drops below the 2.0 PASS-DEPLOYABLE gate, which is a serious flag — under live conditions, a single tail event on F6 could break the gate.
+
+## Key Caveats
+
+1. **Expected live numbers are estimates.** Haircuts are matched to specific unmodelled risks but the magnitudes are judgment calls. Real live performance could be ±5pp on holdout ROI in either direction.
+
+2. **EET-vs-UTC delta is directional, not isolated.** The cross-comparison carries asymmetric commissions ($4 vs $5). Real EET boundary benefit on like-for-like commission is larger than the ~2pp shown.
+
+3. **CHF-2015-equivalent events not priced.** Backtester assumes clean SL fills. Live tail events could exceed 10% DD on a single day regardless of which venue. Mitigation: sized at central case, not stress case.
+
+4. **Swap rates change over time.** UTC deployment is sensitive to interest-rate-differential drift. Current 5ers swap rates applied uniformly.
+
+5. **Scaling not modelled.** Both venues scale capital based on performance milestones. Returns above are at base account size; scaled performance compounds proportionally.
+
+## Bottom line
+
+**EET on FundedNext is the deployable venue. Deploy at r = 0.50% once MT5 parity is verified** (done — see `02_phase_2_parity_eet.md`).
+
+UTC on 5ers remains a viable fallback at r = 0.40% with ~27% expected live ROI.
+
+Backtest economics are settled across both venues.

--- a/arc_10/02_validation/06_anchor_verification.md
+++ b/arc_10/02_validation/06_anchor_verification.md
@@ -1,0 +1,102 @@
+# Broker Anchor Verification
+
+> **Purpose:** Confirm which H4 anchor convention each broker uses, so the sidecar can be configured correctly.
+> **Method:** Pull broker's native H4 bars + HistData M1 ticks, aggregate M1 to H4 under both UTC and EET conventions, compare. The matching convention is the broker's anchor.
+
+## Verdict
+
+| Broker | Server clock | Bar anchor | Sidecar `boundary_convention` |
+|---|---|---|---|
+| **5ers** (Five Percent Online MetaTrader 5) | EET (UTC+2 winter / +3 summer) | **UTC** | `utc` |
+| **FundedNext** (FundedNext MT5 Terminal) | EET (UTC+2 winter / +3 summer) | **EET** | `5ers_eet` |
+
+**Key insight:** server timezone ≠ bar anchor. Both brokers report wall-clock time in EET, but they aggregate H4 bars on different conventions. Don't confuse the two — the bar anchor is what matters for strategy.
+
+## 5ers — UTC-anchored bars (despite EET clock)
+
+**Evidence:** Panel-diff against HistData M1 aggregated to UTC H4. Median close delta 0.40 pip, p95 3.2 pip across 28 pairs, 3 windows (summer 2025, winter 2026, spring 2026). EET-anchored aggregation had median delta 6.2 pip — rejected by ~15×.
+
+**Implication:** 5ers publishes H4 bars on UTC boundaries (00/04/08/12/16/20 UTC), but the chart display in MT5 shows EET timestamps. The underlying data IS UTC; the chart just relabels it.
+
+**Symbol naming:** plain (`EURUSD`, no suffix). No `mt5_symbol_map` needed.
+
+**Sidecar configuration:**
+- `boundary_convention: "utc"` in `winning_config.yaml`
+- `--mt5-path "C:\Program Files\Five Percent Online MetaTrader 5\terminal64.exe"`
+- `--sidecar-root "...\Common\Files\Arc10_5ers"`
+
+## FundedNext — EET-anchored bars
+
+**Evidence:** Same panel-diff methodology. FundedNext H4 bars matched HistData M1 aggregated at +2h offset (EET winter) or +3h (EEST summer). UTC-anchored aggregation rejected at ~15× higher delta.
+
+**Implication:** FundedNext publishes H4 bars on EET-local midnight boundaries. In true-UTC terms:
+- Winter (EET, UTC+2): bars at 22/02/06/10/14/18 UTC
+- Summer (EEST, UTC+3): bars at 21/01/05/09/13/17 UTC
+
+DST transitions happen in late March (spring forward to EEST) and late October (fall back to EET).
+
+**Symbol naming:** plain (`EURUSD`, no suffix). Same as 5ers, no `mt5_symbol_map` needed.
+
+**Sidecar configuration:**
+- `boundary_convention: "5ers_eet"` in `winning_config.yaml`
+- `--mt5-path "C:\Program Files\FundedNext MT5 Terminal\terminal64.exe"`
+- `--sidecar-root "...\Common\Files\Arc10_FundedNext"`
+
+## Why this matters
+
+The strategy was originally validated on EET convention ("5ers_eet" — the boundary used in the original v3.0.2 WFO). When 5ers panel-diff showed 5ers is UTC-anchored, we re-validated the strategy on UTC for 5ers deployment. Both PASS-DEPLOYABLE, but they're slightly different number sets (see `02_validation/05_cost_sweep.md`).
+
+If we pointed a UTC-configured sidecar at FundedNext (EET broker), the sidecar would fetch EET-anchored bars and feed them to the UTC-validated signal logic. Result: wrong signals fired at wrong times. The sidecar wouldn't crash — it would silently produce incorrect output.
+
+**Mitigation:** each broker's deployment uses a fixed config file with a `boundary_convention` and a derived `config_hash`. The EA verifies `Expected_Config_Hash` matches the envelope's `config_hash` on each signal. If an operator mis-configures (UTC sidecar pointing at EET MT5), the EA would refuse the envelope on hash mismatch.
+
+## Cross-pair check
+
+The panel-diff was run across all 28 Arc 10 pairs to ensure the convention is uniform across the symbol universe (not just majors). Result: all 28 pairs match their respective broker's anchor convention with the same offset.
+
+If a broker were to introduce a pair with a different convention (unlikely but possible), the anchor check at sidecar startup (`verify_mt5_h4_alignment`) would flag it before any trades fired.
+
+## Live operational check
+
+The sidecar's anchor probe runs at startup:
+
+1. Read recent H4 bars from MT5 via `copy_rates_from_pos()`
+2. Check that bar `time` values fall on expected grid for the configured convention
+3. If misaligned: refuse to start with error message
+4. If aligned: proceed to first cycle
+
+This is the operational backstop. Even if the static panel-diff was wrong, the live anchor check would catch a convention mismatch at sidecar startup.
+
+## DST handling
+
+EET observes daylight savings (EET → EEST in late March, EEST → EET in late October). UTC does not.
+
+For UTC convention (5ers): no DST concern. Sidecar wakes at 00/04/.../20 UTC year-round.
+
+For EET convention (FundedNext): sidecar handles DST via `zoneinfo.ZoneInfo("Europe/Athens")`. The bar anchor in UTC terms shifts by 1h across DST transitions:
+- Before spring transition: EET = UTC+2, bars at 22 UTC = EET midnight
+- After spring transition: EEST = UTC+3, bars at 21 UTC = EET midnight
+
+The Phase 2 EET parity validation included at least one spring-forward and one fall-back DST transition in its sweep. Both passed byte-identical.
+
+## Source artifacts
+
+| Artifact | Path |
+|---|---|
+| FundedNext panel-diff report | `results/fundednext_panel_diff/panel_diff_report.md` |
+| FundedNext panel-diff data | `results/fundednext_panel_diff/` (raw JSON, 3 windows) |
+| 5ers panel-diff (earlier work) | `results/spread_validation/` or chat history record |
+| Anchor probe code | `deployment/sidecar/sidecar.py` `verify_mt5_h4_alignment()` |
+| Sidecar boundary logic | `deployment/sidecar/boundary.py` |
+
+## How to re-verify if needed
+
+If a broker changes its convention (rare but possible), run:
+
+```
+scripts/fundednext_anchor_check.py  # adapt for other brokers
+```
+
+Pull 2-3 weeks of broker-native H4 bars, compare to HistData M1 aggregated at both UTC and EET offsets, report which convention matches. Process takes ~1 hour.
+
+If both match: broker is doing something unusual (likely UTC server clock + EET bars, or vice versa). Investigate before deploying.

--- a/arc_10/03_deployment/01_architecture.md
+++ b/arc_10/03_deployment/01_architecture.md
@@ -1,0 +1,166 @@
+# Deployment Architecture
+
+> **Audience:** Anyone who needs to understand how the live system is wired up.
+
+## High-level diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                  Contabo VPS (Frankfurt, Win Server 2022)            │
+│                                                                      │
+│  ┌────────────────────────┐         ┌────────────────────────┐     │
+│  │   5ers MT5 Terminal     │         │  FundedNext MT5 Terminal│     │
+│  │  (logged into demo)     │         │  (logged into demo)     │     │
+│  │                         │         │                         │     │
+│  │  • 28 pairs in Market   │         │  • 28 pairs in Market   │     │
+│  │    Watch                │         │    Watch                │     │
+│  │  • EA on EURUSD chart   │         │  • EA on EURUSD chart   │     │
+│  │  • Magic 1010202601     │         │  • Magic 1010202602     │     │
+│  │  • config_hash 4467...  │         │  • config_hash 75d0...  │     │
+│  └───────────┬─────────────┘         └───────────┬─────────────┘     │
+│              │ FILE_COMMON                       │ FILE_COMMON       │
+│              ▼                                   ▼                   │
+│  ┌────────────────────────────────────────────────────────────┐    │
+│  │  C:\Users\Administrator\AppData\Roaming\MetaQuotes\         │    │
+│  │  Terminal\Common\Files\                                     │    │
+│  │  ├── Arc10_5ers\        (5ers paths)                        │    │
+│  │  │   ├── signals_out\      ← sidecar writes here            │    │
+│  │  │   ├── signals_processed\                                 │    │
+│  │  │   ├── signals_failed\                                    │    │
+│  │  │   ├── sidecar.heartbeat                                  │    │
+│  │  │   ├── sidecar_state.json                                 │    │
+│  │  │   ├── ea.heartbeat                                       │    │
+│  │  │   ├── ea_positions.json                                  │    │
+│  │  │   ├── trade_log.csv                                      │    │
+│  │  │   └── logs\                                              │    │
+│  │  └── Arc10_FundedNext\  (FN paths, same structure)          │    │
+│  └────────────────────────────────────────────────────────────┘    │
+│              ▲                                   ▲                   │
+│              │ writes signals                    │                   │
+│  ┌───────────┴─────────────┐         ┌───────────┴─────────────┐     │
+│  │  Arc10Sidecar5ers       │         │  Arc10SidecarFundedNext │     │
+│  │  (NSSM service)         │         │  (NSSM service)         │     │
+│  │                         │         │                         │     │
+│  │  python -m sidecar      │         │  python -m sidecar      │     │
+│  │  --config UTC.yaml      │         │  --config EET.yaml      │     │
+│  │  --mt5-path "5ers"      │         │  --mt5-path "FN"        │     │
+│  │  --sidecar-root "..."   │         │  --sidecar-root "..."   │     │
+│  │                         │         │                         │     │
+│  │  Wakes every 4h UTC     │         │  Wakes every 4h EET     │     │
+│  │  Fetches 28 pairs       │         │  Fetches 28 pairs       │     │
+│  │  Emits signal envelopes │         │  Emits signal envelopes │     │
+│  └─────────────────────────┘         └─────────────────────────┘     │
+│              ▲                                   ▲                   │
+│              │ supervises                        │ supervises        │
+│  ┌───────────┴─────────────┐         ┌───────────┴─────────────┐     │
+│  │  Arc10WatchDog_5ers     │         │  Arc10WatchDog_FundedNext│    │
+│  │  (Task Scheduler, 5min) │         │  (Task Scheduler, 5min) │     │
+│  │                         │         │                         │     │
+│  │  • Check heartbeat fresh│         │  • Same                 │     │
+│  │  • Restart service if   │         │                         │     │
+│  │    stale > 4h10min      │         │                         │     │
+│  └─────────────────────────┘         └─────────────────────────┘     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## The four moving parts
+
+### 1. MT5 Terminals
+
+Each broker has its own MT5 terminal installation. Both running 24/7 on the VPS, logged into their respective accounts, with all 28 Arc 10 pairs in Market Watch.
+
+**Critical:** must stay logged in. If MT5 logs out, the sidecar can't fetch data and the EA can't place trades. NSSM doesn't supervise MT5 — it's a GUI app, not a service.
+
+### 2. Sidecar Services
+
+Each broker has its own NSSM-managed Python sidecar. Each runs `python -m deployment.sidecar` with broker-specific arguments:
+
+- `--winning-config` points to that broker's config file (UTC or EET)
+- `--sidecar-root` points to that broker's `Arc10_*\` subfolder
+- `--mt5-path` points to that broker's `terminal64.exe`
+
+Both services share the SAME repo (`C:\Forex-Backtester`) and SAME Python interpreter (`C:\Python311\python.exe`). Code is identical; only runtime configuration differs.
+
+### 3. EAs
+
+Each MT5 has the Arc10_DLR_Sidecar_EA attached to ONE chart. Same compiled .ex5 on both terminals.
+
+Input parameters differ between brokers:
+- Risk_Per_Trade: 0.0040 (5ers) vs 0.0050 (FundedNext)
+- Magic_Number: 1010202601 vs 1010202602
+- Expected_Config_Hash: 4467366b...840821e vs 75d03904...41cf87
+- Sidecar_Inbox_Dir / etc.: Arc10_5ers vs Arc10_FundedNext
+
+The EA polls its sidecar's `signals_out/` folder via FILE_COMMON. Validates each envelope's config_hash matches Expected_Config_Hash before processing.
+
+### 4. Watchdogs
+
+Each sidecar has a Task Scheduler entry checking heartbeat freshness every 5 minutes. If `sidecar.heartbeat` is older than 4h 10min (one H4 cycle + 10min buffer), watchdog runs `nssm restart Arc10Sidecar<broker>`.
+
+Plus NSSM's own restart-on-crash supervision. Two layers of failure recovery.
+
+## File flow per trade
+
+1. **H4 boundary closes** (e.g. 12:00 UTC for UTC convention)
+2. **Sidecar wakes** at +10s buffer
+3. **Sidecar fetches** H4 + D1 panels for 28 pairs from MT5
+4. **Sidecar computes** signals via `signals.lchar_dlr_long.compute_signal()`
+5. **For any pair that fires:** sidecar writes `Arc10_5ers/signals_out/EURUSD_2026-05-29T12_00_00Z.json` (or similar)
+6. **Sidecar writes** `sidecar.heartbeat` with timestamp
+7. **EA detects** the envelope on next OnTick (every ~few seconds during market hours)
+8. **EA validates** envelope: config_hash matches, schema valid, sidecar heartbeat fresh
+9. **EA places** market buy order with SL set
+10. **Broker fills** the order, returns ticket
+11. **EA writes** `trade_log.csv` entry row
+12. **EA moves** envelope to `signals_processed/`
+
+Future events on the same trade (partial close at TP1, trail modifications, exit) write additional rows to `trade_log.csv`.
+
+## Independence between the two brokers
+
+The two deployments are **fully independent**:
+
+- Different MT5 terminals → different broker connections, different price feeds
+- Different `Arc10_*\` subfolders → no shared files between sidecars
+- Different config_hash → hash mismatch would catch cross-contamination
+- Different magic numbers → broker can distinguish trades from each EA
+- Different NSSM services → one can be restarted/upgraded without affecting the other
+- Different watchdogs → independent failure detection
+
+If 5ers MT5 disconnects, FundedNext keeps trading. If FundedNext sidecar crashes, 5ers sidecar keeps cycling. No shared failure points except:
+- The VPS itself (single point of failure for the whole system)
+- The OS (Windows update could affect both)
+- The repo (a bad git pull would affect both if it broke shared code)
+
+## VPS specs
+
+| Resource | Spec | Used | Margin |
+|---|---|---|---|
+| CPU | 4 cores | ~20% idle, peaks at H4 closes | 80% margin |
+| RAM | 8 GB | ~3 GB used by MT5×2 + sidecars×2 + Windows | 5 GB margin |
+| Disk | 150 GB SSD | <2 GB used | massive margin |
+| Network | 200 Mbit/s | minimal sustained, peaks during fetch | huge margin |
+| Location | Frankfurt (EU) | ~25ms RTT to FundedNext server (London) | acceptable |
+
+Cost: ~$14.59/month. No upgrade needed for current deployment.
+
+## What's NOT on the VPS
+
+- The repo's research code (backtester, WFO, signal discovery). Only deployment code is needed live.
+- Strategy research data (`results/l_arc_10_*` folders). Production sidecar reads only `winning_config.yaml`.
+- ForexFactory news calendar download cache. Downloaded fresh by sidecar every 4 hours.
+- Trade analytics / reporting. Generated from `trade_log.csv` files post-hoc.
+
+Keeping the VPS lean reduces attack surface and noise. Research work happens on local; only deployment artifacts live on VPS.
+
+## Source artifacts
+
+| Artifact | Path |
+|---|---|
+| Sidecar entry point | `deployment/sidecar/__main__.py` |
+| Sidecar main loop | `deployment/sidecar/sidecar.py` |
+| Boundary convention logic | `deployment/sidecar/boundary.py` |
+| EA source | `deployment/ea/Arc10_DLR_Sidecar_EA.mq5` + `include/*.mqh` |
+| Watchdog script | `deployment/ops/watchdog.ps1` |
+| Watchdog install script (reference) | `deployment/ops/install_watchdog_task.ps1` |
+| NSSM | `C:\Tools\nssm.exe` on VPS |

--- a/arc_10/03_deployment/02_5ers_setup.md
+++ b/arc_10/03_deployment/02_5ers_setup.md
@@ -1,0 +1,149 @@
+# 5ers Deployment
+
+> **Purpose:** Document the exact configuration of the 5ers UTC deployment.
+> **Status:** Live on demo $10k account, will continue post-Challenge.
+> **Convention:** UTC.
+
+## Account
+
+- **Broker:** Five Percent Online (5ers)
+- **Server:** `FivePercentOnline-Real`
+- **Account size:** $10k (demo for now; live after Challenge if applicable)
+- **Hard limits:** 10% max DD, 5% daily DD
+
+## Files & paths (on VPS)
+
+| Item | Path |
+|---|---|
+| MT5 install | `C:\Program Files\Five Percent Online MetaTrader 5\` |
+| MT5 terminal64.exe | `C:\Program Files\Five Percent Online MetaTrader 5\terminal64.exe` |
+| Terminal data folder | `C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\10CE948A1DFC9A8C27E56E827008EBD4\` |
+| EA experts folder | `...\10CE948A1DFC9A8C27E56E827008EBD4\MQL5\Experts\Arc10_Sidecar\` |
+| Sidecar root | `C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\` |
+| Sidecar config | `C:\Forex-Backtester\configs\l_arc_10_v3.0.2_utc_rerun\winning_config.yaml` |
+
+## Service & supervision
+
+- **NSSM service name:** `Arc10Sidecar5ers`
+- **Service start type:** Automatic (auto-starts on VPS reboot)
+- **Watchdog task:** `Arc10WatchDog_5ers` (Task Scheduler, every 5 minutes)
+- **Logs:** `C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log`
+
+## Sidecar command-line (exact)
+
+```
+C:\Python311\python.exe -m deployment.sidecar
+  --winning-config "C:\Forex-Backtester\configs\l_arc_10_v3.0.2_utc_rerun\winning_config.yaml"
+  --sidecar-root "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers"
+  --mt5-path "C:\Program Files\Five Percent Online MetaTrader 5\terminal64.exe"
+  --log-level INFO
+```
+
+(NSSM stores these; AppDirectory is `C:\Forex-Backtester`.)
+
+## EA Input parameters
+
+Attached to **ONE chart** on the 5ers MT5 (any pair; EURUSD H4 is the convention).
+
+| Input | Value |
+|---|---|
+| Risk_Per_Trade | `0.0040` |
+| Total_DD_Halt_Pct | `0.07` |
+| Total_DD_CloseAll_Pct | `0.08` |
+| Daily_DD_Halt_Pct | `0.035` |
+| Daily_DD_CloseAll_Pct | `0.045` |
+| Time_Exit_Bars | `240` |
+| SL_ATR_Multiplier_Expected | `3.5` |
+| Sidecar_Inbox_Dir | `Arc10_5ers\signals_out` |
+| Sidecar_Processed_Dir | `Arc10_5ers\signals_processed` |
+| Sidecar_Failed_Dir | `Arc10_5ers\signals_failed` |
+| Sidecar_Heartbeat_Path | `Arc10_5ers\sidecar.heartbeat` |
+| Ea_Heartbeat_Path | `Arc10_5ers\ea.heartbeat` |
+| Ea_Positions_Path | `Arc10_5ers\ea_positions.json` |
+| Trade_Log_Path | `Arc10_5ers\trade_log.csv` |
+| Sidecar_Heartbeat_Max_Age_Sec | `600` |
+| **Expected_Config_Hash** | `4467366b9537871fe9019af45cf26f54e042358f211ff58774497b00c840821e` |
+| News_Calendar_URL | `https://nfs.faireconomy.media/ff_calendar_thisweek.xml` |
+| Enable_News_Filter | `true` |
+| News_Window_Sec | `120` |
+| News_Delay_Buffer_Sec | `5` |
+| News_Delay_Max_Sec | `3600` |
+| News_Refresh_Sec | `14400` |
+| **Magic_Number** | `1010202601` |
+| Signal_Poll_Min_Interval_Sec | `5` |
+
+Plus on the Common tab: ✅ "Allow Algo Trading".
+
+## News filter URL whitelisted in MT5
+
+Tools → Options → Expert Advisors:
+- ✅ Allow WebRequest for listed URL
+- URL: `https://nfs.faireconomy.media`
+
+## Risk per trade rationale
+
+0.40% locked per cost sweep (`02_validation/05_cost_sweep.md`):
+- 5ers carries swap, which is dominant cost vector under UTC
+- At r_base 0.5%, central case (1.5× spread, swap-ON) lands at 10.47% worst-fold DD — breaches 10% hard limit
+- Linear scaling to 0.40% brings central worst-fold DD to 8.38% — 1.6pp margin
+
+Expected live (after haircuts): worst-fold DD ~9.5%, worst-fold ratio ~1.8, holdout ROI ~27%.
+
+## Connection details (operational)
+
+- **Server timezone:** EET (+2 winter / +3 summer) — chart timestamps are EET
+- **Bar anchor convention:** UTC (despite EET clock) — verified by panel-diff
+- **Sidecar wakes at:** 00, 04, 08, 12, 16, 20 UTC (+10s buffer)
+- **Daily DD reset:** UTC midnight (00:00 UTC)
+- **Weekend hold:** allowed (no specific 5ers prohibition for funded — verify if rules change)
+
+## Per-trade economics
+
+| Item | Value |
+|---|---|
+| Risk per trade ($) | $40 (0.40% of $10k) |
+| SL distance | 3.5 × ATR_at_signal |
+| Commission | $4 per lot round-turn |
+| Swap | Real (charged) |
+| Average expected R per trade | ~0.5-0.7R (cost sweep central case) |
+| Expected trades per year | ~225 (3,152 trades / 14 years = 225) |
+| Expected annual ROI (cost-adjusted) | ~27% (after haircuts) |
+
+## Verification checklist (post-deploy)
+
+After deploying or restarting:
+
+```powershell
+# Service status
+& "C:\Tools\nssm.exe" status Arc10Sidecar5ers
+# → SERVICE_RUNNING
+
+# Watchdog status
+Get-ScheduledTask Arc10WatchDog_5ers | Select TaskName, State
+# → State: Ready
+
+# Heartbeat freshness
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\sidecar.heartbeat" -Raw
+# → last_heartbeat_utc within last 4 hours
+# → pairs_processed_last_loop lists all 28 pairs
+
+# Latest logs
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log" -Tail 20
+# → "sidecar starting — config_hash=4467366b... restart_count=N pairs=28"
+# → No tracebacks, no "fetch failed" lines
+```
+
+In MT5 (visual check):
+- Bottom-right shows green connection icon, balance/equity numbers
+- Chart with EA attached shows smiley face icon (top-right)
+- Experts tab in Toolbox shows `[ARC10] EA init magic=1010202601 sidecar_inbox=Common\Files\Arc10_5ers\signals_out`
+- Once first H4 cycle completes: `[ARC10] sidecar-heartbeat stale=false`
+
+## What changes if 5ers becomes the primary deployment
+
+Currently 5ers is the secondary/fallback. If FundedNext path breaks and 5ers becomes primary:
+
+1. Increase capital if 5ers offers it
+2. Risk stays at 0.40% (locked by cost sweep)
+3. No code or config changes
+4. EA continues to operate the same way against the same MT5 install

--- a/arc_10/03_deployment/03_fundednext_setup.md
+++ b/arc_10/03_deployment/03_fundednext_setup.md
@@ -1,0 +1,200 @@
+# FundedNext Deployment
+
+> **Purpose:** Document the exact configuration of the FundedNext EET deployment.
+> **Status:** Live on demo $100k account, ready for $100k Challenge.
+> **Convention:** EET (`5ers_eet`).
+
+## Account
+
+- **Broker:** FundedNext
+- **Server:** FundedNext-Demo (will be different post-Challenge — check FundedNext panel for exact server name)
+- **Account size:** $100k (demo) → $100k Challenge → $100k funded (post-Challenge pass)
+- **Hard limits:** 10% max DD, 5% daily DD
+- **Special add-on:** Swap-free enabled (zero swap cost on all positions, both Challenge and funded)
+- **Weekend holds:** Allowed (confirmed by FundedNext)
+- **News trading:** Allowed (confirmed; we keep news filter ON for consistency with 5ers)
+
+## Files & paths (on VPS)
+
+| Item | Path |
+|---|---|
+| MT5 install | `C:\Program Files\FundedNext MT5 Terminal\` |
+| MT5 terminal64.exe | `C:\Program Files\FundedNext MT5 Terminal\terminal64.exe` |
+| Terminal data folder | `C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\89FE26BBBAB28C077BBF5FA8C1B4DF1C\` |
+| EA experts folder | `...\89FE26BBBAB28C077BBF5FA8C1B4DF1C\MQL5\Experts\Arc10_Sidecar\` |
+| Sidecar root | `C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\` |
+| Sidecar config | `C:\Forex-Backtester\configs\l_arc_10_v3.0.2\winning_config.yaml` |
+
+## Service & supervision
+
+- **NSSM service name:** `Arc10SidecarFundedNext`
+- **Service start type:** Automatic
+- **Watchdog task:** `Arc10WatchDog_FundedNext`
+- **Logs:** `C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\logs\sidecar.stderr.log`
+
+## Sidecar command-line (exact)
+
+```
+C:\Python311\python.exe -m deployment.sidecar
+  --winning-config "C:\Forex-Backtester\configs\l_arc_10_v3.0.2\winning_config.yaml"
+  --sidecar-root "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext"
+  --mt5-path "C:\Program Files\FundedNext MT5 Terminal\terminal64.exe"
+  --log-level INFO
+```
+
+## EA Input parameters
+
+Attached to **ONE chart** on the FundedNext MT5.
+
+| Input | Value |
+|---|---|
+| Risk_Per_Trade | `0.0050` |
+| Total_DD_Halt_Pct | `0.07` |
+| Total_DD_CloseAll_Pct | `0.08` |
+| Daily_DD_Halt_Pct | `0.035` |
+| Daily_DD_CloseAll_Pct | `0.045` |
+| Time_Exit_Bars | `240` |
+| SL_ATR_Multiplier_Expected | `3.5` |
+| Sidecar_Inbox_Dir | `Arc10_FundedNext\signals_out` |
+| Sidecar_Processed_Dir | `Arc10_FundedNext\signals_processed` |
+| Sidecar_Failed_Dir | `Arc10_FundedNext\signals_failed` |
+| Sidecar_Heartbeat_Path | `Arc10_FundedNext\sidecar.heartbeat` |
+| Ea_Heartbeat_Path | `Arc10_FundedNext\ea.heartbeat` |
+| Ea_Positions_Path | `Arc10_FundedNext\ea_positions.json` |
+| Trade_Log_Path | `Arc10_FundedNext\trade_log.csv` |
+| Sidecar_Heartbeat_Max_Age_Sec | `600` |
+| **Expected_Config_Hash** | `75d03904457580b77be63639a281dc550ca584fc5603cfb946102b836d41cf87` |
+| News_Calendar_URL | `https://nfs.faireconomy.media/ff_calendar_thisweek.xml` |
+| Enable_News_Filter | `true` |
+| News_Window_Sec | `120` |
+| News_Delay_Buffer_Sec | `5` |
+| News_Delay_Max_Sec | `3600` |
+| News_Refresh_Sec | `14400` |
+| **Magic_Number** | `1010202602` |
+| Signal_Poll_Min_Interval_Sec | `5` |
+
+Plus on the Common tab: ✅ "Allow Algo Trading".
+
+## News filter URL whitelisted in MT5
+
+Tools → Options → Expert Advisors:
+- ✅ Allow WebRequest for listed URL
+- URL: `https://nfs.faireconomy.media`
+
+## Risk per trade rationale
+
+0.50% locked per cost sweep (`02_validation/05_cost_sweep.md`):
+- FundedNext is swap-free → strict improvement vs UTC (no dominant swap cost)
+- At r_base 0.5%, central case (1.5× spread, swap-OFF, 0.5 slip) lands at 7.80% worst-fold DD — within target
+- Adjacent cells recommend 0.49% (adverse) to 0.53% (optimistic) — band spans r_base
+- Deploy at 0.50%, accept central case with 2.2pp margin to 10% hard limit
+
+Expected live (after haircuts): worst-fold DD ~8.8%, worst-fold ratio ~3.4, holdout ROI ~44%.
+
+## Connection details (operational)
+
+- **Server timezone:** EET (+2 winter / +3 summer)
+- **Bar anchor convention:** EET — verified by panel-diff
+- **Sidecar wakes at:** EET-anchored boundaries = UTC 22/02/06/10/14/18 (winter) or UTC 21/01/05/09/13/17 (summer)
+- **Daily DD reset:** EET midnight (broker-local)
+- **DST handling:** Sidecar handles EET ↔ EEST transitions via `zoneinfo.ZoneInfo("Europe/Athens")`. No operator action needed.
+
+## Per-trade economics
+
+| Item | Value |
+|---|---|
+| Risk per trade ($) | $500 (0.50% of $100k) |
+| SL distance | 3.5 × ATR_at_signal |
+| Commission | $5 per lot round-turn |
+| Swap | None (swap-free add-on) |
+| Average expected R per trade | ~0.7-0.9R (cost sweep central case) |
+| Expected trades per year | ~225 |
+| Expected annual ROI (cost-adjusted) | ~44% (after haircuts) |
+
+## Challenge phase rules (verify current rules before buying)
+
+**Phase 1 (Challenge):**
+- Target: typically +8% profit
+- Max DD: 10% account, 5% daily
+- Min trading days: typically 5 days
+- Time limit: typically 60+ days
+
+**Phase 2 (Verification):**
+- Target: typically +5% profit
+- Same DD limits
+- Same min days
+
+**Funded:**
+- 80% profit split
+- Continues to be on swap-free
+- Can scale account at performance milestones
+
+**Always verify current rules with FundedNext support before purchasing.** Rules change.
+
+## Transition from demo → Challenge → funded
+
+**No system changes required.** Same MT5 install, same sidecar service, same EA.
+
+1. Buy Challenge → FundedNext emails account credentials
+2. In FundedNext MT5: File → Login to Trade Account → enter Challenge credentials
+3. MT5 reconnects, EA detects new balance on next init
+4. Trade as normal
+
+If Challenge passes → repeat for verification phase, then for funded account. Each transition is a re-login, not a re-deploy.
+
+## Verification checklist (post-deploy)
+
+```powershell
+# Service status
+& "C:\Tools\nssm.exe" status Arc10SidecarFundedNext
+# → SERVICE_RUNNING
+
+# Watchdog status
+Get-ScheduledTask Arc10WatchDog_FundedNext | Select TaskName, State
+# → Ready
+
+# Heartbeat freshness
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\sidecar.heartbeat" -Raw
+# → last_heartbeat_utc within last 4 hours (or 5 hours during EEST)
+# → 28 pairs listed
+
+# Logs
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\logs\sidecar.stderr.log" -Tail 20
+# → "sidecar starting — config_hash=75d03904... pairs=28"
+```
+
+In MT5:
+- Bottom-right green connection, balance/equity
+- Chart shows EA smiley face
+- Experts tab: `[ARC10] EA init magic=1010202602 sidecar_inbox=Common\Files\Arc10_FundedNext\signals_out`
+
+## Risk ramp for first weeks live
+
+Don't deploy at full 0.50% on day one. Ramp:
+
+- **Week 1:** Risk_Per_Trade = `0.0020` (0.20%, $200/trade)
+- **Week 2:** if Week 1 clean → `0.0030` (0.30%)
+- **Week 3+:** if Week 2 clean → `0.0050` (0.50%, target)
+
+If anything anomalous happens in any week, hold or scale back. Don't ramp up under pressure.
+
+## What changes between demo and live Challenge
+
+| Item | Demo | Challenge | Funded |
+|---|---|---|---|
+| Account credentials | Demo login | Challenge login | Funded login |
+| Sidecar | Same | Same | Same |
+| EA | Same | Same | Same |
+| Risk | 0.20-0.50% (ramping) | 0.50% | 0.50% |
+| Hard DD limit | 10% | 10% | 10% |
+| Profit target | N/A | +8% (Phase 1) | None |
+| Profit split | N/A | None (challenge) | 80% |
+
+## How to verify swap-free is actually applied
+
+After first overnight position holds, check the trade in MT5's history:
+
+- View → Reports → click trade
+- Check "Swap" column: should be `0.00` for ALL closed trades that held overnight
+
+If swap is NOT 0 on swap-eligible trades, swap-free add-on is not active. Contact FundedNext support immediately. **Don't continue trading at 0.50% risk if swap is being applied** — cost sweep economics break.

--- a/arc_10/03_deployment/04_vps_setup_guide.md
+++ b/arc_10/03_deployment/04_vps_setup_guide.md
@@ -1,0 +1,388 @@
+# VPS Setup Guide
+
+> **Purpose:** Step-by-step runbook for setting up the Arc 10 deployment on a fresh Windows VPS.
+> **Time:** ~3 hours focused work
+> **Prerequisites:** Empty Windows Server 2019/2022 VPS with admin RDP access; broker MT5 installers and credentials available
+
+## Final state after this runbook
+
+- 2x MT5 terminals installed and logged in (5ers + FundedNext)
+- 2x NSSM-managed sidecar services running
+- 2x Task Scheduler watchdog entries supervising heartbeats
+- 2x EAs attached to charts with correct config_hash and magic numbers
+- System runs unattended, restarts on VPS reboot, auto-recovers from sidecar crashes
+
+## Step 1 — Install Python 3.11
+
+Open Administrator PowerShell.
+
+```powershell
+# Download Python 3.11.9
+$installer = "$env:TEMP\python-3.11.9-amd64.exe"
+Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe" -OutFile $installer
+
+# Verify
+Test-Path $installer
+# Should return True
+
+# Install: all users, PATH added, target C:\Python311
+Start-Process -FilePath $installer -ArgumentList "/quiet InstallAllUsers=1 TargetDir=C:\Python311 PrependPath=1 Include_test=0 Include_doc=0" -Wait
+
+# Verify
+Test-Path "C:\Python311\python.exe"
+```
+
+Close this PowerShell window. Open a new Administrator PowerShell to pick up the updated PATH.
+
+```powershell
+python --version
+# → Python 3.11.9
+```
+
+## Step 2 — Install Git for Windows
+
+```powershell
+$installer = "$env:TEMP\GitInstaller.exe"
+Invoke-WebRequest -Uri "https://github.com/git-for-windows/git/releases/download/v2.45.2.windows.1/Git-2.45.2-64-bit.exe" -OutFile $installer
+Start-Process -FilePath $installer -ArgumentList "/VERYSILENT /NORESTART" -Wait
+$env:Path += ";C:\Program Files\Git\cmd"
+git --version
+# → git version 2.45.2.windows.1
+```
+
+## Step 3 — Generate GitHub PAT (one-time)
+
+On any device with browser access:
+
+1. GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens
+2. Generate new token: name "VPS deploy", expiration 90 days
+3. Resource owner: your username
+4. Repository access: select `Forex-Backtester`
+5. Permissions: Contents (read/write), Metadata (read-only — auto-required)
+6. Generate token → copy to clipboard
+
+## Step 4 — Clone the repo
+
+```powershell
+cd C:\
+git clone https://YOUR-USERNAME:YOUR-PAT@github.com/YOUR-USERNAME/Forex-Backtester.git
+cd C:\Forex-Backtester
+git log --oneline -3
+# → Should show recent commits ending in arc-10-eet-parity-validated or later
+```
+
+## Step 5 — Install Python dependencies
+
+```powershell
+cd C:\Forex-Backtester
+pip install MetaTrader5
+pip install -r requirements-dev.txt
+```
+
+Verify:
+
+```powershell
+python -c "import MetaTrader5; print('MT5 lib:', MetaTrader5.__version__)"
+python -c "import pandas, numpy, yaml; print('core deps OK')"
+# → Both should print success
+```
+
+## Step 6 — Install both MT5 terminals
+
+Download installers:
+- 5ers: log into 5ers member area → download MT5 installer
+- FundedNext: log into FundedNext member area → download MT5 installer
+
+Run each installer:
+- **5ers installer:** install to default `C:\Program Files\Five Percent Online MetaTrader 5\`
+- **FundedNext installer:** install to default `C:\Program Files\FundedNext MT5 Terminal\`
+
+Both installers may auto-launch their terminals after install. That's fine — leave them running.
+
+In each MT5:
+
+1. **Login:** File → Login to Trade Account → enter account credentials → OK
+2. **Verify connection:** bottom-right shows green icon + balance/equity
+3. **Add 28 pairs to Market Watch:**
+   - View → Market Watch (Ctrl+M)
+   - Right-click in panel → Symbols (Ctrl+U)
+   - Find each pair, click "Show":
+     AUDCAD, AUDCHF, AUDJPY, AUDNZD, AUDUSD, CADCHF, CADJPY, CHFJPY, EURAUD, EURCAD, EURCHF, EURGBP, EURJPY, EURNZD, EURUSD, GBPAUD, GBPCAD, GBPCHF, GBPJPY, GBPNZD, GBPUSD, NZDCAD, NZDCHF, NZDJPY, NZDUSD, USDCAD, USDCHF, USDJPY
+   - Click OK
+4. **Whitelist news URL:**
+   - Tools → Options → Expert Advisors
+   - ✅ Allow WebRequest for listed URL
+   - Add: `https://nfs.faireconomy.media`
+   - Click OK
+
+Do this for both terminals.
+
+Identify each terminal's data folder hash:
+
+```powershell
+Get-ChildItem "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\" -Directory | ForEach-Object {
+  $origin = Get-Content "$($_.FullName)\origin.txt" -ErrorAction SilentlyContinue
+  [PSCustomObject]@{ TerminalID = $_.Name; Origin = $origin }
+}
+```
+
+Note which terminal ID corresponds to which broker. Save those for the EA file paths.
+
+## Step 7 — Create sidecar root directories
+
+```powershell
+$common = "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files"
+New-Item -ItemType Directory -Force -Path "$common\Arc10_5ers\signals_out","$common\Arc10_5ers\signals_processed","$common\Arc10_5ers\signals_failed","$common\Arc10_5ers\logs" | Out-Null
+New-Item -ItemType Directory -Force -Path "$common\Arc10_FundedNext\signals_out","$common\Arc10_FundedNext\signals_processed","$common\Arc10_FundedNext\signals_failed","$common\Arc10_FundedNext\logs" | Out-Null
+
+Get-ChildItem "$common" -Directory
+# Should show Arc10_5ers and Arc10_FundedNext
+```
+
+## Step 8 — Smoke test sidecars (before installing as services)
+
+Pre-flight check: confirm both sidecars boot cleanly against their MT5s before automating.
+
+```powershell
+# 5ers smoke test
+python -m deployment.sidecar `
+  --winning-config "C:\Forex-Backtester\configs\l_arc_10_v3.0.2_utc_rerun\winning_config.yaml" `
+  --sidecar-root "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers" `
+  --mt5-path "C:\Program Files\Five Percent Online MetaTrader 5\terminal64.exe" `
+  --quick-test --log-level INFO 2> smoke_5ers.log
+
+Get-Content smoke_5ers.log -Tail 20
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\sidecar_state.json" -Raw
+```
+
+Expected: log shows `sidecar starting — config_hash=4467366b...`, state file lists all 28 pairs with recent timestamps.
+
+```powershell
+# FundedNext smoke test
+python -m deployment.sidecar `
+  --winning-config "C:\Forex-Backtester\configs\l_arc_10_v3.0.2\winning_config.yaml" `
+  --sidecar-root "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext" `
+  --mt5-path "C:\Program Files\FundedNext MT5 Terminal\terminal64.exe" `
+  --quick-test --log-level INFO 2> smoke_fn.log
+
+Get-Content smoke_fn.log -Tail 20
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\sidecar_state.json" -Raw
+```
+
+Expected: log shows `sidecar starting — config_hash=75d03904...`, state file lists 28 pairs.
+
+**If either smoke test fails, stop and diagnose.** Common failures:
+- Wrong MT5 path → check exact install dir
+- MT5 not logged in → re-login in MT5 GUI
+- Pair missing from Market Watch → add via Symbols dialog
+- Convention mismatch (anchor probe fails) → verify which broker is which config
+
+## Step 9 — Install NSSM
+
+```powershell
+$nssm_zip = "$env:TEMP\nssm.zip"
+Invoke-WebRequest -Uri "https://nssm.cc/release/nssm-2.24.zip" -OutFile $nssm_zip
+Expand-Archive -Path $nssm_zip -DestinationPath "C:\Tools\" -Force
+Copy-Item "C:\Tools\nssm-2.24\win64\nssm.exe" "C:\Tools\nssm.exe" -Force
+& "C:\Tools\nssm.exe" version
+# → NSSM: ... Version 2.24 64-bit
+```
+
+## Step 10 — Create both NSSM services
+
+Important: NSSM strips quotes via PowerShell. We install with placeholder args, then use NSSM GUI editor to set proper quoting.
+
+### Install 5ers service
+
+```powershell
+$nssm = "C:\Tools\nssm.exe"
+$python = "C:\Python311\python.exe"
+
+# Install with placeholder
+& $nssm install Arc10Sidecar5ers $python "placeholder"
+
+# Set support fields
+& $nssm set Arc10Sidecar5ers AppDirectory "C:\Forex-Backtester"
+& $nssm set Arc10Sidecar5ers AppStdout "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stdout.log"
+& $nssm set Arc10Sidecar5ers AppStderr "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log"
+& $nssm set Arc10Sidecar5ers AppRestartDelay 10000
+& $nssm set Arc10Sidecar5ers AppExit Default Restart
+& $nssm set Arc10Sidecar5ers Start SERVICE_AUTO_START
+
+# Open GUI editor to set Arguments with quotes
+& $nssm edit Arc10Sidecar5ers
+```
+
+In the GUI's "Arguments" field, **paste this exact string** (replace the placeholder):
+
+```
+-m deployment.sidecar --winning-config "C:\Forex-Backtester\configs\l_arc_10_v3.0.2_utc_rerun\winning_config.yaml" --sidecar-root "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers" --mt5-path "C:\Program Files\Five Percent Online MetaTrader 5\terminal64.exe" --log-level INFO
+```
+
+Click "Edit Service" to save. Close GUI.
+
+Start the service:
+
+```powershell
+& $nssm start Arc10Sidecar5ers
+Start-Sleep -Seconds 10
+& $nssm status Arc10Sidecar5ers
+# → SERVICE_RUNNING
+
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log" -Tail 10
+# → Should show "sidecar starting — config_hash=4467366b..."
+```
+
+### Install FundedNext service
+
+Same procedure with different paths/config:
+
+```powershell
+& $nssm install Arc10SidecarFundedNext $python "placeholder"
+
+& $nssm set Arc10SidecarFundedNext AppDirectory "C:\Forex-Backtester"
+& $nssm set Arc10SidecarFundedNext AppStdout "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\logs\sidecar.stdout.log"
+& $nssm set Arc10SidecarFundedNext AppStderr "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\logs\sidecar.stderr.log"
+& $nssm set Arc10SidecarFundedNext AppRestartDelay 10000
+& $nssm set Arc10SidecarFundedNext AppExit Default Restart
+& $nssm set Arc10SidecarFundedNext Start SERVICE_AUTO_START
+
+& $nssm edit Arc10SidecarFundedNext
+```
+
+In Arguments field, paste:
+
+```
+-m deployment.sidecar --winning-config "C:\Forex-Backtester\configs\l_arc_10_v3.0.2\winning_config.yaml" --sidecar-root "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext" --mt5-path "C:\Program Files\FundedNext MT5 Terminal\terminal64.exe" --log-level INFO
+```
+
+Save, close. Start:
+
+```powershell
+& $nssm start Arc10SidecarFundedNext
+& $nssm status Arc10SidecarFundedNext
+# → SERVICE_RUNNING
+
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\logs\sidecar.stderr.log" -Tail 10
+# → "sidecar starting — config_hash=75d03904..."
+```
+
+## Step 11 — Install watchdog tasks
+
+```powershell
+$watchdog = "C:\Forex-Backtester\deployment\ops\watchdog.ps1"
+$staleSec = 15000  # 4h 10min
+$intervalSec = 300  # 5 minutes
+
+$principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -RunLevel Highest
+$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+
+# 5ers watchdog
+$root5 = "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers"
+$action5 = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$watchdog`" -SidecarRoot `"$root5`" -ServiceName Arc10Sidecar5ers -StaleSec $staleSec"
+$trigger5 = New-ScheduledTaskTrigger -Once -At (Get-Date)
+$trigger5.Repetition = $(New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Seconds $intervalSec) -RepetitionDuration (New-TimeSpan -Days 9999)).Repetition
+
+if (Get-ScheduledTask -TaskName "Arc10WatchDog_5ers" -ErrorAction SilentlyContinue) {
+  Unregister-ScheduledTask -TaskName "Arc10WatchDog_5ers" -Confirm:$false
+}
+Register-ScheduledTask -TaskName "Arc10WatchDog_5ers" -Action $action5 -Trigger $trigger5 -Principal $principal -Settings $settings -Description "Arc 10 sidecar watchdog (5ers)"
+
+# FundedNext watchdog
+$rootFN = "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext"
+$actionFN = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$watchdog`" -SidecarRoot `"$rootFN`" -ServiceName Arc10SidecarFundedNext -StaleSec $staleSec"
+$triggerFN = New-ScheduledTaskTrigger -Once -At (Get-Date)
+$triggerFN.Repetition = $(New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Seconds $intervalSec) -RepetitionDuration (New-TimeSpan -Days 9999)).Repetition
+
+if (Get-ScheduledTask -TaskName "Arc10WatchDog_FundedNext" -ErrorAction SilentlyContinue) {
+  Unregister-ScheduledTask -TaskName "Arc10WatchDog_FundedNext" -Confirm:$false
+}
+Register-ScheduledTask -TaskName "Arc10WatchDog_FundedNext" -Action $actionFN -Trigger $triggerFN -Principal $principal -Settings $settings -Description "Arc 10 sidecar watchdog (FundedNext)"
+
+Get-ScheduledTask -TaskName "Arc10WatchDog_*" | Format-Table TaskName, State -AutoSize
+# Both should show State = Ready
+```
+
+## Step 12 — Set up EA on each MT5
+
+### Transfer EA files to VPS
+
+EA source already on VPS in `C:\Forex-Backtester\deployment\ea\`. Compile via MetaEditor (one MT5 → F4 → open Arc10_DLR_Sidecar_EA.mq5 → F7).
+
+Alternative: copy a pre-compiled .ex5 from local machine via RDP file transfer.
+
+The 8 include files plus the main .ex5 go into both MT5's Experts folders:
+
+```powershell
+$5ers_ea_dir = "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\<5ERS_TERMINAL_ID>\MQL5\Experts\Arc10_Sidecar"
+$fn_ea_dir = "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\<FUNDEDNEXT_TERMINAL_ID>\MQL5\Experts\Arc10_Sidecar"
+
+New-Item -ItemType Directory -Force -Path "$5ers_ea_dir\include","$fn_ea_dir\include" | Out-Null
+
+# After compile, copy from one source location to both targets:
+$src = "C:\Forex-Backtester\deployment\ea"
+Copy-Item "$src\Arc10_DLR_Sidecar_EA.ex5" $5ers_ea_dir -Force
+Copy-Item "$src\Arc10_DLR_Sidecar_EA.mq5" $5ers_ea_dir -Force
+Copy-Item "$src\include\*.mqh" "$5ers_ea_dir\include\" -Force
+
+Copy-Item "$src\Arc10_DLR_Sidecar_EA.ex5" $fn_ea_dir -Force
+Copy-Item "$src\Arc10_DLR_Sidecar_EA.mq5" $fn_ea_dir -Force
+Copy-Item "$src\include\*.mqh" "$fn_ea_dir\include\" -Force
+```
+
+### Attach EA on 5ers MT5
+
+In 5ers MT5:
+
+1. View → Navigator (Ctrl+N)
+2. Right-click "Expert Advisors" → Refresh
+3. Expand "Expert Advisors" → "Arc10_Sidecar"
+4. Open EURUSD H4 chart
+5. Drag Arc10_DLR_Sidecar_EA onto chart
+6. In input dialog, set all inputs per `03_deployment/02_5ers_setup.md`
+7. Common tab: ✅ Allow Algo Trading
+8. OK
+9. Enable AutoTrading (toolbar button → green)
+10. Check Experts tab in Toolbox:
+   - Should see `[ARC10] EA init magic=1010202601 sidecar_inbox=Common\Files\Arc10_5ers\signals_out`
+   - Should see `[ARC10] equity init: floor=<balance>`
+   - Should see `[ARC10] sidecar-heartbeat stale=true at ...` (true initially; goes false after first cycle)
+
+### Attach EA on FundedNext MT5
+
+Same procedure with FundedNext-specific inputs per `03_deployment/03_fundednext_setup.md`. Magic 1010202602, config_hash 75d03904..., paths Arc10_FundedNext\...
+
+## Step 13 — Final verification
+
+```powershell
+# Both services running
+Get-Service Arc10Sidecar5ers, Arc10SidecarFundedNext | Format-Table Name, Status, StartType -AutoSize
+# Both Running, Automatic
+
+# Both MT5s running
+Get-Process terminal64 | Select-Object Id, Path
+
+# Both watchdog tasks
+Get-ScheduledTask -TaskName "Arc10WatchDog_*" | Format-Table TaskName, State
+
+# Both heartbeats (after first H4 cycle)
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\sidecar.heartbeat" -Raw
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\sidecar.heartbeat" -Raw
+```
+
+If all green: deployment complete. System will run unattended.
+
+## Disconnect RDP safely
+
+You can disconnect RDP without affecting anything. Services + scheduled tasks + MT5 terminals all keep running. **Do not sign out** — that terminates user session and kills GUI apps (MT5).
+
+## Common gotchas
+
+| Problem | Cause | Fix |
+|---|---|---|
+| Sidecar errors "unrecognized arguments: Files\Five Percent..." | NSSM stripped quotes from `--mt5-path` | Use `nssm edit <service>` GUI to set Arguments manually |
+| Service starts then stops immediately | MT5 not logged in OR wrong --mt5-path | Verify MT5 connection, confirm path exactly |
+| Anchor probe fails on boot | Wrong config pointing at wrong broker | Verify boundary_convention in winning_config matches broker |
+| EA inputs show defaults despite editing | Didn't click OK in input dialog | Right-click chart → Properties → re-edit |
+| Heartbeat never appears | Sidecar service died | Check stderr log; check NSSM `get` outputs |
+| Watchdog keeps restarting service | StaleSec too low | Set StaleSec to ~15000 (4h 10min) |

--- a/arc_10/03_deployment/05_config_artifacts.md
+++ b/arc_10/03_deployment/05_config_artifacts.md
@@ -1,0 +1,214 @@
+# Config Artifacts & EA Input Tables
+
+> **Purpose:** Single reference for every locked configuration value. If you need to verify, restore, or migrate the system, this is the document.
+
+## Winning configs
+
+The strategy uses two locked YAML files — one per convention. These are deterministic ground truth: identical `winning_config.yaml` produces identical `config_hash`, which produces identical sidecar boot identity, which validates against EA `Expected_Config_Hash`.
+
+### EET — FundedNext deployment
+
+| Field | Value |
+|---|---|
+| Path | `configs/l_arc_10_v3.0.2/winning_config.yaml` |
+| Convention | `5ers_eet` |
+| Config hash (SHA-256) | `75d03904457580b77be63639a281dc550ca584fc5603cfb946102b836d41cf87` |
+| Pairs | 28 (standard Arc 10 universe) |
+| Magic number | `1010202602` |
+
+### UTC — 5ers deployment
+
+| Field | Value |
+|---|---|
+| Path | `configs/l_arc_10_v3.0.2_utc_rerun/winning_config.yaml` |
+| Convention | `utc` |
+| Config hash (SHA-256) | `4467366b9537871fe9019af45cf26f54e042358f211ff58774497b00c840821e` |
+| Pairs | 28 (same as EET) |
+| Magic number | `1010202601` |
+
+## How config_hash is computed
+
+The hash is SHA-256 over the canonical-serialized YAML content. The sidecar computes it at boot and logs it. The EA verifies it on each envelope.
+
+```python
+# Conceptually:
+import hashlib, yaml
+with open("configs/l_arc_10_v3.0.2/winning_config.yaml") as f:
+    config_text = f.read()
+config_hash = hashlib.sha256(config_text.encode()).hexdigest()
+```
+
+**Critical:** any change to the YAML — even whitespace, even key order — produces a different hash. To rotate configs:
+
+1. Edit YAML
+2. Recompute hash (`scripts/compute_config_hash.py` or equivalent)
+3. Update EA's `Expected_Config_Hash` input on both MT5s
+4. Restart sidecars to pick up new config
+5. Document the change in `05_history/02_decisions_log.md`
+
+## Pairs in each config
+
+All 28 standard Arc 10 pairs, identical across both conventions:
+
+```
+AUDCAD, AUDCHF, AUDJPY, AUDNZD, AUDUSD,
+CADCHF, CADJPY, CHFJPY,
+EURAUD, EURCAD, EURCHF, EURGBP, EURJPY, EURNZD, EURUSD,
+GBPAUD, GBPCAD, GBPCHF, GBPJPY, GBPNZD, GBPUSD,
+NZDCAD, NZDCHF, NZDJPY, NZDUSD,
+USDCAD, USDCHF, USDJPY
+```
+
+## Locked signal parameters
+
+These live in the `winning_config.yaml` under `signal_params`. Identical between EET and UTC conventions:
+
+| Parameter | Value | What it controls |
+|---|---|---|
+| `atr_period` | 14 | ATR window length (H4 bars) |
+| `sl_atr_multiplier` | 3.5 | Initial SL = entry - 3.5×ATR (long) |
+| `upper_fraction` | 0.55 | Signal bar must close in top 55% of range |
+| `reject_buffer_atr_mult` | 0.10 | Min upward reject from L1 in ATR units |
+| `l1_atr_proximity_min` | 0.50 | Lower bound of L1-to-current proximity |
+| `l1_atr_proximity_max` | 2.50 | Upper bound of L1-to-current proximity |
+| `l1_to_l0_min_atr` | 0.50 | L1 must be at least 0.5×ATR below L0 |
+| `pivot_lookback_h4` | 40 | H4 bars to scan for pivots |
+| `pivot_lookback_d1` | 20 | D1 bars to scan for D1 trend |
+
+(Exact values may differ slightly between EET and UTC if Amendment 3 calibration produced different optima; verify against the YAML if exact reproduction matters.)
+
+## EA input parameters — quick reference
+
+### Risk parameters (these differ per broker)
+
+| Input | 5ers (UTC) | FundedNext (EET) |
+|---|---|---|
+| Risk_Per_Trade | `0.0040` | `0.0050` |
+| Total_DD_Halt_Pct | `0.07` | `0.07` |
+| Total_DD_CloseAll_Pct | `0.08` | `0.08` |
+| Daily_DD_Halt_Pct | `0.035` | `0.035` |
+| Daily_DD_CloseAll_Pct | `0.045` | `0.045` |
+| Magic_Number | `1010202601` | `1010202602` |
+| Expected_Config_Hash | `4467366b...840821e` | `75d03904...41cf87` |
+
+### Strategy parameters (identical across brokers)
+
+| Input | Value |
+|---|---|
+| Time_Exit_Bars | `240` |
+| SL_ATR_Multiplier_Expected | `3.5` |
+| Sidecar_Heartbeat_Max_Age_Sec | `600` |
+| News_Window_Sec | `120` |
+| News_Delay_Buffer_Sec | `5` |
+| News_Delay_Max_Sec | `3600` |
+| News_Refresh_Sec | `14400` |
+| Signal_Poll_Min_Interval_Sec | `5` |
+| Enable_News_Filter | `true` |
+| News_Calendar_URL | `https://nfs.faireconomy.media/ff_calendar_thisweek.xml` |
+
+### Path parameters (only the prefix differs)
+
+5ers paths all start with `Arc10_5ers\`. FundedNext paths all start with `Arc10_FundedNext\`.
+
+| Input | 5ers value | FundedNext value |
+|---|---|---|
+| Sidecar_Inbox_Dir | `Arc10_5ers\signals_out` | `Arc10_FundedNext\signals_out` |
+| Sidecar_Processed_Dir | `Arc10_5ers\signals_processed` | `Arc10_FundedNext\signals_processed` |
+| Sidecar_Failed_Dir | `Arc10_5ers\signals_failed` | `Arc10_FundedNext\signals_failed` |
+| Sidecar_Heartbeat_Path | `Arc10_5ers\sidecar.heartbeat` | `Arc10_FundedNext\sidecar.heartbeat` |
+| Ea_Heartbeat_Path | `Arc10_5ers\ea.heartbeat` | `Arc10_FundedNext\ea.heartbeat` |
+| Ea_Positions_Path | `Arc10_5ers\ea_positions.json` | `Arc10_FundedNext\ea_positions.json` |
+| Trade_Log_Path | `Arc10_5ers\trade_log.csv` | `Arc10_FundedNext\trade_log.csv` |
+
+## Sidecar command-line invocations
+
+### 5ers (UTC)
+
+```
+C:\Python311\python.exe -m deployment.sidecar
+  --winning-config "C:\Forex-Backtester\configs\l_arc_10_v3.0.2_utc_rerun\winning_config.yaml"
+  --sidecar-root "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers"
+  --mt5-path "C:\Program Files\Five Percent Online MetaTrader 5\terminal64.exe"
+  --log-level INFO
+```
+
+### FundedNext (EET)
+
+```
+C:\Python311\python.exe -m deployment.sidecar
+  --winning-config "C:\Forex-Backtester\configs\l_arc_10_v3.0.2\winning_config.yaml"
+  --sidecar-root "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext"
+  --mt5-path "C:\Program Files\FundedNext MT5 Terminal\terminal64.exe"
+  --log-level INFO
+```
+
+## NSSM service config
+
+### Arc10Sidecar5ers
+
+| Setting | Value |
+|---|---|
+| Application | `C:\Python311\python.exe` |
+| Arguments | (see 5ers command-line above) |
+| AppDirectory | `C:\Forex-Backtester` |
+| AppStdout | `...\Arc10_5ers\logs\sidecar.stdout.log` |
+| AppStderr | `...\Arc10_5ers\logs\sidecar.stderr.log` |
+| AppRestartDelay | `10000` ms |
+| AppExit Default | `Restart` |
+| Start | `SERVICE_AUTO_START` |
+
+### Arc10SidecarFundedNext
+
+Same as 5ers but with FundedNext paths/config.
+
+## Watchdog task config
+
+### Both Arc10WatchDog_5ers and Arc10WatchDog_FundedNext
+
+| Setting | Value |
+|---|---|
+| Action | `powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\Forex-Backtester\deployment\ops\watchdog.ps1" -SidecarRoot "..." -ServiceName "..." -StaleSec 15000` |
+| Trigger | Once + Repetition every 300 seconds (5 min), Duration: 9999 days |
+| Principal | SYSTEM, RunLevel Highest |
+| Settings | StartWhenAvailable, AllowStartIfOnBatteries, DontStopIfGoingOnBatteries |
+
+## How to verify all configs are correct
+
+```powershell
+# 1. Check both configs exist in repo
+Test-Path "C:\Forex-Backtester\configs\l_arc_10_v3.0.2\winning_config.yaml"
+Test-Path "C:\Forex-Backtester\configs\l_arc_10_v3.0.2_utc_rerun\winning_config.yaml"
+
+# 2. Recompute hashes and compare
+python -c "import hashlib; print(hashlib.sha256(open('C:/Forex-Backtester/configs/l_arc_10_v3.0.2/winning_config.yaml', 'rb').read()).hexdigest())"
+# Should match 75d03904457580b77be63639a281dc550ca584fc5603cfb946102b836d41cf87
+
+python -c "import hashlib; print(hashlib.sha256(open('C:/Forex-Backtester/configs/l_arc_10_v3.0.2_utc_rerun/winning_config.yaml', 'rb').read()).hexdigest())"
+# Should match 4467366b9537871fe9019af45cf26f54e042358f211ff58774497b00c840821e
+
+# 3. Check sidecar boots log the right hash
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log" -Tail 5
+# → should show config_hash=4467366b...
+
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\logs\sidecar.stderr.log" -Tail 5
+# → should show config_hash=75d03904...
+
+# 4. Confirm EA hash inputs by checking journal lines
+# Look in MT5 Experts tab — boot lines should show magic + sidecar_inbox path matching this doc
+```
+
+## What you cannot change without re-validation
+
+- `sl_atr_multiplier` (3.5) — would invalidate cost sweep and WFO
+- Pair set (the 28) — would invalidate WFO sample
+- `Time_Exit_Bars` (240) — would invalidate exit policy validation
+- DD halt thresholds (3.5%/4.5%/7%/8%) — chosen with margin to broker limits; tighter is OK, looser is not without analysis
+- `SL_ATR_Multiplier_Expected` in EA must match `sl_atr_multiplier` in YAML
+
+## What you CAN change without re-validation
+
+- `Risk_Per_Trade` between 0% and the recommended max (0.5%/0.4%) — pure linear scaling, no edge changes
+- `Sidecar_Heartbeat_Max_Age_Sec` (looser = more tolerant of sidecar lag, tighter = faster halt on issues)
+- `News_*` parameters (slight changes to news handling don't affect strategy)
+- `Signal_Poll_Min_Interval_Sec` (responsiveness vs CPU)
+- Logging levels (INFO/DEBUG/WARNING)

--- a/arc_10/03_deployment/06_broker_specs.md
+++ b/arc_10/03_deployment/06_broker_specs.md
@@ -1,0 +1,165 @@
+# Broker Specifications
+
+> **Purpose:** Reference for each broker's rules, costs, and limits. Verify against current broker terms before relying on these.
+
+## 5ers (Five Percent Online)
+
+### Programs we care about
+
+- **High Stakes:** Confirmed correct program for Arc 10 at full risk
+  - Max DD: 10% of starting balance
+  - Daily DD: 5% of starting balance (some plans 4%)
+  - Profit split: 80%
+  - Scaling: linear to $500K
+  - Min trading days: typically 5-10
+- **Hyper Growth:** Considered for later stage after live validation; faster scaling but tighter rules
+
+### Cost structure
+
+- **Commission:** ~$4 per lot round-turn (verify current rate)
+- **Spread:** Tight (~0.6 pip median on majors per audit, ~3-4x tighter than HistData modeled)
+- **Swap:** Yes (real cost, eligible for swap-on-overnight)
+- **Swap-free add-on:** Not standard; if available, terms may differ
+
+### Server & technical
+
+- **Server timezone:** EET (UTC+2 winter / UTC+3 summer)
+- **Bar anchor convention:** UTC (verified by panel-diff)
+- **Server name pattern:** `FivePercentOnline-*` (Real / Demo)
+- **Symbol naming:** Plain (`EURUSD`, no suffix)
+
+### Compliance flags
+
+- **Copy-trading prohibition:** Running identical EA signals across multiple 5ers accounts simultaneously may trigger compliance review. **Get written confirmation from 5ers support before opening parallel accounts.**
+- **News trading:** Allowed (verify current rules)
+- **Weekend holds:** Allowed (verify current rules)
+- **Hedging:** Allowed (verify current rules)
+
+### Risk for Arc 10
+
+Locked at **0.40% per trade**. Rationale: cost sweep central case at r_base 0.5% breaches 10% DD hard limit (10.47%). Scaling to 0.40% brings DD to 8.38%, 1.6pp margin.
+
+## FundedNext
+
+### Programs we care about
+
+- **$100k Challenge:** Two-phase evaluation → funded account
+  - Phase 1 target: typically +8% profit
+  - Phase 2 target: typically +5% profit
+  - Max DD: 10% of starting balance
+  - Daily DD: 5% of starting balance
+  - Profit split: 80% (funded phase)
+  - Min trading days: typically 5
+
+### Cost structure
+
+- **Commission:** ~$5 per lot round-turn (verify current rate)
+- **Spread:** Tight (similar to 5ers based on demo observation; verify with live data)
+- **Swap:** Zero with swap-free add-on (mandatory for Arc 10 deployment)
+- **Swap-free add-on:** Available; confirmed applies to both Challenge and funded phases
+
+### Server & technical
+
+- **Server timezone:** EET (UTC+2 winter / UTC+3 summer)
+- **Bar anchor convention:** EET (verified by panel-diff)
+- **Server name pattern:** `FundedNext-*` (Demo / Real)
+- **Symbol naming:** Plain (`EURUSD`, no suffix)
+
+### Compliance flags
+
+- **News trading:** Allowed (confirmed)
+- **Weekend holds:** Allowed (confirmed)
+- **Hedging:** Allowed (confirmed)
+- **Copy-trading:** Verify current rules before opening multiple FundedNext accounts in parallel
+
+### Risk for Arc 10
+
+Locked at **0.50% per trade** (r_base). Rationale: cost sweep central case at r_base 0.5% lands at 7.80% worst-fold DD, 2.2pp margin to 10% limit. No scaling needed.
+
+## Cross-broker comparison
+
+| Item | 5ers | FundedNext |
+|---|---|---|
+| Account size we use | $10k demo | $100k Challenge → funded |
+| Risk per trade | 0.40% | 0.50% |
+| Risk dollars/trade | $40 | $500 |
+| Commission | $4/lot RT | $5/lot RT |
+| Swap | ON (real cost) | OFF (swap-free) |
+| Bar anchor | UTC | EET |
+| Max DD | 10% | 10% |
+| Daily DD | 5% | 5% |
+| Profit split | 80% | 80% |
+| Expected live ROI | ~27% | ~44% |
+| Expected worst-fold DD | ~9.5% | ~8.8% |
+
+## What FundedNext rules to verify before purchasing Challenge
+
+Always check current FundedNext rules at purchase time (rules change):
+
+1. **Swap-free add-on still available and applied to both phases?**
+2. **Max DD and daily DD limits unchanged at 10% / 5%?**
+3. **Profit target for Phase 1 and Phase 2?** (Used to be 8% / 5%)
+4. **Min trading days requirement?**
+5. **News trading allowed?**
+6. **Weekend hold allowed?**
+7. **Profit split for funded?** (Was 80%; some firms offer 90% at scale)
+8. **Scaling rules?** (Account size doubling at performance milestones?)
+9. **Inactivity rules?** (Don't trade for X days → account closed?)
+10. **Time limits?** (Some firms cap evaluation at 30 or 60 days)
+
+If any of these have changed in a way that affects the deployment plan, reassess before purchase.
+
+## Backup broker considerations
+
+If 5ers and FundedNext both became unworkable for some reason:
+
+- **FTMO:** Larger prop firm, similar rules. Lower max position size on some accounts. EET broker server.
+- **Topstep:** US-focused; some FX, mainly futures. Different rule structure (trailing DD instead of fixed).
+- **The Funded Trader:** Multiple plans. Volatile rule changes historically.
+- **MyFundedFX, FundingPips:** Newer firms; rule stability less proven.
+
+The sidecar + EA work against any MT5 broker. Adding a new broker requires:
+
+1. Install broker's MT5 on VPS
+2. Login, add 28 pairs to Market Watch, whitelist news URL
+3. Run panel-diff to confirm anchor convention (likely EET or UTC)
+4. Pick matching winning_config
+5. Set up new NSSM service + watchdog
+6. Compile + attach EA with broker-specific inputs
+
+~2 hours work per additional broker once the playbook is established.
+
+## On the swap-free add-on with FundedNext
+
+The cost sweep analysis is **critically dependent** on swap-free being applied. Under UTC convention (swap on), worst-fold DD at r_base 0.5% is 10.47% — breaches the 10% hard limit. Under EET with swap-off, it's 7.80% — safely within bounds.
+
+**If FundedNext stops providing swap-free**, the deployment math changes:
+- Option A: scale risk down to ~0.30-0.35% to bring DD back under limit
+- Option B: switch to 5ers fallback
+
+Verify swap-free status on every overnight position by inspecting the trade history (Swap column should be 0.00 for all closed trades).
+
+## On broker disconnections during trades
+
+Both 5ers and FundedNext have reasonable uptime but periodic disconnects happen. Behavior during disconnect:
+
+- Open positions remain on broker's order book (with SL still active)
+- MT5 reconnects automatically when broker server returns
+- EA detects stale price feed and blocks new entries
+- Sidecar tries to fetch data, logs error, retries on next cycle
+- Once reconnected: sidecar resumes normal cycles, EA resumes normal entry processing
+- Open positions managed throughout (broker holds SL even during MT5 disconnect)
+
+No data loss expected. Trade log captures all events when they happen.
+
+## On broker rule changes (recent history pattern)
+
+Prop firms periodically change rules — especially after market events that hurt their P&L. Common changes:
+
+- Tightening DD limits
+- Capping max lot size
+- Introducing news event restrictions
+- Time limits on Challenges
+- New "consistency" rules (no single day > X% of total profit)
+
+**Monitor broker email and news for rule changes.** If a change materially affects Arc 10 deployment (e.g. new "no overnight holds" rule), reassess immediately. Don't keep trading on outdated rule assumptions.

--- a/arc_10/04_runbook/01_daily_health_check.md
+++ b/arc_10/04_runbook/01_daily_health_check.md
@@ -1,0 +1,97 @@
+# Daily Health Check (30 seconds)
+
+> **Purpose:** Quick check that everything is operating normally.
+> **Frequency:** Once a day, or any time you log into the VPS.
+> **What it does NOT do:** Check if trades are profitable (that's weekly review).
+
+## The check
+
+RDP into the VPS. Open Administrator PowerShell. Run:
+
+```powershell
+# Services running?
+Get-Service Arc10Sidecar5ers, Arc10SidecarFundedNext | Format-Table Name, Status, StartType -AutoSize
+
+# Both MT5s running?
+Get-Process terminal64 | Select-Object Id, Path
+
+# Watchdogs ready?
+Get-ScheduledTask -TaskName "Arc10WatchDog_*" | Format-Table TaskName, State
+
+# Heartbeats fresh? (Should be < 4-5 hours old)
+Write-Host "--- 5ers heartbeat ---"
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\sidecar.heartbeat" -Raw -ErrorAction SilentlyContinue
+Write-Host "--- FundedNext heartbeat ---"
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\sidecar.heartbeat" -Raw -ErrorAction SilentlyContinue
+
+# Recent logs (last 10 lines each)
+Write-Host "--- 5ers latest log ---"
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log" -Tail 10 -ErrorAction SilentlyContinue
+Write-Host "--- FundedNext latest log ---"
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\logs\sidecar.stderr.log" -Tail 10 -ErrorAction SilentlyContinue
+```
+
+## What "healthy" looks like
+
+| Check | Expected |
+|---|---|
+| Services | Both `Running`, `Automatic` |
+| MT5 processes | 2 visible, one from each install path |
+| Watchdog tasks | Both `Ready` |
+| Heartbeats | `last_heartbeat_utc` within last 4 hours (UTC) or 5 hours (EET, accounting for DST) |
+| Logs | No tracebacks; latest line shows successful cycle completion or "sleeping until next H4" |
+
+## What's NOT a problem
+
+- `restart_count` > 1 in heartbeat: services have restarted during deployment (normal early on)
+- Heartbeat older than expected by minutes (broker disconnect, sidecar retrying)
+- "fetch failed" lines for 1-2 specific pairs once in a while (occasional symbol freeze)
+
+## What IS a problem
+
+- Service status `Stopped` or `Paused` → restart needed
+- One or both MT5 not running → restart MT5
+- Heartbeat older than 5h on either sidecar with no recent log activity → investigate
+- Repeated tracebacks → check error message, may need bug fix
+- "anchor probe failed" → MT5 broker disconnected at boot or config mismatch
+- Multiple consecutive cycles with NO pairs processed → MT5 lost connection
+
+If anything looks bad, refer to `04_incident_response.md`.
+
+## In MT5 (visual check, optional)
+
+If you want to look at the MT5 windows:
+
+- 5ers MT5: bottom-right shows balance/equity + green connection icon
+- FundedNext MT5: same
+- Each chart with EA attached shows smiley face icon (top-right)
+- Experts tab at bottom shows recent `[ARC10] ...` log lines (no errors)
+- No red "X" icons or warning popups
+
+## What to do if everything looks good
+
+Disconnect RDP and go about your day. The system runs itself.
+
+## Trades vs health
+
+Health check ≠ performance check. A healthy system might:
+- Have made trades in the last 24h (normal)
+- Have made no trades in the last 24h (also normal — Arc 10 averages ~2-3 trades/week per pair, or ~80/year × 28 pairs = ~225 trades total, so quiet days happen)
+- Be in drawdown (some folds in backtest had multi-week drawdowns)
+
+Don't react to short-term performance via daily check. Performance review is a weekly job (`02_weekly_check.md`).
+
+## Bonus: equity over time
+
+In each MT5: Account History tab → see balance/equity progression. Useful for noting if anything went weird, but don't make trading decisions from this.
+
+## 30-second elevator version
+
+If you only have 30 seconds:
+
+```powershell
+Get-Service Arc10Sidecar5ers, Arc10SidecarFundedNext | Format-Table Name, Status
+Get-Process terminal64 | Measure-Object | Select-Object -ExpandProperty Count  # should be 2
+```
+
+If both services are `Running` and you see 2 terminal64 processes → close PowerShell and disconnect. You're good.

--- a/arc_10/04_runbook/02_weekly_check.md
+++ b/arc_10/04_runbook/02_weekly_check.md
@@ -1,0 +1,205 @@
+# Weekly Check (Sundays, ~30 min)
+
+> **Purpose:** Reconcile trades, look for drift vs backtest, restart VPS during weekend market closure.
+> **When:** Sunday during market closure (before Sunday 22:00 UTC reopen).
+> **Tool:** Manual for now. Will be automated via `scripts/weekly_reconciliation.py` (TBD — build after 4 weeks of live data).
+
+## What the weekly check covers
+
+1. **System health refresh** (5 min) — confirm 7 days of clean operation
+2. **Trade reconciliation** (10 min) — does every broker trade match a logged signal? Does every logged signal match a broker trade?
+3. **Performance review** (5 min) — what's the running P&L, are trades behaving like backtest expectations?
+4. **VPS restart** (10 min, optional) — full VPS reboot during market closure to flush memory leaks, apply Windows updates
+
+## Step 1 — System health refresh
+
+RDP into VPS. Run all checks from `01_daily_health_check.md`. Plus:
+
+```powershell
+# Look at NSSM service uptime
+& "C:\Tools\nssm.exe" status Arc10Sidecar5ers
+& "C:\Tools\nssm.exe" status Arc10SidecarFundedNext
+
+# How many restart events in the past week?
+Get-EventLog -LogName Application -Source nssm -After (Get-Date).AddDays(-7) -ErrorAction SilentlyContinue | Format-Table TimeGenerated, EntryType, Message -AutoSize
+
+# Disk space (should be plenty)
+Get-PSDrive C | Select-Object Used, Free
+```
+
+Expected:
+- Both services running with high uptime (no recent restarts in normal week)
+- Disk space > 20GB free
+
+## Step 2 — Trade reconciliation
+
+For each broker, pull last 7 days of trades from MT5 + compare to logs.
+
+### Manual approach (until script exists)
+
+In each MT5:
+1. Account History (Ctrl+Shift+H) → "Last Week" (or custom range)
+2. Right-click → Save as Report → save as CSV
+
+Now you have broker's trade history.
+
+Cross-check against EA's trade log:
+
+```powershell
+# 5ers EA trade log
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\trade_log.csv" | Where-Object { $_ -match "entry|exit" } | Select-Object -Last 50
+
+# FundedNext EA trade log
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\trade_log.csv" | Where-Object { $_ -match "entry|exit" } | Select-Object -Last 50
+```
+
+Cross-reference:
+- Every `entry` event in trade_log → should have matching broker trade with same ticket
+- Every closed broker trade → should have matching `exit` event with reason
+
+**Phantom trades** (broker trade with no entry log) → manual intervention or bug
+**Lost signals** (entry log with no broker trade) → execution failure
+
+### What you're looking for
+
+- [ ] Trade count matches between EA log and broker
+- [ ] All exit reasons are expected (`trail_stop`, `initial_sl_hit`, `time_exit` — NOT `external_close`)
+- [ ] No DD halt events in `trade_log.csv`
+- [ ] No `news_discard` or `news_delay` events that suggest a calendar issue
+
+### Signal envelopes accounting
+
+```powershell
+# How many signals were generated this week?
+Get-ChildItem "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\signals_processed\" | Where-Object { $_.LastWriteTime -gt (Get-Date).AddDays(-7) } | Measure-Object | Select-Object Count
+Get-ChildItem "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\signals_failed\" | Where-Object { $_.LastWriteTime -gt (Get-Date).AddDays(-7) } | Measure-Object | Select-Object Count
+
+# Same for FundedNext
+```
+
+Expected: ~5-15 signals/week per broker. `signals_failed` count should be 0 in normal operation. Any failed signal needs investigation.
+
+## Step 3 — Performance review
+
+Each MT5 → "Account" tab or Account History → Reports section.
+
+| Metric | Expected (1 week) | Red flag |
+|---|---|---|
+| Trades | 5-15 per broker | 0 trades (signal generation issue) |
+| Win rate | ~35-45% (long-only, asymmetric R) | <25% sustained |
+| Net P&L | varies (single week high variance) | -3% in single week (rare, but possible) |
+| Daily DD reached | usually <2% peak intraday | approaching 4% (close to halt) |
+| Total DD | first 2 weeks: 0-3% | >7% (close to halt) |
+
+**Note:** Single weeks have very high variance. Don't over-react. Pattern-match across 4+ weeks.
+
+## Step 4 — VPS restart (optional, recommended weekly)
+
+Sunday during market closure is the ideal time to restart the VPS. Reasons:
+- Flush any Windows memory leaks accumulated over the week
+- Apply pending Windows updates that need a reboot
+- Clear any zombie processes
+- Test that services + EAs auto-restart cleanly
+
+### Pre-restart check
+
+```powershell
+# Confirm no positions are open right now (markets are closed, but double-check)
+# In each MT5: Trade tab → should be empty
+
+# Confirm market is closed
+# Friday 22:00 UTC through Sunday 22:00 UTC = forex closed
+```
+
+If positions are open during weekend — yes they CAN be open across weekend, but verify no open positions before restart to be safe.
+
+### Restart
+
+```powershell
+# Triggering a reboot
+shutdown /r /t 0
+```
+
+VPS reboots. RDP session ends. Reconnect after ~3-5 minutes.
+
+### Post-restart verification
+
+After VPS comes back:
+
+```powershell
+# Both services should be auto-started
+Get-Service Arc10Sidecar5ers, Arc10SidecarFundedNext | Format-Table Name, Status
+
+# Both MT5s should be running (they were configured to auto-start at boot — if not, manually launch)
+Get-Process terminal64 | Select-Object Id, Path
+
+# Watchdogs should be Ready
+Get-ScheduledTask -TaskName "Arc10WatchDog_*" | Format-Table TaskName, State
+```
+
+**If MT5s did NOT auto-start:** they're GUI apps, not services. Add them to Windows startup folder:
+
+```powershell
+# Shortcut paths
+$startup = "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup"
+
+$shell = New-Object -ComObject WScript.Shell
+
+# 5ers shortcut
+$shortcut5 = $shell.CreateShortcut("$startup\5ers MT5.lnk")
+$shortcut5.TargetPath = "C:\Program Files\Five Percent Online MetaTrader 5\terminal64.exe"
+$shortcut5.WorkingDirectory = "C:\Program Files\Five Percent Online MetaTrader 5"
+$shortcut5.Save()
+
+# FundedNext shortcut
+$shortcutFN = $shell.CreateShortcut("$startup\FundedNext MT5.lnk")
+$shortcutFN.TargetPath = "C:\Program Files\FundedNext MT5 Terminal\terminal64.exe"
+$shortcutFN.WorkingDirectory = "C:\Program Files\FundedNext MT5 Terminal"
+$shortcutFN.Save()
+```
+
+Now they'll auto-start on every VPS boot.
+
+## Step 5 — Log review for anything weird
+
+```powershell
+# Check for errors over the past week
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log" | Where-Object { $_ -match "ERROR|Traceback|failed" } | Select-Object -Last 30
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\logs\sidecar.stderr.log" | Where-Object { $_ -match "ERROR|Traceback|failed" } | Select-Object -Last 30
+```
+
+Notable issues to look for:
+- Repeated symbol fetch failures
+- "MT5 not initialized" errors
+- "anchor probe failed" — convention drift?
+- Python tracebacks
+
+If you see anything weird, save the log lines and investigate (see `04_incident_response.md`).
+
+## What the automated weekly script will do (future)
+
+`scripts/weekly_reconciliation.py` (TBD):
+
+1. Connect to both MT5s via Python `MetaTrader5` lib
+2. Pull broker trade history for past 7 days
+3. Read trade_log.csv from both sidecar roots
+4. Read signals_processed/ and signals_failed/ contents
+5. Cross-reference:
+   - Every broker trade → matching `entry` event in trade_log
+   - Every signal envelope → either matching `entry` event OR documented `rejected` reason
+   - Every exit event → matching broker trade close
+6. Compute live R-multiples vs backtest expectations
+7. Detect anomalies (phantom trades, lost signals, drift)
+8. Output: `results/weekly_reports/YYYY_MM_DD_weekly_report.md`
+
+Build this AFTER 4 weeks of live data, so edge cases are known.
+
+## Why weekend market closure is the right time
+
+- Markets closed Friday 22:00 UTC through Sunday 22:00 UTC
+- No new signals fire during this period (sidecar sleeps)
+- No open positions can change P&L
+- Safe to restart, update, modify configuration
+- Watchdog will tolerate up to 4h 10min of staleness without action
+
+If you must do maintenance during market hours, see `03_restart_procedures.md` for safe sequencing.

--- a/arc_10/04_runbook/03_restart_procedures.md
+++ b/arc_10/04_runbook/03_restart_procedures.md
@@ -1,0 +1,211 @@
+# Restart Procedures
+
+> **Purpose:** Safely restart individual components without affecting open trades.
+
+## Restart hierarchy
+
+From least invasive to most:
+
+1. Restart ONE sidecar service (other broker unaffected)
+2. Restart BOTH sidecar services
+3. Restart ONE MT5 (and its sidecar)
+4. Restart whole VPS
+
+## What happens to open positions during a restart
+
+**Broker holds positions and SL orders regardless of EA state.** When an EA or sidecar restarts:
+
+- Open positions stay open at broker
+- Initial SL stays in place at broker
+- Trailing SL stays in place (last value before restart)
+- TP1 partial-close logic resumes (EA reconstructs from broker state)
+- Bar counter (`bar_ord`) reconstructs from entry time
+- `peak_high_bid` reconstructs as max of entry and current — conservative (may re-anchor lower than pre-restart peak, but trail SL still ratchets correctly going forward)
+
+Net: a restart is safe for open positions.
+
+## Restart ONE sidecar service
+
+Use when:
+- Sidecar logs show repeated errors
+- Heartbeat is stale and you suspect sidecar is hung
+- After config changes (rare)
+
+```powershell
+# 5ers
+& "C:\Tools\nssm.exe" restart Arc10Sidecar5ers
+Start-Sleep -Seconds 10
+& "C:\Tools\nssm.exe" status Arc10Sidecar5ers
+# Should show SERVICE_RUNNING
+
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log" -Tail 10
+# Should show "sidecar starting — config_hash=4467366b... restart_count=N"
+```
+
+For FundedNext substitute `Arc10SidecarFundedNext` and `Arc10_FundedNext`.
+
+**What happens during this restart (~10-30 seconds):**
+- Watchdog may also kick in if heartbeat goes stale during restart (harmless, double-restart)
+- EA sees heartbeat stale temporarily, blocks new entries
+- Existing positions continue to manage normally
+- Once sidecar boots and cycles, heartbeat refreshes, EA resumes
+
+## Restart BOTH sidecars
+
+Use when:
+- VPS-wide issue suspected (e.g. Windows update affecting Python or MT5 lib)
+- After git pull that includes sidecar changes
+
+```powershell
+# Restart both at once
+& "C:\Tools\nssm.exe" restart Arc10Sidecar5ers
+& "C:\Tools\nssm.exe" restart Arc10SidecarFundedNext
+Start-Sleep -Seconds 15
+
+# Verify both running
+Get-Service Arc10Sidecar5ers, Arc10SidecarFundedNext | Format-Table Name, Status
+```
+
+Same impact as single-sidecar restart, but doubled.
+
+## Restart ONE MT5 terminal
+
+Use when:
+- MT5 broker disconnected and won't reconnect
+- MT5 frozen / not responding
+- After manual EA changes
+
+**Important:** when MT5 restarts, its EA also restarts (EA is a chart-attached process). The sidecar continues running, but won't be able to fetch data while MT5 is down.
+
+```powershell
+# Stop sidecar first (to avoid spamming errors during MT5 restart)
+& "C:\Tools\nssm.exe" stop Arc10Sidecar5ers
+
+# Now restart 5ers MT5
+Get-Process terminal64 | Where-Object { $_.Path -like "*Five Percent*" } | Stop-Process -Force
+
+# Wait a few seconds
+Start-Sleep -Seconds 5
+
+# Launch MT5 fresh
+Start-Process "C:\Program Files\Five Percent Online MetaTrader 5\terminal64.exe"
+```
+
+In the MT5 GUI:
+1. If login is remembered, MT5 auto-logs in
+2. If not, manually log in (File → Login)
+3. Verify connection (green icon bottom-right)
+4. Verify EA is still attached to chart (smiley face top-right) — if not, re-attach
+
+Then restart the sidecar:
+
+```powershell
+& "C:\Tools\nssm.exe" start Arc10Sidecar5ers
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log" -Tail 10
+```
+
+For FundedNext, substitute paths.
+
+## Restart whole VPS
+
+Use when:
+- Weekly maintenance (preferred during weekend market closure)
+- Windows updates require reboot
+- VPS performance degraded
+
+**Always restart during weekend market closure if possible.** Avoid restarting during live trading hours.
+
+```powershell
+# Pre-flight check
+Get-Process terminal64 | Select-Object Id, Path
+# Note both MT5s are running
+# Optionally close them manually first (gracefully): File → Exit in each
+
+# Trigger reboot
+shutdown /r /t 0
+```
+
+RDP disconnects. Reconnect after ~3-5 minutes.
+
+**Post-reboot verification:**
+
+```powershell
+# Services should auto-start
+Get-Service Arc10Sidecar5ers, Arc10SidecarFundedNext | Format-Table Name, Status
+
+# Watchdogs should be ready
+Get-ScheduledTask -TaskName "Arc10WatchDog_*" | Format-Table TaskName, State
+
+# MT5s should be running (if startup shortcuts were set up — see 02_weekly_check.md)
+Get-Process terminal64 | Select-Object Id, Path
+```
+
+If MT5s didn't auto-start, launch them manually. If they keep not auto-starting, add to Windows startup folder.
+
+## When NOT to restart
+
+- Don't restart during live trading hours unless absolutely necessary
+- Don't restart immediately after a trade enters (give the EA a minute to log the entry event)
+- Don't restart if a trade is about to hit TP1 or SL (wait a few minutes for the event to log, then restart)
+
+## What to do if a restart fails
+
+### Sidecar service won't start
+
+```powershell
+# Check NSSM config
+& "C:\Tools\nssm.exe" get Arc10Sidecar5ers Application
+& "C:\Tools\nssm.exe" get Arc10Sidecar5ers AppParameters
+& "C:\Tools\nssm.exe" get Arc10Sidecar5ers AppDirectory
+
+# Check stderr for last error
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log" -Tail 50
+
+# Try running the command manually
+cd C:\Forex-Backtester
+python -m deployment.sidecar `
+  --winning-config "configs\l_arc_10_v3.0.2_utc_rerun\winning_config.yaml" `
+  --sidecar-root "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers" `
+  --mt5-path "C:\Program Files\Five Percent Online MetaTrader 5\terminal64.exe" `
+  --quick-test --log-level INFO
+```
+
+Common causes:
+- MT5 not running → start MT5 first
+- MT5 not logged in → log in
+- Wrong --mt5-path → check exact path
+- Config hash mismatch → check winning_config.yaml against stored hash
+
+### MT5 won't launch
+
+- Check if another terminal64 process is hanging: `Get-Process terminal64`
+- Force-kill stuck processes: `Stop-Process -Name terminal64 -Force`
+- Re-launch from start menu or shortcut
+
+### VPS won't boot
+
+- Use Contabo control panel → console access (VNC)
+- Last resort: restore from snapshot (Contabo offers periodic snapshots)
+- If catastrophic: redeploy from scratch using `04_vps_setup_guide.md`
+
+## Confirming healthy post-restart state
+
+```powershell
+# All systems check
+Write-Host "--- Services ---"
+Get-Service Arc10Sidecar5ers, Arc10SidecarFundedNext | Format-Table Name, Status
+
+Write-Host "`n--- MT5 Processes ---"
+Get-Process terminal64 | Select-Object Id, Path
+
+Write-Host "`n--- Watchdogs ---"
+Get-ScheduledTask -TaskName "Arc10WatchDog_*" | Format-Table TaskName, State
+
+Write-Host "`n--- 5ers heartbeat ---"
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\sidecar.heartbeat" -Raw
+
+Write-Host "`n--- FundedNext heartbeat ---"
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext\sidecar.heartbeat" -Raw
+```
+
+If everything shows Running/Ready and heartbeats are recent, you're back to healthy state.

--- a/arc_10/04_runbook/04_incident_response.md
+++ b/arc_10/04_runbook/04_incident_response.md
@@ -1,0 +1,289 @@
+# Incident Response
+
+> **Purpose:** What to do when something goes wrong.
+> **Organized by:** symptom → cause → fix.
+
+## Quick triage
+
+| You see this | Severity | Go to |
+|---|---|---|
+| Service stopped | Medium | §1 |
+| Heartbeat stale > 6h | Medium | §2 |
+| Anchor probe fails | High | §3 |
+| Repeated tracebacks in logs | Medium | §4 |
+| Phantom trades on broker | High | §5 |
+| Lost signals (envelope but no trade) | High | §6 |
+| Single bad trade (loss > expected) | Low | §7 |
+| Account approaching DD halt | High | §8 |
+| MT5 disconnected | Medium | §9 |
+| News URL returns 401/403 | Low | §10 |
+
+## §1 — Sidecar service stopped
+
+**Symptom:** `Get-Service Arc10Sidecar*` shows `Stopped` or `Paused`.
+
+**First check:** look at stderr log for the reason.
+
+```powershell
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log" -Tail 50
+```
+
+**Common causes:**
+- Python script crashed with unhandled exception → see traceback in log
+- NSSM auto-restart limit hit → check exit code in log
+- Windows shut down the service → check Windows event log
+
+**Fix:** restart the service per `03_restart_procedures.md`. If it won't start, run manually with `--quick-test` to see the error in real time.
+
+## §2 — Heartbeat stale > 6 hours
+
+**Symptom:** Heartbeat `last_heartbeat_utc` is more than ~6 hours old (one full H4 + significant buffer).
+
+**Possible causes:**
+- Sidecar hung but service shows running (Python deadlock — rare but possible)
+- MT5 disconnected for extended period, sidecar still cycling but writing partial state
+- VPS clock skew (timezone confusion)
+
+**Diagnosis:**
+
+```powershell
+# Is sidecar actually doing anything?
+Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\logs\sidecar.stderr.log" -Tail 30
+
+# Is the process actually alive?
+Get-Process python | Select-Object Id, StartTime, CPU
+```
+
+If process exists but log hasn't been written in hours → sidecar is hung. Watchdog should have restarted by now (15000s threshold). If watchdog also didn't fire, check:
+
+```powershell
+Get-ScheduledTask Arc10WatchDog_5ers | Get-ScheduledTaskInfo
+# Look at LastRunTime, LastTaskResult
+```
+
+**Fix:** manually restart sidecar service. If recurrent, the threshold (StaleSec) may need adjustment or sidecar has a bug.
+
+## §3 — Anchor probe fails on boot
+
+**Symptom:** Sidecar log shows:
+```
+ERROR ... H4 alignment probe failed: bars not on expected anchor convention
+```
+
+**This is a HIGH severity issue.** Convention mismatch = silent wrong signals.
+
+**Possible causes:**
+- Broker changed bar anchor convention (very rare, but possible)
+- Sidecar pointed at wrong MT5 (operator error in `--mt5-path`)
+- Wrong `winning_config.yaml` for this broker
+
+**Fix:**
+
+1. **Stop the sidecar immediately** so it doesn't fire wrong signals:
+   ```powershell
+   & "C:\Tools\nssm.exe" stop Arc10Sidecar5ers
+   ```
+
+2. Verify which MT5 the sidecar is talking to:
+   ```powershell
+   & "C:\Tools\nssm.exe" get Arc10Sidecar5ers AppParameters
+   ```
+   Confirm `--mt5-path` points to the expected broker's terminal64.exe.
+
+3. Verify the config matches the convention:
+   ```powershell
+   Get-Content "C:\Forex-Backtester\configs\l_arc_10_v3.0.2_utc_rerun\winning_config.yaml" | Select-String -Pattern "boundary_convention"
+   # Should match expected convention for this broker (utc for 5ers, 5ers_eet for FundedNext)
+   ```
+
+4. Run anchor probe manually:
+   ```powershell
+   cd C:\Forex-Backtester
+   # Manually invoke probe to see which convention the broker's data actually matches
+   python scripts/fundednext_anchor_check.py  # or equivalent
+   ```
+
+5. If broker convention has actually changed, **stop and investigate before trading more**. Strategy needs re-validation under new convention.
+
+## §4 — Repeated tracebacks in logs
+
+**Symptom:** Multiple `Traceback` lines in `sidecar.stderr.log`.
+
+**Common patterns:**
+
+### MT5 connection lost mid-cycle
+
+```
+ConnectionError: terminal not initialized
+```
+
+**Fix:** restart MT5 (often it auto-recovers; if not, manual restart). Sidecar will resume on next cycle.
+
+### Symbol fetch failure
+
+```
+copy_rates_from_pos returned None for GBPNZD
+```
+
+**Possible causes:** symbol temporarily unavailable, broker maintenance window, symbol removed from broker offering.
+
+**Fix:** check if symbol is still in Market Watch. If pair was removed, the strategy needs re-validation on the reduced symbol set (high impact — flag immediately).
+
+### News calendar fetch failure
+
+```
+HTTPError: 404 fetching ForexFactory calendar
+```
+
+**Possible cause:** ForexFactory changed URL or temporarily down.
+
+**Fix:** verify URL still works in browser. If permanently changed, update `News_Calendar_URL` in EA inputs on both MT5s. Until fixed, EA falls back to "no news data" mode (allows all signals through; safer than rejecting).
+
+### Memory leak
+
+```
+MemoryError: ...
+```
+
+**Fix:** restart sidecar. If recurrent, restart whole VPS. If still recurrent, this is a real bug — log details and investigate in code.
+
+## §5 — Phantom trades on broker
+
+**Symptom:** Broker history shows trade with the correct magic number, but no `entry` event in `trade_log.csv`.
+
+**This is HIGH severity.** Implies either operator intervention or an EA bug.
+
+**Possible causes:**
+- Manual trade placed in MT5 with same magic number (you accidentally clicked Buy?)
+- EA placed trade but failed to write log (rare — file permissions issue?)
+- Position opened during EA restart, log entry lost
+
+**Fix:**
+
+1. **Don't close the position manually** unless it's clearly wrong (could mess up state).
+2. Investigate: was it placed at a real signal time? Is the position size correct (matches Risk_Per_Trade)?
+3. If trade matches a recent envelope in `signals_processed/`, the log write failed — log it manually for record-keeping.
+4. If trade matches no signal envelope, it's manual or anomalous. Decide whether to close (probably yes — system did not authorize).
+
+## §6 — Lost signals
+
+**Symptom:** Envelope in `signals_processed/` (or `signals_failed/`) but no corresponding broker trade.
+
+**Possible causes:**
+- Envelope rejected by EA (check `signals_failed/`)
+- EA rejected for staleness, hash mismatch, news, or DD halt
+- Order placement failed (broker rejected lot size, spread too wide, etc.)
+
+**Diagnosis:**
+
+```powershell
+# Find the envelope
+ls "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\signals_failed\" -ErrorAction SilentlyContinue
+ls "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers\signals_processed\" -ErrorAction SilentlyContinue
+
+# Check EA log in MT5 Experts tab — look for events around the signal timestamp
+# Should show why the envelope was rejected (news_discard, hash_mismatch, stale, etc.)
+```
+
+**Fix:** root cause depends on rejection reason. Common cases:
+- Stale envelope → sidecar cycle ran late, signal timestamp too old. Acceptable miss; review sidecar performance.
+- Hash mismatch → operator error (wrong config). Update EA input.
+- News discard → expected behavior; check news filter calibration.
+- DD halt → expected behavior; account approaching limits.
+
+## §7 — Single bad trade
+
+**Symptom:** A single trade lost more than expected (e.g. -2R instead of -1R).
+
+**Possible causes:**
+- Slippage on SL fill (broker filled at worse price than SL level)
+- Gap-through-SL (price gapped over the SL during news or market close)
+- Multi-trade simultaneous loss (correlation event)
+
+**Fix:**
+- For single bad fill: log it, monitor for pattern. Single events happen.
+- For gap-through: this is the unmodeled tail risk. Acceptable.
+- For correlation: this is normal — Arc 10 doesn't manage correlation; expects DD halt to catch large losses.
+
+If pattern (multiple unexpected -2R+ losses in a week): investigate broker fill quality, consider escalating to broker support.
+
+## §8 — Account approaching DD halt
+
+**Symptom:** Daily DD nearing 3.5% or total DD nearing 7%.
+
+**This is HIGH severity.** Approach to halt means a stretch of losing trades.
+
+**What the system does automatically:** at 3.5% daily (or 7% total), no new entries. At 4.5% (or 8%), force close all.
+
+**What you should NOT do:**
+- Don't close open positions manually unless you're absolutely sure they shouldn't continue
+- Don't restart EA expecting to "reset" anything
+- Don't increase risk to "make it back"
+
+**What you SHOULD do:**
+- Verify the system is operating correctly (check logs, no bugs)
+- Note which folds/conditions historically had similar drawdowns (look at WFO data)
+- Wait. The system halts entries and waits for daily DD to reset (UTC or EET midnight depending on broker).
+
+**If the system actually halts (4.5% or 8% close-all):**
+- Trading stops automatically
+- Re-enabling trading requires verification that the system is healthy
+- Consider reducing risk for the next week (manual reduction of Risk_Per_Trade)
+
+## §9 — MT5 disconnected
+
+**Symptom:** MT5 bottom-right shows red icon, "No connection" text, or stale prices.
+
+**Possible causes:**
+- Broker server maintenance
+- Broker connection issue
+- VPS network problem
+- MT5 internal hang
+
+**Diagnosis:** check if internet connectivity works on VPS:
+
+```powershell
+Test-NetConnection -ComputerName 8.8.8.8 -Port 53
+Test-NetConnection -ComputerName -Port 443 # to broker host (find in MT5 properties)
+```
+
+**Fix:**
+- Wait 5-10 minutes (usually auto-reconnects)
+- If still disconnected: File → Login (re-trigger connection)
+- If still disconnected: restart MT5
+- If still disconnected: investigate VPS network or contact broker
+
+## §10 — News URL returns 401/403/404
+
+**Symptom:** Sidecar log shows news fetch errors.
+
+**Possible cause:** ForexFactory changed URL or blocked the user-agent.
+
+**Fix:**
+- Check the URL in a browser: https://nfs.faireconomy.media/ff_calendar_thisweek.xml
+- If URL changed: update `News_Calendar_URL` in EA inputs on both MT5s
+- If access blocked: investigate user-agent or find alternative news source
+
+**While broken:** the EA's news filter defaults to "no news data" → allows all signals. This is the safer default than "all signals blocked", but it means trades fire through news events. Monitor for unexpected losses during news windows.
+
+## When to escalate vs. when to wait
+
+**Wait it out:**
+- Single bad trade
+- Daily DD up to 2%
+- One symbol fetch failure
+- Brief broker disconnect (<10 min)
+- One night of weird behavior
+
+**Investigate same day:**
+- Repeated tracebacks
+- Heartbeat stale 6+ hours despite watchdog
+- Phantom trade
+- Total DD up to 6%
+
+**Escalate immediately (consider halting):**
+- Anchor probe fails (convention drift)
+- Multiple phantom trades
+- Total DD 7%+ (system halts entries automatically)
+- Total DD 8%+ (system force-closes; investigate before re-enabling)
+- Trade behavior significantly diverges from backtest expectations across 2+ weeks

--- a/arc_10/04_runbook/05_emergency_kill.md
+++ b/arc_10/04_runbook/05_emergency_kill.md
@@ -1,0 +1,147 @@
+# Emergency Kill
+
+> **Purpose:** Stop everything. Close all positions. Halt new entries.
+> **When to use:** Major issue you don't understand. Suspect serious bug. Account compromised.
+> **Time to execute:** ~2 minutes if you're already RDP'd in.
+
+## What "emergency kill" means
+
+In order of urgency:
+
+1. **Stop new trades from entering** — disable EA AutoTrading
+2. **Close all open positions** — flatten the account
+3. **Stop sidecar services** — prevent any further signal generation
+4. **Investigate** — find what went wrong
+
+## Procedure (do these IN ORDER)
+
+### Step 1 — Disable AutoTrading on both MT5s (immediately stops new entries)
+
+Easiest way: in each MT5, click the AutoTrading button in the toolbar. It turns from green to red.
+
+Alternatively via PowerShell — not directly possible (AutoTrading is a GUI toggle), but you can stop the sidecars (Step 3) which will halt envelope production. EAs still active but won't receive new envelopes.
+
+**To verify:**
+- AutoTrading button is RED in both MT5s
+- Any new envelope sidecar emits will be ignored by EA
+
+### Step 2 — Close all open positions
+
+In EACH MT5:
+
+1. Trade tab (Ctrl+T)
+2. Select all positions (Ctrl+A or right-click → Select All)
+3. Right-click → "Close" or "Close all positions"
+4. Confirm
+
+Alternatively, the EA itself has an emergency-flatten function but the simplest is manual GUI close.
+
+**To verify:**
+- Trade tab shows no open positions
+- Account History (Ctrl+Shift+H) shows all positions closed today
+
+### Step 3 — Stop sidecar services
+
+```powershell
+& "C:\Tools\nssm.exe" stop Arc10Sidecar5ers
+& "C:\Tools\nssm.exe" stop Arc10SidecarFundedNext
+
+# Verify
+Get-Service Arc10Sidecar5ers, Arc10SidecarFundedNext | Format-Table Name, Status
+# Both should show Stopped
+```
+
+**Also disable watchdog tasks** so they don't try to auto-restart the services:
+
+```powershell
+Disable-ScheduledTask -TaskName "Arc10WatchDog_5ers"
+Disable-ScheduledTask -TaskName "Arc10WatchDog_FundedNext"
+```
+
+### Step 4 — Optional: detach EAs from charts
+
+In each MT5:
+- Right-click chart with EA → Expert Advisors → Remove
+
+This guarantees the EA can't fire ANY trade even if AutoTrading gets re-enabled later. Most paranoid level of safety.
+
+## What is STILL safe after the kill
+
+- VPS still running
+- MT5 still connected to brokers
+- Accounts still exist with current balance
+- Repo and configs intact
+- Backtest results intact
+- Trade logs preserved (for investigation)
+
+## What needs to be done to RESUME after the kill
+
+1. **Investigate the issue.** Don't resume until you understand what went wrong and have fixed it.
+2. Re-enable watchdogs:
+   ```powershell
+   Enable-ScheduledTask -TaskName "Arc10WatchDog_5ers"
+   Enable-ScheduledTask -TaskName "Arc10WatchDog_FundedNext"
+   ```
+3. Re-start sidecars:
+   ```powershell
+   & "C:\Tools\nssm.exe" start Arc10Sidecar5ers
+   & "C:\Tools\nssm.exe" start Arc10SidecarFundedNext
+   ```
+4. Verify heartbeats refresh on next H4 cycle.
+5. Re-attach EAs if removed (drag from Navigator to chart, re-enter inputs).
+6. Re-enable AutoTrading in each MT5.
+
+## When you might use emergency kill
+
+**Use it:**
+- You suspect the EA is making wrong-direction trades (long/short confusion)
+- Account is approaching DD halt rapidly and you don't trust system to halt cleanly
+- You've discovered a critical bug in the EA or sidecar
+- Account or VPS appears to have been compromised
+- Broker rule changed and current behavior may violate new rules
+
+**Don't use it:**
+- A single losing trade (normal)
+- A losing day (normal)
+- Approaching daily DD (system will halt itself)
+- Slight unexpected behavior (investigate without killing — let it keep running while you check)
+
+## Why "kill then investigate" is safer than "investigate first"
+
+Time pressure under uncertainty leads to errors. If you're confused about what's happening:
+- Stop the system (cost: a few hours of missed trades)
+- Investigate calmly (benefit: understand the issue without active risk)
+- Resume with confidence (benefit: don't compound an unknown problem)
+
+The cost of "kill it now, investigate next" is small. The cost of "let it keep running while I figure this out" can be unbounded.
+
+## The fastest possible kill (15 seconds)
+
+If you're already RDP'd in and need to act in seconds:
+
+```powershell
+# Stop both sidecars (envelopes cease)
+& "C:\Tools\nssm.exe" stop Arc10Sidecar5ers
+& "C:\Tools\nssm.exe" stop Arc10SidecarFundedNext
+
+# Disable watchdogs
+Disable-ScheduledTask -TaskName "Arc10WatchDog_5ers"
+Disable-ScheduledTask -TaskName "Arc10WatchDog_FundedNext"
+```
+
+That's the most you can do via PowerShell in 15 seconds. Open positions are still open (broker controls them), but new entries cannot fire. Then deal with open positions via MT5 GUI.
+
+## Backup: contact broker support
+
+If you can't access the VPS (network down, RDP locked out, etc.):
+- Contact 5ers and/or FundedNext support
+- Request emergency closure of all positions on your account
+- Explain "automated trading system malfunction, need to halt all activity"
+
+Most prop firms have emergency contact procedures.
+
+**Save broker support contacts NOW** before you need them:
+- 5ers: (from your dashboard)
+- FundedNext: (from your dashboard)
+
+Document them in `05_history/02_decisions_log.md` or `00_executive_summary.md` for quick reference.

--- a/arc_10/04_runbook/06_live_tracking_framework.md
+++ b/arc_10/04_runbook/06_live_tracking_framework.md
@@ -1,0 +1,189 @@
+# Live Tracking Framework
+
+> **Purpose:** Define what "system performing as expected" looks like in numbers, BEFORE live data arrives.
+> **Why now:** future-you in drawdown will rationalise in either direction. Past-you, calibrated to backtest, is the right person to set the bands.
+> **Use:** weekly review, compare actual live results to these bands. Inside band = normal variance. Outside band = investigate.
+
+## The cardinal rule
+
+**This document is written from a calibrated state. Do not edit it from a stressed state.**
+
+If live performance violates these bands, the document does not get edited to fit the data. The data forces a decision: investigate, pause, or trigger kill criteria. Editing the bands to accommodate poor performance defeats the entire point.
+
+If you genuinely believe a band needs updating (e.g. after 12+ months of live data you have a better empirical distribution), update it in a calibrated state with explicit justification, version-bumped.
+
+## Per-trade R-distribution expectation
+
+Backtest distribution from the WFO pool (EET v3.0.2, ~3,152 trades over 14 years):
+
+| Metric | Backtest value | Live expected | Variance band (acceptable) |
+|---|---|---|---|
+| Mean R per trade | +0.42 | +0.30 to +0.40 (cost haircut) | ±0.10 |
+| Median R per trade | −0.15 to −0.20 | similar | — (median always negative; mean is what matters) |
+| Win rate | ~38% | 33-43% | 28-48% over any 50+ trade window |
+| Largest single win R | +5.0 to +8.0 (rare) | similar | clip outliers when computing means |
+| Largest single loss R | −1.0 (clean SL hit) | −1.0 to −1.3 (slippage tail) | −1.5R is alarming, −2.0R+ is investigate |
+| % of trades with TP1 fired | ~55% | 50-60% | — |
+| % of trades exited via trail_stop | ~50% | 45-55% | — |
+| % of trades exited via initial_sl_hit | ~38% | 35-45% | — |
+| % of trades exited via time_exit | ~7% | 5-12% | high time-exit % = trend regimes weak |
+
+**Why mean is positive but median is negative:** asymmetric R distribution. Most trades lose ~1R (initial SL hit) or partial-close-then-trail to ~0R. The minority of trades that catch runners produce +2R, +3R, +5R outcomes. The right tail funds the strategy.
+
+**Variance bands are wide because:** 50 trades is small statistical mass. Backtest at 50 trades had folds with win rates of 30% AND 48% within the same year. Don't react to a single 50-trade window.
+
+## Cumulative ROI expectation
+
+Based on EET expected live (44% annualised holdout ROI, after haircuts). At 0.50% risk per trade, ~225 trades per year.
+
+| Trade count | Expected days elapsed | Expected ROI | 25% confidence band | 75% confidence band |
+|---|---|---|---|---|
+| 25 | ~40 | +4% | −2% to +10% | — |
+| 50 | ~80 | +9% | 0% to +18% | — |
+| 100 | ~160 | +19% | +5% to +33% | — |
+| 200 | ~320 | +38% | +15% to +60% | — |
+| 365 (one year) | ~365 | +44% | +20% to +70% | — |
+
+**How to use:**
+- Live ROI inside the 25-75% band → normal, no action
+- Live ROI below the 25% band → flag for review, not yet kill criteria
+- Live ROI below 0% at 100+ trades → investigate seriously, check for systematic issue
+- Live ROI tracking at the median → ideal, no action needed
+- Live ROI above 75% band → also note (could be regime-favorable, could be over-leveraged via fat tails)
+
+**Critically:** these are estimates with high variance. A 50-trade ROI of −3% is within the realm of normal variance. Don't react to short windows.
+
+## Per-pair frequency expectation
+
+Per the WFO pool, signal frequency varies materially across the 28 pairs. Some pairs (heavy USD crosses, JPY pairs) signal more frequently than others (tight Euro-area crosses).
+
+Top frequency pairs (most signals/year):
+- USDJPY, EURJPY, GBPJPY (all JPY) — ~10-15 trades/year each
+- EURUSD, GBPUSD, USDCAD — ~8-12 trades/year
+- AUDUSD, NZDUSD — ~8-10 trades/year
+
+Bottom frequency pairs:
+- EURCHF, CADCHF (CHF cross-pairs) — ~3-5 trades/year (CHF tight-band intervention regimes)
+- NZDCHF, AUDCHF — ~4-6 trades/year
+
+**Flag if:** any pair fires >2x its expected frequency in any quarter (might indicate convention drift or symbol-specific issue) or <0.3x its expected frequency over 6 months (might indicate symbol unavailable or broken data feed).
+
+## Daily DD expectation
+
+Most live days will have minimal intraday DD because Arc 10 runs ~1-2 open positions on average across 28 pairs.
+
+| Daily DD level | Frequency in backtest | Action |
+|---|---|---|
+| 0 to 1% | ~75% of days | Normal — no action |
+| 1% to 2% | ~20% of days | Normal — no action |
+| 2% to 3% | ~4% of days | Note, no action |
+| 3% to 3.5% | ~0.8% of days | Watch — approaching halt threshold |
+| 3.5% to 4.5% | very rare | System halts new entries — review |
+| 4.5%+ | should not occur | System force-closes all — investigate immediately |
+
+**Why this matters:** if live DD distribution is materially different (e.g. 4% of days hitting 2-3% DD instead of 0.8%), that's a signal of either:
+- Position sizing miscalibration
+- Broker fill quality worse than modeled
+- Concurrent trade load higher than backtest assumed
+- Tail event clustering (multiple losing positions correlating)
+
+## Total DD expectation
+
+The internal "something's wrong" threshold:
+
+| Total DD level | Action |
+|---|---|
+| 0 to 5% | Normal |
+| 5% to 7% | Note — track, but normal |
+| **7%** | **Internal pause-and-review trigger** |
+| 8%+ | System force-closes (CloseAll threshold) |
+| 10%+ | Broker hard limit — account terminated |
+
+**At 7% total DD:**
+1. Stop and verify the system is operating correctly (no bugs, no operator error, no broker issue)
+2. Cross-check against backtest worst-fold DD (expected live ~8.8% EET, ~9.5% UTC)
+3. If system is operating correctly and DD is within expected worst-fold range → continue per plan (this is what the system is designed to survive)
+4. If anything looks off → trigger emergency kill procedure (`04_runbook/05_emergency_kill.md`) and investigate
+
+**Why 7% (not 8%):** 8% triggers the system's automatic CloseAll. By 7% you want operator-level awareness so you can choose to continue, pause, or kill BEFORE the system makes the decision for you. 7% provides a 1pp human decision buffer.
+
+## Win rate over rolling windows
+
+Win rate variance is high at short windows. Backtest showed:
+
+| Window | Min win rate seen | Max win rate seen | Mean |
+|---|---|---|---|
+| 25 trades | 22% | 56% | 38% |
+| 50 trades | 27% | 49% | 38% |
+| 100 trades | 31% | 45% | 38% |
+| Full year | 33% | 44% | 38% |
+
+**Don't react to single 25-trade win rate.** Even a 22% win rate over 25 trades was within backtest variance. Only react if 50-trade rolling win rate drops below 27% sustained for multiple windows.
+
+## Monthly sign expectation
+
+Backtest sign consistency was 11/11 folds (yearly) positive. Monthly is noisier.
+
+In backtest, individual months:
+- ~65-70% of months were positive
+- ~30-35% of months were negative
+- No fold (year) was negative overall
+
+**Live tracking:** 
+- 1 negative month in 6 → normal
+- 2 negative months in 6 → note but normal
+- **3 negative months in 6 → investigate** (rare in backtest; possible regime shift or systematic issue)
+- 4+ negative months in 6 → triggers kill criteria review (`07_kill_criteria.md`)
+
+## What live data CAN'T tell you in the first month
+
+- Whether expected ROI is being achieved (sample too small)
+- Whether DD profile matches backtest (haven't hit drawdown yet)
+- Whether broker fill quality matches modeled costs (need 50+ trades for meaningful spread/slippage stats)
+
+**First month conclusions:**
+- System is running operationally (yes/no)
+- Trades fired when expected (yes/no — cross-check signal envelopes vs broker trades)
+- No surprising errors in logs (yes/no)
+- Fill quality looks similar to backtest at a glance (within order of magnitude)
+
+That's it. Don't try to conclude ROI or edge from one month.
+
+## Quarterly review structure
+
+Every 3 months (= ~50-75 trades), do a structured review against these bands:
+
+1. Trade count: matches expected ~55-70 per quarter?
+2. Win rate: inside 28-48% band over the quarter?
+3. Mean R per trade: inside +0.20 to +0.50 band?
+4. Cumulative ROI: tracking inside the cumulative ROI table band?
+5. Per-pair frequency: any pair >2x or <0.3x expected?
+6. DD profile: max daily DD seen vs expected distribution?
+7. Total DD: max total DD seen vs expected worst-fold?
+
+If 0-1 bands violated: normal variance, continue.
+If 2-3 bands violated: investigate root cause, continue trading at current risk.
+If 4+ bands violated: review against `07_kill_criteria.md`, decide whether to pause, reduce risk, or kill.
+
+## What to capture each quarter (raw data)
+
+After each quarterly review, append a row to a tracking ledger (build it as you go):
+
+| Quarter | Trades | Win % | Mean R | ROI | Max Daily DD | Max Total DD | Bands violated | Action |
+|---|---|---|---|---|---|---|---|---|
+| Q1 (date range) | | | | | | | | |
+
+The ledger lives in a private place (not in the repo for privacy of live numbers if you prefer). The decision-making process IS in the repo (this doc + kill criteria).
+
+## Why writing this BEFORE live data matters
+
+The single highest-value piece of the entire `arc_10/` consolidation is this document + `07_kill_criteria.md`.
+
+Configs and scripts can be reconstructed from git history. The calibrated decision framework — what "normal" looks like, what "wrong" looks like, what triggers action — cannot be reconstructed under drawdown stress. Stressed-you will rationalise either:
+
+- "It's just variance, keep going" (when it's actually broken)
+- "It's broken, stop everything" (when it's actually variance)
+
+Calibrated-you, with WFO numbers fresh, can write down the bands honestly. Then stressed-you just has to look at the document and follow it.
+
+**Treat this document as a contract with future-you.** It supersedes any in-the-moment intuition.

--- a/arc_10/04_runbook/07_kill_criteria.md
+++ b/arc_10/04_runbook/07_kill_criteria.md
@@ -1,0 +1,175 @@
+# Kill Criteria
+
+> **Purpose:** Define explicit triggers for stopping Arc 10 deployment, written from a calibrated state.
+> **Why now:** future-you in drawdown is the wrong person to decide whether to keep going. Past-you, calibrated, is the right one. Write the rules now, follow them later.
+> **Status:** These are HARD triggers. Hitting one means stop trading. Re-evaluation is required before restarting.
+
+## The cardinal rule
+
+**If a kill criterion is hit, the system stops trading. Period. No "let me wait one more week."**
+
+The reason to write this now: in the moment, you will rationalise continuing. "It's just a bad week." "The next trade will recover." "I'll close manually if it gets worse." These rationalisations are how blown accounts happen.
+
+When a kill criterion fires:
+1. Run emergency kill procedure (`04_runbook/05_emergency_kill.md`)
+2. Stop trading
+3. Cool down for at least 7 days (no re-evaluation during the cool-down)
+4. Then evaluate per the "Restart criteria" section below
+5. If restart conditions aren't met → system stays stopped
+
+## What counts vs what doesn't
+
+**Counts toward kill criteria:** automated EA trades on the live account.
+
+**Does NOT count:** demo trades, backtest trades, trades from prior systems (KH-24), manual trades (which should never happen — see emergency kill if you ever placed one).
+
+**Aggregation:** combined across both 5ers and FundedNext if both are live. The kill criteria apply to the overall Arc 10 deployment, not per-broker. Reason: bad performance on either signals the same underlying issue.
+
+## The kill criteria (in priority order)
+
+### #1 — System-level: prop firm hard limit hit
+
+If either 5ers or FundedNext kills the account (10% total DD or 5% daily DD breach), the system stops automatically — broker terminates account.
+
+**Action:** investigate root cause before opening any new account. Do not buy another Challenge until you understand what happened. This is the only "involuntary kill" — the others are deliberate.
+
+### #2 — Operator-level: total DD ≥ 8.5% (expected worst-fold + buffer)
+
+Backtest worst-fold DD (cost-adjusted, EET live-expected) is 8.8%. Hitting 8.5% means you're at the edge of "this is what the system is designed to survive."
+
+System auto-halts new entries at 7%, auto-CloseAll at 8%. The 8.5% threshold gives a 0.5pp buffer past CloseAll for cases where positions slipped through CloseAll before fully exiting.
+
+**Action:** kill, cool down, investigate.
+
+### #3 — Variance-level: cumulative ROI below 25% confidence band at 200+ trades
+
+The live-tracking framework specifies a 25% confidence band at 200 trades of approximately +15% ROI. If actual cumulative ROI at 200 trades is below this (e.g. cumulative +5% or negative), this exceeds normal variance.
+
+**Threshold:** cumulative ROI < +5% at 200+ trades.
+
+**Action:** kill, cool down, investigate. Possible causes: regime shift, broker fill degradation, hidden bug, market structure change.
+
+**Why 200 trades:** below 200, sample noise is high enough that bad luck can produce low ROI. At 200+ trades, sustained underperformance is signal not noise.
+
+### #4 — Consistency-level: 4+ negative months in any 6-month window
+
+Backtest had ~30-35% negative months. 2 negative months in 6 is normal. 3 is unusual but possible. **4 in 6 is outside backtest experience and signals systematic issue.**
+
+**Threshold:** 4 negative months in any rolling 6-month window.
+
+**Action:** kill, cool down, investigate.
+
+### #5 — Drawdown-duration-level: total DD > 5% for > 60 consecutive days
+
+Backtest had drawdown periods that lasted weeks. Few exceeded 60 days. If account is in 5%+ DD for 60+ consecutive days without recovery, the system isn't reverting to its expected positive expectancy.
+
+**Threshold:** total DD > 5% sustained for 60+ days.
+
+**Action:** kill, cool down, investigate.
+
+### #6 — Process-level: 3 consecutive kill criteria warnings without trigger
+
+Even if no kill criterion is hit outright, getting close repeatedly (e.g. DD spiking to 7-7.9% three times in 6 months without breach) is a signal that the system is operating closer to its limits than designed.
+
+**Threshold:** 3 incidents in 6 months where DD reaches 7% (system halt threshold) or worst weekly performance < −3% ROI.
+
+**Action:** review (not full kill). Consider risk reduction. If issues continue: kill.
+
+### #7 — Trust-level: any unexplained discrepancy you can't resolve
+
+Phantom trade. Lost signal. Sidecar reporting fresh heartbeat but no trades for 2 weeks despite signals expected. Account balance off by an amount that doesn't reconcile to trade log.
+
+**Action:** kill, cool down, investigate. Don't trade a system you don't fully understand.
+
+This is the catch-all: any "I don't know what just happened" event triggers kill.
+
+## What does NOT trigger kill
+
+Things that LOOK alarming but are within expected variance:
+
+- **Single bad day:** even −3% in one day is rare but possible in backtest. Not kill criteria.
+- **Single bad week:** −2% in one week is uncomfortable but within variance.
+- **Single bad month:** monthly variance is high. One negative month is normal.
+- **Approaching but not breaching DD:** the system halts at 7%, CloseAll at 8%. Approaching these activates system protection, not kill criteria.
+- **Lower trade frequency than expected for a month:** Arc 10 is a signal-frequency-variable system. Some months are quiet.
+- **Higher trade frequency than expected:** as long as DD is controlled, more signals is fine.
+- **Backtest expectation deviation in early sample:** 25-50 trades is too small to draw conclusions. Don't react.
+- **Broker rule changes:** these may require config changes but don't auto-trigger kill. Reassess against new rules.
+
+## Restart criteria (after a kill)
+
+If you killed the system, here's what's required before restarting:
+
+### Mandatory before any restart
+
+1. **Cool-down period:** minimum 7 calendar days from kill date. No restart during this period. Use it to investigate without time pressure.
+
+2. **Root cause identified:** you must be able to articulate WHY the kill happened. "Bad luck" is not a root cause; "this kill criterion fired because X" is. Document in `05_history/02_decisions_log.md`.
+
+3. **Decision documented:** write a new entry in the decisions log explaining what changed (if anything) and why restart is justified.
+
+### Restart conditions vary by kill type
+
+| Kill type | Restart conditions |
+|---|---|
+| #1 prop firm hard limit | Cannot restart same account; open new account ONLY after root cause + fix |
+| #2 8.5%+ DD | Restart at reduced risk (0.30% instead of 0.50%); revert to full risk after 50 trades clean |
+| #3 ROI below band at 200+ trades | Significant investigation required; may need re-validation against new data; consider whether strategy is still alive |
+| #4 4 negative months in 6 | Investigate regime; consider risk reduction; restart only if you understand cause |
+| #5 prolonged DD | Same as #4 |
+| #6 repeated near-misses | Reduce risk before restart |
+| #7 unexplained discrepancy | Bug must be fixed and verified before restart |
+
+### If you can't articulate WHY → don't restart
+
+The hardest case: you killed the system, the cool-down passes, and you don't have a clear root cause. The temptation is to attribute it to bad luck and restart.
+
+**Don't.** If you can't explain why, you can't predict if it'll happen again. Better to leave the system dormant for an extra month while investigating than to restart blindly.
+
+If still no clear root cause after 30 days: strongly consider that the strategy no longer has edge (regime shift, validation drift, market structure change) and that further investigation is needed before deploying any version of it.
+
+## What to do during cool-down
+
+Productive activities (no trading):
+- Read `04_incident_response.md` and `05_emergency_kill.md` carefully
+- Review trade logs in detail — what does the actual loss path look like?
+- Cross-check live trades against backtest expectations on the same period
+- Investigate any unusual log entries
+- Check broker fill quality (compare actual fills vs SL levels)
+- If suspecting bug: re-run sidecar against historical data, compare to backtest
+- Talk to anyone with relevant context (broker support if relevant)
+
+Unproductive activities (avoid):
+- Re-tuning parameters to fit the bad period
+- Looking for new strategies to deploy "instead"
+- Doubling down on the existing strategy at higher risk to "make it back"
+
+## Why these specific numbers
+
+| Criterion | Threshold | Rationale |
+|---|---|---|
+| DD limit | 8.5% | Backtest worst-fold live-expected ~8.8%; 8.5% catches imminent breach |
+| ROI band | 25% confidence at 200+ trades | Below this, sample large enough that bad ROI is signal |
+| Negative months | 4 in 6 | Backtest rarely had 3, never had 4. Outside experience. |
+| DD duration | 60 days | Backtest had recovery within 60 days in nearly all cases |
+| Near-misses | 3 in 6 months | Pattern of near-misses = operating too close to limits |
+
+These thresholds are calibrated to the backtest. If a backtest re-validation produces different numbers, update thresholds in a calibrated state with explicit version bump.
+
+## What this document is NOT
+
+- **It is NOT a stop-loss for individual trades.** That's the EA's `SL_ATR_Multiplier_Expected` = 3.5×ATR. This document is the kill switch for the entire strategy deployment.
+
+- **It is NOT performance targets.** Performance targets are aspirational; kill criteria are floor conditions.
+
+- **It is NOT optional.** If a kill criterion fires, the system stops. There's no "but I think it'll recover."
+
+- **It is NOT permanent.** Restart is allowed under explicit conditions documented above. But the kill itself is non-negotiable.
+
+## Pre-commitment
+
+By deploying Arc 10 live, the implicit contract is: you will follow these criteria. The criteria exist precisely because in-the-moment decision-making fails under drawdown stress.
+
+If you find yourself in 2027 trying to talk yourself out of a kill: re-read this paragraph. The Arc 10 deployment process explicitly anticipated this moment. Past-you knew that future-you would want to keep going. Past-you decided the rules anyway, calibrated to the data.
+
+Follow the rules.

--- a/arc_10/05_history/01_arc_lineage.md
+++ b/arc_10/05_history/01_arc_lineage.md
@@ -1,0 +1,97 @@
+# Arc Lineage
+
+> **Purpose:** Brief history of how we got to Arc 10. Helps future you avoid repeating dead ends.
+> **For full chronology with rationale:** see `02_decisions_log.md` and `03_eliminated_approaches.md`.
+
+## The story in 5 lines
+
+1. NNFX indicator-sweep approach failed (GPT-4 hallucinated MQL4→Python conversions)
+2. Bounded-event "Phase JL" approach invalidated by forward bias in pool construction
+3. KGL/KH arc produced the KH-24 live system (now retired in favour of Arc 10)
+4. L_ARC_PROTOCOL (the current research methodology) governed Arcs 1–10
+5. Arc 10 v3.0.2 — DLR signal + three-stage exit — validated and deployed
+
+## Pre-Arc work (~6 months)
+
+**Stonehill / NNFX indicator sweep:** classical NNFX framework with indicator-based entries. Used GPT-4 + Aider to translate MQL4 indicators to Python. **Failed because GPT-4 produced hallucinated conversions** that didn't replicate MQL4 behaviour. Both GPT-4 and Aider permanently excluded from the toolchain after this.
+
+**Phase JL — Bounded events:** new approach. Define "bounded events" (e.g. swing-low rejections) and build a pool from them. **Failed because pool construction had forward bias** — the criteria selecting events used future information. All Phase JL results invalidated. Permanent lesson: ex-ante population construction is non-negotiable.
+
+## KGL/KH arc
+
+Refined the bounded-event idea with strict ex-ante population. Produced the **KH-24 EA** (`kb_exhaustion_bar` 4H trend-pullback, long-only, 28 FX pairs). Deployed live; now being retired in favour of Arc 10.
+
+KGL/KH proved:
+- Ex-ante pool construction works
+- Worst-fold WFO is the right gate
+- One-day D1 lag (no same-day D1 close) is correct and must never be reverted
+
+## L_ARC_PROTOCOL (current methodology)
+
+Six-step pipeline for signal discovery:
+
+1. **Plumbing** — pool construction, feature engineering
+2. **Path-shape clustering** — group trades by forward trajectory archetype (NOT by magnitude)
+3. **Capturability** — does an exit policy exist that extracts the trajectory's edge?
+4. **Extractability** — does the signal exit policy survive realistic cost modelling?
+5. **Cross-fold stability** — does the signal hold across folds with worst-fold gate?
+6. **WFO** — final walk-forward optimisation under realistic costs
+
+Arcs 1–9 explored various signal candidates. Arc 10 was the keeper.
+
+## Arc 10 versions
+
+| Version | Date | What changed |
+|---|---|---|
+| Arc 10 v1.x | early development | Initial DLR signal definition |
+| Arc 10 v2.x | mid development | Three-stage exit policy refinement |
+| **Arc 10 v3.0.2** | current | Locked deployment version |
+| (future) | TBD | post-live-data refinements (deferred until 4+ weeks live) |
+
+## What survived from earlier arcs
+
+Despite the dead ends, several methodology pieces survived:
+
+- **Worst-fold WFO gating** — from KGL/KH
+- **Long-only constraint** — empirical asymmetry found in KGL
+- **28-pair universe** — established in NNFX phase, kept throughout
+- **Ex-ante population construction** — hard lesson from Phase JL
+- **No future information in features** — same lesson, generalised
+- **Per-bar audit fingerprints** — methodology refinement during Arc 8
+- **Strategy Tester scenario validation** — from KH-24 live deployment work
+- **D1 one-day lag** — established in KGL, never reverted
+
+## What's NOT in Arc 10 from earlier work
+
+- **Indicator-based entries** — abandoned in NNFX phase
+- **Volume features** — failed when switched brokers (microstructure doesn't port)
+- **Magnitude-based clustering** — replaced with path-shape clustering
+- **GPT-4 or Aider for code** — permanently excluded
+- **KH-24 strategy code** — different system, kept in repo for historical reference only
+
+## Wave 1 of arcs (current cleanup)
+
+Arcs 1-10 form "wave 1" of L_ARC_PROTOCOL research. Arc 10 succeeded; arcs 1-9 either failed or were superseded. Closing wave 1 means writing closure documents for each so the lineage is preserved.
+
+After wave 1 closure: any further research becomes "wave 2" — built on top of the proven Arc 10 / KGL methodology.
+
+## What's next: Lω (Lomega) discovery engine
+
+**Lω (Lomega)** is a supervised feature discovery engine. Clusters the full dataset by forward price geometry, works backward to find predictive conditions. Designed as fallback if the L_ARC signal pipeline exhausts candidates without a deployable system.
+
+**Status:** plan document drafted (`LOMEGA_DISCOVERY_PLAN.md`). Execution deferred — Arc 10 is the current deployed system; Lω only runs if we need new signal candidates after Arc 10 fully matures.
+
+## Lessons that compounded across arcs
+
+1. **One change per phase, pre-committed gate.** Bundling changes destroys interpretability.
+2. **Worst-fold metric is the only deployment-relevant number.** Mean-fold is bait.
+3. **Path-shape clustering before magnitude features.** Recurring failure: "found a signal, can't extract R" → because we clustered on outcome magnitudes, not on trajectory shapes.
+4. **Broker data is not portable.** Volume + microstructure metrics fail when broker changes. Tested empirically (FTMO → 5ers).
+5. **The break instinct is reliable signal.** When the body says stop, listen. Forced productivity through fatigue produces bugs.
+
+## Where to find raw data
+
+- Arc closure docs: `results/l_arc_<N>/ARC_CLOSURE.md` (and `__archive_for_research_reference__/` for failed arcs)
+- KGL/KH arc history: scattered across earlier results folders
+- Phase JL (invalidated): preserved in archive for "what NOT to do" reference
+- NNFX phase: mostly deleted; methodology documented in journal

--- a/arc_10/05_history/02_decisions_log.md
+++ b/arc_10/05_history/02_decisions_log.md
@@ -1,0 +1,239 @@
+# Decisions Log
+
+> **Purpose:** Record the key decisions that shaped Arc 10's deployment, and why each was made.
+> **Why it matters:** Stops future you from re-litigating settled questions or unwinding good calls.
+
+## Strategy decisions
+
+### Long-only
+**When:** during DLR signal discovery
+**What:** trade only long setups; ignore short equivalents
+**Why:** the DLR signal is asymmetric — long-side pool produces ~2x the worst-fold ratio of the short-side equivalent. Long-only halves the implementation complexity and the cost surface. Worth the constraint.
+**Status:** locked
+
+### H4 timeframe
+**When:** during KGL arc
+**What:** trade H4 bars (not H1, H2, D1)
+**Why:** worst-fold ratio is highest on H4 in the tested set. H1/H2 add signals but lower per-trade R. D1 has clean structure but signal frequency too low for meaningful WFO statistics.
+**Status:** locked
+
+### 28-pair universe
+**When:** NNFX-era
+**What:** trade the 28 major+cross pairs derived from AUD/CAD/CHF/EUR/GBP/JPY/NZD/USD
+**Why:** broadest correlated-but-distinct universe supported by all major prop brokers. Provides ~225 trades/year diversification.
+**Status:** locked. Any change requires re-validation.
+
+### sl_atr_multiplier = 3.5
+**When:** Step 3 capturability analysis, current arc
+**What:** initial SL distance = 3.5 × ATR_at_signal
+**Why:** tested 2.0 / 2.5 / 3.0 / 3.5 / 4.0. 3.5× produced best balance: wide enough to absorb normal noise, tight enough to bound loss within Risk_Per_Trade × equity.
+**Status:** locked. The single most-tested parameter.
+
+### Three-stage exit policy (sl_partial_close_1r_runner_trail)
+**When:** Step 3-4 of current arc
+**What:** initial SL → partial close 50% at +1R → runner trails by 1×R off rolling high
+**Why:** captures ~60% of total return at +1R partial + ~40% at trailing runner. Tested vs full-TP variants (worse) and no-partial variants (worse). The split is the optimal balance found in extractability testing.
+**Status:** locked
+
+### Time exit at 240 bars
+**When:** Step 3 of current arc
+**What:** force-close positions still open after 240 H4 bars (~40 calendar days)
+**Why:** positions older than 240 bars have exhausted directional thesis. Net contribution positive but small; main purpose is bounding exposure.
+**Status:** locked
+
+## Risk decisions
+
+### Risk_Per_Trade per broker
+
+**FundedNext: 0.50%** — at r_base, cost sweep central case lands at 7.80% worst-fold DD (2.2pp margin to 10% hard limit).
+
+**5ers: 0.40%** — at r_base 0.5%, cost sweep central case breaches 10% DD hard limit (10.47%). Linear scaling to 0.40% brings central worst-fold DD to 8.38% (1.6pp margin).
+
+**Rationale documented:** `02_validation/05_cost_sweep.md`. Re-evaluate after 4+ weeks of live data.
+
+### Why FundedNext at 0.50% specifically (not 0.45% or 0.55%)
+
+Amendment 3 linear scaling formula: `r_recommended = 0.005 × (0.080 / worst_DD_at_r_base)`.
+
+Three reference cells were evaluated:
+
+| Cell | Worst DD @ r_base 0.5% | r_recommended |
+|---|---|---|
+| Optimistic (1.0× spread / 0.5 slip) | 7.49% | 0.0053 |
+| **Central (1.5× spread / 0.5 slip)** | **7.80%** | **0.0051** |
+| Adverse (2.0× spread / 1.0 slip) | 8.20% | 0.0049 |
+
+**Why 0.50% wins over 0.55%:** the adverse cell recommends scaling *down* to 0.49%. Deploying at 0.55% violates the adverse cell entirely (would push worst-fold DD to 9.02% pre-live-haircut, ~10.2% post-haircut — breaches hard limit). 0.55% only works if you assume optimistic costs every single trade.
+
+**Why 0.50% wins over 0.45%:** at 0.45%, you're leaving expected ROI on the table without meaningful DD reduction. Central case worst-fold DD at 0.45% would be ~7.0% — versus 7.8% at 0.50%. 0.8pp DD reduction for 10% expected-ROI reduction is not a favorable trade. You haven't moved out of the worst-fold envelope; you've just reduced position size into a still-risky envelope.
+
+**Why 0.50% wins over 0.49% (rounding):** operationally, 0.50% is a cleaner round number to communicate, calculate, and remember. The 0.01pp difference is statistical noise vs operational simplicity.
+
+The choice is **deploy at central-case recommendation, accept adverse-cell tightness, monitor live for haircut accuracy**. If live worst-fold DD systematically exceeds 8.8% in the first 6 months, reassess.
+
+### Why 5ers at 0.40% specifically (not 0.42% or 0.38%)
+
+Same Amendment 3 scaling on UTC central case:
+
+| Cell (UTC, realistic) | r_base DD | At r = 0.38% | At r = 0.40% | At r = 0.42% |
+|---|---|---|---|---|
+| Central (1.5× / swap-ON / 0 slip) | 10.47% | 7.96% | **8.38%** | 8.79% |
+| Adverse (2.0× / swap-ON / 0 slip) | 10.96% | 8.33% | 8.77% | 9.21% |
+
+**Why 0.40% wins over 0.42%:** at 0.42%, central-case worst-fold DD lands at 8.79%, leaving only 1.2pp margin to hard limit. Adverse cell at 0.42% lands at 9.21% — 0.79pp margin. Too tight for an operationally robust deployment.
+
+**Why 0.40% wins over 0.38%:** marginal DD reduction (8.38 → 7.96 = 0.42pp) at the cost of 5% expected ROI. Not a worthwhile trade if 0.40% is operationally fine.
+
+**Critical asymmetry vs FundedNext:** on UTC, swap is the dominant cost vector, and there's NO equivalent of FundedNext's swap-free add-on for 5ers. UTC at any risk level above 0.40% requires accepting that a single bad fold could approach the hard limit. The 1.6pp margin at 0.40% is the floor of "operationally tolerable."
+
+### Why a per-pair swap filter was rejected (curve-fit risk)
+
+**The idea:** apply swap-aware filtering — skip trades on pairs where swap cost is high (e.g. -2 pips/day overnight) when expected hold time is long. Theoretically tightens UTC numbers.
+
+**Why it was rejected:**
+
+1. **Pair-specific swap rates are broker-specific, time-varying, and unstable.** Swap on AUDJPY at 5ers in Q1 2026 ≠ swap on AUDJPY at 5ers in Q3 2026 ≠ swap on AUDJPY at any other broker. Per-pair filter trained on historical swap data is overfitting to a moment-in-time snapshot.
+
+2. **Expected hold time isn't known in advance.** A trade could TP1-and-trail-for-a-day OR be a runner held 30 days. Filter would need to use ex-ante hold-time prediction, which is exactly the kind of forward-information bias `02_history/03_eliminated_approaches.md` documents as a permanent failure mode.
+
+3. **Reduces signal count without proportionate DD reduction.** Backtest analysis showed swap-filter variants reduced trade count by 15-25% but only improved worst-fold DD by 0.5-1.0pp. Worse ratio outcomes than the unfiltered version.
+
+4. **Adds a calibration knob.** "Swap rate threshold" becomes another parameter to maintain, document, and re-validate across brokers. Operational complexity tax.
+
+5. **The real solution is the FundedNext swap-free path.** If swap is the dominant cost, eliminate it entirely (FundedNext) rather than filter around it (5ers). The decision tree shouldn't be "modify the strategy to fit 5ers swap reality" — it should be "deploy to FundedNext where swap doesn't exist."
+
+**Status:** permanently rejected as a strategy modification. Operational decision (which broker to deploy on) is the right knob, not strategy modification.
+
+### DD halt thresholds
+**Daily halt:** 3.5% (vs prop firm's 5%)
+**Daily CloseAll:** 4.5%
+**Total halt:** 7% (vs prop firm's 10%)
+**Total CloseAll:** 8%
+
+**Why these specific numbers:** halt thresholds (3.5%/7%) provide ~30% safety margin to the broker's hard limits. CloseAll thresholds (4.5%/8%) provide ~10-20% margin and act as a hard floor. Numbers chosen to allow the system to operate normally without daily false-triggers while catching genuine drawdown excursions before broker limits hit.
+
+### Risk ramp for first 3 weeks live
+**Week 1:** 0.20%
+**Week 2:** 0.30%
+**Week 3+:** 0.50%
+
+**Why:** real live execution may differ from backtest in subtle ways. Validating at low risk first means costs are small if discovered. Increment only if previous week was clean.
+
+## Deployment decisions
+
+### FundedNext as primary, 5ers as secondary
+**When:** post-cost-sweep
+**What:** deploy on FundedNext $100k Challenge first; keep 5ers as fallback
+**Why:** FundedNext (EET, swap-free) produces ~1.7× holdout ROI of 5ers (44% vs 27%) with more DD margin. Economic case is decisive.
+**Status:** primary deployment
+
+### High Stakes program on 5ers (vs Hyper Growth)
+**When:** account setup phase
+**What:** if/when deploying on 5ers funded, use High Stakes program
+**Why:** Hyper Growth's tighter daily DD (3-4%) doesn't suit Arc 10's worst-fold DD profile. High Stakes' 5% daily + 10% total + 80% split fits better.
+**Status:** confirmed correct program for Arc 10 at full risk
+
+### Swap-free mandatory on FundedNext
+**When:** cost sweep analysis
+**What:** swap-free add-on must be active throughout Challenge + funded
+**Why:** without swap-free, FundedNext deployment fails the cost sweep (swap drains worst-fold ROI to ~17%, DD breaches limit). Swap-free turns EET into the deployable convention.
+**Status:** locked. Confirm swap is 0.00 on every overnight position. If FundedNext changes terms, reassess immediately.
+
+### News filter ON despite FundedNext allowing news trading
+**When:** deployment configuration
+**What:** Enable_News_Filter = true on both brokers
+**Why:** consistency between brokers. Same EA behavior regardless of broker. Slight downside (some valid signals near news get discarded) accepted for operational simplicity.
+**Status:** active. Revisit if news-discard rate is high in live data.
+
+### Two separate MT5 installations (not one with multi-account)
+**When:** VPS setup
+**What:** install Five Percent Online MT5 AND FundedNext MT5 separately
+**Why:** each broker's MT5 binary is signed with broker-specific features (server lists, branding). One MT5 with multi-account login doesn't work cleanly across brokers.
+**Status:** locked
+
+### Sidecar config_hash baked into envelope
+**When:** parity validation phase
+**What:** every envelope carries a config_hash; EA validates against Expected_Config_Hash
+**Why:** prevents cross-broker contamination. If operator misconfigures (UTC sidecar pointing at FundedNext EA), envelopes get rejected on hash mismatch — caught at EA init time rather than after wrong trades fire.
+**Status:** locked
+
+### Common\Files\Arc10_<broker>\ subfolder layout (vs FILE_COMMON-free EA)
+**When:** VPS deployment
+**What:** use FILE_COMMON path resolution with broker-specific subfolders (`Arc10_5ers\`, `Arc10_FundedNext\`)
+**Why:** EAs share the user-wide `Common\Files\` folder regardless of MT5 install location (even in portable mode). Using broker-specific subfolders is the simplest isolation that requires zero EA code changes.
+**Status:** locked
+
+### NSSM for service management (vs Windows Task Scheduler)
+**When:** VPS setup
+**What:** use NSSM to wrap Python sidecar as Windows service
+**Why:** Task Scheduler can't supervise a long-running Python process well. NSSM handles restart-on-crash, log capture, service start/stop properly. Industry standard for this use case.
+**Status:** locked
+
+### Watchdog StaleSec = 15000 (4h 10min)
+**When:** watchdog deployment
+**What:** restart sidecar if heartbeat older than 15000s
+**Why:** sidecar writes heartbeat once per H4 cycle. Default StaleSec=120 would constantly restart. 15000s = one full cycle + 10min buffer to absorb broker disconnects without spurious restarts.
+**Status:** locked
+
+## Validation methodology decisions
+
+### Worst-fold WFO gate ≥ 2.0
+**When:** L_ARC_PROTOCOL design (Step 5)
+**What:** worst-fold ROI/DD ratio must be ≥ 2.0 to PASS-DEPLOYABLE
+**Why:** below 2.0 means a single bad fold is too close to wiping out a year. 2.0 is the boundary between "edge survives in worst case" and "edge is luck-dependent across folds".
+**Status:** locked. Arc 10 v3.0.2 hits 5.42 (UTC) / 6.43 (EET).
+
+### Sign consistency 11/11 required
+**When:** L_ARC_PROTOCOL design (Step 5)
+**What:** every fold must be net positive on its 12-month evaluation
+**Why:** mixed sign = strategy is sometimes losing. Even if mean ROI is positive, deployment risk is high.
+**Status:** locked. Arc 10 hits 11/11 even at 4× spread stress.
+
+### Cost sweep at 1.5× spread, 0.5 pip slip as central case
+**When:** cost sweep design
+**What:** central evaluation cell uses 1.5× HistData spread and 0.5 pip slip
+**Why:** HistData baseline is conservative (modeled spreads wider than 5ers/FundedNext actual). 1.5× is the upper-realistic case. 0.5 pip slip is realistic for liquid hours.
+**Status:** locked. Adverse cells (2.0× / 1.0 slip) and stress cells (3.0× / 4.0×) defined as ranges, not central.
+
+### Phase 2 parity: byte-identical signal output required
+**When:** L_ARC_PROTOCOL design
+**What:** sidecar's signal output must match lab byte-for-byte (modulo documented residuals)
+**Why:** without byte-identity, we can't claim the WFO numbers apply to the live system. Phase 2 is the bridge between research and deployment.
+**Status:** locked. Arc 10 v3.0.2 passes on both conventions.
+
+## Operations decisions
+
+### Restart VPS weekly during market closure
+**When:** deployment runbook design
+**What:** reboot VPS once a week, Sunday before market reopen
+**Why:** flushes memory leaks, applies Windows updates, tests auto-recovery, verifies system can resume from cold. Net cost: ~10 minutes per week. Net benefit: bounded risk of stale-state issues.
+**Status:** recommended (not enforced)
+
+### Weekly reconciliation script — build AFTER 4 weeks of live data
+**When:** post-deployment planning
+**What:** defer building the auto-reconciliation script until edge cases are known
+**Why:** building it now means guessing at edge cases. Building after 4 weeks of real data means matching the actual failure modes.
+**Status:** deferred
+
+### Improvements backlog frozen pre-live
+**When:** end of validation
+**What:** Arc 10 v3.0.2 is locked; improvements documented but not implemented
+**Why:** premature optimization without live data is guessing. Wait for real conditions, then improve with evidence.
+**Status:** active. Backlog in repo, deferred.
+
+## Tooling decisions
+
+### Cursor for small patches, Claude Code for big multi-file work
+**What:** fixed assignment of tasks to tools
+**Why:** Cursor is faster for small targeted changes. Claude Code handles cross-file refactors better. Aider permanently excluded after hallucination history.
+**Status:** locked
+
+### Direct-to-main for analysis-path work; PRs gated on engine touches
+**What:** different git workflow rules for different code paths
+**Why:** analysis-path (configs, scripts, docs) is low-risk and high-velocity. Engine-path (signals, sim, EA) is high-risk and needs review.
+**Status:** active
+
+### No force-push, ever
+**What:** force-push to main is forbidden
+**Why:** history preservation is non-negotiable for an audit-driven research pipeline.
+**Status:** locked

--- a/arc_10/05_history/03_eliminated_approaches.md
+++ b/arc_10/05_history/03_eliminated_approaches.md
@@ -1,0 +1,156 @@
+# Eliminated Approaches
+
+> **Purpose:** Document what didn't work, and why. Prevents future you from re-trying dead ends without remembering the failure mode.
+
+## GPT-4 + Aider for code translation
+
+**What was tried:** translate MQL4 indicators to Python using GPT-4 and Aider, automated. Goal: build a fast Python backtester with NNFX-style indicators ported from MT4.
+
+**What happened:** GPT-4 confidently produced wrong code. Hallucinated function signatures, invented MQL4 features that don't exist, silently changed behaviour. Aider's automated commits made the issue worse — bad code committed without human review.
+
+**Severity:** invalidated months of indicator validation work.
+
+**Decision:** GPT-4 and Aider both **permanently excluded** from the toolchain. All code goes through human-reviewed editors (Cursor, Claude Code).
+
+**Lesson:** never trust LLM-generated code in regulatory/precision paths without test coverage proving equivalence. Auto-commits without review are dangerous.
+
+## Phase JL — Bounded events with forward-biased pool
+
+**What was tried:** define "bounded event" candidates (e.g. swing patterns), build a pool of events, run WFO on that pool.
+
+**What happened:** the criteria selecting events into the pool used future information. Specifically, the "is this a swing-low" test peeked forward to confirm the swing fully formed. So the pool was constructed from completed-future swings, not from real-time signals. WFO trained on this pool was learning "given a perfect swing has formed, what happens next?" — not "given a candidate swing right now, will it become a real swing?"
+
+**How discovered:** results too good to be true. Mean fold ratios >20, holdout matching in-sample. Closer look at pool construction revealed the bias.
+
+**Severity:** entire Phase JL invalidated. Months of work.
+
+**Decision:** ex-ante population construction is **non-negotiable**. Pool criteria must be computable from information available at signal-bar close, with no peek-forward.
+
+**Lesson:** any feature derived from "what happens later" is contamination. The pool is the contract: "these are real candidates as they appeared in real time."
+
+## Indicator sweep (NNFX-style)
+
+**What was tried:** standard NNFX framework — combine an indicator-based baseline + confirmation indicators + volume filter + exit indicator.
+
+**What happened:** signals worked in some configurations but didn't survive cross-fold validation. Indicator parameter sensitivity was high. WFO showed best-fit indicators changed wildly between folds — overfitting to fold-specific noise rather than capturing real edge.
+
+**Severity:** moderate. Generated some learning but no deployable system.
+
+**Decision:** abandon classical indicator-based entries. The DLR signal in Arc 10 is structural (pivot detection) rather than indicator-based.
+
+**Lesson:** indicator parameters are too flexible. Real edge needs to be in market structure, not in tuning knobs.
+
+## Volume features
+
+**What was tried:** include tick volume / "real" volume from MT5 in feature set. Used to gate signal entries.
+
+**What happened:** worked on FTMO data. Failed when migrated to 5ers data. Reason: tick volume is broker-specific microstructure metric. Different brokers count differently. Volume on FTMO ≠ volume on 5ers ≠ volume on FundedNext.
+
+**Severity:** would have been catastrophic if deployed. Strategy validated on FTMO would not have worked on 5ers.
+
+**Decision:** **broker data is not portable.** Microstructure metrics (volume, spread, tick frequency) cannot be used for signal generation if the strategy might deploy across multiple brokers.
+
+**Lesson:** any feature that depends on broker-specific data delivery must be validated on EACH broker the strategy might deploy to. Volume specifically is unsafe.
+
+## Magnitude-based clustering
+
+**What was tried:** cluster trade outcomes by forward magnitude (e.g. "trades that went +3R", "trades that went -1R", etc.).
+
+**What happened:** identified clusters but couldn't reverse-engineer entry signals that selected one cluster vs another. Recurring pattern: "we found a profitable cluster" → "we can't build a signal that picks it" → "without the picker, the cluster is fool's gold."
+
+**Severity:** burned multiple arcs (1-3 of L_ARC) trying to make this work.
+
+**Decision:** cluster by **path shape**, not by magnitude. Two trades with different magnitudes can have the same trajectory archetype. Two trades with the same magnitude can have completely different paths.
+
+**Lesson:** magnitude is the outcome you want, not the structure you can predict. Predict structure → outcomes follow.
+
+## Whole-pool MFE/MAE optimisation
+
+**What was tried:** for each candidate exit policy, compute its outcome on every trade in the pool. Pick the exit policy with the best aggregate metric.
+
+**What happened:** over-optimisation. The selected exit policy was perfectly tuned to the in-sample pool but degraded sharply out-of-sample. The aggregation flattened out per-pair, per-regime variation.
+
+**Severity:** silently shipped slightly-overfit exit policies in early arcs until cross-fold validation caught it.
+
+**Decision:** exit policy must be selected by **cross-fold stability**, not whole-pool optimisation. Same exit policy must rank highly across all folds independently.
+
+**Lesson:** if a metric is computed across the whole pool, the selection is optimising for whole-pool fit. Cross-fold is the only honest selection criterion.
+
+## Aggressive signal frequency
+
+**What was tried:** loosen entry gates to get more signals per pair per year, on the theory that more trades = lower variance.
+
+**What happened:** more signals = more marginal-quality signals. Mean fold ROI went up but worst-fold ratio went down. Sign consistency broke.
+
+**Severity:** low — caught by worst-fold gate.
+
+**Decision:** keep signal gates tight. Better to have fewer high-conviction signals than many low-conviction.
+
+**Lesson:** signal frequency is a vanity metric. Worst-fold ratio is the real metric.
+
+## Same-day D1 close in features
+
+**What was tried:** at signal bar close, use today's D1 bar (still in progress) for D1 context features.
+
+**What happened:** in live execution, intraday D1 bar isn't closed yet at the H4 signal bar close. The live sidecar can't access "today's D1 close" until end-of-day. Backtest was assuming intraday access. Live would silently use yesterday's D1.
+
+**Severity:** would have caused live ≠ backtest divergence in subtle ways.
+
+**Decision:** **D1 features are one-day lagged.** Always use yesterday's D1 close, never today's. Confirmed in EA code; never to be reverted.
+
+**Lesson:** ask "would this information actually be available in real time?" for every feature. Lookahead doesn't just mean future bars — same-bar D1 is lookahead if D1 hasn't closed yet.
+
+## Bundled changes per phase
+
+**What was tried:** in some early arcs, change multiple parameters between phases to "save time."
+
+**What happened:** when results changed, couldn't tell which parameter mattered. Multiple phases wasted re-running with isolated changes.
+
+**Severity:** lost weeks of interpretability per arc.
+
+**Decision:** **one change per phase. Pre-commit the gate (what would PASS look like) before running.** If the change doesn't pass, revert it cleanly.
+
+**Lesson:** interpretability is bandwidth. Bundling destroys it. The discipline cost is small; the recovery cost is huge.
+
+## Mean-fold-only deployment gate (briefly)
+
+**What was tried:** in one arc, considered relaxing the worst-fold gate to a mean-fold gate, on the theory that "worst-fold is too strict."
+
+**What happened:** would have deployed a strategy with one fold near 0 ROI. Live performance variance would have been high. Caught by self-review before deployment.
+
+**Decision:** worst-fold is the deployment gate. Mean-fold is informational only.
+
+**Lesson:** the strict gate is strict for a reason. Relaxing it is "small change" until it isn't.
+
+## Multi-strategy parallel deployment (considered)
+
+**What was tried:** considered running Arc 10 alongside KH-24 on the same account, to diversify.
+
+**What happened:** correlation between signals not validated. Combined position size could exceed risk limits during overlapping signals.
+
+**Decision:** **one strategy per account.** KH-24 will be retired before Arc 10 takes over. If multiple strategies on one account becomes desirable later, requires explicit correlation validation.
+
+**Lesson:** strategy diversification without correlation analysis is just doubling exposure.
+
+## Strategy Tester as ground truth
+
+**What was tried:** validate strategy logic exclusively via MT5 Strategy Tester runs.
+
+**What happened:** ST has known modeling differences vs real tick stream. Numbers from ST didn't match the Python lab. Hard to debug which was "correct."
+
+**Decision:** Python lab is the ground truth for strategy logic. ST validates EA mechanics only (entry placement, partial close, trail, time exit), not strategy P&L.
+
+**Lesson:** use each tool for what it's good at. ST is for execution mechanics. Lab is for strategy logic.
+
+## What we keep checking
+
+Even with all the above lessons, we still routinely check:
+
+- Forward bias in feature/pool construction (every new arc)
+- Broker portability of new features (microstructure flag)
+- One-change-per-phase discipline (process review)
+- Worst-fold gate strictness (when tempted to relax)
+- D1 lag preservation (when modifying signal code)
+- ex-ante population construction (every dispatch involving pool changes)
+
+These six checks are baked into the L_ARC_PROTOCOL methodology and into the dispatch templates.

--- a/arc_10/05_history/04_open_items.md
+++ b/arc_10/05_history/04_open_items.md
@@ -1,0 +1,111 @@
+# Open Items
+
+> **Purpose:** Track known unresolved items that didn't gate deployment but should be tracked.
+> **Why this exists:** small items get lost without a tracker. Annual reviews catch them.
+
+## How to use
+
+- Each item has a status: `open`, `monitoring`, `resolved`, `wontfix`
+- On weekly check (or quarterly), spot-check this list
+- When an item is resolved, move it to "Resolved" section with date
+- Add new items as they appear
+
+## Open
+
+### §6.1-A TP1/SL same-bar diagnostic
+**Status:** open (deferred)
+**What:** scenario s8 (same-bar TP1 + SL touch) couldn't be engineered against real broker data. No canonical-R candidate exists where price traverses 4.5×ATR within a single H4 bar.
+**Why deferred:** the dual-touch handler in EA code is simple and visually verifiable (long-only: check TP1 first, only SL if TP1 didn't fire). No real-world risk if mechanic isn't ST-exercised.
+**Resolve when:** first live dual-touch scenario fires naturally (will likely be a news-spike day). Inspect trade log to verify TP1-first precedence held.
+
+### §2.9.1 integrity_report.md text divergence follow-up
+**Status:** open (low priority)
+**What:** during §2.9 closure, there was a noted text-level (not data-level) divergence in `integrity_report.md` between two run iterations. The actual data was byte-identical; only some descriptive text in the report differed.
+**Resolution path:** trace the report template to find which field is non-deterministic (likely a timestamp or runtime metric being captured in narrative text rather than just in data fields).
+**Resolve when:** next time `integrity_report.md` is regenerated. Compare to prior. Fix template if divergence persists.
+
+### EET-vs-UTC delta directional caveat
+**Status:** monitoring
+**What:** cost sweep shows EET produces ~1.9-2.1pp lower worst-fold DD than UTC across all realistic cells. But the comparison carries asymmetric commissions ($4 UTC vs $5 EET). The "true" EET boundary benefit at like-for-like commission is a LOWER bound on what's shown.
+**Implication:** real EET advantage is larger than the numbers say. Conservative direction (doesn't change decision).
+**Resolve when:** if 5ers commission changes to match FundedNext (or vice versa), re-run cost comparison.
+
+### "EET is better than UTC" claim verification with live data
+**Status:** monitoring
+**What:** backtest claim that EET produces better DD profile due to broker-day boundary timing. Should hold in live, but is an empirical claim verifiable only with actual trade data.
+**Resolve when:** after ~6 months live data on both brokers (if running both). Compare actual DD profiles on identical trade-set periods. Confirm EET is empirically better.
+
+### Risk-decoupling test flake (A2 KMeans)
+**Status:** open (research-only path, not deployment-blocking)
+**What:** `tests/protocol_runtime/test_risk_decoupling_invariant.py` has a pre-existing cross-environment CI flake on `test_a1` / `test_a6_risk_decoupled` at 4× risk ratio.
+**Cause:** `core/steps/classifier_persistence.py` assumes cluster IDs start at 0. GBPUSD 2018-05-29 outlier produces a 23.69% deviation vs 20% tolerance.
+**Why deferred:** affects strategy research path only. Doesn't impact deployed sidecar/EA correctness.
+**Resolve when:** post-FundedNext deployment. Fix classifier_persistence to handle non-zero-starting cluster IDs.
+
+### Token PAT exposure remediation
+**Status:** open (operator decision)
+**What:** GitHub fine-grained PAT was pasted into chat during VPS deployment session. Token starts with `github_pat_11BWNZKSA0...`.
+**Risk:** anyone reading the chat history has read/write access to the repo until token expires (Aug 27, 2026 per session memory).
+**Resolution path:** revoke the token; generate new one; update VPS git remote URL.
+**Status note:** operator declined to revoke. Token expires Aug 2026 regardless. Decision logged.
+
+### Weekly reconciliation script
+**Status:** open (deferred until 4 weeks live data)
+**What:** automated Sunday script to pull broker trades, cross-reference with EA trade_log.csv, detect phantom trades / lost signals / drift, output weekly report.
+**Why deferred:** building before live data means guessing at edge cases. Build after edge cases are observed.
+**Resolve when:** ~4 weeks post-Challenge deployment. Build per `04_runbook/02_weekly_check.md` spec.
+
+### Auto-start for MT5 terminals on VPS reboot
+**Status:** open (low priority)
+**What:** MT5 terminals are GUI apps, not services. After VPS reboot, they don't auto-start unless added to Windows startup folder.
+**Workaround:** runbook in `04_runbook/02_weekly_check.md` includes a PowerShell snippet to add MT5 startup shortcuts if not already present.
+**Resolve when:** next VPS reboot. Verify shortcuts work or add them.
+
+### News calendar URL stability
+**Status:** monitoring
+**What:** EA pulls from `https://nfs.faireconomy.media/ff_calendar_thisweek.xml`. URL has changed historically (ForexFactory has moved their feed before).
+**Resolution path:** if URL changes, update `News_Calendar_URL` input on both EAs. Until fixed, news filter falls back to "no news data" mode (allows all signals through).
+**Resolve when:** if URL change detected via repeated 404 errors in logs.
+
+### Wave 1 arc closures
+**Status:** in progress
+**What:** Arcs 1-9 from L_ARC_PROTOCOL wave 1 need closure documents written. Arc 10 succeeded; the others either failed or were superseded.
+**Why this matters:** wave 1 closure preserves the research lineage for future reference (what didn't work, why).
+**Resolve when:** currently being worked on per memory. Track progress separately.
+
+### Lω (Lomega) plan execution decision
+**Status:** open (conditional)
+**What:** Lomega is the fallback discovery engine if L_ARC pipeline exhausts candidates. Plan documented in `LOMEGA_DISCOVERY_PLAN.md`. Hardware assessed as suitable.
+**Trigger to execute:** if Arc 10 deployment goes poorly (per kill criteria) AND no other L_ARC arc candidates are deployable, execute Lomega plan.
+**Resolve when:** decision point reached or Arc 10 succeeds long-term.
+
+## Monitoring
+
+### FundedNext rule stability
+**Status:** monitoring
+**What:** FundedNext (and prop firms generally) change rules periodically. Current Arc 10 deployment depends on swap-free add-on + weekend hold + 10%/5% DD limits.
+**Action:** quarterly verification against current FundedNext rules.
+**Trigger to resolve:** if any material rule change. Reassess deployment validity.
+
+### 5ers copy-trading policy clarification
+**Status:** open (pending broker confirmation)
+**What:** running identical EA signals across multiple 5ers accounts simultaneously may trigger copy-trading prohibition compliance review.
+**Action needed:** get written confirmation from 5ers support before opening parallel 5ers accounts.
+**Resolve when:** confirmation received and documented.
+
+## Resolved
+
+(Move items here with resolution date when closed. Starts empty.)
+
+## How to add new items
+
+Format:
+```
+### <Short title>
+**Status:** open | monitoring | resolved | wontfix
+**What:** plain description
+**Why deferred / monitoring:** rationale
+**Resolve when:** trigger condition or target date
+```
+
+Keep titles short and scannable. Detail in the body. One item per finding.

--- a/arc_10/05_history/04_open_items.md
+++ b/arc_10/05_history/04_open_items.md
@@ -44,7 +44,7 @@
 
 ### Token PAT exposure remediation
 **Status:** open (operator decision)
-**What:** GitHub fine-grained PAT was pasted into chat during VPS deployment session. Token starts with `github_pat_11BWNZKSA0...`.
+**What:** GitHub fine-grained PAT was pasted into chat during VPS deployment session. Token value redacted from this doc (`github_pat_[REDACTED]`).
 **Risk:** anyone reading the chat history has read/write access to the repo until token expires (Aug 27, 2026 per session memory).
 **Resolution path:** revoke the token; generate new one; update VPS git remote URL.
 **Status note:** operator declined to revoke. Token expires Aug 2026 regardless. Decision logged.

--- a/arc_10/05_history/05_pre_mortem.md
+++ b/arc_10/05_history/05_pre_mortem.md
@@ -1,0 +1,182 @@
+# Pre-Mortem
+
+> **Purpose:** List the most likely ways Arc 10 could fail, before live deployment. Future-you, when something goes wrong, can check this list. If it's a predicted failure mode → continue per plan. If it's a surprise → stop and investigate.
+
+## Why write this
+
+When a strategy starts struggling, the first question is: "is this normal variance, a predicted failure mode, or a surprise?"
+
+Without a pre-mortem, every failure feels like a surprise. Every drawdown becomes an emergency. Every losing month becomes evidence the system is broken.
+
+With a pre-mortem, you have a calibration: most failures will fit one of these patterns. Recognizing the pattern lets you respond per plan instead of improvising.
+
+## The most likely failure modes (in rough order of probability)
+
+### 1. Worst-fold-equivalent drawdown period
+
+**What it looks like:** total DD approaches 8-9%. Lasts 2-8 weeks. Multiple consecutive losing weeks. Win rate drops to ~30%.
+
+**Why it happens:** the backtest had F4 2013 with 7.35% worst-fold DD. Live worst-fold DD expected ~8.8% after haircuts. Hitting this in any single year is roughly expected.
+
+**Confidence this is the issue:** if total DD is between 5-8.5%, system is running, no operational errors → very likely this is just a worst-fold-equivalent period.
+
+**Response:** continue per plan. The system halts entries at 7% and CloseAll at 8% automatically. If it breaches 8.5%, kill criteria fire (`07_kill_criteria.md`). Otherwise: this is what the system was designed to survive.
+
+### 2. Multi-week quiet period
+
+**What it looks like:** few or no trades for 2-3 weeks. Signal_processed/ count low. Account balance unchanged.
+
+**Why it happens:** Arc 10's signal frequency varies. Quiet markets (low ATR, sideways action, holiday weeks) produce fewer signals across all 28 pairs simultaneously.
+
+**Confidence this is the issue:** if sidecar logs show normal cycle completion every 4h, heartbeats fresh, just no signals firing across 28 pairs.
+
+**Response:** wait. This is normal. Don't tinker with thresholds.
+
+### 3. Live R-distribution slightly worse than backtest
+
+**What it looks like:** mean R per trade in live is +0.20 instead of +0.40. Cumulative ROI tracks below median but inside band.
+
+**Why it happens:** the haircuts in the cost sweep are estimates. Live broker fill quality, slippage tail, gap-through-SL events — all contribute. Some pessimistic assumptions may be slightly understated.
+
+**Confidence this is the issue:** if mean R is +0.20 to +0.30 (vs expected +0.30 to +0.40) at 100+ trades, this is within haircut error.
+
+**Response:** continue. This is what haircuts are for — actual live being slightly worse than ideal backtest is expected.
+
+### 4. Broker disconnect coverage gap
+
+**What it looks like:** sidecar logs show "MT5 not initialized" errors. Some H4 cycles miss completely. Signal that should have fired didn't.
+
+**Why it happens:** brokers periodically disconnect, restart MT5, do maintenance. Sidecar can't fetch data during disconnect. If disconnect spans an H4 boundary, that cycle is missed.
+
+**Confidence this is the issue:** if errors are intermittent (a few per week), self-recover, no pattern.
+
+**Response:** monitor. Acceptable if rare. If frequent (multiple per day): contact broker support, consider broker change.
+
+### 5. News-event gap-through-SL
+
+**What it looks like:** single trade with -1.5R to -2R loss instead of expected -1R. Trade closed during a news event.
+
+**Why it happens:** SL fills at next-available tick after news spike. If price gaps over SL level, fill is worse than SL price.
+
+**Confidence this is the issue:** if trade closure timestamp coincides with major news event (NFP, CPI, central bank announcement).
+
+**Response:** log the event. Acceptable if rare (1-3 per year). The news filter blocks new entries near news, but existing positions aren't closed pre-news (deliberate — closing positions before news is its own risk).
+
+### 6. EA execution latency miss
+
+**What it looks like:** envelope written to signals_out/, no broker trade follows. Or trade fills at noticeably worse price than envelope's entry_price_estimate.
+
+**Why it happens:** EA polls every 5 seconds. If broker spread widens during the 5s window, the trade fills at a worse price than the signal expected.
+
+**Confidence this is the issue:** if pattern correlates with broker spread spikes (visible in logs).
+
+**Response:** acceptable if rare. If frequent: reduce `Signal_Poll_Min_Interval_Sec` to 2-3 seconds (faster polling = more responsive but more CPU).
+
+### 7. Equity calculation drift
+
+**What it looks like:** EA's reported equity diverges from broker's reported equity. Daily DD calculations off by 0.1-0.3%.
+
+**Why it happens:** EA caches equity at H4 boundaries and during trade events. Broker calculates continuously. Floating positions, swap (if applicable), commissions credited at different cadences cause drift.
+
+**Confidence this is the issue:** if difference is <0.5% and self-corrects after next H4 cycle.
+
+**Response:** acceptable. The system's DD halt thresholds have safety margin to absorb 0.5% drift. If divergence grows >1%: investigate.
+
+### 8. Hidden bug surfacing under specific conditions
+
+**What it looks like:** unexpected behavior — wrong direction trade, wrong lot size, wrong SL placement, missing TP1 partial. Trade log doesn't match what should have happened.
+
+**Why it happens:** despite ST validation + Phase 2 parity, edge cases exist that weren't tested.
+
+**Confidence this is the issue:** if the unexpected behavior is reproducible (e.g. happens on every JPY pair under certain conditions) rather than random.
+
+**Response:** stop trading. Investigate. Bug fix + re-validation. Don't restart until fixed and tested.
+
+### 9. Regime shift — strategy edge degrades
+
+**What it looks like:** cumulative ROI below band at 200+ trades. Win rate persistently low across multiple windows. No identifiable bug — system is operating correctly but producing bad results.
+
+**Why it happens:** markets change. Strategies built on historical patterns can lose edge when those patterns no longer hold. Volatility regime shifts. Central bank policy regime shifts. Microstructure changes.
+
+**Confidence this is the issue:** if no operational issues, no bugs, but performance is sustained outside expected bands. The hardest failure mode to diagnose.
+
+**Response:** triggers kill criterion #3 (ROI below band at 200+ trades). Stop trading. Deep investigation. Possibly the strategy needs re-validation against newer data, or Lomega discovery engine to find new signal candidates.
+
+### 10. FundedNext rule change invalidating deployment
+
+**What it looks like:** FundedNext changes terms — removes swap-free, tightens daily DD, prohibits weekend holds, etc.
+
+**Why it happens:** prop firms change rules. Often after market events that hurt their P&L.
+
+**Confidence this is the issue:** broker email notification or FAQ change.
+
+**Response:** reassess. Some changes are manageable (small DD tightening can be absorbed). Others (swap-free removal) invalidate the cost sweep economics and require switching brokers or accepting reduced risk.
+
+### 11. Operator error during maintenance
+
+**What it looks like:** after a config change, restart, or update — system behaves unexpectedly. EA inputs wrong. Sidecar pointing at wrong broker. Service not auto-starting.
+
+**Why it happens:** complex multi-component system. Easy to mis-configure under time pressure.
+
+**Confidence this is the issue:** if anomaly started immediately after a maintenance action.
+
+**Response:** revert the change. Verify against `04_vps_setup_guide.md` configuration. Restart carefully.
+
+### 12. VPS-level issue
+
+**What it looks like:** VPS unresponsive. RDP fails. Sidecar logs show extended gaps.
+
+**Why it happens:** VPS provider outage, network issue, Windows update gone wrong, hard drive failure.
+
+**Confidence this is the issue:** contact Contabo support for VPS health status.
+
+**Response:** depends on cause. Provider outage: wait. Disk failure: restore from snapshot. Network: investigate. May need to redeploy from `04_vps_setup_guide.md` if VPS is unrecoverable.
+
+## Less likely but possible
+
+### 13. Broker fraud / insolvency
+
+Rare but real. If broker goes bankrupt or fraudulent, account is lost. Mitigation: prop firms historically more stable than retail brokers; choose well-established firms.
+
+**Response:** unrecoverable for that account. Move to backup broker.
+
+### 14. Black swan market event
+
+CHF-2015-equivalent. Single day with multi-R moves on multiple pairs. Could exceed 10% account DD in hours.
+
+**Response:** broker terminates account at 10% DD. Outside system control.
+
+### 15. Code drift via dependency update
+
+Sidecar uses MetaTrader5 Python lib + various libraries. If a `pip install -U` updates a dependency, behavior could subtly change.
+
+**Mitigation:** lock dependency versions (`requirements.txt` with `==` pinning). Don't auto-update.
+
+## What NOT in the pre-mortem (because unlikely to be the issue)
+
+- "Strategy logic was wrong all along" — extensively WFO-validated across 14 years and 11 folds. If this fails, it's regime shift (#9), not logic.
+- "Cost modeling was wildly wrong" — modeled conservatively. If costs are an issue, they're 10-20% off, not 100%+ off. Covered by haircut framework.
+- "Wrong pairs" — 28-pair universe well-validated. Adding/removing pairs requires explicit re-validation, not first-line response.
+- "Wrong timeframe" — H4 chosen via comparison across H1/H2/H4/D1. Switching is not in scope.
+
+## How to use this list when something goes wrong
+
+1. Observe the failure symptom (drawdown, missing trades, weird behavior, etc.)
+2. Scan this list for matching patterns
+3. If matches → respond per "Response" section for that mode
+4. If no match → STOP and investigate. This is a surprise, not a predicted failure.
+5. After resolving (or after the live event passes): consider whether to add this as a new pattern to the list
+
+**Surprises are dangerous because you have no playbook.** Predicted failures are routine because the playbook is written.
+
+The goal of this pre-mortem is to maximize the percentage of live events that are "predicted" rather than "surprise."
+
+## Reviewing this document
+
+Annually, or after any significant incident:
+- Did the failure mode appear in this list?
+- If yes: was the response correct?
+- If no: should it be added?
+- Are any items in this list now obviously wrong / shouldn't be there?
+
+Update the document with explicit version-bumped reasoning, only in a calibrated state (not during drawdown).

--- a/arc_10/README.md
+++ b/arc_10/README.md
@@ -1,0 +1,101 @@
+# Arc 10 — Live Algorithmic FX Trading System
+
+> **Status:** Live on FundedNext (EET, $100k Challenge) + 5ers (UTC, $10k demo)
+> **Strategy:** Arc 10 v3.0.2 — DLR signal, three-stage exit policy, 28 FX pairs, H4 timeframe
+> **Validation:** PASS-DEPLOYABLE on both EET and UTC conventions, signal parity byte-identical
+> **Last updated:** 2026-05-29
+
+---
+
+## Read this first
+
+This folder is the single source of truth for Arc 10. If you want to:
+
+- **Understand what Arc 10 is** → start at `00_executive_summary.md`
+- **Understand the strategy logic** → `01_strategy/`
+- **Verify the validation work** → `02_validation/`
+- **Understand the live deployment** → `03_deployment/`
+- **Operate the live system** → `04_runbook/`
+- **Understand why decisions were made** → `05_history/`
+
+Everything in this folder is curated. Underlying data lives in `results/` and is linked from the markdown documents — not duplicated. If you need to regenerate or audit any artifact, the source paths are documented.
+
+---
+
+## Quick navigation by question
+
+| Question | Document |
+|---|---|
+| What does Arc 10 do? | `00_executive_summary.md` |
+| How does the signal work? | `01_strategy/signal_logic.md` |
+| What are the WFO numbers? | `02_validation/01_wfo_results.md` |
+| EET vs UTC — which is better? | `02_validation/05_cost_sweep.md` |
+| How is it deployed on VPS? | `03_deployment/04_vps_setup_guide.md` |
+| What do I check each day? | `04_runbook/01_daily_health_check.md` |
+| Why did we pick FundedNext? | `05_history/02_decisions_log.md` |
+| What approaches were rejected? | `05_history/03_eliminated_approaches.md` |
+
+---
+
+## Critical facts (memorize these)
+
+| Fact | Value |
+|---|---|
+| Strategy version | Arc 10 v3.0.2 |
+| Active brokers | FundedNext (EET, $100k), 5ers (UTC, $10k) |
+| Risk per trade — FundedNext | 0.50% |
+| Risk per trade — 5ers | 0.40% |
+| Max DD limit (hard, both) | 10% |
+| Daily DD limit (hard, both) | 5% |
+| Internal safety target — total DD | < 8% |
+| Internal safety target — daily DD | < 4% |
+| Config hash — UTC (5ers) | `4467366b9537871fe9019af45cf26f54e042358f211ff58774497b00c840821e` |
+| Config hash — EET (FundedNext) | `75d03904457580b77be63639a281dc550ca584fc5603cfb946102b836d41cf87` |
+| Magic number — 5ers | `1010202601` |
+| Magic number — FundedNext | `1010202602` |
+| VPS provider | Contabo Cloud (Frankfurt, 4 cores, 8 GB RAM) |
+| MT5 install — 5ers | `C:\Program Files\Five Percent Online MetaTrader 5\` |
+| MT5 install — FundedNext | `C:\Program Files\FundedNext MT5 Terminal\` |
+| Sidecar root — 5ers | `Common\Files\Arc10_5ers\` |
+| Sidecar root — FundedNext | `Common\Files\Arc10_FundedNext\` |
+
+---
+
+## Git tags
+
+| Tag | What it marks |
+|---|---|
+| `arc-10-st-validated` | EA execution mechanics validated |
+| `arc-10-topology-validated` | Single-chart-multi-pair fix landed |
+| `arc-10-parity-validated` | Sidecar↔lab signal parity on UTC byte-identical |
+| `arc-10-eet-parity-validated` | Sidecar↔lab signal parity on EET byte-identical |
+
+---
+
+## Sub-folder index
+
+- **`01_strategy/`** — How the system trades
+- **`02_validation/`** — Proof the system works (WFO, parity, ST scenarios, cost sweep)
+- **`03_deployment/`** — How the live system is wired up
+- **`04_runbook/`** — Operational procedures
+- **`05_history/`** — Lineage and rationale
+
+---
+
+## Source artifacts (raw data)
+
+Markdown docs reference these. Do not edit unless re-running the corresponding validation.
+
+| Artifact | Path |
+|---|---|
+| EET WFO results | `results/l_arc_10_v3.0.2/step_5/wfo_results.csv` |
+| EET pool | `results/l_arc_10_v3.0.2/step_1/pool.parquet` |
+| UTC WFO ledger | `results/l_arc_10_v3_0_2_utc_rerun/trade_ledger_utc.parquet` |
+| Phase 2 UTC parity report | `results/phase_2_parity/parity_report.md` |
+| Phase 2 EET parity report | `results/phase_2_parity_eet/parity_report.md` |
+| Cost sweep report | `ARC_10_DEPLOYMENT_COMPARISON_EET_VS_UTC.md` |
+| FundedNext anchor verdict | `results/fundednext_panel_diff/panel_diff_report.md` |
+| Winning config — UTC | `configs/l_arc_10_v3.0.2_utc_rerun/winning_config.yaml` |
+| Winning config — EET | `configs/l_arc_10_v3.0.2/winning_config.yaml` |
+| EA source | `deployment/ea/Arc10_DLR_Sidecar_EA.mq5` + `deployment/ea/include/*.mqh` |
+| Sidecar source | `deployment/sidecar/*.py` |


### PR DESCRIPTION
## Summary

Adds the `arc_10/` consolidated documentation folder — the single source
of truth for everything Arc 10. Pure documentation; no code, configs,
or data files changed or moved.

Triggered by the deployment-complete milestone: Arc 10 v3.0.2 went live
on FundedNext (EET) demo and 5ers (UTC) demo with full validation
(WFO PASS-DEPLOYABLE, sidecar parity byte-identical, ST scenarios
green, cost sweep deployable, anchor verified, EAs attached and
sidecars running as NSSM services with watchdog supervision).

## Folder structure

```
arc_10/
├── README.md
├── 00_executive_summary.md
├── 01_strategy/      (4 docs)
├── 02_validation/    (6 docs)
├── 03_deployment/    (6 docs)
├── 04_runbook/       (7 docs)
└── 05_history/       (5 docs)
```

30 markdown files. All referenced artifacts (`results/`, `configs/`,
`deployment/`, etc.) stay where they are — `arc_10/` links to them
via plain paths.

## Why this folder exists

Without consolidated docs, finding "the current state of the Arc 10
deployment" requires reading 10+ scattered files across `results/`,
chat transcripts, ARC_CLOSURE docs, dispatch summaries, etc.
`arc_10/` collapses all of that into a curated reading path:
**README → executive summary → relevant subfolder**.

This is the operational holy grail for future maintenance, debugging,
re-deployment after VPS migration, and onboarding any future
collaborator.

## Path verification results

- [x] All 30 markdown files in place at correct paths
- [x] All path references in markdown verified against the repo — 22/25 listed paths + all 8 `deployment/ea/include/*.mqh` resolve; 3 discrepancies flagged below
- [x] Cost sweep reference points to correct full report location — see note below
- [x] Root README updated (section added above "Start Here")

**Step 4 (cost sweep link):** The full report does NOT exist at the
`ARC_10_DEPLOYMENT_COMPARISON_EET_VS_UTC.md` repo-root path the curated
doc originally cited. The actual full report lives at
`results/l_arc_10_v3.0.2/fundednext_cost_sweep/fundednext_cost_sweep_report.md`.
Per Step 4, the single source-artifact line in
`arc_10/02_validation/05_cost_sweep.md` was repointed to that real
location. No other content changed.

### Paths flagged for operator review

These referenced paths do **not** currently resolve in the repo. Per the
dispatch (Step 3), the markdown was **not** changed — flagging for your
call:

1. **`results/fundednext_panel_diff/panel_diff_report.md`** — referenced
   as the FundedNext anchor verdict (in `06_anchor_verification.md`). No
   `panel_diff` artifact found anywhere in the repo. May live only in
   chat history / memory, or under a different name.
2. **`ARC_10_DEPLOYMENT_COMPARISON_EET_VS_UTC.md`** (repo root) —
   referenced as the cost-sweep full report. Not present in the repo.
   The `05_cost_sweep.md` source-artifact line was repointed to the real
   report (see Step 4 note above); other references to this filename
   elsewhere in the docs were left unchanged per Step 3.
3. **`tests/ea/scenarios.json`** — referenced as the ST scenario
   definitions (in `04_st_scenarios.md`). The actual file is at
   **`tests/ea/scenarios/scenarios.json`** (one directory deeper).

## Scope of THIS PR

- Add `arc_10/` folder with 30 markdown files
- Update root README to point to it
- One Step-4 one-line path fix in `05_cost_sweep.md`
- Nothing else

## Out of scope (deferred to future PRs)

- Building `scripts/weekly_reconciliation.py` (deferred until 4+
  weeks live data)
- Acting on the documented improvements backlog
- Reorganising `results/` (no benefit to moving large artifact files)
- Adding live-data documentation (waits for live data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)