### PR TITLE
[Docs] Arc 10 deployment retrospective + generic sidecar/EA build guide

### DIFF
--- a/arc_10/05_history/06_deployment_retrospective.md
+++ b/arc_10/05_history/06_deployment_retrospective.md
@@ -1,0 +1,152 @@
+# Arc 10 Deployment Week — Retrospective
+
+> **Purpose:** Capture the decision-making and gotchas from the final-mile deployment week that don't live anywhere else in the docs.
+> **Scope:** the week ending 2026-05-29 — final EA validation, parity work, VPS deployment, documentation consolidation.
+> **Not a runbook.** This is meta-knowledge: lessons, near-misses, things future-you should know.
+
+## The bugs that almost shipped
+
+### The r_atr bug (caught by user reasoning, not by tests)
+
+**What it was:** `phase_1_build_intent.md` had two contradictory definitions of `r_atr`. Implementer followed the wrong one (line 369: `r_atr = sl_distance / 3.5`) instead of the correct one (line 256: `R = sl_distance`). TP1 was firing at +1×ATR instead of +3.5×ATR. All R-multiples would have been ~3.5× smaller than backtest.
+
+**How it was caught:** during ST scenario s8 investigation, user noticed P&L numbers didn't match expected on a known-canonical test trade. Traced back to TP1 level being wrong.
+
+**Why no test caught it:** the ST scenarios were running against the bugged EA and producing internally-consistent results. The bug was equivalent to "TP1 is at 1R" — which is itself a valid (though wrong) strategy. Tests verified the strategy as-coded, not the strategy as-intended.
+
+**Lesson:** specifications with internal contradictions are the worst kind of bug source. The `phase_1_build_intent.md` had two truths; the implementer picked one; tests verified the implementation matched the picked truth.
+
+**What we should have done:** the spec doc should have been single-sourced for r_atr. One definition, referenced everywhere else. The fact that line 256 and line 369 differed was a documentation bug that became a code bug.
+
+**What helped catch it:** human in the loop scrutinising fill prices on real outputs. Without that, the bug ships and live performance would have been ~30% of expected.
+
+### The FILE_COMMON portable-mode discovery
+
+**What it was:** MQL5 `FILE_COMMON` flag resolves to user-wide `AppData\Roaming\MetaQuotes\Terminal\Common\Files\` — even in portable mode. Both MT5s share that folder. Without isolation, both EAs would have collided on `Arc10\signals_out\`.
+
+**How it was caught:** during VPS deployment, while trying to verify portable mode worked. Wrote a test MQL5 script using FILE_COMMON. File landed in user-wide AppData, not the install dir.
+
+**Why this matters:** initial assumption was "portable mode isolates everything." That was wrong. The MQL5 folder IS isolated in portable mode; FILE_COMMON is NOT.
+
+**Fix shipped:** broker-specific subfolders (`Arc10_5ers\`, `Arc10_FundedNext\`). Zero EA code changes, all input-parameter strings. Documented in `arc_10/05_history/02_decisions_log.md`.
+
+**Lesson:** assumed isolation behaviors should be verified, not assumed. A 30-second test script saved a multi-day debugging session.
+
+### The NSSM quoting gotcha
+
+**What it was:** NSSM commands run from PowerShell strip quotes from arguments. The `--mt5-path "C:\Program Files\Five Percent Online MetaTrader 5\terminal64.exe"` argument arrived at Python argparse unquoted; argparse parsed "Files\Five..." as extra positional args; sidecar errored out and restarted in a loop.
+
+**How it was caught:** sidecar logs showed `unrecognized arguments: Files\Five Percent Online MetaTrader 5\terminal64.exe` after service start.
+
+**Fix shipped:** use `nssm edit <service>` GUI to set Arguments field manually. Quotes survive the GUI path.
+
+**Lesson:** when a tool layer interposes between you and the target process, quote semantics are not transparent. PowerShell → NSSM → Python is three quoting boundaries. Each can mangle. The GUI bypasses the PowerShell quoting layer.
+
+**Captured in:** `arc_10/03_deployment/04_vps_setup_guide.md` Step 10.
+
+### The "broker server clock vs bar anchor" PR #227 regression
+
+**What it was:** PR #227's `_verify_broker_offset` check refused to start sidecar on 5ers (EET server clock + UTC bar anchors) when running with `convention=utc`. Conflated server clock with bar anchor convention — two independent attributes.
+
+**Fix:** PR #230 removed `_verify_broker_offset` entirely. `verify_mt5_h4_alignment` (which validates anchors, not clocks) is the authoritative gate.
+
+**Lesson:** validation logic added defensively can itself become a deployment blocker. The check was well-intentioned but conflated two things that look related but aren't. Anchor probe is what actually matters; server clock is irrelevant to strategy.
+
+## The near-mistakes
+
+### Almost bought the Challenge before the soak
+
+User pushed multiple times to buy the FundedNext Challenge immediately after deployment completed. Rationale was "system is ready, why wait?"
+
+**What we said no to (and why):** demo soak through the weekend provides a free real-conditions validation period. Buying the Challenge before soak means using paid-clock time for what could be done in free time. If anything weird surfaces in demo, fixing on demo is zero-cost; fixing on Challenge is paid-clock pressure.
+
+**Result:** held back the purchase. Plan: verify soak Saturday + Sunday, buy Monday or Tuesday.
+
+**Lesson:** deployment-complete energy is real and biases toward action. Build in a deliberate cool-down between deployment and money-on-the-line.
+
+### Almost rationalised the token exposure
+
+User pasted GitHub PAT in chat. Twice. Was offered the chance to revoke. Declined.
+
+**What we said:** flagged the exposure. Repeated the warning. Did not override the user's decision but ensured they made it consciously.
+
+**What we didn't do:** refuse to continue, or pretend the issue was less significant than it was.
+
+**Lesson:** the user's call on security trade-offs is theirs. The role is to ensure they understood the trade-off, not to enforce a particular choice. Documented in `arc_10/05_history/04_open_items.md` (which had to be redacted before merge).
+
+## The decisions that compounded
+
+### Risk locking happened BEFORE deployment, not during
+
+The 0.50% / 0.40% risk decisions were locked from the cost sweep, weeks before deployment. By the time we were in the VPS setting up services, those numbers were inputs, not variables.
+
+**Why this mattered:** during the operational chaos of deployment (NSSM quoting bugs, FILE_COMMON discovery, EA inputs), there was zero cognitive load on "what should the risk be?" That question was settled.
+
+**Lesson:** make economic decisions in calm; operational decisions in chaos. Don't let the chaos contaminate the economic decisions.
+
+### The "improvements backlog frozen pre-live" decision
+
+Multiple times during the week, ideas surfaced for tweaks. Each was logged in the backlog and explicitly deferred until 4+ weeks of live data.
+
+**Why this mattered:** preventing the system from drifting under pre-live anxiety. Improvements made without real-data evidence are guesses, and guesses compound into a system you can no longer reason about.
+
+**Lesson:** the right time to act on improvements is when you have evidence they're needed. Pre-live, you have no evidence — so you have no improvements to make.
+
+### The structure-first approach proved itself again
+
+When we found that 5ers panel-diff showed UTC bar anchors (despite EET server clock), the response was not "tune the sidecar to look at server clock." It was "verify which is the actual bar anchor convention and use that."
+
+**Why this mattered:** server-clock-based logic would have been fragile (depends on broker timezone choices) and wrong (server clock doesn't determine bar boundaries). Structure-first means anchoring to what actually matters mechanically, not what's visible on the surface.
+
+**Lesson:** when something looks confusing, dig down to the mechanical truth. Don't pattern-match on surface symptoms.
+
+## The good calls
+
+- **Weekend soak before Challenge.** Free validation time used properly.
+- **Two MT5 installations, not one.** Multi-account doesn't work cleanly across brokers; separate installs were the right choice.
+- **NSSM over Task Scheduler.** Production-grade service supervision.
+- **Watchdog at 5min interval with 4h10min stale threshold.** Aggressive enough to catch real issues, tolerant enough not to spuriously restart during normal H4 gaps.
+- **Same compiled .ex5 on both brokers.** Single source of truth for execution logic; only inputs differ.
+- **Config hash verification per envelope.** Catches operator misconfig before any wrong trade fires.
+- **Risk ramp 0.20 → 0.30 → 0.50.** First-weeks-live should be cheap; risk goes up only after evidence accumulates.
+
+## The questionable calls
+
+- **PAT exposure.** Won't fully assess as good/bad without seeing whether it ever causes a problem. Cost-aware user decision, documented.
+- **Skipping s9/s10 (restart recovery scenarios).** These will be exercised by the first real VPS reboot. Acceptable but not ideal.
+- **No real news event tested before live.** First NFP/CPI release will be the first real exercise of the news filter. Will need to monitor closely.
+
+## What the next deployment should do differently
+
+If/when deploying Arc 11 or a follow-on system to a new prop firm:
+
+1. **Specification doc should be single-source for all parameters.** No two locations defining the same number. (r_atr bug is the precedent.)
+2. **Verify isolation assumptions empirically before relying on them.** (FILE_COMMON discovery is the precedent.)
+3. **Test the NSSM quoting before committing to argument-heavy commands.** (NSSM gotcha is the precedent.)
+4. **Build the parity validation as a sidecar test framework, not a one-off.** (Could be reused across signals.)
+5. **Run a soak period before live, always.** (Even if "the system is ready" — the soak surfaces operational issues that are invisible at deploy time.)
+
+## What this week proved
+
+Arc 10 is a real automated trading system, end-to-end:
+- Validated economically (cost sweep deployable)
+- Validated mechanically (Phase 2 parity byte-identical, ST scenarios pass)
+- Deployed operationally (NSSM services, watchdog supervision, both brokers independent)
+- Documented (30-doc holy grail, merged to repo main)
+- Survivable (DD halts, kill criteria, emergency procedures all in place)
+
+Most retail traders never get this far. The discipline that got us here is the same discipline that needs to carry forward through live deployment.
+
+## What this week did NOT prove
+
+- That the system makes money live. That's the next chapter.
+- That the system survives a real market shock (CHF 2015 equivalent).
+- That risk levels hold up under live tail conditions.
+
+These get answered by time and live data, not by deployment.
+
+## Final lesson
+
+The biggest risk between research validation and live trading is **the discipline gap during deployment week**. Validation results are clean; deployment is chaotic. Bugs hide in the chaos. The way through is to slow down at the operational steps, not to rush them because the strategy is "already validated."
+
+Strategy validation tells you whether the edge exists. Deployment discipline tells you whether the edge survives to the broker. Both matter.

--- a/docs/SIDECAR_EA_BUILD_GUIDE.md
+++ b/docs/SIDECAR_EA_BUILD_GUIDE.md
@@ -1,0 +1,351 @@
+# Sidecar + EA Build Guide
+
+> **Purpose:** Generic how-to for building a Python sidecar + MQL5 EA for a new trading system, abstracted from Arc 10's specific implementation.
+> **Audience:** future-you (or a CC dispatch) building a follow-on system from a validated signal.
+> **Prerequisites:** validated signal logic in Python lab. Cost sweep done. WFO PASS-DEPLOYABLE.
+
+## Architecture overview
+
+The deployment pattern is **Path B — Python sidecar + thin MQL5 EA**:
+
+```
+MT5 Terminal (logged into broker)
+    ↓ Python MetaTrader5 lib
+Python Sidecar (runs as Windows service via NSSM)
+    ↓ writes envelope JSON files
+Common\Files\<broker>\signals_out\
+    ↓ reads via FILE_COMMON
+MQL5 EA (attached to one chart in MT5)
+    ↓ places orders
+Broker
+```
+
+**Why Path B over alternatives:**
+- Strategy logic stays in Python (the lab language)
+- EA stays thin (~25K lines MQL5 total)
+- Lab ↔ sidecar parity provable via byte-identical signal output
+- EA only does execution mechanics (validated separately via ST scenarios)
+- Sidecar can be restarted/upgraded without touching the EA
+
+**Alternatives we considered and rejected:**
+- **Pure MQL5 EA** — would require porting Python signal logic to MQL5. Path that destroyed multiple early arcs (GPT-4 hallucinated conversions). Permanently excluded.
+- **Direct Python → broker via FIX/API** — most prop brokers don't offer it. Tied to MT5 for broker compatibility.
+- **One process for both** — couples lifecycle concerns. Sidecar dies → EA dies. Separation gives independence.
+
+## The four components
+
+### 1. The lab (Python signal logic)
+
+**Stays where it is.** The validated signal lives in `signals/<signal_name>.py` (or similar). For Arc 10: `signals/lchar_dlr_long.py`.
+
+**Contract:** the signal exports a `compute_signal(h4_panel, d1_panel, config) -> SignalDecision` function. Pure function, no side effects, deterministic output for given input. This is what gets reused in the sidecar.
+
+**Why this matters:** the sidecar imports and calls THIS function. There's no separate "live version" — same code, same behavior, byte-identical output.
+
+### 2. The sidecar (Python service)
+
+**Location:** `deployment/sidecar/` in repo.
+
+**Responsibilities:**
+- Wake on the configured H4 boundary schedule
+- Fetch H4 + D1 panels from MT5 for the pair universe
+- Call the lab's `compute_signal()` for each pair
+- Write signal envelopes (JSON) to `signals_out/`
+- Write heartbeat
+- Persist state across restarts
+- Probe MT5 alignment at boot
+- Handle DST and convention conversions
+
+**Key modules** (Arc 10 pattern, adapt for new system):
+- `__main__.py` — entry point, arg parsing
+- `sidecar.py` — main loop
+- `signal_runner.py` — wraps lab signal call
+- `signal_emitter.py` — writes envelopes
+- `mt5_data_fetcher.py` — MT5 data layer
+- `boundary.py` — convention logic (UTC vs EET vs other)
+- `heartbeat.py` — heartbeat writer
+- `h4_schedule.py` — boundary computation
+
+### 3. The EA (MQL5)
+
+**Location:** `deployment/ea/` in repo.
+
+**Responsibilities:**
+- Poll `signals_out/` for envelopes
+- Validate envelope schema + config_hash + freshness
+- Compute position size from risk + SL distance
+- Place market order with SL set on broker
+- Monitor positions per H4 bar
+- Execute partial close at TP1
+- Trail SL per the exit policy
+- Time-exit at configured bar count
+- Enforce equity DD halts
+- Reconstruct state on restart
+
+**Key MQL5 files** (Arc 10 pattern, adapt for new system):
+- `<Name>_EA.mq5` — entry point + main loop (OnInit, OnTick, OnDeinit)
+- `include/SignalPoller.mqh` — envelope polling + validation
+- `include/PositionManager.mqh` — entry placement + position tracking
+- `include/ExitPolicyEngine.mqh` — exit logic (TP1, trail, time, etc.)
+- `include/EquityGuards.mqh` — DD halt enforcement
+- `include/RecoveryManager.mqh` — state reconstruction on restart
+- `include/HeartbeatWriter.mqh` — EA-side heartbeat (for health check)
+- `include/TradeLogger.mqh` — trade_log.csv writes
+- `include/NewsFilter.mqh` — news event filtering
+
+### 4. Ops infrastructure
+
+- **NSSM service** wrapping the Python sidecar
+- **Task Scheduler watchdog** restarting sidecar on heartbeat staleness
+- **Windows startup shortcuts** for MT5 terminals (so they auto-start on VPS reboot)
+
+## Build sequence (for a new system)
+
+### Phase 0 — Strategy validation (prerequisite)
+
+Before you build anything in this guide:
+- Signal logic validated in lab
+- WFO PASS-DEPLOYABLE
+- Cost sweep deployable
+- Exit policy locked
+- Pair universe locked
+- Conventions locked (UTC, EET, other)
+
+If any of those is open, **do not start building the sidecar/EA**. Premature build = wasted work when the strategy changes.
+
+### Phase 1 — Sidecar build (~1 week)
+
+Reference dispatch: see git history for `DISPATCH_B_SIDECAR_BUILD.md` from Arc 10. Adapt for new system.
+
+**Deliverables:**
+
+1. **`winning_config.yaml`** — the locked strategy config. Includes:
+   - `boundary_convention` (utc / 5ers_eet / other)
+   - `pairs` (list of 28 or whatever)
+   - `signal_params` (whatever the lab uses)
+   - `exit_policy` parameters
+   - `risk_params` (Risk_Per_Trade, DD halts)
+   - `news_filter` settings
+
+2. **`config_hash`** — SHA-256 of the canonical-serialized YAML. Computed at sidecar boot, logged on every cycle, baked into envelopes.
+
+3. **Sidecar core loop:**
+   - Computes next H4 close based on `boundary_convention`
+   - Sleeps until target + 10s buffer
+   - Fetches H4 + D1 panels via `MetaTrader5.copy_rates_from_pos()`
+   - For each pair: calls `lab.compute_signal()`
+   - For each fire: writes envelope to `signals_out/<PAIR>_<iso_ts>.json`
+   - Writes heartbeat
+   - Persists state
+   - Sleeps until next cycle
+
+4. **CLI:**
+   ```
+   python -m deployment.sidecar
+     --winning-config <path>
+     --sidecar-root <path>
+     --mt5-path <terminal64 path>
+     --log-level INFO
+     [--quick-test]   # bypass H4 boundary wait for smoke tests
+     [--iterations N] # run N cycles then exit
+   ```
+
+5. **Unit tests:**
+   - Boundary computation per convention
+   - Envelope schema generation
+   - Heartbeat write
+   - Anchor probe
+   - State persistence + reload
+   - DST transitions
+
+**Gates before Phase 2:**
+- Sidecar boots, anchor probe passes
+- All 28 pairs fetched in single cycle
+- Envelope written matches schema
+- Heartbeat written
+- State persistence survives restart
+
+### Phase 2 — EA build (~1 week)
+
+Reference: Arc 10 EA at `deployment/ea/`.
+
+**Deliverables:**
+
+1. **Main EA file** (`.mq5`):
+   - OnInit: read inputs, init equity floor, reconstruct state from positions
+   - OnTick: poll signals, manage positions, write heartbeat, check DD
+   - OnDeinit: clean exit, write final state
+
+2. **Include modules** (`.mqh`):
+   - `SignalPoller` — reads `signals_out/`, validates, hands off to PositionManager
+   - `PositionManager` — places entries, tracks positions per pair (last_processed_h4_bar)
+   - `ExitPolicyEngine` — TP1 partial close, trail, time exit
+   - `EquityGuards` — daily + total DD halt enforcement
+   - `RecoveryManager` — reconstruct positions from broker on restart
+   - `NewsFilter` — defer/discard entries near scheduled news
+   - `HeartbeatWriter` — EA-side heartbeat
+   - `TradeLogger` — trade_log.csv emission
+
+3. **Inputs** (configurable per broker):
+   - `Risk_Per_Trade` (per-broker)
+   - DD halt thresholds (universal)
+   - Time_Exit_Bars (universal)
+   - SL_ATR_Multiplier_Expected (universal — must match config YAML)
+   - Sidecar path inputs (per-broker subfolder)
+   - `Magic_Number` (per-broker)
+   - `Expected_Config_Hash` (per-broker)
+   - News filter settings (universal)
+
+4. **ST scenario tests:**
+   - Scenarios.json defining 10-12 test cases
+   - fake_sidecar.py emitting synthetic envelopes
+   - Run each scenario in MT5 Strategy Tester
+   - Verify trade_log.csv matches expected events
+
+**Gates before Phase 3:**
+- All ST scenarios pass (or have documented valid-skip / defer-to-live reasoning)
+- EA attaches cleanly to MT5
+- No memory leaks in extended Strategy Tester run
+
+### Phase 3 — Parity validation (~2 days)
+
+**Goal:** prove the sidecar's signal output is byte-identical to the lab's signal output on the same historical panels.
+
+**Method:**
+1. Fetch historical H4 + D1 panels from broker via Python MetaTrader5 lib
+2. Aggregate / align to the configured convention
+3. For each candidate bar (lab signal ∪ lab prefilter_pass ∪ random sample): run sidecar's `run_signal()` and lab's `compute_signal()` on the same panel
+4. Compare fire/no-fire decision + audit field values
+5. Acceptance gates:
+   - ≥99.5% byte-identical signal emission
+   - 0 true logic divergence
+   - Audit field deltas ≤ 1e-9
+   - Pool x-check exact on all pairs
+
+**Outputs:**
+- `parity_report.md` per convention
+- `divergence_ledger.parquet` documenting any tolerated residuals
+
+**Gates before Phase 4:**
+- Parity gate passes
+- Any divergence rows are timing-only / live-harmless
+
+### Phase 4 — VPS deployment
+
+Follow `arc_10/03_deployment/04_vps_setup_guide.md` — the steps are generic enough to reuse. Substitute the system-specific paths, magic numbers, config hashes.
+
+## Patterns that work
+
+### Convention-aware sidecar via single module
+
+Don't fork the sidecar for different conventions. Put all convention logic in one module (Arc 10: `boundary.py`). All other sidecar layers delegate to it. Adding a new convention = one new branch in `boundary.py`, not a new sidecar codebase.
+
+### Config hash baked into envelope
+
+The envelope carries the config_hash that produced it. EA validates against `Expected_Config_Hash`. Catches misconfiguration at envelope-receive time, not after a wrong trade fires.
+
+### Same compiled .ex5 across brokers
+
+Don't compile per-broker. Same binary, different inputs. Reduces drift risk.
+
+### FILE_COMMON path resolution
+
+Even in portable mode, MT5's `FILE_COMMON` resolves to user-wide AppData. For multi-broker on one Windows user, use broker-specific subfolders (`Arc10_5ers\`, `Arc10_FundedNext\`). Zero EA code changes; all input parameter strings.
+
+### NSSM for service supervision
+
+PowerShell can't supervise a long-running Python process reliably. NSSM handles restart-on-crash, log capture, service start/stop properly.
+
+### Watchdog at 5min checking heartbeat 4h10min threshold
+
+Tight enough to catch real issues. Tolerant enough not to spuriously restart during normal H4 gaps.
+
+## Patterns that DON'T work
+
+### Indicator-based entries (NNFX-style)
+
+Tested. Fails. Indicator parameters are too flexible; overfit to fold-specific noise. Use structural signals instead.
+
+### GPT-4 for MQL→Python conversions
+
+Permanently excluded. Hallucinates function signatures. Aider permanently excluded for same reason.
+
+### Volume features
+
+Don't port across brokers. Microstructure metric, not strategy edge.
+
+### Same-day D1 in features
+
+Lookahead. D1 isn't closed yet at H4 bar close. Always use yesterday's D1, never today's.
+
+### Whole-pool MFE/MAE optimization
+
+Overfits. Use cross-fold stability instead.
+
+### Magnitude clustering
+
+Identifies winners post-hoc but can't predict them ex-ante. Use path-shape clustering instead.
+
+### Bundled changes per phase
+
+Destroys interpretability. One change per phase. Pre-commit the gate.
+
+## Quick reference — what each file does
+
+| File | What |
+|---|---|
+| `signals/<name>.py` | Lab signal logic (pure function) |
+| `configs/<name>/winning_config.yaml` | Locked strategy config |
+| `deployment/sidecar/__main__.py` | Sidecar CLI entry |
+| `deployment/sidecar/sidecar.py` | Main loop |
+| `deployment/sidecar/boundary.py` | Convention logic |
+| `deployment/sidecar/signal_runner.py` | Wraps lab signal call |
+| `deployment/sidecar/signal_emitter.py` | Envelope writer |
+| `deployment/sidecar/mt5_data_fetcher.py` | MT5 data layer |
+| `deployment/sidecar/heartbeat.py` | Heartbeat writer |
+| `deployment/sidecar/h4_schedule.py` | Boundary computation |
+| `deployment/ea/<Name>_EA.mq5` | EA entry point |
+| `deployment/ea/include/SignalPoller.mqh` | Envelope polling |
+| `deployment/ea/include/PositionManager.mqh` | Position management |
+| `deployment/ea/include/ExitPolicyEngine.mqh` | Exit logic |
+| `deployment/ea/include/EquityGuards.mqh` | DD halts |
+| `deployment/ea/include/RecoveryManager.mqh` | Restart recovery |
+| `deployment/ea/include/NewsFilter.mqh` | News filtering |
+| `deployment/ea/include/HeartbeatWriter.mqh` | EA-side heartbeat |
+| `deployment/ea/include/TradeLogger.mqh` | trade_log.csv writer |
+| `deployment/ops/watchdog.ps1` | Heartbeat watchdog |
+| `deployment/ops/install_watchdog_task.ps1` | Task Scheduler installer |
+
+## When to use this guide
+
+- Building a new strategy from a validated signal
+- Porting Arc 10 to a fundamentally different broker (different MT5 platform / different data feed)
+- Migrating from one prop firm to another with structural differences
+
+## When NOT to use this guide
+
+- Tweaking Arc 10 parameters → just change the YAML + recompute hash
+- Adding a new pair → just add to the YAML + re-run parity
+- New convention → add a branch in `boundary.py`, don't rebuild
+
+## Estimated build time (for a new system)
+
+If you have a validated signal already in the lab:
+
+- Phase 1 (sidecar): ~1 week
+- Phase 2 (EA): ~1 week
+- Phase 3 (parity): ~2 days
+- Phase 4 (deployment): ~3 hours focused work + soak
+
+**Total: ~2.5 weeks from validated lab signal to live VPS deployment.**
+
+Most of the time is in the EA (MQL5 is fiddly) and parity validation (must be byte-identical, no shortcuts).
+
+## What this guide doesn't cover
+
+- Strategy validation (that's the L_ARC_PROTOCOL methodology — see `L_PROTOCOL.md`)
+- Cost sweep methodology (see `arc_10/02_validation/05_cost_sweep.md` and the cost-sweep dispatch pattern)
+- WFO methodology (see `BACKTESTER_ARCHITECTURE.md` and L_PROTOCOL)
+- Broker selection (see `arc_10/03_deployment/06_broker_specs.md`)
+
+These are upstream concerns. This guide picks up AFTER strategy is validated and starts at "build the sidecar+EA."


### PR DESCRIPTION
## Summary
- Add `arc_10/05_history/06_deployment_retrospective.md` — deployment-week meta-knowledge: the bugs that almost shipped (r_atr, FILE_COMMON, NSSM quoting, PR #227 regression), near-mistakes, compounding decisions, and what the next deployment should do differently.
- Add `docs/SIDECAR_EA_BUILD_GUIDE.md` — generic, system-agnostic how-to for building a Python sidecar + thin MQL5 EA from a validated lab signal, abstracted from Arc 10.

## Why
- Retrospective slots into the existing `arc_10/05_history/` sequence (alongside decisions_log, open_items, pre_mortem) as Arc-10-specific history.
- Build guide is non-arc reference material for future follow-on systems, so it lives in `docs/`.

## Reviewer notes
- Docs-only change; no code or live-execution paths touched.
- LF→CRLF warnings on commit are expected on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)