### PR TITLE
Arc 10 v3.0.2: canonical EA-faithful documentation pass (doc-only)

### DIFF
--- a/L_PROTOCOL.md
+++ b/L_PROTOCOL.md
@@ -519,6 +519,18 @@ Holdout = "2021-01-01 to present at time of arc closure" — matches §2 Step 5 
 
 `r_max = 2.0%` is the **deployment cap** (per-trade risk feasibility on 5ers prop firm). Revised by Amendment 3.1 (2026-05-25) — no longer a gate threshold; strategies whose intrinsic `r_safe` or `r_hard` overshoots `r_max` deploy at `r_max` with sub-budget DD utilisation. Tracker fields `r_safe_capped_at_rmax` / `r_hard_capped_at_rmax` flag the cap activation. Locked value.
 
+### Amendment 7 — portfolio-level DD gating + EA-faithful (floating-equity) sizing
+
+Effective 2026-05-31 (Arc 10 v3.0.2 EA-faithful canonical run). Applies to all future arcs at Step 5. Two binding requirements:
+
+**(a) DD is gated portfolio-level, not per-trade-sequential.** Drawdown gates (daily, total/trailing, from-initial) are evaluated on the **concurrent open book** — the full set of simultaneously-open positions marked together — not on a sequential per-trade or per-fold-isolated basis. Concurrency and correlated-currency clusters drive DD non-linearly: a single-currency cluster that is a benign per-trade event can be a portfolio breach when its positions are open together. The per-day max-DD artefact (Amendment 6) and the chained-DD measurement both consume the concurrent-book equity curve. This generalises the deferred A5 combined-portfolio-DD flag to every architecture.
+
+**(b) Sizing must match the live execution basis (floating-equity), and be validated against it.** The Step 5 deployable run sizes each entry exactly as the deployed EA does — `risk_amount = ACCOUNT_EQUITY × r_base` with equity **including floating open P&L**, re-read per entry — not linear-overlay or closed-balance sizing. Linear/closed sizing understates the procyclical concurrency tail (entries size larger when the open book is up, into a possible reversal). The deployable verdict is taken from the EA-faithful (floating-equity) run; linear and closed-equity runs are retained as reconstruction-validation steps only (each must reproduce the same portfolio worst-fold trailing DD under a `mult ≡ r_base` + zero-cost reduction). Where a strategy has no live EA yet, the floating-equity simulator stands in and must be re-validated against the EA once built.
+
+**DD reporting:** report on **both** the trailing (peak-to-trough) and from-initial references. From-initial is the prop-firm MLL basis (the deployment-binding number); trailing is the conservative planning anchor. A candidate that passes from-initial but fails trailing is gated, not deployable, at that risk.
+
+Precedent: Arc 10 v3.0.2 — `results/l_arc_10_v3.0.2_ea_faithful/` + `arc_10/02_validation/07_canonical_wfo.md`. Amendment 7 is documented inline here — no separate archive file.
+
 ---
 
 ## §4 Architecture search conventions

--- a/arc_10/00_executive_summary.md
+++ b/arc_10/00_executive_summary.md
@@ -8,23 +8,21 @@ The system was developed under the L_ARC_PROTOCOL research methodology — six-s
 
 ## What it produces
 
-Across 14 years of historical data (2010-2024 in-sample folds + 2021-2026 holdout), Arc 10 v3.0.2 produces:
+Across 14 years of EA-faithful walk-forward validation (2010–2020 in-sample folds F1–F11 + 2021–2026 holdout, floating-equity sizing matched to the live EA), Arc 10 v3.0.2 at the **0.40% operating tier** produces — FundedNext, EET, governed, costed (full basis in `02_validation/07_canonical_wfo.md`):
 
