### PR TITLE
[Docs] Add Sunday weekly check runbook + disaster recovery short doc

### DIFF
--- a/arc_10/03_deployment/07_disaster_recovery.md
+++ b/arc_10/03_deployment/07_disaster_recovery.md
@@ -1,0 +1,143 @@
+# Disaster Recovery
+
+> **Purpose:** What to do if the deployment is lost catastrophically.
+> **Audience:** future-you in a fire. Possibly a different chat or operator.
+> **Detail level here:** pointer + summary. Full step-by-step in `Catastrophe/DISASTER_RECOVERY.md` (outside repo).
+
+## Scenarios
+
+### Scenario 1: VPS lost (hardware failure, provider issue, accidental deletion)
+
+**What still exists:** GitHub repo, your local workstation, broker accounts, broker MT5 installers downloadable from broker websites.
+
+**Recovery time:** ~3-4 hours.
+
+**Procedure:**
+1. Provision new VPS (Contabo or equivalent — Windows Server 2022, 4 cores, 8 GB RAM, Frankfurt)
+2. Follow `arc_10/03_deployment/04_vps_setup_guide.md` from Step 1 to Step 13
+3. Confirm validation: `arc_10/03_deployment/02_5ers_setup.md` and `03_fundednext_setup.md` checklists
+4. Resume trading
+
+### Scenario 2: GitHub repo lost (account compromise, data loss event)
+
+**What still exists:** Your local workstation copy of the repo. VPS copy of the repo. `Catastrophe/` folder (if you've maintained it).
+
+**Recovery time:** ~30 minutes.
+
+**Procedure:**
+1. Create new GitHub account or use existing
+2. Push your local repo to new origin
+3. Update VPS remote: `git remote set-url origin <new>`
+4. All continues normally. No deployment changes needed.
+
+### Scenario 3: BOTH GitHub repo AND your local workstation lost
+
+**What still exists:** `Catastrophe/` folder offsite backup, VPS (with its local repo copy).
+
+**Recovery time:** ~1 hour.
+
+**Procedure:**
+1. RDP to VPS
+2. From VPS, `git push` the current repo to a new GitHub remote
+3. Restore your local from the new GitHub remote
+4. All continues normally.
+
+### Scenario 4: Total loss — VPS, GitHub, local workstation all gone
+
+**What still exists:** ONLY the `Catastrophe/` folder offsite backup (external drive, cloud, etc.).
+
+**Recovery time:** ~6-8 hours assuming new hardware available.
+
+**Procedure:**
+1. Retrieve `Catastrophe/` folder from offsite backup
+2. Open `Catastrophe/DISASTER_RECOVERY.md` (the full rebuild runbook)
+3. Follow that runbook end to end — it's self-contained and assumes nothing exists
+4. Either rebuild on new hardware OR feed `Catastrophe/` contents + the runbook to a fresh Claude/CC instance and let it execute
+
+### Scenario 5: Broker account terminated (rule violation, etc.)
+
+**What still exists:** Everything else.
+
+**Recovery time:** depends on broker process.
+
+**Procedure:**
+1. Determine cause: did the system violate a rule, or is it broker error?
+2. If system violation: investigate via trade_log.csv, identify which trade(s) caused breach
+3. If broker error: appeal via broker support
+4. Continue trading on the other broker (5ers ↔ FundedNext are independent) while resolving
+5. Once resolved or accepted as lost: open new account, re-login MT5, resume
+
+### Scenario 6: Strategy degrades materially (live results diverge significantly from backtest)
+
+This is the trickiest scenario because it's not a single catastrophic event.
+
+**Procedure:**
+1. Reference `arc_10/04_runbook/07_kill_criteria.md` — do any triggers fire?
+2. If yes: follow kill procedure
+3. If no but concerning: pause-and-review per `arc_10/04_runbook/06_live_tracking_framework.md`
+4. Investigation: compare recent live trades to backtest expectations per `arc_10/04_runbook/02_weekly_check.md`
+5. Decision tree: continue / reduce risk / pause / kill
+
+This isn't recovery — it's risk management. But it's the scenario most likely to actually happen.
+
+## The Catastrophe folder
+
+If you haven't built/maintained one, build one NOW.
+
+**What it should contain:**
+- Repo at deployed tag (zip)
+- Compiled EA binary + source
+- Both locked YAML configs + their hashes
+- Frozen Python requirements
+- Copy of this `arc_10/` folder
+- Full DISASTER_RECOVERY.md runbook
+- Verification hashes for tamper detection
+
+**Where it should live:**
+- Local external drive (always plug in monthly to verify it's there)
+- Cloud backup (Dropbox, Google Drive, Backblaze)
+- Both ideally
+
+**When to rebuild it:**
+- After any pivotal system change (not risk parameter changes — actual system changes)
+- After any config_hash change
+- After any EA source change
+- After any sidecar logic change
+- Annually as a sanity check regardless
+
+**See `Catastrophe/README.md` for the full description.** That folder lives OUTSIDE the repo at `C:\Users\panap\Documents\Forex-Backtester-Catastrophe\` (or similar).
+
+## Failure mode pre-mortem
+
+For thinking through "what's the most likely catastrophic failure?" see `arc_10/05_history/05_pre_mortem.md`. That document is the planning input to this one.
+
+## What's NOT recoverable
+
+Some things can't be recovered after loss:
+
+- **Broker password if lost AND no backup:** contact broker support. May lose account access entirely.
+- **Open positions during account closure:** the broker closes them at market. Could be at a loss.
+- **In-flight Challenge progress:** if a Challenge account is terminated mid-Challenge, that purchase is lost.
+- **VPS-only state that didn't get pulled:** any trade_log.csv data between last weekly check and the VPS loss event. ~1 week of records.
+
+## Discipline for surviving catastrophes
+
+1. **Weekly check matters.** It's how you avoid losing more than a week of records if VPS dies.
+2. **Catastrophe folder backup quarterly.** External drive + cloud.
+3. **Don't put broker passwords in the repo.** They're in your password manager (which has its own backup).
+4. **Test recovery once a year.** Stand up a fresh VPS in parallel, follow the runbook end-to-end, verify it works. Then tear it down. Cheap insurance.
+
+## What's the actual risk profile?
+
+**Probability over a 1-year period (rough estimates):**
+
+- VPS provider issue requiring reprovision: ~5%
+- Repo loss: <1%
+- Both repo + local lost simultaneously: <<1%
+- Broker account terminated due to system fault: <2% (with 0.50% risk + 7%/8% DD halts)
+- Broker account terminated due to broker rule change: ~5%
+- Strategy degradation requiring kill: see kill criteria for specific triggers
+
+Most likely scenario you'll actually face: minor operational disruption (VPS reboot, MT5 reconnect, sidecar restart) — handled automatically by watchdog and NSSM. Almost certainly never triggers any disaster recovery procedure.
+
+**The Catastrophe folder is insurance, not a plan you expect to use.** It exists so that "if everything goes wrong" doesn't end the system.

--- a/arc_10/04_runbook/08_sunday_weekly_check.md
+++ b/arc_10/04_runbook/08_sunday_weekly_check.md
@@ -1,0 +1,331 @@
+# Sunday Weekly Check — Step by Step
+
+> **When:** Every Sunday during market closure (Friday 22:00 UTC → Sunday 22:00 UTC).
+> **Time required:** ~30 minutes total. ~5 min of your active attention, ~25 min for CC to process.
+> **Goal:** verify last week's trading matches expectations, archive data, catch anomalies early.
+
+---
+
+## Before you start
+
+Open three things:
+
+1. **RDP to VPS** (for Step 1)
+2. **Both local MT5 terminals** (for Step 2)
+3. **Fresh Claude chat with this project loaded** (for Step 3)
+
+---
+
+## Step 1 — VPS logs (5 minutes)
+
+### 1a. RDP into VPS
+
+Connect via Remote Desktop to the VPS as you normally would.
+
+### 1b. Open Administrator PowerShell
+
+Right-click Start → "Windows PowerShell (Admin)".
+
+### 1c. Paste this command
+
+```powershell
+$date = Get-Date -Format "yyyy-MM-dd"
+$out = "C:\Temp\weekly_archive_$date"
+Remove-Item -Recurse -Force $out -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path "$out\5ers", "$out\5ers\signals_processed", "$out\5ers\signals_failed", "$out\FundedNext", "$out\FundedNext\signals_processed", "$out\FundedNext\signals_failed" | Out-Null
+
+$src5 = "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_5ers"
+$srcF = "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\Files\Arc10_FundedNext"
+
+# 5ers
+Copy-Item "$src5\trade_log.csv" "$out\5ers\" -ErrorAction SilentlyContinue
+Copy-Item "$src5\sidecar.heartbeat" "$out\5ers\" -ErrorAction SilentlyContinue
+Copy-Item "$src5\sidecar_state.json" "$out\5ers\" -ErrorAction SilentlyContinue
+Copy-Item "$src5\logs\sidecar.stderr.log" "$out\5ers\" -ErrorAction SilentlyContinue
+Copy-Item "$src5\logs\sidecar.stdout.log" "$out\5ers\" -ErrorAction SilentlyContinue
+Copy-Item "$src5\ea.heartbeat" "$out\5ers\" -ErrorAction SilentlyContinue
+Copy-Item "$src5\ea_positions.json" "$out\5ers\" -ErrorAction SilentlyContinue
+Get-ChildItem "$src5\signals_processed" -ErrorAction SilentlyContinue | Where-Object { $_.LastWriteTime -gt (Get-Date).AddDays(-8) } | Copy-Item -Destination "$out\5ers\signals_processed\"
+Get-ChildItem "$src5\signals_failed" -ErrorAction SilentlyContinue | Where-Object { $_.LastWriteTime -gt (Get-Date).AddDays(-8) } | Copy-Item -Destination "$out\5ers\signals_failed\"
+
+# FundedNext
+Copy-Item "$srcF\trade_log.csv" "$out\FundedNext\" -ErrorAction SilentlyContinue
+Copy-Item "$srcF\sidecar.heartbeat" "$out\FundedNext\" -ErrorAction SilentlyContinue
+Copy-Item "$srcF\sidecar_state.json" "$out\FundedNext\" -ErrorAction SilentlyContinue
+Copy-Item "$srcF\logs\sidecar.stderr.log" "$out\FundedNext\" -ErrorAction SilentlyContinue
+Copy-Item "$srcF\logs\sidecar.stdout.log" "$out\FundedNext\" -ErrorAction SilentlyContinue
+Copy-Item "$srcF\ea.heartbeat" "$out\FundedNext\" -ErrorAction SilentlyContinue
+Copy-Item "$srcF\ea_positions.json" "$out\FundedNext\" -ErrorAction SilentlyContinue
+Get-ChildItem "$srcF\signals_processed" -ErrorAction SilentlyContinue | Where-Object { $_.LastWriteTime -gt (Get-Date).AddDays(-8) } | Copy-Item -Destination "$out\FundedNext\signals_processed\"
+Get-ChildItem "$srcF\signals_failed" -ErrorAction SilentlyContinue | Where-Object { $_.LastWriteTime -gt (Get-Date).AddDays(-8) } | Copy-Item -Destination "$out\FundedNext\signals_failed\"
+
+# Health snapshot
+$health = @"
+=== Weekly Health Snapshot $date ===
+Services:
+$(Get-Service Arc10Sidecar5ers, Arc10SidecarFundedNext | Format-Table Name, Status, StartType -AutoSize | Out-String)
+
+MT5 Processes:
+$(Get-Process terminal64 -ErrorAction SilentlyContinue | Select-Object Id, StartTime, Path | Format-Table -AutoSize | Out-String)
+
+Watchdogs:
+$(Get-ScheduledTask -TaskName "Arc10WatchDog_*" -ErrorAction SilentlyContinue | Format-Table TaskName, State -AutoSize | Out-String)
+
+5ers restart_count: $((Get-Content "$src5\sidecar_state.json" -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).restart_count)
+FundedNext restart_count: $((Get-Content "$srcF\sidecar_state.json" -Raw -ErrorAction SilentlyContinue | ConvertFrom-Json).restart_count)
+
+Disk free (C:):
+$((Get-PSDrive C).Free / 1GB) GB
+"@
+$health | Out-File "$out\HEALTH_SNAPSHOT.txt"
+
+# Zip it
+Compress-Archive -Path $out -DestinationPath "$out.zip" -Force
+Write-Host ""
+Write-Host "================================================================"
+Write-Host "DONE. Archive ready at: $out.zip"
+Write-Host "Now: drag this zip into your RDP session (RDP file copy) or open"
+Write-Host "the C:\Temp folder via the RDP shared drive."
+Write-Host "================================================================"
+```
+
+Hit Enter. Should take ~10-15 seconds. Look for the "DONE" banner at the end.
+
+### 1d. Copy the zip to your local machine
+
+The zip is at `C:\Temp\weekly_archive_YYYY-MM-DD.zip` on the VPS.
+
+Get it to local however you prefer:
+- RDP drag-and-drop (if your RDP client allows it)
+- RDP shared drive (if you have one mounted)
+- Or upload to a transfer service
+
+### 1e. Save it locally
+
+On your local machine, save the zip to:
+
+```
+C:\Users\panap\Documents\Forex-Backtester\arc_10\06_live_reports\
+```
+
+Don't unzip yet — Claude will unzip it during Step 3.
+
+---
+
+## Step 2 — MT5 trade history exports (5 minutes)
+
+Open **each** MT5 on your **local** machine (not on VPS — local has the same broker logins).
+
+### For 5ers MT5:
+
+1. View → Toolbox → History tab (or Ctrl+Shift+H)
+2. Right-click in the history pane → "Custom period..."
+3. Set date range: **last Sunday** to **today**
+4. Right-click → "Report" → "Save as Detailed Report" (HTML)
+5. Save as `5ers_history_YYYY-MM-DD.html` to:
+   ```
+   C:\Users\panap\Documents\Forex-Backtester\arc_10\06_live_reports\
+   ```
+
+### For FundedNext MT5:
+
+Same procedure. Save as `fundednext_history_YYYY-MM-DD.html`.
+
+You should now have THREE files in `06_live_reports\`:
+- `weekly_archive_YYYY-MM-DD.zip`
+- `5ers_history_YYYY-MM-DD.html`
+- `fundednext_history_YYYY-MM-DD.html`
+
+---
+
+## Step 3 — Claude review (~20 minutes Claude time, ~2 minutes your time)
+
+### 3a. Open a fresh Claude chat with this project loaded
+
+The project knowledge already has the `arc_10/` docs (executive summary, kill criteria, live tracking framework, decisions log, pre-mortem). Claude has the context.
+
+### 3b. Upload the three files
+
+Drag-and-drop into the chat:
+- The VPS zip
+- The 5ers history HTML
+- The FundedNext history HTML
+
+### 3c. Paste this exact prompt
+
+```
+This is the Sunday weekly check for Arc 10 live trading. I've uploaded:
+
+1. `weekly_archive_YYYY-MM-DD.zip` — VPS export (sidecar logs, trade_log.csv,
+   signal envelopes, heartbeats, health snapshot for both 5ers and FundedNext)
+2. `5ers_history_YYYY-MM-DD.html` — MT5 broker history for 5ers, last 7 days
+3. `fundednext_history_YYYY-MM-DD.html` — MT5 broker history for FundedNext,
+   last 7 days
+
+Please run a complete weekly review and produce a single weekly_report.md.
+
+Use the project knowledge for expected behavior:
+- `arc_10/04_runbook/06_live_tracking_framework.md` — what numbers should
+  look like
+- `arc_10/04_runbook/07_kill_criteria.md` — hard triggers
+- `arc_10/05_history/05_pre_mortem.md` — known failure modes to
+  pattern-match against
+- `arc_10/00_executive_summary.md` — system state and expectations
+
+Do these checks (don't skip any; flag any you can't complete):
+
+## System health
+- Are both NSSM services running per HEALTH_SNAPSHOT.txt?
+- Are both MT5 processes alive with reasonable uptime?
+- Did restart_count increase since last week? If yes, investigate logs.
+- Any ERROR/Traceback/failed lines in sidecar.stderr.log for either broker?
+- Heartbeats fresh? (last_heartbeat_utc within ~4-5 hours of zip creation time)
+
+## Trade reconciliation
+For each broker (5ers, FundedNext):
+- Parse trade_log.csv: count entries, exits, partial closes, time exits,
+  equity halts
+- Parse MT5 history HTML: count broker-side trades
+- Cross-reference: every broker trade should match an EA entry. Every EA
+  entry should match a broker trade. Flag mismatches.
+- For each completed trade, compute the actual R-multiple
+  (achieved P&L ÷ initial risk in dollars)
+- Compare actual R-distribution to expected (live_tracking_framework.md):
+  - Win rate range
+  - Mean R-multiple
+  - R-distribution shape
+
+## Signal accounting
+For each broker:
+- Count signal envelopes in signals_processed/ from last 7 days
+- Count signal envelopes in signals_failed/ (should be 0; investigate any)
+- For each envelope, was there a matching EA entry? If not, what
+  rejection reason?
+
+## Anomaly flags
+Check for any of these:
+- Trade with R-multiple > +5R or < -1.5R (slippage check)
+- Spread on entry materially worse than backtest assumption (~1.5×
+  HistData baseline)
+- Daily DD > 3% on any day this week (close to halt threshold)
+- Total DD > 5% running (close to internal pause threshold)
+- Single pair generating >50% of trades this week (clustering)
+- Any trade closed via reason "external_close" (manual intervention or
+  unexpected broker action)
+- Any unusual gaps in trade_log.csv timestamps
+
+## Kill criteria check
+Cross-reference current state against arc_10/04_runbook/07_kill_criteria.md.
+Are any triggers approaching? Flag explicitly.
+
+## Output format
+Produce a single markdown file: `weekly_report_YYYY-MM-DD.md`
+Structure:
+1. Headline: GREEN / YELLOW / RED status
+2. System health summary (one section)
+3. Trade reconciliation table (5ers + FundedNext side by side)
+4. R-distribution comparison vs expected
+5. Anomalies and flags (or "none")
+6. Kill criteria status (each trigger, current value, distance to trigger)
+7. Recommendations (carry on / pause and review / kill)
+8. Raw data preserved (links to source files)
+
+Be specific. If something is wrong, name it precisely. If everything is fine,
+say so without padding. Don't generate concerns that aren't there. Don't
+hide concerns that are.
+
+If you find concerning patterns, suggest specific follow-up actions.
+```
+
+### 3d. Wait for Claude to process
+
+Will take ~5-20 minutes depending on data volume. Claude does the analysis end to end without further input.
+
+---
+
+## Step 4 — Review and archive
+
+### 4a. Read the weekly report
+
+Claude produces a single `weekly_report_YYYY-MM-DD.md`. Read it.
+
+**Three possible outcomes:**
+
+**GREEN (everything healthy):**
+- Save the report to:
+  `C:\Users\panap\Documents\Forex-Backtester\arc_10\06_live_reports\weekly_reports\YYYY-MM-DD.md`
+- Extract the VPS zip contents to:
+  - 5ers data → `arc_10\06_live_reports\5ers\YYYY-MM-DD\`
+  - FundedNext data → `arc_10\06_live_reports\FundedNext\YYYY-MM-DD\`
+- Move the MT5 history HTML files into the same date folder per broker
+- Done. Close the chat. See you next Sunday.
+
+**YELLOW (concerns flagged but not critical):**
+- Same archiving as GREEN
+- Add a notes.md to the date folder describing what was flagged and what (if anything) you decided to do
+- Monitor more closely during the week. Daily health checks instead of nothing-during-the-week.
+- See `arc_10/04_runbook/04_incident_response.md` if any flag matches a documented incident pattern.
+
+**RED (kill criteria approaching or unexpected behavior):**
+- DO NOT continue trading without investigation
+- See `arc_10/04_runbook/07_kill_criteria.md` — do any triggers actually fire? If yes, follow kill procedure (`05_emergency_kill.md`).
+- If not actual kill triggers but still concerning, escalate to a deep dive before next Sunday
+- Don't ramp risk this week
+- Do NOT close the chat — keep it open for investigation
+
+### 4b. Cleanup VPS
+
+Once the data is archived locally, you can delete from VPS to save space:
+
+```powershell
+Remove-Item -Recurse -Force "C:\Temp\weekly_archive_YYYY-MM-DD"
+Remove-Item -Force "C:\Temp\weekly_archive_YYYY-MM-DD.zip"
+```
+
+(Optional. The data is only ~10-50MB per week. You can let it accumulate for a year before disk is an issue.)
+
+---
+
+## What you do NOT need to do
+
+- Manually compare trades line by line (Claude does this)
+- Compute R-multiples by hand (Claude does this)
+- Check kill criteria against actuals (Claude does this)
+- Worry about the format of MT5 history exports (Claude parses HTML)
+
+The runbook makes this a ~5-minute active job for you. Claude does the analytical work.
+
+---
+
+## When to deviate from this runbook
+
+**Skip the weekly check ONLY if:**
+- VPS is genuinely unreachable (no RDP, can't get logs) — note it, do it Monday
+- You're traveling and don't have access — note it, do it within 7 days when you can
+
+**NEVER skip the weekly check because:**
+- "The week seemed fine, probably nothing to find"
+- "I checked the heartbeats yesterday"
+- "Daily P&L looked OK"
+
+Weekly review is a discipline, not a response to perceived need. Most of the time it confirms nothing's wrong; that's the point.
+
+---
+
+## Monthly extension (first Sunday of each month)
+
+In addition to the weekly check, run an extended analysis once a month. See `arc_10/04_runbook/09_monthly_calibration.md` (TBD — build when first month of live data exists).
+
+---
+
+## Source files (where the data comes from)
+
+| Source | What it contains | Used for |
+|---|---|---|
+| VPS sidecar logs | All sidecar boot + cycle events, errors | System health |
+| VPS trade_log.csv | Every EA event (entries, exits, partials, etc.) | Trade reconciliation |
+| VPS signal envelopes | Each signal the sidecar fired | Signal accounting |
+| VPS heartbeats | Latest cycle state | Health verification |
+| MT5 history HTML | Broker's record of every trade | Cross-check vs EA log |
+
+If any source file is missing from the upload to Claude, mention it in the prompt and Claude will work around it.

--- a/arc_10/06_live_reports/README.md
+++ b/arc_10/06_live_reports/README.md
@@ -1,0 +1,75 @@
+# Live Reports
+
+> Operational record of Arc 10 live trading. Generated weekly from VPS exports and MT5 history.
+
+## Folder structure
+
+```
+06_live_reports/
+├── README.md                  ← this file
+├── 5ers/
+│   └── YYYY-MM-DD/            ← each Sunday's pull, broker-organized
+│       ├── trade_log.csv
+│       ├── sidecar.stderr.log
+│       ├── sidecar.heartbeat
+│       ├── sidecar_state.json
+│       ├── ea.heartbeat
+│       ├── ea_positions.json
+│       ├── signals_processed/
+│       ├── signals_failed/
+│       └── mt5_history.html
+├── FundedNext/
+│   └── YYYY-MM-DD/
+│       └── (same structure)
+└── weekly_reports/
+    └── YYYY-MM-DD.md          ← Claude-generated review per week
+```
+
+## How data lands here
+
+Follow `arc_10/04_runbook/08_sunday_weekly_check.md` every Sunday. The runbook produces:
+- Raw data per broker per week → goes into broker/date folder
+- Weekly review report → goes into weekly_reports/
+
+## Retention
+
+**Forever.** This is the operational record.
+
+- Per-week file sizes: ~5-15 MB compressed
+- After 1 year of trading: ~500-800 MB total
+- After 5 years: ~3-4 GB total
+
+Don't delete. If disk becomes a concern at year 3-5, compress older years into zips.
+
+## What you do with this data
+
+**Right after each weekly check:**
+- Read the generated weekly_report.md
+- If GREEN: archive and move on
+- If YELLOW: add a notes.md to the date folder
+- If RED: see `arc_10/04_runbook/07_kill_criteria.md` and `04_incident_response.md`
+
+**Periodically (every month or so):**
+- Scan recent weekly_reports/ for patterns
+- Compare against expectations in `arc_10/04_runbook/06_live_tracking_framework.md`
+- Note any drift in `arc_10/05_history/04_open_items.md`
+
+**Quarterly:**
+- Update the expected-performance ranges in live_tracking_framework.md if statistical mass justifies it
+- Re-evaluate kill criteria thresholds if any have proven mis-calibrated
+- Verify FundedNext rules haven't changed materially
+
+**Annually:**
+- Roll up the year's weekly reports into an annual review
+- Compare live actuals vs WFO expectations
+- Decision: continue / scale / modify / kill
+
+## Important
+
+These files are operational record. Do not edit them after archive. If a correction is needed, add a notes.md to the date folder explaining what's wrong; don't modify the original.
+
+## When the weekly check breaks
+
+If a Sunday goes by without a weekly check (RDP down, traveling, etc.), note it in the next week's report. Don't create a placeholder report; the gap is the record.
+
+If the weekly check produces a RED status, that report stays — it's the historical record of what happened. Don't delete a RED report after the issue is resolved.

--- a/scripts/weekly/README.md
+++ b/scripts/weekly/README.md
@@ -1,0 +1,27 @@
+# Weekly Check Scripts
+
+> Scripts and templates supporting the Sunday weekly check.
+> See `arc_10/04_runbook/08_sunday_weekly_check.md` for the full runbook.
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `weekly_review_prompt.md` | The exact prompt to paste into Claude after uploading the VPS archive + MT5 history exports |
+
+## Note on the VPS pull command
+
+The PowerShell command that pulls weekly data from the VPS lives **inline in the runbook** (`08_sunday_weekly_check.md` Step 1c), not as a separate `.ps1` file.
+
+Reason: the command is short enough that having it in the runbook keeps the Sunday process self-contained — open one doc, follow it. Splitting it into a separate script adds a layer of "wait, which file again?" friction that doesn't help.
+
+If you want to convert it into a `.ps1` file later (for reuse outside the runbook), the entire command is documented in the runbook and trivially copy-paste-able.
+
+## Future additions
+
+When live data justifies it:
+- `monthly_calibration.md` — extension of the weekly check (first Sunday of each month)
+- `reconciliation_engine.py` — automated cross-reference script (build after 4+ weeks of live data)
+- `quarterly_review.md` — broader scope check (every 3 months)
+
+None of these exist yet. Build when needed, not before.

--- a/scripts/weekly/weekly_review_prompt.md
+++ b/scripts/weekly/weekly_review_prompt.md
@@ -1,0 +1,108 @@
+# Weekly Review Prompt (for Claude chat)
+
+> **Purpose:** the prompt you paste into Claude after uploading the Sunday weekly archive.
+> **Used by:** `arc_10/04_runbook/08_sunday_weekly_check.md` Step 3.
+> **Note:** copy the text below verbatim into the chat.
+
+---
+
+```
+This is the Sunday weekly check for Arc 10 live trading. I've uploaded:
+
+1. `weekly_archive_YYYY-MM-DD.zip` — VPS export (sidecar logs, trade_log.csv,
+   signal envelopes, heartbeats, health snapshot for both 5ers and FundedNext)
+2. `5ers_history_YYYY-MM-DD.html` — MT5 broker history for 5ers, last 7 days
+3. `fundednext_history_YYYY-MM-DD.html` — MT5 broker history for FundedNext,
+   last 7 days
+
+Please run a complete weekly review and produce a single weekly_report.md.
+
+Use the project knowledge for expected behavior:
+- `arc_10/04_runbook/06_live_tracking_framework.md` — what numbers should
+  look like
+- `arc_10/04_runbook/07_kill_criteria.md` — hard triggers
+- `arc_10/05_history/05_pre_mortem.md` — known failure modes to
+  pattern-match against
+- `arc_10/00_executive_summary.md` — system state and expectations
+
+Do these checks (don't skip any; flag any you can't complete):
+
+## System health
+- Are both NSSM services running per HEALTH_SNAPSHOT.txt?
+- Are both MT5 processes alive with reasonable uptime?
+- Did restart_count increase since last week? If yes, investigate logs.
+- Any ERROR/Traceback/failed lines in sidecar.stderr.log for either broker?
+- Heartbeats fresh? (last_heartbeat_utc within ~4-5 hours of zip creation time)
+
+## Trade reconciliation
+For each broker (5ers, FundedNext):
+- Parse trade_log.csv: count entries, exits, partial closes, time exits,
+  equity halts
+- Parse MT5 history HTML: count broker-side trades
+- Cross-reference: every broker trade should match an EA entry. Every EA
+  entry should match a broker trade. Flag mismatches.
+- For each completed trade, compute the actual R-multiple
+  (achieved P&L ÷ initial risk in dollars)
+- Compare actual R-distribution to expected (live_tracking_framework.md):
+  - Win rate range
+  - Mean R-multiple
+  - R-distribution shape
+
+## Signal accounting
+For each broker:
+- Count signal envelopes in signals_processed/ from last 7 days
+- Count signal envelopes in signals_failed/ (should be 0; investigate any)
+- For each envelope, was there a matching EA entry? If not, what
+  rejection reason?
+
+## Anomaly flags
+Check for any of these:
+- Trade with R-multiple > +5R or < -1.5R (slippage check)
+- Spread on entry materially worse than backtest assumption (~1.5×
+  HistData baseline)
+- Daily DD > 3% on any day this week (close to halt threshold)
+- Total DD > 5% running (close to internal pause threshold)
+- Single pair generating >50% of trades this week (clustering)
+- Any trade closed via reason "external_close" (manual intervention or
+  unexpected broker action)
+- Any unusual gaps in trade_log.csv timestamps
+
+## Kill criteria check
+Cross-reference current state against arc_10/04_runbook/07_kill_criteria.md.
+Are any triggers approaching? Flag explicitly.
+
+## Output format
+Produce a single markdown file: `weekly_report_YYYY-MM-DD.md`
+Structure:
+1. Headline: GREEN / YELLOW / RED status
+2. System health summary (one section)
+3. Trade reconciliation table (5ers + FundedNext side by side)
+4. R-distribution comparison vs expected
+5. Anomalies and flags (or "none")
+6. Kill criteria status (each trigger, current value, distance to trigger)
+7. Recommendations (carry on / pause and review / kill)
+8. Raw data preserved (links to source files)
+
+Be specific. If something is wrong, name it precisely. If everything is fine,
+say so without padding. Don't generate concerns that aren't there. Don't
+hide concerns that are.
+
+If you find concerning patterns, suggest specific follow-up actions.
+```
+
+---
+
+## When to modify this prompt
+
+**Update when:**
+- The live tracking framework's expected ranges change (post-calibration)
+- Kill criteria thresholds change
+- New anomaly patterns emerge that should be auto-flagged
+- The pre-mortem document gets new entries
+
+**Don't update for:**
+- A single weird week (it's normal data variance)
+- One-off operational issues
+- Cosmetic preferences
+
+This prompt is the analytical contract. Keep it stable so weekly reports are comparable across time.


### PR DESCRIPTION
## Summary
Adds the operational infrastructure for the Sunday weekly check
procedure and brief disaster recovery documentation. Markdown-only;
no code, configs, or data files changed.

## What this enables

**Weekly check workflow:**
Sunday → open `arc_10/04_runbook/08_sunday_weekly_check.md` → follow
4 steps → ~30 minutes total (~5 min active attention).

The runbook contains:
- An inline PowerShell command to pull all needed VPS data into a zip
- Instructions for exporting MT5 history from both broker terminals
- The exact analytical prompt to paste into Claude
- Archive procedure for the generated weekly_report.md

**Disaster recovery awareness:**
`arc_10/03_deployment/07_disaster_recovery.md` enumerates 6 scenarios
(VPS lost, repo lost, total loss, broker terminated, strategy
degradation) with brief recovery procedures. Points to the Catastrophe
folder (operator-maintained, outside repo) for the full rebuild
runbook.

## File changes
5 new files added:
- arc_10/04_runbook/08_sunday_weekly_check.md
- arc_10/03_deployment/07_disaster_recovery.md
- arc_10/06_live_reports/README.md
- scripts/weekly/README.md
- scripts/weekly/weekly_review_prompt.md

2 new folders implicitly created:
- arc_10/06_live_reports/ (will hold archived weekly data going forward)
- scripts/weekly/ (will hold weekly check supporting scripts)

## Why now
The system is live on demo as of 2026-05-29. Before live data starts
accumulating (FundedNext Challenge purchase imminent), the weekly
check infrastructure needs to exist so the first week of live data
gets properly reviewed and archived.

## Out of scope
- The Catastrophe folder (lives outside repo, operator handles)
- Automated reconciliation script (deferred until 4+ weeks of live data)
- Monthly calibration extension (build when first month exists)
- Any changes to live system behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