-- **Worst-fold ROI: 22.46%** annualised (EET convention, F9 2018)
-- **Worst-fold DD: 7.35%** (F4 2013)
-- **Worst-fold ratio: 6.43** (F6 2015 — the load-bearing fold)
-- **Mean fold ROI: 49.87%** annualised
-- **Holdout ROI: 52.83%** (2021-2026, 1,093 trades)
-- **Sign consistency: 11/11 folds positive** — even at 4× spread stress
+- **Worst-fold ROI: 14.42%** annualised (F9 2018)
+- **Mean fold ROI: 32.48%** annualised
+- **Worst-fold DD: 5.49% from-initial** (FundedNext's actual MLL basis, F5 2014) / **8.21% trailing** (conservative planning anchor, F10 2019)
+- **Worst daily DD: 4.11%** (F1 2010) — under the 5% daily limit
+- **Holdout, per year (never a CAGR):** 2021 +38.79% · 2022 +24.11% · 2023 +27.26% · 2024 +42.86% · 2025 +52.55% · 2026 +2.72% (raw ~4-month partial, not annualised)
+- **0 account kills** across all 11 folds + 6 holdout years
+- **Sign consistency: 11/11 folds + 6/6 holdout years positive**
 
-Pre-cost. After realistic cost modeling (1.5× spread, 0.5 pip slippage, $5 commission, swap-free):
-- Worst-fold ROI: 18.47% → ~16.6% expected live (after haircuts)
-- Worst-fold DD: 7.80% → ~8.8% expected live
-- Holdout ROI: 46.24% → ~44% expected live
+These are post-cost (1.5× spread, $5/lot RT commission, swaps off, 0.5 pip slip) and governed (daily 3.5/4.5%, total 7/8%). **0.40% is the only risk level clearing both hard limits on the conservative trailing basis;** 0.50% FAILS it (trailing 10.89%, daily 5.16%) and is a gated upgrade only — see `02_validation/07_canonical_wfo.md`.
 
 ## Where it runs
 
-- **FundedNext** ($100k Challenge → funded): EET convention, 0.50% risk per trade. Primary deployment target.
+- **FundedNext** ($100k Challenge → funded): EET convention, **0.40% operating risk per trade** (0.50% is a gated, evidence-only upgrade — not routine; see `02_validation/07_canonical_wfo.md`). Primary deployment target.
 - **5ers** ($10k demo): UTC convention, 0.40% risk per trade. Secondary deployment, used for cross-broker validation and as fallback.
 
 Both run on a single Contabo Cloud VPS (Frankfurt, 4 cores, 8 GB RAM, Windows Server 2022).
@@ -65,7 +63,7 @@ The sidecar is **convention-aware**: same code, two convention paths, selected b
 
 ## What changes when going from Challenge to funded
 
-Nothing in the code or config. Same MT5 install, same sidecar service, same EA. Only the FundedNext account login changes; EA re-initializes against the new balance. Risk stays at 0.50%.
+Nothing in the code or config. Same MT5 install, same sidecar service, same EA. Only the FundedNext account login changes; EA re-initializes against the new balance. Risk stays at the 0.40% operating tier.
 
 ## How to run a sanity check
 

--- a/arc_10/01_strategy/exit_policy.md
+++ b/arc_10/01_strategy/exit_policy.md
@@ -100,7 +100,7 @@ This was quantified in the Phase 2 EET parity work and is documented as a known 
 
 ## What can go wrong
 
-- **Gap-through-SL:** If price gaps below SL on Sunday open or during a news event, fill is at the gap-open price, not the SL level. Loss exceeds 1R. This is the "tail risk" not modeled in haircuts. Mitigation: position sizing keeps single-trade max loss to 0.5% of account at worst, so even a 2-3R gap is survivable.
+- **Gap-through-SL:** If price gaps below SL on Sunday open or during a news event, fill is at the gap-open price, not the SL level. Loss exceeds 1R. This is the "tail risk" not modeled in haircuts. Mitigation: position sizing keeps single-trade max loss to ~0.40% of account at worst (the operating risk tier), so even a 2-3R gap is survivable.
 - **Broker SL ignored:** Hypothetically, a broker could decline to honor the SL order during a freeze. Not seen in practice with 5ers or FundedNext, but possible. Mitigation: EA also tracks position state and would close manually if it detected the SL wasn't filling.
 - **EA crashes mid-position:** Recovery logic reconstructs position state from broker on restart. Logs as `recovery_reconstructed` event. Trail SL is re-anchored at the last known peak (conservative).
 - **Sidecar dies but EA stays alive:** EA detects stale heartbeat (>10 minutes by default), blocks new entries, manages existing positions normally. Watchdog auto-restarts sidecar within 5 minutes.

--- a/arc_10/02_validation/01_wfo_results.md
+++ b/arc_10/02_validation/01_wfo_results.md
@@ -1,67 +1,70 @@
 # WFO Results — Arc 10 v3.0.2
 
-> **Verdict:** PASS-DEPLOYABLE on both EET and UTC conventions.
-> **Source artifact:** `results/l_arc_10_v3.0.2/step_5/wfo_results.csv` (EET), `results/l_arc_10_v3_0_2_utc_rerun/` (UTC re-validation).
-> **Methodology:** Walk-forward optimization, 11 in-sample folds (2010-2020) + 1 holdout (2021-2026).
+> **Verdict:** PASS-DEPLOYABLE at the 0.40% operating tier (FundedNext/EET, from-initial basis).
+> **Canonical source:** `02_validation/07_canonical_wfo.md` → `results/l_arc_10_v3.0.2_ea_faithful/` (EA-faithful, floating-equity sizing — the live-matched basis). The EET figures below are that run.
+> **Legacy source (indicative only):** `results/l_arc_10_v3_0_2_utc_rerun/` (UTC, linear-overlay — not re-run on floating-equity sizing).
+> **Methodology:** Walk-forward optimization, 11 in-sample folds (2010–2020) + per-year holdout (2021–2026). DD reported on both references; from-initial is FundedNext's actual MLL basis, trailing is the conservative planning anchor.
 
-## Headline numbers — EET (FundedNext target)
+## Headline numbers — EET (FundedNext), 0.40% operating tier
 
 | Metric | Value | Fold |
 |---|---|---|
-| Worst-fold ROI | 22.46% | F9 (2018) |
-| Worst-fold DD | 7.35% | F4 (2013) |
-| **Worst-fold ratio** | **6.43** | **F6 (2015) — load-bearing** |
-| Mean fold ROI | 49.87% | — |
-| Holdout ROI | 52.83% | 2021-2026 |
-| Holdout DD | 5.50% | — |
-| Sign consistency | 11/11 positive | All folds |
-| Total in-sample trades | 2,059 | — |
-| Total holdout trades | 1,093 | — |
+| Worst-fold ROI | 14.42% | F9 (2018) |
+| Mean fold ROI | 32.48% | — |
+| Worst-fold DD (from-initial) | 5.49% | F5 (2014) |
+| Worst-fold DD (trailing) | 8.21% | F10 (2019) |
+| Worst daily DD | 4.11% | F1 (2010) |
+| Holdout ROI | per year (no CAGR) | 2021–2026 |
+| Account kills | 0 | all folds + holdout |
+| Sign consistency | 11/11 folds + 6/6 holdout yrs positive | — |
+| Total in-sample trades | 2,059 | F1–F11 |
+| Total holdout trades | 1,093 | 2021–2026 |
 | **Total trades** | **3,152** | — |
 
-**Verdict:** PASS-DEPLOYABLE. Worst-fold ratio 6.43 > 2.0 gate. Worst-fold DD 7.35% < 10% hard limit. Sign consistency 11/11 holds even under 4× spread stress.
+**Verdict:** PASS-DEPLOYABLE at 0.40% on FundedNext's from-initial basis (5.49% < 8% target); PASS-VIABLE on the conservative trailing basis (8.21% < 10% hard limit). Worst daily 4.11% < 5%, 0 kills. 0.50% FAILS the trailing/daily basis (10.89% / 5.16%) and is a gated upgrade only.
 
-## Per-fold breakdown — EET, r_base 0.5%
+## Per-fold breakdown — EET, 0.40% operating tier (governed)
 
-Pre-cost overlay. Numbers from `results/l_arc_10_v3.0.2/step_5/wfo_results.csv`.
+From `results/l_arc_10_v3.0.2_ea_faithful/per_fold.csv` (governors ON). DD on both references.
 
-| Fold | Year | Trades | ROI | DD | Ratio |
+| Fold | Year | Trades | ROI | Trailing DD | From-init DD | Daily DD |
+|---|---|---|---|---|---|---|
+| F1 | 2010 | 201 | 25.07% | 8.13% | 3.00% | 4.11% |
+| F2 | 2011 | 182 | 28.09% | 7.88% | 2.53% | 3.55% |
+| F3 | 2012 | 179 | 31.81% | 4.06% | 0.17% | 1.69% |
+| F4 | 2013 | 195 | 46.88% | 7.45% | 0.61% | 2.14% |
+| F5 | 2014 | 192 | 32.30% | 6.12% | **5.49%** | 2.50% |
+| F6 | 2015 | 190 | 22.26% | 5.71% | 4.73% | 3.08% |
+| F7 | 2016 | 171 | 31.96% | 5.60% | 2.35% | 2.47% |
+| F8 | 2017 | 190 | 50.83% | 7.19% | 2.40% | 2.17% |
+| F9 | 2018 | 176 | **14.42%** | 5.32% | 0.84% | 2.20% |
+| F10 | 2019 | 195 | 34.76% | **8.21%** | 1.26% | 2.41% |
+| F11 | 2020 | 188 | 38.92% | 6.21% | 4.05% | 3.28% |
+
+Holdout, per year (never collapsed to a single CAGR):
+
+| Year | Trades | ROI | Trailing DD | From-init DD | Daily DD |
 |---|---|---|---|---|---|
-| F1 | 2010 | 201 | ~36.9% | ~3.4% | ~10.8 |
-| F2 | 2011 | 187 | ~42.1% | ~3.0% | ~14.0 |
-| F3 | 2012 | 191 | ~46.5% | ~2.3% | ~20.0 |
-| F4 | 2013 | 187 | 64.39% | **7.35%** | 8.76 |
-| F5 | 2014 | 204 | ~47.1% | ~2.6% | ~18.2 |
-| F6 | 2015 | 193 | 29.25% | 5.29% | **5.53** |
-| F7 | 2016 | 207 | ~44.0% | ~3.3% | ~13.3 |
-| F8 | 2017 | 200 | ~69.0% | ~2.5% | ~27.4 |
-| F9 | 2018 | 191 | **22.46%** | 3.39% | 6.63 |
-| F10 | 2019 | 195 | ~48.7% | ~4.5% | ~10.8 |
-| F11 | 2020 | 206 | ~54.0% | ~2.6% | ~20.6 |
-| **Holdout** | 2021-2026 | 1,093 | **52.83%** | **5.50%** | 9.60 |
+| 2021 | 212 | 38.79% | 5.95% | 1.04% | 2.50% |
+| 2022 | 179 | 24.11% | 7.05% | 1.66% | 2.25% |
+| 2023 | 189 | 27.26% | 6.71% | 0.90% | 2.02% |
+| 2024 | 191 | 42.86% | 5.57% | 2.62% | 2.46% |
+| 2025 | 251 | 52.55% | 5.83% | 3.54% | 3.22% |
+| 2026p | 71 | +2.72% (raw ~4-mo partial) | 4.74% | 0.61% | 1.99% |
 
 **Key observations:**
 
-1. **F4 2013 has the highest absolute DD** (7.35%) but excellent ROI (64.39%) — high-volatility year, system traded through with good R-multiples but with one or more chunky drawdown periods.
-2. **F6 2015 has the worst ratio** (5.53) — moderate ROI vs higher relative DD. Likely impacted by CHF-pegging crisis early in the year.
-3. **F9 2018 has lowest ROI** (22.46%) — calm year with fewer signals; system held its discipline.
-4. **F8 2017 was the best fold** (69% ROI) — strong trending year, runner trails captured well.
-5. **Holdout** (5 years, 1,093 trades) shows the system maintains its edge out-of-sample at 52.83% annualized.
+1. **Worst-fold ROI is F9 2018 (14.42%)** — a calm, low-signal year; the system held discipline and still returned double digits.
+2. **Worst trailing DD is F10 2019 (8.21%); worst from-initial DD is F5 2014 (5.49%).** FundedNext measures on from-initial, where the worst fold sits comfortably under the 8% in-system target.
+3. **Worst daily DD is F1 2010 (4.11%)** — the May 2010 Flash Crash fold; the close-all governor fired but no account was killed (`governor_log.csv`).
+4. **F8 2017 was the strongest fold** (50.83% ROI) — strong trending year, runner trails captured well.
+5. **All 6 holdout years positive,** maintaining the edge out-of-sample at the 0.40% operating tier.
 
-## Headline numbers — UTC (5ers target)
+## UTC (5ers, secondary) — legacy linear-overlay WFO
 
-| Metric | Value | Fold |
-|---|---|---|
-| Worst-fold ROI | 26.49% | F6 |
-| Worst-fold DD | 9.22% | F4 |
-| Worst-fold ratio | 5.42 | F6 |
-| Mean fold ROI | 49.87% | — |
-| Holdout ROI | 59.07% | 2021-2026 |
-| Holdout DD | 5.30% | — |
-| Sign consistency | 11/11 positive | All folds |
-| Total trades | 3,152 | — |
+> **Not re-run on the EA-faithful floating-equity basis.** The 5ers/UTC path is secondary; the canonical numbers above are EET/FundedNext (floating-equity, the live-matched basis). The earlier UTC WFO used linear-overlay sizing and is retained for reference only at `results/l_arc_10_v3_0_2_utc_rerun/`. Treat its figures as indicative, not canonical, until a floating-equity UTC run is produced.
 
-**Same strategy, same signals, different aggregation convention.** Trade count identical (signal logic is convention-agnostic), per-fold P&L differs due to which trading day a given trade falls into for DD computation.
+**Same strategy, same signals, different aggregation convention.** Trade count is identical (signal logic is convention-agnostic, 3,152 total); per-fold P&L differs only in which broker-day a trade's DD falls into. Under UTC with swaps ON, the realistic central cost cell breached the 10% hard limit at r_base 0.5%, which is why 5ers deploys at 0.40% (see `05_cost_sweep.md`). No floating-equity re-validation has been run for UTC; the EA-faithful canonical applies to FundedNext/EET only.
 
 ## Why EET vs UTC differs structurally
 
@@ -81,7 +84,7 @@ For full cost-adjusted comparison see `02_validation/05_cost_sweep.md`.
 - **Strategy edge in live markets post-2026.** WFO uses historical data; live performance could differ if market structure changes substantially.
 - **Robustness to broker-specific microstructure.** The validation assumes broker spreads, slippage, and fills similar to HistData / 5ers / FundedNext panel-diff samples. Other brokers untested.
 - **Robustness to extreme tail events.** CHF 2015 was in the data and the system survived F6 with 29% ROI / 5.29% DD. A similar event with worse pre-emptive positioning could exceed historical worst-case.
-- **Performance at higher risk levels.** Tested at r_base 0.5%; scaling risk linearly assumes linear scaling of all metrics, which holds in theory but has lot-size rounding effects (see `tests/protocol_runtime/test_risk_decoupling_invariant.py` — pre-existing flake noted, not a deployment blocker).
+- **Performance at higher risk levels.** Swept at 0.40% and 0.50%; 0.50% FAILS the conservative trailing/daily basis and is gated (`07_canonical_wfo.md`). Risk scaling has lot-size rounding effects (see `tests/protocol_runtime/test_risk_decoupling_invariant.py` — pre-existing flake noted, not a deployment blocker).
 
 ## Cross-arc sign consistency check
 
@@ -96,12 +99,12 @@ For each of the 11 folds + holdout: was the fold positive?
 
 ## What r_base means
 
-The WFO ran at `risk_per_trade = 0.005` (0.5% per trade). For deployment, risk was adjusted per broker:
+The WFO was swept at `risk_per_trade` ∈ {0.40%, 0.50%}. Deployment runs at the **0.40% operating tier**:
 
-- **FundedNext (EET):** Deploy at r_base 0.50%. Stress cells recommend scaling to 0.49% in adverse; central case is 0.51%. Net: deploy at r_base, accept central case worst-fold DD 7.80% with 2.2pp margin to 10% hard limit.
-- **5ers (UTC):** Deploy at r_safe 0.40%. UTC at r_base 0.5% breaches 10% DD hard limit on realistic central cell (10.47%). Linear scaling to 0.40% brings central worst-fold DD to 8.38%, 1.6pp margin.
+- **FundedNext (EET):** Deploy at **0.40%** — worst-fold DD 5.49% from-initial / 8.21% trailing, daily 4.11%, 0 kills. The only level clearing both hard limits on the conservative trailing basis. 0.50% FAILS (trailing 10.89% > 10%, daily 5.16% > 5%) and is a gated upgrade only (`07_canonical_wfo.md`, `04_runbook/09_risk_and_payout_protocol.md`).
+- **5ers (UTC):** Deploy at 0.40%. The legacy UTC cost sweep showed r_base 0.5% breaching the 10% hard limit on the realistic central cell; 0.40% is the secondary-path operating level (not re-run on floating-equity sizing).
 
-Risk locking rationale documented in `02_validation/05_cost_sweep.md` and `05_history/02_decisions_log.md`.
+Risk rationale documented in `02_validation/07_canonical_wfo.md`, `05_cost_sweep.md`, and `05_history/02_decisions_log.md`.
 
 ## Full data location
 

--- a/arc_10/02_validation/05_cost_sweep.md
+++ b/arc_10/02_validation/05_cost_sweep.md
@@ -2,7 +2,9 @@
 
 > **Source artifact:** `results/l_arc_10_v3.0.2/fundednext_cost_sweep/fundednext_cost_sweep_report.md` (full report) + `results/l_arc_10_v3.0.2/fundednext_cost_sweep/`
 > **Verdict:** EET is the deployable venue. UTC remains viable as fallback.
-> **Risk locked:** 0.50% EET (FundedNext) / 0.40% UTC (5ers).
+> **Operating risk: 0.40% (both venues).** The 0.50% column FAILS the conservative trailing/daily basis — gated upgrade only.
+>
+> ⚠️ **Basis note (read first).** The grids below are the **legacy linear-overlay cost-sensitivity sweep.** They establish the canonical **cost basis** — cell 5 = 1.5× spread, $5/lot RT commission, swaps off, 0.5 pip slip — and prove sign-consistency under spread stress; that analysis stands. But the **absolute ROI/DD outputs and the risk decision are superseded** by the EA-faithful floating-equity run at 0.40%: `02_validation/07_canonical_wfo.md` → `results/l_arc_10_v3.0.2_ea_faithful/`. Where a grid cell's ROI/DD differs from the canonical doc, the canonical doc wins. Read the grids for cost *sensitivity*, not for deployable absolutes.
 
 ## Executive summary
 
@@ -12,16 +14,15 @@
 | Commission | $5/lot RT | $4/lot RT |
 | Daily-DD boundary | EET (broker midnight) | UTC (midnight) |
 | Max DD limit | 10% | 10% |
-| **Backtest worst-fold ratio (central cell)** | **5.44** | **2.43** |
-| **Backtest worst-fold DD (central cell)** | **7.80%** | **10.47%** |
-| **Backtest worst-fold ROI (central cell)** | **18.47%** | **12.90%** |
-| **Backtest holdout ROI (central cell)** | **46.24%** | **34.94%** |
-| Recommended risk | **0.50%** (r_base) | **0.40%** |
-| Expected live holdout ROI | **~44%** | **~28%** |
-| Expected live worst-fold DD | **~8.8%** | **~9.5%** |
-| Verdict | **PASS-DEPLOYABLE** | **DD-tight, deployable with discipline** |
+| Canonical cost basis | cell 5: 1.5× spread / 0.5 slip / swaps off | cell 10: 1.5× spread / 0.5 slip / swaps ON |
+| **Operating risk** | **0.40%** | **0.40%** |
+| **Worst-fold ROI @ 0.40% (EA-faithful)** | **14.42%** | legacy — not re-run on floating-equity |
+| **Worst-fold DD @ 0.40% (EA-faithful)** | **5.49% from-init / 8.21% trailing** | legacy — see UTC note in `01_wfo_results.md` |
+| **Worst daily DD @ 0.40%** | **4.11%** | legacy |
+| **Holdout @ 0.40%** | per-year (no CAGR), 6/6 positive | legacy |
+| Verdict | **PASS-DEPLOYABLE (from-init) / PASS-VIABLE (trailing)** | secondary, deploy at 0.40% with discipline |
 
-**EET wins on every economic axis.** UTC remains deployable but with thinner margins and lower returns.
+**EET is the deployable venue** — swap-free turns the cost economics favourable. The EA-faithful absolute outputs are in `07_canonical_wfo.md`; the grids below show cost *sensitivity* on the legacy linear-overlay basis. UTC has not been re-run on floating-equity sizing — treat its figures as indicative.
 
 ## Methodology
 
@@ -38,13 +39,15 @@ Both sweeps verified clean: G1–G4 correctness gates passed, baseline reproduct
 
 ## EET Results (FundedNext)
 
-### Baseline (pre-cost overlay)
+### Baseline (canonical, EA-faithful)
 
-From `results/l_arc_10_v3.0.2/` EET WFO. PASS-DEPLOYABLE: worst-fold ratio 6.43, worst-fold DD 7.35%, holdout 52.83%.
+EA-faithful floating-equity run at the 0.40% operating tier: worst-fold ROI 14.42% (F9 2018), worst-fold DD 5.49% from-initial / 8.21% trailing, worst daily 4.11%, 0 kills. PASS-DEPLOYABLE on from-initial. Source: `07_canonical_wfo.md` → `results/l_arc_10_v3.0.2_ea_faithful/`.
 
-See `01_wfo_results.md` for full per-fold breakdown.
+See `01_wfo_results.md` and `07_canonical_wfo.md` for the full per-fold breakdown.
 
-### 15-cell grid at r_base = 0.5%
+### 15-cell cost-sensitivity grid (legacy linear-overlay, r_base 0.5%)
+
+> Cost *sensitivity* only — absolute ROI/DD superseded by `07_canonical_wfo.md`. The cell-5 (1.5× / 0.5 slip) cost definition is retained as the canonical cost basis.
 
 | Cell | Spread | Slip | Ratio | DD | Worst ROI | Mean ROI | Holdout ROI | Holdout DD | Verdict |
 |---|---|---|---|---|---|---|---|---|---|
@@ -64,27 +67,19 @@ See `01_wfo_results.md` for full per-fold breakdown.
 | 14 | 4.0× | 0.5 | 1.85 | 9.70% | 8.83% | 25.85% | 29.85% | 8.73% | FAIL (ratio) |
 | 15 | 4.0× | 1.0 | 1.62 | 9.85% | 7.68% | 24.36% | 28.03% | 8.92% | FAIL (ratio) |
 
-**Sign consistency 11/11 in every cell of the EET grid**, including 4× spread stress. Worst fold by ROI: F9 (2018) at 18.47%. Worst fold by DD: F4 (2013) at 7.80%.
+**Sign consistency 11/11 in every cell of the EET grid**, including 4× spread stress — the load-bearing robustness result, and it holds on the EA-faithful run too. (The per-cell ROI/DD above are legacy linear-overlay sensitivity figures; canonical absolutes at 0.40% are worst ROI 14.42% / worst DD 5.49% from-init / 8.21% trailing — see `07_canonical_wfo.md`. The worst-DD fold under EA-faithful is F10 2019 on trailing and F5 2014 on from-initial, not F4 2013.)
 
 ### Recommended risk for EET
 
-Per Amendment 3 linear scaling: `r_recommended = 0.005 × (0.080 / worst_DD_at_r_base)`.
+**Recommendation: deploy at the 0.40% operating tier.**
 
-| Reference cell | Worst DD @ r_base | r_recommended |
-|---|---|---|
-| Optimistic (1.0× / 0.5 slip) | 7.49% | 0.0053 |
-| **Central (1.5× / 0.5 slip)** | **7.80%** | **0.0051** |
-| Adverse (2.0× / 1.0 slip) | 8.20% | 0.0049 |
-
-**Recommendation: deploy at r_base = 0.50%.**
-
-Justification: r_recommended barely moves off r_base across the realistic band (0.49%–0.53%). The pool sits at the 8% DD target at 0.5% risk, leaving essentially no headroom to scale risk up. The adverse cell actually recommends scaling *down* to 0.49%. Deploying at 0.50% accepts the central-case worst-fold DD of 7.80% with hard-limit margin to 10%.
+The legacy Amendment-3 linear-scaling exercise suggested ~0.50% on the linear-overlay basis. The EA-faithful floating-equity run supersedes it: at **0.50%** worst-fold DD is **10.89% trailing / 6.85% from-initial**, daily **5.16%** — the trailing and daily figures FAIL the hard limits. At **0.40%** worst-fold DD is **8.21% trailing / 5.49% from-initial**, daily **4.11%**, 0 kills — the only level clearing both hard limits on the conservative trailing basis. 0.50% is a gated, evidence-only upgrade (`07_canonical_wfo.md`; `04_runbook/09_risk_and_payout_protocol.md` §7), not the deploy level.
 
 ## UTC Results (5ers)
 
-### Baseline (pre-cost overlay)
+### Baseline (legacy linear-overlay — not re-run on floating-equity)
 
-PASS-DEPLOYABLE but tighter: worst-fold ratio 5.42, worst-fold DD 9.22%, holdout 59.07%.
+UTC was tighter than EET on the legacy linear-overlay WFO (swaps ON dominate the cost surface). It has **not** been re-validated on the EA-faithful floating-equity basis; treat UTC figures as indicative and deploy the secondary path at 0.40%. See the UTC note in `01_wfo_results.md`.
 
 ### 30-cell grid at r_base = 0.5%
 
@@ -150,18 +145,21 @@ Backtest numbers above are pre-deployment. Expected live applies haircuts for un
 - Mean / holdout DD: × 1.05
 - Worst-fold DD: × 1.13
 
-### EET expected live (r = 0.50%, central cell)
+### EET expected live (0.40% operating tier)
 
-| Metric | Backtest | Expected live |
-|---|---|---|
-| Worst-fold ROI | 18.47% | **~16.6%** |
-| Worst-fold DD | 7.80% | **~8.8%** |
-| Worst-fold ratio | 5.44 | ~3.4 |
-| Mean fold ROI | 43.50% | **~41.3%** |
-| Holdout ROI | 46.24% | **~43.9%** |
-| Holdout DD | 6.17% | **~6.5%** |
+The EA-faithful canonical run already models cell-5 costs and the governors, so its 0.40% figures **are** the modelled-live expectation — no separate haircut overlay is applied. The only residual not in the model is the intrabar tick-gap (live-only).
 
-Worst-fold DD ~8.8% leaves ~1.2pp to the 10% hard limit.
+| Metric | EA-faithful @ 0.40% |
+|---|---|
+| Worst-fold ROI | 14.42% (F9 2018) |
+| Mean-fold ROI | 32.48% |
+| Worst-fold DD (from-initial) | 5.49% (F5 2014) — 2.5pp margin to 8% target |
+| Worst-fold DD (trailing) | 8.21% (F10 2019) — 1.8pp margin to 10% hard limit |
+| Worst daily DD | 4.11% (F1 2010) — under 5% |
+| Holdout | per-year, 6/6 positive (no CAGR) |
+| Kills | 0 |
+
+Source: `07_canonical_wfo.md`. The legacy haircut method above applied to the superseded linear-overlay 0.50% run and is retained only for historical context.
 
 ### UTC expected live (r = 0.40%, central cell)
 
@@ -181,13 +179,13 @@ Worst-fold DD ~9.5% leaves ~0.5pp to the 10% hard limit. Tighter margin than EET
 ### Primary: EET on FundedNext
 
 Economic case is decisive:
-- ~1.7× holdout ROI vs UTC (44% vs 26.6% expected live)
+- materially higher holdout ROI vs UTC (swap-free removes the dominant UTC cost vector; canonical FundedNext per-year holdout in `07_canonical_wfo.md`, UTC not re-run on floating-equity)
 - ~0.7pp more DD margin to the 10% hard limit
 - Higher ratio cushion across every realistic cell
 - 11/11 sign consistency holds even at 4× spread stress
 
 **Deployment parameters:**
-- Risk: 0.50% per trade (r_base, no scaling needed)
+- Risk: 0.40% per trade (operating tier; 0.50% gated upgrade only)
 - Account: FundedNext $100k Challenge + swap-free add-on (non-negotiable)
 - Commission expectation: $5/lot round-turn
 - Spread expectation: 1×–1.5× HistData baseline (verified via demo)
@@ -217,7 +215,7 @@ UTC is deployable, but with materially lower returns and thinner DD margin. The 
 
 ## Bottom line
 
-**EET on FundedNext is the deployable venue. Deploy at r = 0.50% once MT5 parity is verified** (done — see `02_phase_2_parity_eet.md`).
+**EET on FundedNext is the deployable venue. Deploy at the 0.40% operating tier** (MT5 parity verified — see `02_phase_2_parity_eet.md`; canonical numbers in `07_canonical_wfo.md`).
 
 UTC on 5ers remains a viable fallback at r = 0.40% with ~27% expected live ROI.
 

--- a/arc_10/02_validation/07_canonical_wfo.md
+++ b/arc_10/02_validation/07_canonical_wfo.md
@@ -1,0 +1,98 @@
+# Canonical WFO — Arc 10 v3.0.2 (EA-faithful, floating-equity)
+
+> **This is the source of truth for every Arc 10 number.** All other validation docs resolve to the figures here. Where an older doc still cites a different ROI/DD, this doc wins and that doc is stale.
+> **Source artifacts (committed, tracked):** `results/l_arc_10_v3.0.2_ea_faithful/` — `matrix.csv`, `per_fold.csv`, `governor_log.csv`, `EA_FAITHFUL_WFO.md`. Every figure below traces to those CSVs. Nothing here is asserted without a CSV row behind it.
+
+## Why this run is canonical
+
+This is the first WFO whose **position sizing matches what trades live.** The live EA sizes every entry as `risk_amount = ACCOUNT_EQUITY × r_base` with equity **including floating open P&L**, re-read per entry (`PositionManager.mqh:143`). This run reproduces that exactly: `mult = r_base × (realized + Σ open floating MtM)` at each entry, equity stepping continuously on floating marks and on closes, per-fold reset. Earlier runs sized linearly or off closed balance — close, but not what the broker sees. The basis correction is the whole point: it measures the **procyclical concurrency tail** (entries size larger when the open book is up, into a possible reversal) that linear/closed sizing cannot see.
+
+## The basis (state this wherever these numbers are quoted)
+
+| Dimension | Setting |
+|---|---|
+| Convention | EET (FundedNext broker trading day) |
+| Sizing | **Floating-equity** — `ACCOUNT_EQUITY × r_base`, floating P&L included, re-read per entry (matches live EA) |
+| Cost cell | Cell 5: **swaps OFF** (FundedNext swap-free add-on), **1.5× spread**, **$5/lot RT commission**, **0.5 pip slip × n_fills** (n_fills = 3 if TP1 hit else 2) |
+| Governors | **ON** — daily 3.5% halt / 4.5% close-all; total 7% halt / 8% close-all |
+| Exit | `sl_partial_close_1r_runner_trail` @ **3.5× ATR** initial SL |
+| Universe | 28-pair ex-ante bounded population |
+| Risk levels swept | r_base ∈ {0.40%, 0.50%} |
+| DD references | **BOTH** reported. **From-initial = FundedNext's actual MLL basis.** Trailing = conservative planning anchor. |
+| Determinism | `random_state=42`, `n_jobs=1`, `lineterminator="\n"`; frame sha `05dea9…9ee58a` |
+
+**No CAGR anywhere.** Search folds F1–F11 are annualised over their own ~1-year span. Holdout is reported **per year** (2021–2025 full + 2026 raw partial). The 2026 figure is a **raw ~4-month partial return, never annualised.**
+
+## Canonical matrix (`matrix.csv`)
+
+| risk% | gov | worst-fold ROI% | mean-fold ROI% | trailing DD% | from-init DD% | daily DD% | kills | verdict (trailing) | verdict (from-init) |
+|---|---|---|---|---|---|---|---|---|---|
+| **0.40** | on | **14.42** | **32.48** | **8.21** | **5.49** | **4.11** | **0** | PASS-VIABLE | **PASS-DEPLOYABLE** |
+| 0.40 | off | 14.42 | 32.48 | 8.21 | 5.49 | 4.11 | 0 | PASS-VIABLE | PASS-DEPLOYABLE |
+| 0.50 | off | 18.23 | 41.86 | 10.16 | 6.85 | 5.16 | 0 | **FAIL** | PASS-DEPLOYABLE |
+| 0.50 | on | 18.23 | 40.95 | 10.89 | 6.85 | 5.16 | 0 | **FAIL** | PASS-DEPLOYABLE |
+
+- **0.40% is the deployable operating tier.** Only level clearing both hard limits on the conservative trailing basis (8.21% < 10% trailing, 4.11% < 5% daily) AND PASS-DEPLOYABLE on FundedNext's actual from-initial basis (5.49% < 8% target). 0 kills.
+- **0.50% FAILS on the trailing basis** (10.89% gov-on > 10% hard limit; daily 5.16% > 5%). It passes only on the from-initial basis (6.85%). It is marginal and gated, not a routine step — see §"Risk position" and `../04_runbook/09_risk_and_payout_protocol.md`.
+- Worst-fold ROI is **F9 2018** (14.42% / 18.23%). Worst trailing DD is **F10 2019** (8.21%) at 0.40%, **F1 2010** (10.89%) at 0.50% gov-on. Worst from-init is **F5 2014** (5.49% / 6.85%). Worst daily is **F1 2010** (4.11% / 5.16%).
+
+## Full per-fold + per-holdout-year (`per_fold.csv`, 0.40% governed — the operating config)
+
+| fold | yr | n | ROI% | trailing DD% | from-init DD% | daily DD% | kills | fires |
+|---|---|---|---|---|---|---|---|---|
+| F1 | 2010 | 201 | 25.07 | 8.13 | 3.00 | 4.11 | 0 | 1 |
+| F2 | 2011 | 182 | 28.09 | 7.88 | 2.53 | 3.55 | 0 | 1 |
+| F3 | 2012 | 179 | 31.81 | 4.06 | 0.17 | 1.69 | 0 | 0 |
+| F4 | 2013 | 195 | 46.88 | 7.45 | 0.61 | 2.14 | 0 | 0 |
+| F5 | 2014 | 192 | 32.30 | 6.12 | **5.49** | 2.50 | 0 | 0 |
+| F6 | 2015 | 190 | 22.26 | 5.71 | 4.73 | 3.08 | 0 | 0 |
+| F7 | 2016 | 171 | 31.96 | 5.60 | 2.35 | 2.47 | 0 | 0 |
+| F8 | 2017 | 190 | 50.83 | 7.19 | 2.40 | 2.17 | 0 | 0 |
+| F9 | 2018 | 176 | **14.42** | 5.32 | 0.84 | 2.20 | 0 | 0 |
+| F10 | 2019 | 195 | 34.76 | **8.21** | 1.26 | 2.41 | 0 | 0 |
+| F11 | 2020 | 188 | 38.92 | 6.21 | 4.05 | 3.28 | 0 | 0 |
+| **2021** | 2021 | 212 | 38.79 | 5.95 | 1.04 | 2.50 | 0 | 0 |
+| **2022** | 2022 | 179 | 24.11 | 7.05 | 1.66 | 2.25 | 0 | 0 |
+| **2023** | 2023 | 189 | 27.26 | 6.71 | 0.90 | 2.02 | 0 | 0 |
+| **2024** | 2024 | 191 | 42.86 | 5.57 | 2.62 | 2.46 | 0 | 0 |
+| **2025** | 2025 | 251 | 52.55 | 5.83 | 3.54 | 3.22 | 0 | 0 |
+| **2026p** | 2026 | 71 | **2.72 (raw ~4-mo partial)** | 4.74 | 0.61 | 1.99 | 0 | 0 |
+
+Mean-fold ROI 32.48% is the simple mean of F1–F11. Sign consistency: **11/11 search folds positive, 6/6 holdout years positive.** Governor fires at 0.40% governed: F1 + F2 daily-halt (1 each), **0 kills, 0 close-alls.** Full per-row figures (incl. 0.50% cells) in `per_fold.csv`.
+
+## Supersession chain
+
+Every run below is retained on disk and self-validates against the **9.22% reconstruction gate**: a linear (`mult ≡ r_base`) + zero-cost reduction reproduces the **9.22%** portfolio worst-fold trailing DD (F4 2013), proving the reconstruction (`build_schedules`, open-book marks, `_flat`) is sound before any sizing variation is layered on.
+
+| Run | Sizing basis | Status | Folder |
+|---|---|---|---|
+| **EA-faithful** | **floating equity (live-matched)** | **CANONICAL** | `results/l_arc_10_v3.0.2_ea_faithful/` |
+| Canonical compound | closed equity (`e_bal`, realized only) | superseded | `results/l_arc_10_v3.0.2_canonical_compound/` |
+| Canonical linear | linear `mult ≡ r_base` | superseded | `results/l_arc_10_v3.0.2_canonical/` |
+| Governed/floating, ungoverned sequential | intermediate validation variants | superseded | (within above) |
+
+The only difference between EA-faithful and the compound run is per-entry sizing (floating equity vs closed `e_bal`); reconstruction is reused verbatim. The linear→compound step was a benign +0.30pp; the compound→floating step is the procyclical tail (§ below).
+
+## Findings appendix
+
+**Procyclical amplification (`EA_FAITHFUL_WFO.md` §4, 0.50% gov-on):** sizing off floating equity vs closed equity moves worst-fold trailing DD from 10.73% → 10.89% = **+0.16pp**; from-init 6.89% → 6.85% (−0.04pp); daily 5.00% → 5.16% (+0.15pp); mean-fold ROI 40.72% → 40.95% (+0.23pp). **Benign** — floating sizing amplifies DD only marginally when the open book is up. (These four figures are from the cross-run comparison in `EA_FAITHFUL_WFO.md`, derived from the compound and floating CSVs.)
+
+**Daily-DD sweep — keep close-all at 4.5%:** the worst daily-DD event is **F1 2010 at 5.16%** (`per_fold.csv`, 0.50%), where the governor fired both `daily_halt` (2010-04-27) and `daily_close_all` (2010-05-06 — the Flash Crash) with **0 kills** (`governor_log.csv`). That event is a single-bar gap: the daily DD is threshold-invariant — lowering the close-all below 4.5% does not catch it sooner (price gaps straight through) and only costs ROI on benign days. **Governors stay 3.5/4.5 daily, 7/8 total.**
+
+**Gap risk is single-currency bounded, not portfolio-wide.** A news spike hits one currency's correlated cluster (e.g. an EUR or GBP event), not all 28 pairs at once — peak concurrent exposure on such an event is ~5%, not portfolio-wide. Weekend gaps reset the daily measure (Monday opens fresh) but accrue to total DD. The CSV evidence: even the Flash Crash fold killed 0 accounts and stayed within the from-initial basis.
+> *Source note:* the ~5% single-currency peak and the close-all flatten-budget figure below come from the operator daily-DD + gap sweep that calibrated the governors; they are **not** rows in the EA-faithful `matrix.csv`/`per_fold.csv`. The governor-fire pattern and the 5.16% daily figure that anchor them **are** CSV-sourced (`governor_log.csv`, `per_fold.csv`).
+
+**Slippage is not the binding risk.** The close-all flatten budget is ~11 pips/position on the worst concurrent flatten (F1 2010, ~12-position book) versus a realistic ~1–2 pip fill → roughly **5× margin**. The binding residual is the **intrabar tick-gap assumption** (open-book marked at H4-bar resolution, not tick), which is only resolvable with live data.
+
+## Risk position (canonical — mirrored in `../04_runbook/09_risk_and_payout_protocol.md`)
+
+- **0.40% = launch / operating tier.** The only level clearing both hard limits (trailing 8.21% < 10%, daily 4.11% < 5%, 0 kills) and PASS-DEPLOYABLE on FundedNext's from-initial basis (5.49%).
+- **0.50% = marginal, gated — NOT a routine buffer-triggered step.** FAILS trailing (10.89% > 10%) and daily (5.16% > 5%) on the conservative basis; passes only from-initial (6.85%). Viable only after a substantial banked buffer **and** a live gap-event confirms the tick EA caps daily under 5%. It is a future evidence-gated upgrade, not an automatic step.
+- **MLL is static from-initial.** FundedNext's Maximum Loss Limit is 10% of initial; the floor does not re-base on scaling (retained profit expands room within a tier). The EA total-DD floor is now an operator-set input, fail-loud (OPEN-001 resolved — see `../05_history/07_open_issue_dd_restart_rebaselining.md`).
+
+## Honesty constraints
+
+- **Canonical for the MODELLED system, not ground truth.** Two unclosable gaps remain: (1) intrabar tick resolution — the open book is marked at H4-bar resolution of the intrabar low, a tick trigger could differ; (2) live close-all slippage on N concurrent positions is unmodelled (budgeted ~5× safe above, but not proven live).
+- The **tick-gap assumption is the live-only residual.** Everything else is settled in backtest.
+- Same-bar entry order is the deterministic trade-id tiebreak (H4 has no finer timestamp); same-bar opens contribute ~0 floating (offset-0 mark).
+- Every figure in this doc traces to a row in `results/l_arc_10_v3.0.2_ea_faithful/`. The CSVs are not duplicated here beyond the key rows; read them for full precision.

--- a/arc_10/03_deployment/03_fundednext_setup.md
+++ b/arc_10/03_deployment/03_fundednext_setup.md
@@ -86,13 +86,12 @@ Tools → Options → Expert Advisors:
 
 ## Risk per trade rationale
 
-0.50% locked per cost sweep (`02_validation/05_cost_sweep.md`):
+**0.40% operating tier**, locked per the EA-faithful canonical run (`02_validation/07_canonical_wfo.md`):
 - FundedNext is swap-free → strict improvement vs UTC (no dominant swap cost)
-- At r_base 0.5%, central case (1.5× spread, swap-OFF, 0.5 slip) lands at 7.80% worst-fold DD — within target
-- Adjacent cells recommend 0.49% (adverse) to 0.53% (optimistic) — band spans r_base
-- Deploy at 0.50%, accept central case with 2.2pp margin to 10% hard limit
+- At 0.40% (floating-equity sizing, cell-5 costs, governed): worst-fold DD **5.49% from-initial / 8.21% trailing**, worst daily **4.11%**, 0 kills — the only level clearing both hard limits on the conservative trailing basis
+- 0.50% FAILS (10.89% trailing / 5.16% daily) — gated, evidence-only upgrade, not the deploy level (`04_runbook/09_risk_and_payout_protocol.md` §7)
 
-Expected live (after haircuts): worst-fold DD ~8.8%, worst-fold ratio ~3.4, holdout ROI ~44%.
+Modelled-live figures (EA-faithful already includes costs + governors): worst-fold DD 5.49% from-initial / 8.21% trailing; holdout per-year, 6/6 positive (no CAGR).
 
 ## Connection details (operational)
 
@@ -106,13 +105,13 @@ Expected live (after haircuts): worst-fold DD ~8.8%, worst-fold ratio ~3.4, hold
 
 | Item | Value |
 |---|---|
-| Risk per trade ($) | $500 (0.50% of $100k) |
+| Risk per trade ($) | $400 (0.40% of $100k) |
 | SL distance | 3.5 × ATR_at_signal |
 | Commission | $5 per lot round-turn |
 | Swap | None (swap-free add-on) |
 | Average expected R per trade | ~0.7-0.9R (cost sweep central case) |
-| Expected trades per year | ~225 |
-| Expected annual ROI (cost-adjusted) | ~44% (after haircuts) |
+| Expected trades per year | ~190-210 |
+| Expected annual ROI | mean-fold 32.48%; holdout per-year 24–53% (no CAGR) |
 
 ## Challenge phase rules (verify current rules before buying)
 
@@ -173,11 +172,11 @@ In MT5:
 
 ## Risk ramp for first weeks live
 
-Don't deploy at full 0.50% on day one. Ramp:
+Don't deploy at the full 0.40% operating tier on day one. Ramp:
 
 - **Week 1:** Risk_Per_Trade = `0.0020` (0.20%, $200/trade)
 - **Week 2:** if Week 1 clean → `0.0030` (0.30%)
-- **Week 3+:** if Week 2 clean → `0.0050` (0.50%, target)
+- **Week 3+:** if Week 2 clean → `0.0040` (0.40%, operating tier)
 
 If anything anomalous happens in any week, hold or scale back. Don't ramp up under pressure.
 
@@ -188,7 +187,7 @@ If anything anomalous happens in any week, hold or scale back. Don't ramp up und
 | Account credentials | Demo login | Challenge login | Funded login |
 | Sidecar | Same | Same | Same |
 | EA | Same | Same | Same |
-| Risk | 0.20-0.50% (ramping) | 0.50% | 0.50% |
+| Risk | 0.20-0.40% (ramping) | 0.40% | 0.40% |
 | Hard DD limit | 10% | 10% | 10% |
 | Profit target | N/A | +8% (Phase 1) | None |
 | Profit split | N/A | None (challenge) | 80% |
@@ -200,4 +199,4 @@ After first overnight position holds, check the trade in MT5's history:
 - View → Reports → click trade
 - Check "Swap" column: should be `0.00` for ALL closed trades that held overnight
 
-If swap is NOT 0 on swap-eligible trades, swap-free add-on is not active. Contact FundedNext support immediately. **Don't continue trading at 0.50% risk if swap is being applied** — cost sweep economics break.
+If swap is NOT 0 on swap-eligible trades, swap-free add-on is not active. Contact FundedNext support immediately. **Don't continue trading if swap is being applied** — the swap-free assumption underpins the EET cost economics, and at any risk level the daily/total DD margin erodes once swap is charged.

--- a/arc_10/03_deployment/05_config_artifacts.md
+++ b/arc_10/03_deployment/05_config_artifacts.md
@@ -207,7 +207,7 @@ Get-Content "C:\Users\Administrator\AppData\Roaming\MetaQuotes\Terminal\Common\F
 
 ## What you CAN change without re-validation
 
-- `Risk_Per_Trade` between 0% and the recommended max (0.5%/0.4%) — pure linear scaling, no edge changes
+- `Risk_Per_Trade` between 0% and the 0.40% operating tier — pure linear scaling, no edge changes. (0.50% is a gated upgrade, not a free knob — see `04_runbook/09_risk_and_payout_protocol.md` §7.)
 - `Sidecar_Heartbeat_Max_Age_Sec` (looser = more tolerant of sidecar lag, tighter = faster halt on issues)
 - `News_*` parameters (slight changes to news handling don't affect strategy)
 - `Signal_Poll_Min_Interval_Sec` (responsiveness vs CPU)

--- a/arc_10/03_deployment/06_broker_specs.md
+++ b/arc_10/03_deployment/06_broker_specs.md
@@ -74,23 +74,23 @@ Locked at **0.40% per trade**. Rationale: cost sweep central case at r_base 0.5%
 
 ### Risk for Arc 10
 
-Locked at **0.50% per trade** (r_base). Rationale: cost sweep central case at r_base 0.5% lands at 7.80% worst-fold DD, 2.2pp margin to 10% limit. No scaling needed.
+Locked at the **0.40% operating tier**. Rationale (EA-faithful floating-equity, `02_validation/07_canonical_wfo.md`): at 0.40% worst-fold DD is 5.49% from-initial / 8.21% trailing, daily 4.11%, 0 kills — the only level clearing both hard limits on the conservative trailing basis. 0.50% FAILS (10.89% trailing / 5.16% daily) and is a gated upgrade only.
 
 ## Cross-broker comparison
 
 | Item | 5ers | FundedNext |
 |---|---|---|
 | Account size we use | $10k demo | $100k Challenge → funded |
-| Risk per trade | 0.40% | 0.50% |
-| Risk dollars/trade | $40 | $500 |
+| Risk per trade | 0.40% | 0.40% (operating; 0.50% gated) |
+| Risk dollars/trade | $40 | $400 |
 | Commission | $4/lot RT | $5/lot RT |
 | Swap | ON (real cost) | OFF (swap-free) |
 | Bar anchor | UTC | EET |
 | Max DD | 10% | 10% |
 | Daily DD | 5% | 5% |
 | Profit split | 80% | 80% |
-| Expected live ROI | ~27% | ~44% |
-| Expected worst-fold DD | ~9.5% | ~8.8% |
+| Expected ROI @ 0.40% | legacy (not re-run on floating-equity) | mean-fold 32.48%; holdout 24–53%/yr (no CAGR) |
+| Worst-fold DD @ 0.40% | legacy | 5.49% from-init / 8.21% trailing |
 
 ## What FundedNext rules to verify before purchasing Challenge
 
@@ -131,7 +131,7 @@ The sidecar + EA work against any MT5 broker. Adding a new broker requires:
 
 ## On the swap-free add-on with FundedNext
 
-The cost sweep analysis is **critically dependent** on swap-free being applied. Under UTC convention (swap on), worst-fold DD at r_base 0.5% is 10.47% — breaches the 10% hard limit. Under EET with swap-off, it's 7.80% — safely within bounds.
+The cost economics are **critically dependent** on swap-free being applied. With swap ON, swap is the dominant cost vector and erodes the DD margin (the legacy UTC sweep breached the 10% hard limit at r_base 0.5%). With swap OFF (EET, FundedNext), the EA-faithful run at 0.40% lands at 5.49% from-initial / 8.21% trailing — safely within bounds (`02_validation/07_canonical_wfo.md`).
 
 **If FundedNext stops providing swap-free**, the deployment math changes:
 - Option A: scale risk down to ~0.30-0.35% to bring DD back under limit

--- a/arc_10/03_deployment/07_disaster_recovery.md
+++ b/arc_10/03_deployment/07_disaster_recovery.md
@@ -134,7 +134,7 @@ Some things can't be recovered after loss:
 - VPS provider issue requiring reprovision: ~5%
 - Repo loss: <1%
 - Both repo + local lost simultaneously: <<1%
-- Broker account terminated due to system fault: <2% (with 0.50% risk + 7%/8% DD halts)
+- Broker account terminated due to system fault: <2% (with 0.40% operating risk + 7%/8% DD halts)
 - Broker account terminated due to broker rule change: ~5%
 - Strategy degradation requiring kill: see kill criteria for specific triggers
 

--- a/arc_10/04_runbook/06_live_tracking_framework.md
+++ b/arc_10/04_runbook/06_live_tracking_framework.md
@@ -30,19 +30,22 @@ Backtest distribution from the WFO pool (EET v3.0.2, ~3,152 trades over 14 years
 
 **Why mean is positive but median is negative:** asymmetric R distribution. Most trades lose ~1R (initial SL hit) or partial-close-then-trail to ~0R. The minority of trades that catch runners produce +2R, +3R, +5R outcomes. The right tail funds the strategy.
 
+> **Source note:** these per-trade R stats are pool-level (the WFO trade pool), **not** rows in the EA-faithful `matrix.csv`/`per_fold.csv`. They are **basis-invariant**: R-multiples are normalised to per-trade risk, so the floating-equity sizing correction (which re-bases ROI/DD) does not change them. Mean R +0.42 therefore stands under the canonical run. Re-derive from the trade pool if a precise distribution is needed.
+
 **Variance bands are wide because:** 50 trades is small statistical mass. Backtest at 50 trades had folds with win rates of 30% AND 48% within the same year. Don't react to a single 50-trade window.
 
 ## Cumulative ROI expectation
 
-Based on EET expected live (44% annualised holdout ROI, after haircuts). At 0.50% risk per trade, ~225 trades per year.
+Anchored on the EA-faithful **0.40% operating tier**: mean-fold ROI **32.48%/yr**, full holdout years ranging 24.11%–52.55%, worst search fold 14.42%. At 0.40%, ~190–210 trades/year (so ~200 trades ≈ one year). Derived from `07_canonical_wfo.md` per-fold + holdout — no haircut overlay (the EA-faithful run already includes costs + governors).
 
-| Trade count | Expected days elapsed | Expected ROI | 25% confidence band | 75% confidence band |
+| Trade count | Expected days elapsed | Expected ROI (central) | 25% low band | 75% high band |
 |---|---|---|---|---|
-| 25 | ~40 | +4% | −2% to +10% | — |
-| 50 | ~80 | +9% | 0% to +18% | — |
-| 100 | ~160 | +19% | +5% to +33% | — |
-| 200 | ~320 | +38% | +15% to +60% | — |
-| 365 (one year) | ~365 | +44% | +20% to +70% | — |
+| 25 | ~45 | +4% | −3% | +9% |
+| 50 | ~90 | +8% | −2% | +16% |
+| 100 | ~180 | +16% | +2% | +28% |
+| 200 (~one year) | ~365 | +32% | +14% (worst fold) | +53% (best holdout yr) |
+
+Central tracks the mean-fold / mean-holdout-year (~32%); the low band is the worst observed fold (F9 2018, 14.42%), the high band the best holdout year (2025, 52.55%). Derived, not haircut — bands are wide because annual variance across folds is wide.
 
 **How to use:**
 - Live ROI inside the 25-75% band → normal, no action
@@ -101,7 +104,7 @@ The internal "something's wrong" threshold:
 
 **At 7% total DD:**
 1. Stop and verify the system is operating correctly (no bugs, no operator error, no broker issue)
-2. Cross-check against backtest worst-fold DD (expected live ~8.8% EET, ~9.5% UTC)
+2. Cross-check against the EA-faithful worst-fold DD at 0.40%: **8.21% trailing / 5.49% from-initial** (FundedNext measures from-initial). UTC is the legacy secondary path.
 3. If system is operating correctly and DD is within expected worst-fold range → continue per plan (this is what the system is designed to survive)
 4. If anything looks off → trigger emergency kill procedure (`04_runbook/05_emergency_kill.md`) and investigate
 

--- a/arc_10/04_runbook/07_kill_criteria.md
+++ b/arc_10/04_runbook/07_kill_criteria.md
@@ -33,9 +33,9 @@ If either 5ers or FundedNext kills the account (10% total DD or 5% daily DD brea
 
 **Action:** investigate root cause before opening any new account. Do not buy another Challenge until you understand what happened. This is the only "involuntary kill" — the others are deliberate.
 
-### #2 — Operator-level: total DD ≥ 8.5% (expected worst-fold + buffer)
+### #2 — Operator-level: total DD ≥ 8.5% (past the auto-CloseAll)
 
-Backtest worst-fold DD (cost-adjusted, EET live-expected) is 8.8%. Hitting 8.5% means you're at the edge of "this is what the system is designed to survive."
+EA-faithful worst-fold DD at the 0.40% operating tier is **8.21% trailing / 5.49% from-initial** (FundedNext, the primary firm, measures from-initial). Hitting 8.5% total means you're past the worst backtested trailing fold and past the system's own protection — "this is beyond what the system is designed to survive."
 
 System auto-halts new entries at 7%, auto-CloseAll at 8%. The 8.5% threshold gives a 0.5pp buffer past CloseAll for cases where positions slipped through CloseAll before fully exiting.
 
@@ -43,7 +43,7 @@ System auto-halts new entries at 7%, auto-CloseAll at 8%. The 8.5% threshold giv
 
 ### #3 — Variance-level: cumulative ROI below 25% confidence band at 200+ trades
 
-The live-tracking framework specifies a 25% confidence band at 200 trades of approximately +15% ROI. If actual cumulative ROI at 200 trades is below this (e.g. cumulative +5% or negative), this exceeds normal variance.
+The live-tracking framework (`06_live_tracking_framework.md`, re-derived from `07_canonical_wfo.md`) specifies a 25% low band at 200 trades (~one year) of approximately **+14% ROI** — the worst observed fold (F9 2018). If actual cumulative ROI at 200 trades is well below this (e.g. cumulative +5% or negative), this exceeds normal variance.
 
 **Threshold:** cumulative ROI < +5% at 200+ trades.
 
@@ -113,7 +113,7 @@ If you killed the system, here's what's required before restarting:
 | Kill type | Restart conditions |
 |---|---|
 | #1 prop firm hard limit | Cannot restart same account; open new account ONLY after root cause + fix |
-| #2 8.5%+ DD | Restart at reduced risk (0.30% instead of 0.50%); revert to full risk after 50 trades clean |
+| #2 8.5%+ DD | Restart at reduced risk (0.30%); return to the 0.40% operating tier after 50 trades clean |
 | #3 ROI below band at 200+ trades | Significant investigation required; may need re-validation against new data; consider whether strategy is still alive |
 | #4 4 negative months in 6 | Investigate regime; consider risk reduction; restart only if you understand cause |
 | #5 prolonged DD | Same as #4 |
@@ -148,8 +148,8 @@ Unproductive activities (avoid):
 
 | Criterion | Threshold | Rationale |
 |---|---|---|
-| DD limit | 8.5% | Backtest worst-fold live-expected ~8.8%; 8.5% catches imminent breach |
-| ROI band | 25% confidence at 200+ trades | Below this, sample large enough that bad ROI is signal |
+| DD limit | 8.5% | EA-faithful worst-fold 8.21% trailing / 5.49% from-init @ 0.40%; 8.5% sits just past the 8% auto-CloseAll |
+| ROI band | < +5% at 200+ trades (low band ~+14%) | Below the worst-fold floor, sample large enough that bad ROI is signal |
 | Negative months | 4 in 6 | Backtest rarely had 3, never had 4. Outside experience. |
 | DD duration | 60 days | Backtest had recovery within 60 days in nearly all cases |
 | Near-misses | 3 in 6 months | Pattern of near-misses = operating too close to limits |

--- a/arc_10/04_runbook/08_sunday_weekly_check.md
+++ b/arc_10/04_runbook/08_sunday_weekly_check.md
@@ -314,7 +314,7 @@ Weekly review is a discipline, not a response to perceived need. Most of the tim
 
 ## Monthly extension (first Sunday of each month)
 
-In addition to the weekly check, run an extended analysis once a month. See `arc_10/04_runbook/09_monthly_calibration.md` (TBD — build when first month of live data exists).
+In addition to the weekly check, run an extended analysis once a month. See `arc_10/04_runbook/10_monthly_calibration.md` (TBD — build when first month of live data exists; the `09` slot is taken by `09_risk_and_payout_protocol.md`).
 
 ---
 

--- a/arc_10/04_runbook/09_risk_and_payout_protocol.md
+++ b/arc_10/04_runbook/09_risk_and_payout_protocol.md
@@ -1,10 +1,11 @@
 # Risk & Payout Protocol — Arc 10 v3.0.2 (FundedNext)
 
 > **Purpose:** Pre-commit risk levels, payout timing, and scaling behaviour from a calibrated state, so no sizing or withdrawal decision is ever made emotionally or mid-drawdown.
-> **Why now:** future-you, up 8% or down 6%, is the wrong person to decide whether to raise risk or take a payout. Past-you, calibrated to the whole-period DD analysis, is the right one. Write the rules now, follow them later.
+> **Why now:** future-you, up 8% or down 6%, is the wrong person to decide whether to raise risk or take a payout. Past-you, calibrated to the EA-faithful WFO, is the right one. Write the rules now, follow them later.
 > **Primary firm:** FundedNext (Stellar 2-Step). 5ers is secondary.
+> **Source of truth for all numbers:** `arc_10/02_validation/07_canonical_wfo.md` → `results/l_arc_10_v3.0.2_ea_faithful/` CSVs.
 > **Status:** Logic LOCKED. Two FundedNext mechanics remain pending final confirmation (§6) — flagged inline; the safe assumption applies until confirmed.
-> **Companion docs:** `07_kill_criteria.md` (hard stops), `06_live_tracking_framework.md` (performance bands).
+> **Companion docs:** `07_kill_criteria.md` (hard stops), `06_live_tracking_framework.md` (performance bands), `../02_validation/07_canonical_wfo.md` (the numbers).
 
 ## The cardinal rule
 
@@ -18,12 +19,12 @@ You do not decide "I feel ready to raise risk." You pre-commit the trigger here,
 
 The DD floor and limit structure that everything below is built on:
 
-- **DD basis: equity** (floating counts intraday).
+- **DD basis: equity** (floating counts intraday). FundedNext measures the Maximum Loss Limit **from-initial** — this is the live basis that matters most.
 - **Maximum Loss Limit (MLL):** 10% of initial balance. Floor sits at **initial − 10%** (e.g. $90k on a $100k account). Profit *expands* allowable loss room: unwithdrawn profit adds to the MLL (at $120k equity, allowable loss = $10k + $20k = $30k; you can fall to $90k). **The floor is fixed at initial − 10% within a tier; the room above it grows with retained profit.**
 - **Daily Loss Limit:** 5% of initial, resets **00:00 server time** (server = GMT+3 summer / GMT+2 winter — DST-switching; EA day-anchor must track server midnight, not a fixed UTC offset). Intraday profit increases that day's available daily room.
 - **Internal governors (operator cushions inside FundedNext's limits, NOT FundedNext's numbers):** daily 3.5% halt / 4.5% close-all; total 7% halt / 8% close-all. Validated: −9% halt test confirmed entries blocked under deep drawdown.
 
-**Whole-period analysis result (costed, governed, EET, r_base 0.5%):** from-initial DD **3.75%** over 16 years vs the 8% in-system target — structurally unbreachable once a buffer exists. This is the basis the system runs on.
+**EA-faithful WFO result (floating-equity sizing, costed, governed, EET — the live-matched basis):** see `../02_validation/07_canonical_wfo.md`. At the **0.40% operating tier**, worst-fold DD is **5.49% from-initial / 8.21% trailing**, worst daily **4.11%**, **0 kills** across 11 search folds + 6 holdout years. From-initial is FundedNext's actual basis and sits comfortably under the 8% in-system target. This is the basis the system runs on.
 
 **The core principle:** within a tier, risk capacity grows with retained profit — the floor is fixed and profit expands the room. Across a scale, this resets (§4). Risk is therefore a **sawtooth**: build within a tier, reset at each scale.
 
@@ -35,15 +36,15 @@ Risk per trade is a function of banked buffer and tier, not of confidence, strea
 
 | Stage | Condition | Risk/trade | Rationale |
 |---|---|---|---|
-| **Initial launch** | first-ever live deployment, £0 buffer | **0.30–0.40%** | No live track record + thinnest buffer. De-risk the front-loaded high-concurrency period until both exist. |
-| **Steady-state** | buffer ≥ [CONFIRM threshold, ROI %], held ≥10 trading days | **0.50%** | Full validated risk. The whole-period 3.75% DD result is at 0.50%. |
-| **Through scaling** | post-scale, new tier | **0.50% carries** | % risk and % DD are scale-invariant; the system is live-validated by then. A new tier resets the *buffer*, not the validation — so 0.50% holds; only re-launch at 0.30–0.40% if a scale coincides with a regime you have no live data for. |
-| **Beyond 0.50%** | see §7 | **deferred** | Real upside on an expanding-room account, but gated on a daily-DD sweep — never a discretionary live call. |
+| **Initial launch** | first-ever live deployment, £0 buffer | **0.30–0.40%** | No live track record + thinnest buffer. De-risk the front-loaded high-concurrency period; ramp toward the 0.40% operating tier as the first clean weeks accrue. |
+| **Operating tier** | post-ramp, normal running | **0.40%** | The validated operating level. EA-faithful worst-fold DD 5.49% from-initial / 8.21% trailing, daily 4.11%, 0 kills — the only level clearing **both** hard limits on the conservative trailing basis. |
+| **Through scaling** | post-scale, new tier | **0.40% carries** | % risk and % DD are scale-invariant; the system is live-validated by then. A new tier resets the *buffer*, not the validation — so 0.40% holds; re-launch at 0.30% only if a scale coincides with a regime you have no live data for. |
+| **0.50% (marginal upgrade)** | see §7 | **gated, deferred** | Real upside on an expanding-room account, but it FAILS the conservative trailing/daily basis (10.89% trailing, 5.16% daily). Evidence-gated only — never an automatic buffer-triggered step. |
 
 **Hard rules:**
-- Never exceed 0.50% without a re-gate (§7). 0.50% is the validated ceiling.
+- **0.40% is the operating ceiling for routine running.** 0.50% is not a normal buffer-triggered step; it is a marginal, evidence-gated upgrade (§7).
 - Risk never rises during an open drawdown, even if a balance spike crosses a threshold intrabar. Triggers read realized, day-close equity — not floating.
-- The 0.30–0.40% launch is a one-time first-deployment de-risk; it is not re-applied at every scale (the % behaviour is identical at any tier; only the very first live period lacks a track record).
+- The 0.30–0.40% launch ramp is a one-time first-deployment de-risk; it is not re-applied at every scale (the % behaviour is identical at any tier; only the very first live period lacks a track record).
 
 ---
 
@@ -52,9 +53,9 @@ Risk per trade is a function of banked buffer and tier, not of confidence, strea
 **Key confirmed fact: a qualifying cycle requires 4% growth, NOT a withdrawal.** You do not have to withdraw to bank a qualifying cycle or to make scaling progress. This unlocks **bank-and-hold**: leave profit in, let it expand your MLL room, carry maximum safety through the entire tier.
 
 **The optimal within-tier play:**
-1. **Do not withdraw mid-tier.** Retained profit expands the MLL room (§1) and carries the buffer that holds your 0.50% risk. Withdrawing mid-tier shrinks both — it pulls equity back toward the floor and reduces allowable loss. There is no scaling reason to withdraw (qualification is performance-based), so the only reason to withdraw mid-tier is income need.
+1. **Do not withdraw mid-tier.** Retained profit expands the MLL room (§1) and carries the buffer. Withdrawing mid-tier shrinks both — it pulls equity back toward the floor and reduces allowable loss. There is no scaling reason to withdraw (qualification is performance-based), so the only reason to withdraw mid-tier is income need.
 2. **Scaling is the income event.** At a scale, profit is realized (§4) — that is the natural payout point. Hold through the tier, get paid at the scale, restart larger. No mid-tier withdrawal required.
-3. **If income is needed mid-tier:** withdraw only profit above the buffer line that holds 0.50% risk. Never withdraw below it. Mechanics: rewards requested at cycle ends (21d first, then 14d); min request $20 (carried forward if under); crypto methods cap $2,000/request, RiseWorks unlimited; reward split 80% (→90% post-scale).
+3. **If income is needed mid-tier:** withdraw only profit above the buffer line that holds the operating tier. Never withdraw below it. Mechanics: rewards requested at cycle ends (21d first, then 14d); min request $20 (carried forward if under); crypto methods cap $2,000/request, RiseWorks unlimited; reward split 80% (→90% post-scale).
 
 **The emotion-removal point:** the temptation is to withdraw early ("take some off the table"). On this structure, mid-tier withdrawal is strictly negative — it shrinks both the buffer and the loss room, for no scaling benefit. Bank-and-hold to the scale event is the disciplined default.
 
@@ -79,7 +80,7 @@ Risk per trade is a function of banked buffer and tier, not of confidence, strea
 **Consequence — risk capacity is a sawtooth, not a monotonic compound:**
 - *Within* a tier: floor fixed, room expands with retained profit → capacity grows.
 - *At* a scale: profit paid out, balance steps +25%, limits re-base, buffer resets to zero → capacity drops back to a fresh (larger) tier's starting point.
-- Net trend is upward and the tiers get larger, but each scale is a reset, not a carry. **This is why §2 holds 0.50% rather than escalating risk across scales** — there is no compounding buffer to "spend" on higher risk; each tier starts fresh.
+- Net trend is upward and the tiers get larger, but each scale is a reset, not a carry. **This is why §2 holds 0.40% rather than escalating risk across scales** — there is no compounding buffer to "spend" on higher risk; each tier starts fresh.
 
 **Strategic shape:** hold-and-bank through each tier (max safety, expanding room) → qualify on 4×4% over 2 months → scale event realizes profit (your income) → restart larger → repeat. Scaling is simultaneously the growth mechanism and the payout mechanism.
 
@@ -89,15 +90,15 @@ Risk per trade is a function of banked buffer and tier, not of confidence, strea
 
 | Trigger (measured, day-close equity) | Action |
 |---|---|
-| First-ever launch | risk = 0.30–0.40%, withdraw nothing |
-| Buffer ≥ threshold, held ≥10d | risk → 0.50% |
+| First-ever launch | risk = 0.30–0.40% ramp, withdraw nothing |
+| Ramp clean, normal running | risk = 0.40% (operating tier) |
 | Mid-tier, income needed | withdraw only profit above buffer line; else bank-and-hold |
 | 4 qualifying cycles (≥4% each) + ≥2 months | close all, contact Support, scale |
-| Scale processed | profit realized; restart at +25% balance; limits re-base; risk holds 0.50% |
-| Considering risk > 0.50% | freeze; run §7 daily-DD sweep; no live discretion |
+| Scale processed | profit realized; restart at +25% balance; limits re-base; risk holds 0.40% |
+| Considering risk > 0.40% (i.e. 0.50%) | freeze; run §7 daily-DD sweep + require live gap-event evidence; no live discretion |
 | Any kill criterion (`07_kill_criteria.md`) | stop — overrides everything here |
 
-Risk never rises during open drawdown. Withdrawal never drops equity below the buffer line. Risk never exceeds 0.50% without a re-gate.
+Risk never rises during open drawdown. Withdrawal never drops equity below the buffer line. Risk never exceeds 0.40% without the §7 re-gate.
 
 ---
 
@@ -110,27 +111,30 @@ Risk never rises during open drawdown. Withdrawal never drops equity below the b
 - Scaling: 4 qualifying cycles + ≥2 months + manual; +25%/step to $4M; sub-4% cycle doesn't count, doesn't reset.
 - Cycle cadence 21d then 14d. Min reward $20 (carried if under); crypto cap $2k/request, RiseWorks unlimited; split 80%→90% post-scale, +15% challenge-phase reward on scale.
 - Internal governors 3.5/4.5 daily, 7/8 total — operator cushions, −9% halt validated.
+- Operating risk 0.40% (EA-faithful canonical, `../02_validation/07_canonical_wfo.md`).
 
 **Pending final confirmation (safe assumption applies until confirmed):**
 1. `[CONFIRM]` Scale-event profit handling — working model: profit paid out, account restarts flat at +25% balance, limits re-base. (Alternative: profit rolls into new balance. The two give different post-scale buffers — confirm before first scale.)
 2. `[CONFIRM]` Cycle 4%-growth measurement basis — closed balance vs equity at cycle boundaries (§4).
-3. `[CONFIRM]` Steady-state buffer threshold that unlocks 0.50% (set as ROI %, not currency).
+3. `[CONFIRM]` Live gap-event behaviour at 0.50% — whether the tick EA actually caps daily under 5% on a real spike (the §7 gate to the marginal upgrade).
 
-None block deployment at 0.30–0.40%. Items 1–2 gate the first scale; item 3 gates the step to 0.50%.
+None block deployment at 0.30–0.40%. Items 1–2 gate the first scale; item 3 gates any step to 0.50%.
 
 ---
 
-## 7 — Risk beyond 0.50% (deferred candidate)
+## 7 — Risk beyond the 0.40% operating tier (0.50% marginal upgrade — deferred candidate)
 
-Real upside exists: on an account where the floor is fixed and room expands with retained profit, higher risk once deep in buffer risks *expanded* room against a fixed floor — high-EV, and the upside compounds within a tier. **But it is gated, not discretionary.**
+Real upside exists: on an account where the floor is fixed and room expands with retained profit, higher risk deep in buffer is high-EV and compounds within a tier. **But 0.50% is gated, not discretionary — and on the conservative basis it FAILS.**
 
-**Why it is not a free knob:** DD scales ~linearly with risk, but **breach behaviour does not.** From-initial total DD headroom (3.75% at 0.50%) is the *misleading* number — it looks like room to push. The binding constraint is the **5% daily limit**, where concurrency and correlated-currency clusters go non-linear: the same EUR/GBP concurrent cluster that is a ~4.7% floating daily event at 0.50% becomes a daily breach at higher risk. Total-DD room hides this.
+**Why 0.50% is not a free knob:** DD scales ~linearly with risk, but **breach behaviour does not.** From-initial DD headroom (6.85% at 0.50%) is the *misleading* number — it looks like room to push. The binding constraints are the **trailing DD** (10.89% gov-on at 0.50% > 10% hard limit) and the **5% daily limit** (5.16% at 0.50% > 5%), where concurrency and correlated-currency clusters go non-linear: the single-currency cluster that is a ~4–5% floating daily event at 0.40% tips over the daily line at 0.50%. Total-DD room hides this. The worst case is **F1 2010 (the Flash Crash)** — a single-bar gap that fired the close-all and reached 5.16% daily at 0.50% (`governor_log.csv`, `per_fold.csv`).
 
-**The gate for any risk above 0.50%:**
-- Re-run the **daily-DD and governor-firing sweep** (the costed-governed simulator, swept across r_base) at each candidate level — not the total-DD analysis. Daily breach probability is the thing that kills accounts and the thing that goes non-linear.
-- Buffer-gated: only considered when deep in a tier's buffer, never at launch.
-- Post-live, on real fills — the modeled give-back and governor timing must be confirmed against live behaviour first.
-- Never a live discretionary call. "Scale further if it feels right" is the sentence that blows the account; "scale further after a daily-DD sweep confirms breach probability at that level" is the same upside with discipline intact.
+**The gate for 0.50%:**
+- Re-run the **daily-DD and governor-firing sweep** (the costed-governed simulator, swept across r_base) — not the total-DD analysis. Daily/trailing breach probability is the thing that kills accounts and the thing that goes non-linear.
+- **Require live gap-event evidence:** a real spike day must confirm the tick EA caps daily under 5% before 0.50% is considered. This is the live-only residual (intrabar tick resolution) the backtest cannot close.
+- Buffer-gated: only considered deep in a tier's buffer, never at launch.
+- Never a live discretionary call. "Scale further if it feels right" is the sentence that blows the account; "scale further after a daily-DD sweep + a confirmed live gap-event" is the same upside with discipline intact.
+
+**Note on governors:** the daily-DD sweep already proved tightening the close-all is pointless — the worst daily event (F1 2010, 5.16%) is a single-bar gap, threshold-invariant; lowering the 4.5% close-all does not catch it sooner and only costs ROI on benign days. **Governors stay 3.5/4.5 daily, 7/8 total.**
 
 **Do not bend the system to the 4%-per-cycle pace.** No close-timing or sizing changes to make a cycle "look good" — that is discretionary drift the whole protocol exists to prevent. Note the pace requirement, measure against it, do not trade to it.
 
@@ -138,7 +142,8 @@ Real upside exists: on an account where the floor is fixed and room expands with
 
 ## Version
 
-- **v0.3** — full FundedNext model. Confirmed: qualification = 4% growth not withdrawal (bank-and-hold unlocked); scaling sawtooth (profit realized at scale, limits re-base, buffer resets per tier); cycle cadence + reward mechanics. §2 ladder reworked (0.50% holds through scaling, no escalation across tiers); §3 bank-and-hold default; §4 sawtooth; §7 beyond-0.50% deferred candidate (daily-DD-sweep-gated). 3 items pending final confirm.
+- **v0.4** — re-based on the EA-faithful (floating-equity, live-matched) canonical WFO (`../02_validation/07_canonical_wfo.md`). **0.40% is now the operating tier; 0.50% is a marginal, evidence-gated upgrade that FAILS the conservative trailing (10.89%) and daily (5.16%) basis** — replaces the prior "0.50% validated ceiling / 3.75% from-initial" framing, which rested on a superseded whole-period continuous-equity figure. From-initial at 0.50% is 6.85% (not 3.75%). FundedNext mechanics (static MLL, bank-and-hold, sawtooth scaling, cadence, reward split) unchanged. §7 reworked to gate 0.50% on a daily-DD sweep + live gap evidence. Gap (single-currency bounded) + slippage (~5× margin) findings added as the risk-surface basis for the 0.40% call.
+- v0.3 — full FundedNext model. Confirmed: qualification = 4% growth not withdrawal (bank-and-hold unlocked); scaling sawtooth; cycle cadence + reward mechanics. (Superseded: held 0.50% as the validated ceiling on the whole-period 3.75% from-initial figure.)
 - v0.2 — MLL-stays-at-initial (later refined to the profit-expanding-room model); daily reset, scaling step, reward split confirmed.
 - v0.1 — initial draft, post whole-period DD analysis.
 - Cardinal rule throughout: written calibrated, followed live, never edited stressed.

--- a/arc_10/05_history/02_decisions_log.md
+++ b/arc_10/05_history/02_decisions_log.md
@@ -45,31 +45,28 @@
 
 ### Risk_Per_Trade per broker
 
-**FundedNext: 0.50%** — at r_base, cost sweep central case lands at 7.80% worst-fold DD (2.2pp margin to 10% hard limit).
+**FundedNext: 0.40% (operating tier)** — EA-faithful floating-equity run: worst-fold DD 5.49% from-initial / 8.21% trailing, daily 4.11%, 0 kills. The only level clearing both hard limits on the conservative trailing basis. 0.50% FAILS (10.89% trailing / 5.16% daily) and is a gated, evidence-only upgrade — not a routine step.
 
-**5ers: 0.40%** — at r_base 0.5%, cost sweep central case breaches 10% DD hard limit (10.47%). Linear scaling to 0.40% brings central worst-fold DD to 8.38% (1.6pp margin).
+**5ers: 0.40%** — legacy UTC cost sweep had r_base 0.5% breaching the 10% hard limit on the realistic central cell; 0.40% is the secondary-path operating level (not re-run on floating-equity sizing).
 
-**Rationale documented:** `02_validation/05_cost_sweep.md`. Re-evaluate after 4+ weeks of live data.
+**Rationale documented:** `02_validation/07_canonical_wfo.md` (canonical), `05_cost_sweep.md` (legacy cost sensitivity). Re-evaluate after 4+ weeks of live data.
 
-### Why FundedNext at 0.50% specifically (not 0.45% or 0.55%)
+### Why FundedNext at 0.40% (and why 0.50% is gated, not routine)
 
-Amendment 3 linear scaling formula: `r_recommended = 0.005 × (0.080 / worst_DD_at_r_base)`.
+> **Supersession note.** An earlier version of this entry locked FundedNext at **0.50%** via the Amendment-3 linear-scaling formula on the legacy linear-overlay cost sweep (central-cell worst-fold DD 7.80%, "deploy at r_base, 2.2pp margin"). That premise was **superseded** by the EA-faithful floating-equity run (`02_validation/07_canonical_wfo.md`), which sizes exactly as the live EA does (`ACCOUNT_EQUITY × r_base`, floating P&L included). On that basis 0.50% FAILS the conservative trailing/daily hard limits. The 0.40% rationale below replaces it.
 
-Three reference cells were evaluated:
+The EA-faithful run sweeps 0.40% and 0.50%:
 
-| Cell | Worst DD @ r_base 0.5% | r_recommended |
-|---|---|---|
-| Optimistic (1.0× spread / 0.5 slip) | 7.49% | 0.0053 |
-| **Central (1.5× spread / 0.5 slip)** | **7.80%** | **0.0051** |
-| Adverse (2.0× spread / 1.0 slip) | 8.20% | 0.0049 |
+| risk | worst-fold trailing DD | worst-fold from-init DD | worst daily DD | verdict |
+|---|---|---|---|---|
+| **0.40%** | **8.21%** | **5.49%** | **4.11%** | PASS (clears both hard limits) |
+| 0.50% | 10.89% | 6.85% | 5.16% | FAIL trailing (>10%) + daily (>5%) |
 
-**Why 0.50% wins over 0.55%:** the adverse cell recommends scaling *down* to 0.49%. Deploying at 0.55% violates the adverse cell entirely (would push worst-fold DD to 9.02% pre-live-haircut, ~10.2% post-haircut — breaches hard limit). 0.55% only works if you assume optimistic costs every single trade.
+**Why 0.40% is the operating tier:** it is the only level clearing both the 10% trailing and 5% daily hard limits with margin (trailing 1.8pp, daily 0.9pp), at 0 kills, while PASS-DEPLOYABLE on FundedNext's actual from-initial basis (5.49% < 8% target).
 
-**Why 0.50% wins over 0.45%:** at 0.45%, you're leaving expected ROI on the table without meaningful DD reduction. Central case worst-fold DD at 0.45% would be ~7.0% — versus 7.8% at 0.50%. 0.8pp DD reduction for 10% expected-ROI reduction is not a favorable trade. You haven't moved out of the worst-fold envelope; you've just reduced position size into a still-risky envelope.
+**Why 0.50% is not routine:** on the live-matched floating-equity basis it breaches the trailing (10.89%) and daily (5.16%) limits. It passes only from-initial (6.85%). It is a future **evidence-gated** upgrade — admissible only deep in a banked buffer AND after a real live gap-event confirms the tick EA caps daily under 5% (`04_runbook/09_risk_and_payout_protocol.md` §7). Never an automatic buffer-triggered step.
 
-**Why 0.50% wins over 0.49% (rounding):** operationally, 0.50% is a cleaner round number to communicate, calculate, and remember. The 0.01pp difference is statistical noise vs operational simplicity.
-
-The choice is **deploy at central-case recommendation, accept adverse-cell tightness, monitor live for haircut accuracy**. If live worst-fold DD systematically exceeds 8.8% in the first 6 months, reassess.
+The choice is **deploy at 0.40%, treat 0.50% as a gated upgrade, monitor live for tick-gap behaviour.** If live worst-fold DD systematically exceeds the 8.21% trailing / 5.49% from-initial envelope in the first 6 months, reassess.
 
 ### Why 5ers at 0.40% specifically (not 0.42% or 0.38%)
 
@@ -94,7 +91,7 @@ Same Amendment 3 scaling on UTC central case:
 
 1. **Pair-specific swap rates are broker-specific, time-varying, and unstable.** Swap on AUDJPY at 5ers in Q1 2026 ≠ swap on AUDJPY at 5ers in Q3 2026 ≠ swap on AUDJPY at any other broker. Per-pair filter trained on historical swap data is overfitting to a moment-in-time snapshot.
 
-2. **Expected hold time isn't known in advance.** A trade could TP1-and-trail-for-a-day OR be a runner held 30 days. Filter would need to use ex-ante hold-time prediction, which is exactly the kind of forward-information bias `02_history/03_eliminated_approaches.md` documents as a permanent failure mode.
+2. **Expected hold time isn't known in advance.** A trade could TP1-and-trail-for-a-day OR be a runner held 30 days. Filter would need to use ex-ante hold-time prediction, which is exactly the kind of forward-information bias `05_history/03_eliminated_approaches.md` documents as a permanent failure mode.
 
 3. **Reduces signal count without proportionate DD reduction.** Backtest analysis showed swap-filter variants reduced trade count by 15-25% but only improved worst-fold DD by 0.5-1.0pp. Worse ratio outcomes than the unfiltered version.
 
@@ -115,7 +112,7 @@ Same Amendment 3 scaling on UTC central case:
 ### Risk ramp for first 3 weeks live
 **Week 1:** 0.20%
 **Week 2:** 0.30%
-**Week 3+:** 0.50%
+**Week 3+:** 0.40% (operating tier)
 
 **Why:** real live execution may differ from backtest in subtle ways. Validating at low risk first means costs are small if discovered. Increment only if previous week was clean.
 
@@ -124,7 +121,7 @@ Same Amendment 3 scaling on UTC central case:
 ### FundedNext as primary, 5ers as secondary
 **When:** post-cost-sweep
 **What:** deploy on FundedNext $100k Challenge first; keep 5ers as fallback
-**Why:** FundedNext (EET, swap-free) produces ~1.7× holdout ROI of 5ers (44% vs 27%) with more DD margin. Economic case is decisive.
+**Why:** FundedNext (EET, swap-free) produces materially higher holdout ROI than 5ers (UTC, swaps ON) with more DD margin — swap-free removes the dominant UTC cost vector. Economic case is decisive. (Canonical FundedNext per-year holdout in `02_validation/07_canonical_wfo.md`; UTC not re-run on floating-equity.)
 **Status:** primary deployment
 
 ### High Stakes program on 5ers (vs Hyper Growth)
@@ -181,7 +178,7 @@ Same Amendment 3 scaling on UTC central case:
 **When:** L_ARC_PROTOCOL design (Step 5)
 **What:** worst-fold ROI/DD ratio must be ≥ 2.0 to PASS-DEPLOYABLE
 **Why:** below 2.0 means a single bad fold is too close to wiping out a year. 2.0 is the boundary between "edge survives in worst case" and "edge is luck-dependent across folds".
-**Status:** locked. Arc 10 v3.0.2 hits 5.42 (UTC) / 6.43 (EET).
+**Status:** locked. Arc 10 v3.0.2 clears it comfortably on the EA-faithful run — every fold positive, worst-fold ROI/DD well above 2.0, 0 kills (`02_validation/07_canonical_wfo.md`).
 
 ### Sign consistency 11/11 required
 **When:** L_ARC_PROTOCOL design (Step 5)

--- a/arc_10/05_history/05_pre_mortem.md
+++ b/arc_10/05_history/05_pre_mortem.md
@@ -16,7 +16,7 @@ With a pre-mortem, you have a calibration: most failures will fit one of these p
 
 **What it looks like:** total DD approaches 8-9%. Lasts 2-8 weeks. Multiple consecutive losing weeks. Win rate drops to ~30%.
 
-**Why it happens:** the backtest had F4 2013 with 7.35% worst-fold DD. Live worst-fold DD expected ~8.8% after haircuts. Hitting this in any single year is roughly expected.
+**Why it happens:** the EA-faithful backtest at 0.40% has worst-fold DD of 8.21% trailing (F10 2019) / 5.49% from-initial (F5 2014); FundedNext measures from-initial. Hitting a worst-fold-equivalent period in any single year is roughly expected.
 
 **Confidence this is the issue:** if total DD is between 5-8.5%, system is running, no operational errors → very likely this is just a worst-fold-equivalent period.
 

--- a/arc_10/05_history/06_deployment_retrospective.md
+++ b/arc_10/05_history/06_deployment_retrospective.md
@@ -78,7 +78,7 @@ User pasted GitHub PAT in chat. Twice. Was offered the chance to revoke. Decline
 
 ### Risk locking happened BEFORE deployment, not during
 
-The 0.50% / 0.40% risk decisions were locked from the cost sweep, weeks before deployment. By the time we were in the VPS setting up services, those numbers were inputs, not variables.
+The risk decisions were locked from the validation work, weeks before deployment — later re-based by the EA-faithful floating-equity run to **0.40% operating / 0.50% gated** (`../02_validation/07_canonical_wfo.md`). By the time we were in the VPS setting up services, those numbers were inputs, not variables.
 
 **Why this mattered:** during the operational chaos of deployment (NSSM quoting bugs, FILE_COMMON discovery, EA inputs), there was zero cognitive load on "what should the risk be?" That question was settled.
 
@@ -108,7 +108,7 @@ When we found that 5ers panel-diff showed UTC bar anchors (despite EET server cl
 - **Watchdog at 5min interval with 4h10min stale threshold.** Aggressive enough to catch real issues, tolerant enough not to spuriously restart during normal H4 gaps.
 - **Same compiled .ex5 on both brokers.** Single source of truth for execution logic; only inputs differ.
 - **Config hash verification per envelope.** Catches operator misconfig before any wrong trade fires.
-- **Risk ramp 0.20 → 0.30 → 0.50.** First-weeks-live should be cheap; risk goes up only after evidence accumulates.
+- **Risk ramp 0.20 → 0.30 → 0.40 (operating tier).** First-weeks-live should be cheap; risk goes up only after evidence accumulates.
 
 ## The questionable calls
 

--- a/arc_10/README.md
+++ b/arc_10/README.md
@@ -28,6 +28,7 @@ Everything in this folder is curated. Underlying data lives in `results/` and is
 |---|---|
 | What does Arc 10 do? | `00_executive_summary.md` |
 | How does the signal work? | `01_strategy/signal_logic.md` |
+| **Canonical numbers (source of truth)** | **`02_validation/07_canonical_wfo.md`** |
 | What are the WFO numbers? | `02_validation/01_wfo_results.md` |
 | EET vs UTC — which is better? | `02_validation/05_cost_sweep.md` |
 | How is it deployed on VPS? | `03_deployment/04_vps_setup_guide.md` |
@@ -43,7 +44,7 @@ Everything in this folder is curated. Underlying data lives in `results/` and is
 |---|---|
 | Strategy version | Arc 10 v3.0.2 |
 | Active brokers | FundedNext (EET, $100k), 5ers (UTC, $10k) |
-| Risk per trade — FundedNext | 0.50% |
+| Risk per trade — FundedNext | 0.40% (operating; 0.50% gated upgrade only) |
 | Risk per trade — 5ers | 0.40% |
 | Max DD limit (hard, both) | 10% |
 | Daily DD limit (hard, both) | 5% |


### PR DESCRIPTION
## Summary
Brings the entire `arc_10/` doc set to the EA-faithful (floating-equity, live-matched) canonical reality. Replaces every pre-EA-faithful figure (0.50% launch, single-number/CAGR holdout, unlabelled DD) with the canonical numbers and flips the operating risk to **0.40%**. Source of truth for all numbers: the committed `results/l_arc_10_v3.0.2_ea_faithful/` CSVs (`matrix.csv`, `per_fold.csv`, `governor_log.csv`).

## What changed (18 files, doc-only / analysis-path)
- **NEW** `arc_10/02_validation/07_canonical_wfo.md` — canonical WFO: basis block (EET, floating-equity sizing, cell-5 costs, governors, 3.5×ATR, 28 pairs, both DD refs), 0.40/0.50 matrix, full per-fold + per-year holdout, supersession chain, findings appendix (daily-sweep / slippage / gap / procyclical +0.16pp), honesty constraints. Referenced from README as source of truth.
- **Rewrite** `04_runbook/09_risk_and_payout_protocol.md` → v0.4. 0.40% operating tier; **0.50% reframed as marginal/evidence-gated** (FAILS trailing 10.89% / daily 5.16%). Drops the superseded "0.50% validated ceiling / 3.75% from-initial" framing. FundedNext mechanics (static MLL, bank-and-hold, sawtooth scaling, cadence, reward split) preserved.
- **Heavy replaces:** `00_executive_summary`, `02_validation/01_wfo_results`, `02_validation/05_cost_sweep` (grids relabeled legacy cost-sensitivity under a basis banner), `05_history/02_decisions_log`, `README`.
- **Propagation (feeds weekly review):** `04_runbook/06_live_tracking_framework` (bands re-derived on mean-fold 32.48% / worst-fold 14.42%), `04_runbook/07_kill_criteria` (DD basis → 8.21% trailing / 5.49% from-init; restart → 0.40%).
- **Consistency fixes** where docs still stated 0.50% as the deploy risk or stale ROI/DD: `03_fundednext_setup`, `06_broker_specs`, `05_config_artifacts`, `07_disaster_recovery`, `01_strategy/exit_policy`, `05_pre_mortem`, `06_deployment_retrospective`.
- **L_PROTOCOL Amendment 7:** portfolio-level DD gating + EA-faithful (floating-equity) sizing + both DD references — applies to all future arcs.
- **Cross-ref repairs:** `02_decisions_log` `02_history/` → `05_history/`; `08_sunday_weekly_check` `09_monthly_calibration` → `10` (09 slot now taken by the risk/payout doc).

## Why
The earlier docs were built on the pre-EA-faithful linear/closed-equity sweep, which understated the procyclical concurrency tail. The EA-faithful run sizes exactly as the live EA does (`ACCOUNT_EQUITY × r_base`, floating P&L included) and shows **0.50% FAILS** the conservative trailing/daily hard limits while **0.40% clears both** (8.21% trailing / 5.49% from-initial / 4.11% daily, 0 kills). The deployment docs literally instructed the wrong risk; this pass removes that contradiction.

## Reviewer notes
- **Doc-only** — no engine/EA/config code touched; analysis-path.
- Two intentional residuals, flagged in the docs: (1) the `05_cost_sweep` grids retain their original linear-overlay cell numbers as a **labeled legacy cost-sensitivity exhibit** (only cell 5 exists in the EA-faithful run; the basis banner says canonical absolutes live in `07_canonical_wfo.md`); (2) **UTC/5ers** has no floating-equity run, so it is marked legacy/indicative rather than re-asserted with invented figures.
- No CAGR anywhere; holdout per-year; 2026 is a raw ~4-month partial, flagged.
- Out of scope (flag only): root `CLAUDE.md` says "Six amendments" — now seven with Amendment 7.

## Checks (paste results)
Doc-only change — code checks N/A (no Python, engine, indicator, or config changes):
- [ ] ruff check . — N/A (no code changed)
- [ ] pytest -q — N/A (no code changed)
- [ ] python scripts/smoke_test_selfcontained_v198.py -q --mode fast — N/A (no code changed)
- [x] Indicator contracts respected — N/A (docs only, untouched)
- [x] Config-driven only (no hardcoded params) — N/A (docs only)
- [x] Results unchanged unless intended (trade counts stable) — every figure traces to the committed EA-faithful CSVs; no result artifacts regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)