### PR TITLE
Arc 10 EA: FundedNext-aligned sizing + daily-DD anchor + ±5min news (FIX 1-3)

### DIFF
--- a/deployment/ea/Arc10_DLR_Sidecar_EA.mq5
+++ b/deployment/ea/Arc10_DLR_Sidecar_EA.mq5
@@ -48,7 +48,7 @@ input int     Sidecar_Heartbeat_Max_Age_Sec = 600;     // 10 min
 input string  Expected_Config_Hash        = "";        // fill at deploy
 input string  News_Calendar_URL           = ARC10_NEWS_DEFAULT_URL;
 input bool    Enable_News_Filter          = true;
-input int     News_Window_Sec             = 120;
+input int     News_Window_Sec             = 300;       // ±5min high-impact blackout (FIX 3); entries delayed past it, exits deferred within it
 input int     News_Delay_Buffer_Sec       = 5;
 input int     News_Delay_Max_Sec          = 3600;
 input int     News_Refresh_Sec            = 14400;     // 4h
@@ -187,7 +187,10 @@ void ArcAttemptEntry(const ArcSignalEnvelope &sig)
      }
    string err;
    int slot;
-   ulong ticket = ArcPlaceEntry(sig, Risk_Per_Trade, Magic_Number, g_trade, err, slot);
+   // base_equity = STATIC initial-balance floor (Initial_Equity_Floor), NOT
+   // ACCOUNT_EQUITY — FundedNext-aligned constant risk-per-trade (FIX 1).
+   ulong ticket = ArcPlaceEntry(sig, Risk_Per_Trade, Initial_Equity_Floor,
+                                Magic_Number, g_trade, err, slot);
    if(ticket == 0)
      {
       PrintFormat("[ARC10] entry failed %s: %s", sig.signal_id, err);
@@ -339,7 +342,32 @@ void ArcManagePositions()
          g_arc_pos_count--;
          continue;
         }
-      ArcExitOnTickTp1(slot, g_trade);
+      // FIX 3: defer the EA's OWN discretionary exits (TP1 partial, queued
+      // trail/time close) while inside the ±News_Window_Sec high-impact
+      // blackout. Closing in-window forfeits 60% of in-window profit
+      // (FundedNext article 10701685). Detection still runs every bar
+      // (ArcExitOnNewBar sets pending_close and it stays queued); only
+      // EXECUTION is held until the window clears, then fires on a later
+      // tick. NOT gated: risk-governor close-alls (ArcEquityCloseAllManaged,
+      // run earlier in OnTick) and broker-side SL fills (which surface via
+      // the PositionSelectByTicket==false branch above) — both must always
+      // fire for safety, and losses count 100% regardless of the window.
+      bool news_exit_blocked =
+         Enable_News_Filter
+         && ArcNewsInBlackout(g_arc_positions[slot].pair, TimeGMT(), News_Window_Sec);
+      // Diagnostic, throttled to ≤1 line/60s across all slots so a multi-tick
+      // blackout window doesn't flood the journal. Only meaningful when a
+      // close is actually being held (pending_close) or TP1 is suppressed.
+      static datetime g_arc_last_blackout_log = 0;
+      if(news_exit_blocked && TimeGMT() - g_arc_last_blackout_log >= 60)
+        {
+         PrintFormat("[ARC10] news-exit blackout: holding discretionary exits for %s (%s) pending_close=%s",
+                     g_arc_positions[slot].pair, g_arc_positions[slot].signal_id,
+                     g_arc_positions[slot].pending_close ? "true" : "false");
+         g_arc_last_blackout_log = TimeGMT();
+        }
+      if(!news_exit_blocked)
+         ArcExitOnTickTp1(slot, g_trade);
       // Emit partial_close trade-log row on the first tick after a TP1
       // partial fires (idempotent via partial_close_logged flag).
       if(g_arc_positions[slot].tp1_fired
@@ -363,7 +391,7 @@ void ArcManagePositions()
                           0, 0, AccountInfoDouble(ACCOUNT_EQUITY), "");
          g_arc_positions[slot].partial_close_logged = true;
         }
-      if(g_arc_positions[slot].pending_close)
+      if(g_arc_positions[slot].pending_close && !news_exit_blocked)
         {
          double px = ArcExitExecuteQueued(slot, g_trade);
          ArcLogTradeEvent(Trade_Log_Path, "exit",

--- a/deployment/ea/include/EquityGuards.mqh
+++ b/deployment/ea/include/EquityGuards.mqh
@@ -1,16 +1,20 @@
 //+------------------------------------------------------------------+
 //| EquityGuards.mqh                                                  |
 //|                                                                   |
-//| 5ers EET broker trading day daily-DD tracking + total-DD guard.   |
-//| Per dispatch §2.9 thresholds:                                     |
-//|   Daily DD >= 3.5% : halt new entries today                       |
-//|   Daily DD >= 4.5% : close all + halt today                       |
-//|   Total DD >= 7%   : halt new entries                             |
-//|   Total DD >= 8%   : close all + halt indefinitely                |
+//| Daily-DD + total-DD guards, both anchored to the STATIC initial   |
+//| balance floor (FIX 2 — FundedNext daily limit = fixed % of INITIAL |
+//| balance, not of day-start equity; help article 8019811).          |
+//| Thresholds (of the static floor):                                 |
+//|   Daily DD >= 3.5% : halt new entries today      ($3,500 @ $100k)  |
+//|   Daily DD >= 4.5% : close all + halt today       ($4,500 @ $100k) |
+//|   Total DD >= 7%   : halt new entries             ($7,000 @ $100k) |
+//|   Total DD >= 8%   : close all + halt indefinitely ($8,000 @ $100k)|
 //|                                                                   |
-//| EET trading-day boundary: 00:00 EET = 22:00 UTC (winter) or 21:00 |
-//| UTC (summer). We use a fixed EET offset look-up — MT5 server time |
-//| can drift; UTC is the canonical anchor.                           |
+//| The EET trading-day boundary is still tracked, but ONLY to reset  |
+//| the per-day entry-halt flag at rollover — the daily anchor itself |
+//| no longer re-snapshots equity. EET 00:00 = 22:00 UTC (winter) or  |
+//| 21:00 UTC (summer); fixed EET-offset look-up (MT5 server time can  |
+//| drift; UTC is the canonical anchor).                              |
 //+------------------------------------------------------------------+
 #ifndef ARC10_EQUITY_GUARDS_MQH
 #define ARC10_EQUITY_GUARDS_MQH
@@ -19,8 +23,8 @@
 
 double   g_arc_eq_total_floor = 0.0;       // operator-set static total-DD anchor (Initial_Equity_Floor)
 bool     g_arc_eq_floor_fail = false;      // true if floor input unset/implausible → EA halts (fail-loud)
-double   g_arc_eq_day_start = 0.0;         // equity at start of current EET day
-datetime g_arc_eq_day_start_utc = 0;       // EET-day-start instant in UTC
+double   g_arc_eq_day_start = 0.0;         // daily-DD anchor = STATIC initial floor (FIX 2; = g_arc_eq_total_floor, not day-start equity)
+datetime g_arc_eq_day_start_utc = 0;       // EET-day-start instant in UTC (tracks rollover for the entry-halt flag reset only)
 bool     g_arc_eq_entries_halted_today = false;
 bool     g_arc_eq_entries_halted_total = false;
 bool     g_arc_eq_close_all_pending = false;
@@ -102,8 +106,8 @@ datetime ArcLastSunOfMonthUtc(int year, int month, int hour, int min, int sec)
 //| no live-equity capture. An unset/implausible floor (<= 0 or        |
 //| < 1000) HALTS the EA (fail-loud) rather than silently capturing    |
 //| live equity — this makes correctness independent of MT5            |
-//| profile-persistence. Daily DD stays floating/equity-based and is   |
-//| anchored here to current live equity — deliberately untouched.     |
+//| profile-persistence. Daily DD is ALSO anchored to this static      |
+//| floor (FIX 2) — see the ``g_arc_eq_day_start`` note below.         |
 //+------------------------------------------------------------------+
 void ArcEquityInit(double floor_input)
   {
@@ -122,21 +126,30 @@ void ArcEquityInit(double floor_input)
       g_arc_eq_total_floor = floor_input;
       PrintFormat("[ARC10] equity init: floor=%.2f source=input", g_arc_eq_total_floor);
      }
-   // Daily-DD day-start anchor: a FIXED equity SNAPSHOT, taken once here at
-   // OnInit and again only at each EET-day rollover (see ArcEquityOnTick).
-   // It is NOT the total floor, NOT live/per-tick equity — between rollovers
-   // it is held constant so daily_dd = (day_start - equity)/day_start
-   // registers real intraday loss as equity falls. Re-snapshotting on a
-   // mid-day OnInit re-fire (restart) is DELIBERATE and ACCEPTED: daily risk
-   // is bounded to one day by the natural rollover, and we intentionally do
-   // NOT persist day-start to a state file or restore a prior value (no JSON
-   // state on the daily side). Do not "fix" this to live-track or to persist.
+   // Daily-DD anchor (FIX 2): the STATIC initial-balance floor, NOT a
+   // day-start equity snapshot and NOT live/per-tick equity. FundedNext's
+   // daily loss limit is a FIXED percentage of the INITIAL balance, not of
+   // day-start equity (FundedNext help article 8019811 — Daily Loss Limit
+   // = Initial Balance × %). Anchoring to day-start equity was dangerous on
+   // growth: once equity rose past ~$111k the EA's 4.5%-of-day-start trigger
+   // exceeded the fixed $4,500 dollar limit, so the EA believed it had room
+   // while the account was actually breaching. Anchoring to the static floor
+   // makes the governors fire at fixed dollars (3.5% → $3,500 halt /
+   // 4.5% → $4,500 close-all of the floor) at every equity level.
+   //
+   // CONSEQUENCE: the anchor is held constant for the life of the account
+   // (it equals the total-DD floor). It is NOT re-snapshotted at EET
+   // rollover anymore (see ArcEquityOnTick) — only the per-day entry-halt
+   // FLAG resets at rollover. Behaviour is identical to the old equity-
+   // snapshot scheme while equity == initial; the fix's value appears only
+   // once equity moves off the initial balance. Do NOT "fix" this back to a
+   // day-start equity snapshot — that re-introduces the growth breach.
    g_arc_eq_day_start_utc = ArcEetDayStartUtc(TimeGMT());
-   g_arc_eq_day_start = AccountInfoDouble(ACCOUNT_EQUITY);   // fixed snapshot
+   g_arc_eq_day_start = g_arc_eq_total_floor;   // STATIC floor anchor (FIX 2)
    g_arc_eq_entries_halted_today = false;
    g_arc_eq_entries_halted_total = false;
    g_arc_eq_close_all_pending = false;
-   PrintFormat("[ARC10] daily day-start: equity=%.2f eet_day_utc=%s source=init-snapshot",
+   PrintFormat("[ARC10] daily-DD anchor: static_floor=%.2f eet_day_utc=%s source=init-static-floor",
                g_arc_eq_day_start, TimeToString(g_arc_eq_day_start_utc));
   }
 
@@ -155,20 +168,26 @@ bool ArcEquityOnTick(
    // ArcEquityAllowEntry, so there is nothing to close.
    if(g_arc_eq_floor_fail)
       return false;
-   // EET-day rollover: re-snapshot the daily day-start to current equity and
-   // hold it fixed until the next rollover. Only mutation of g_arc_eq_day_start
-   // outside OnInit — never updated per-tick.
+   // EET-day rollover: the daily-DD anchor is STATIC (= initial-balance
+   // floor, FIX 2) and is deliberately NOT re-snapshotted here — FundedNext's
+   // daily limit is a fixed % of the initial balance, not of day-start equity
+   // (article 8019811). We only reset the per-day entry-halt FLAG so a day
+   // that hit the 3.5% halt clears at the next EET day; if equity is still
+   // below the threshold the next tick re-sets the flag immediately.
    datetime current_day_utc = ArcEetDayStartUtc(TimeGMT());
    if(current_day_utc != g_arc_eq_day_start_utc)
      {
       g_arc_eq_day_start_utc = current_day_utc;
-      g_arc_eq_day_start = AccountInfoDouble(ACCOUNT_EQUITY);   // fixed snapshot
       g_arc_eq_entries_halted_today = false;
-      // Total-DD halt state persists across days.
-      PrintFormat("[ARC10] daily day-start: equity=%.2f eet_day_utc=%s source=eet-rollover",
+      // Total-DD halt state persists across days. Daily anchor held static.
+      PrintFormat("[ARC10] eet-rollover: daily-DD anchor held static=%.2f eet_day_utc=%s",
                   g_arc_eq_day_start, TimeToString(g_arc_eq_day_start_utc));
      }
    double equity = AccountInfoDouble(ACCOUNT_EQUITY);
+   // Both DDs reference the STATIC floor now (FIX 2). g_arc_eq_day_start
+   // == g_arc_eq_total_floor, so daily_dd and total_dd share a basis and
+   // differ only by their thresholds (daily 3.5/4.5 < total 7/8). This is
+   // the fixed-dollar FundedNext daily limit: 4.5% of the floor = $4,500.
    double daily_dd = (g_arc_eq_day_start - equity) / g_arc_eq_day_start;
    double total_dd = (g_arc_eq_total_floor - equity) / g_arc_eq_total_floor;
    if(total_dd >= total_close_all_pct)

--- a/deployment/ea/include/NewsFilter.mqh
+++ b/deployment/ea/include/NewsFilter.mqh
@@ -1,13 +1,21 @@
 //+------------------------------------------------------------------+
 //| NewsFilter.mqh                                                    |
 //|                                                                   |
-//| ForexFactory weekly XML calendar — red-impact ±120s blackout.     |
-//| Per phase_1_build_intent.md §8:                                   |
+//| ForexFactory weekly XML calendar — high-impact ±5min blackout     |
+//| (FIX 3 — widened from ±120s; FundedNext profit-split rule article |
+//| 10701685: a trade opened OR closed within 5 min before/after a    |
+//| high-impact event has only 40% of in-window PROFIT credited while |
+//| losses count 100%, so we keep BOTH entries and the strategy's own |
+//| (non-forced) exits out of the window).                            |
+//| Per phase_1_build_intent.md §8 (window widened by FIX 3):         |
 //|   Feed: https://nfs.faireconomy.media/ff_calendar_thisweek.xml    |
 //|   Refresh: every 4 hours                                          |
-//|   Policy: DELAY entry until event_time + 120s + 5s buffer.        |
+//|   Entry policy: DELAY entry until event_time + window + 5s buffer.|
 //|           Discard if delay would exceed signal.entry_bar_open_utc |
 //|           + 3600s.                                                |
+//|   Exit policy: ArcNewsInBlackout() defers the EA's discretionary  |
+//|           TP1 / trail / time closes while in-window. Risk-governor |
+//|           close-alls and broker-side SL fills are NOT gated.      |
 //|   Tester-mode: filter wholly disabled (matches Python sim).       |
 //+------------------------------------------------------------------+
 #ifndef ARC10_NEWS_FILTER_MQH
@@ -199,6 +207,37 @@ int ArcNewsDecide(
       return 1;
      }
    return 0;
+  }
+
+//+------------------------------------------------------------------+
+//| True if ``now_utc`` falls within ±window_sec of a high-impact     |
+//| event touching ``pair``'s base or quote currency (FIX 3).         |
+//|                                                                   |
+//| Used to defer the strategy's own (non-forced) EXITS — TP1 partial,|
+//| trail-stop close, time-exit close — out of the FundedNext profit- |
+//| split blackout (article 10701685). Symmetric ±window: covers the  |
+//| 5 min BEFORE and AFTER the event. Returns false in tester mode    |
+//| (filter disabled, matches Python sim) and when no calendar is     |
+//| loaded. Callers MUST NOT gate risk-governor close-alls or broker- |
+//| side SL fills with this — only the EA's discretionary closes.     |
+//+------------------------------------------------------------------+
+bool ArcNewsInBlackout(const string pair, datetime now_utc, int window_sec)
+  {
+   ArcNewsEnsureInit();
+   if(g_arc_news_tester_mode)
+      return false;
+   string base_ccy  = StringSubstr(pair, 0, 3);
+   string quote_ccy = StringSubstr(pair, 3, 3);
+   for(int i = 0; i < g_arc_news_count; i++)
+     {
+      datetime evt = g_arc_news[i].time_utc;
+      if(now_utc < evt - window_sec || now_utc > evt + window_sec)
+         continue;
+      string ccy = g_arc_news[i].currency;
+      if(ccy == base_ccy || ccy == quote_ccy)
+         return true;
+     }
+   return false;
   }
 
 //+------------------------------------------------------------------+

--- a/deployment/ea/include/PositionManager.mqh
+++ b/deployment/ea/include/PositionManager.mqh
@@ -138,12 +138,21 @@ int ArcPositionFindByPair(const string sym)
   }
 
 //+------------------------------------------------------------------+
-//| Compute lot size from risk %, account equity, SL distance (price) |
+//| Compute lot size from risk %, STATIC base equity, SL distance.    |
+//|                                                                   |
+//| FundedNext-aligned sizing: risk is a fixed % of the STATIC        |
+//| initial-balance floor (``base_equity``, threaded in from the      |
+//| caller — = Initial_Equity_Floor), NOT floating ACCOUNT_EQUITY.    |
+//| This makes risk-per-trade constant ($risk_pct × floor) regardless |
+//| of current equity, matching FundedNext's static DD limits and     |
+//| removing procyclical breach-risk-scaling. base_equity is passed   |
+//| as a parameter because the floor global lives in EquityGuards.mqh,|
+//| which is #included AFTER this file (so not in scope here).        |
+//| Do NOT read ACCOUNT_EQUITY for sizing.                            |
 //+------------------------------------------------------------------+
-double ArcComputeLots(const string symbol, double risk_pct, double sl_distance_price)
+double ArcComputeLots(const string symbol, double risk_pct, double sl_distance_price, double base_equity)
   {
-   double equity = AccountInfoDouble(ACCOUNT_EQUITY);
-   double risk_amount = equity * risk_pct;
+   double risk_amount = base_equity * risk_pct;
    double tick_value = SymbolInfoDouble(symbol, SYMBOL_TRADE_TICK_VALUE);
    double tick_size  = SymbolInfoDouble(symbol, SYMBOL_TRADE_TICK_SIZE);
    if(tick_size <= 0.0 || tick_value <= 0.0 || sl_distance_price <= 0.0)
@@ -172,6 +181,7 @@ double ArcComputeLots(const string symbol, double risk_pct, double sl_distance_p
 ulong ArcPlaceEntry(
    const ArcSignalEnvelope &sig,
    double risk_pct,
+   double base_equity,
    long magic,
    CTrade &trade,
    string &err_out,
@@ -190,12 +200,19 @@ ulong ArcPlaceEntry(
       err_out = StringFormat("symbol_select_failed:%s", symbol);
       return 0;
      }
-   double lots = ArcComputeLots(symbol, risk_pct, sig.sl_distance_price);
+   double lots = ArcComputeLots(symbol, risk_pct, sig.sl_distance_price, base_equity);
    if(lots <= 0.0)
      {
       err_out = "lot_size_zero";
       return 0;
      }
+   // Sizing audit line — proves the STATIC initial-balance basis in the
+   // journal (base_equity should equal Initial_Equity_Floor, e.g. 100000,
+   // NOT current ACCOUNT_EQUITY). risk_amount = base_equity × risk_pct.
+   PrintFormat("[ARC10] sizing %s: base_equity=%.2f risk_pct=%.4f risk_amount=%.2f "
+               "sl_dist=%.5f lots=%.2f basis=static-initial",
+               symbol, base_equity, risk_pct, base_equity * risk_pct,
+               sig.sl_distance_price, lots);
    double ask = SymbolInfoDouble(symbol, SYMBOL_ASK);
    if(ask <= 0.0)
      {

--- a/tests/ea/scenarios/scenarios.json
+++ b/tests/ea/scenarios/scenarios.json
@@ -79,7 +79,7 @@
       "pair": "EURUSD",
       "signal_bar_close_price": 1.0842,
       "atr14": 0.00214,
-      "narrative": "Calendar contains a high-impact USD or EUR event within ±120s of entry_bar_open_utc. EA delays entry until event_time + 125s. If delay would push past signal+1h, signal is discarded. This scenario sets up the delay case; news event fires before entry, then entry fires at delay_to.",
+      "narrative": "Calendar contains a high-impact USD or EUR event within ±300s of entry_bar_open_utc (FIX 3 widened the window from ±120s to ±5min). EA delays entry until event_time + 305s (News_Window_Sec + News_Delay_Buffer_Sec). If delay would push past signal+1h, signal is discarded. This scenario sets up the delay case; news event fires before entry, then entry fires at delay_to.",
       "expected_events": ["news_delay", "entry"],
       "expected_exit_reason_substring": "",
       "historical_signal_bar_close": null,
@@ -252,11 +252,11 @@
     },
     {
       "id": "s18",
-      "title": "Daily day-start fixed across ticks, re-snapshots at EET rollover",
+      "title": "Daily-DD anchor is the STATIC floor, never re-snapshots (FIX 2)",
       "pair": "EURUSD",
       "signal_bar_close_price": 1.0842,
       "atr14": 0.00214,
-      "narrative": "Verifies the daily-DD day-start anchor (OPEN-001 correction). At OnInit the EA snapshots day-start equity once ('[ARC10] daily day-start: equity=… source=init-snapshot'). Across every tick of that EET day the anchor is HELD FIXED — there is no per-tick reassignment, so daily_dd = (day_start - equity)/day_start moves only because live equity moves, correctly registering intraday loss. At the next EET-day rollover (00:00 EET = 22:00 UTC winter / 21:00 UTC summer) the anchor re-snapshots to current equity once ('… source=eet-rollover'). The total-DD floor is independent and unaffected.",
+      "narrative": "Verifies the daily-DD anchor after FIX 2. FundedNext's daily loss limit is a fixed % of the INITIAL balance, not of day-start equity (help article 8019811), so the anchor is the STATIC floor (= Initial_Equity_Floor), set once at OnInit ('[ARC10] daily-DD anchor: static_floor=100000.00 … source=init-static-floor') and NEVER re-snapshotted to equity. daily_dd = (static_floor - equity)/static_floor, so the 4.5% close-all fires at a fixed $4,500 at every equity level. At each EET-day rollover (00:00 EET = 22:00 UTC winter / 21:00 UTC summer) the EA logs '[ARC10] eet-rollover: daily-DD anchor held static=100000.00 …' and resets ONLY the per-day entry-halt flag — the anchor value does not change. The total-DD floor shares the same static basis and is unaffected.",
       "expected_events": [],
       "expected_exit_reason_substring": "",
       "historical_signal_bar_close": "2026-03-10T08:00:00Z",
@@ -264,15 +264,15 @@
       "ea_input_overrides": {
         "Initial_Equity_Floor": 100000
       },
-      "setup_note": "DAILY_ANCHOR_FIXED_AND_ROLLOVER: set Initial_Equity_Floor=100000 (so total-floor logic is valid and visibly separate). Run across ≥2 EET days. PASS = (a) exactly ONE '[ARC10] daily day-start: … source=init-snapshot' line at start; (b) NO further day-start lines until a rollover — proving the anchor is fixed across intraday ticks (it is mutated only at OnInit and rollover); (c) exactly ONE '… source=eet-rollover' line per EET-day boundary crossed (22:00 UTC winter / 21:00 UTC summer), each showing the fresh equity snapshot. The floor journal line ('floor=100000.00 source=input') is unchanged across the whole run. Observable-only; no trade events required."
+      "setup_note": "DAILY_ANCHOR_STATIC_FLOOR: set Initial_Equity_Floor=100000. Run across ≥2 EET days. PASS = (a) exactly ONE '[ARC10] daily-DD anchor: static_floor=100000.00 … source=init-static-floor' line at start; (b) every '[ARC10] eet-rollover: daily-DD anchor held static=100000.00 …' line per EET-day boundary crossed shows the SAME 100000.00 value (the anchor never trails equity); (c) at no point does the daily anchor print a live-equity value. The floor journal line ('floor=100000.00 source=input') is unchanged across the whole run. Observable-only; no trade events required."
     },
     {
       "id": "s19",
-      "title": "Mid-day restart re-snapshots daily day-start (not persisted, not live)",
+      "title": "Mid-day restart — daily anchor stays the static floor, never live equity (FIX 2)",
       "pair": "EURUSD",
       "signal_bar_close_price": 1.0842,
       "atr14": 0.00214,
-      "narrative": "Verifies the accepted restart behavior of the daily anchor (OPEN-001 correction item 3). A mid-day EA restart (OnInit re-fire via input-edit, same trigger as s9/s10) re-snapshots day-start to CURRENT equity — it does NOT restore a prior day-start from any state file and does NOT live-track. This is deliberate: daily risk is bounded to one day by the natural EET rollover, and there is intentionally no JSON state on the daily side. The total floor, by contrast, is re-read from the operator input (s13/s14) and is decoupled from this.",
+      "narrative": "Verifies the restart behavior of the daily anchor after FIX 2. A mid-day EA restart (OnInit re-fire via input-edit, same trigger as s9/s10) re-reads the daily anchor from the STATIC floor (= Initial_Equity_Floor), NOT from current equity. Whether the restart happens at $100k or after the account has drawn down, the daily anchor is always the 100000 floor — it never captures live equity, so the daily DD limit cannot drift with equity. The total floor is likewise re-read from the operator input (s13/s14); both now share the static-floor basis.",
       "expected_events": [],
       "expected_exit_reason_substring": "",
       "historical_signal_bar_close": "2026-03-10T08:00:00Z",
@@ -280,7 +280,7 @@
       "ea_input_overrides": {
         "Initial_Equity_Floor": 100000
       },
-      "setup_note": "DAILY_ANCHOR_RESTART_RESNAPSHOT: set Initial_Equity_Floor=100000. Start tester; note the first '[ARC10] daily day-start: equity=<E0> source=init-snapshot'. While running and BEFORE any EET rollover, edit any EA input to force a restart (s9/s10 input-edit procedure). PASS = a SECOND 'source=init-snapshot' line appears reflecting the equity at restart (<E1>, current equity — NOT <E0> restored from disk, NOT the 100000 floor). Confirms the daily anchor re-snapshots on restart and is neither persisted nor live-tracked. The floor line still reads 'floor=100000.00 source=input' both times (total-floor logic untouched)."
+      "setup_note": "DAILY_ANCHOR_RESTART_STATIC: set Initial_Equity_Floor=100000. Start tester; note the first '[ARC10] daily-DD anchor: static_floor=100000.00 … source=init-static-floor'. While running and BEFORE any EET rollover, edit any EA input to force a restart (s9/s10 input-edit procedure). PASS = the SECOND 'source=init-static-floor' line still reads static_floor=100000.00 — NOT a live-equity value at restart. Confirms the daily anchor is the static floor and is decoupled from live equity. The floor line also reads 'floor=100000.00 source=input' both times (total-floor logic untouched)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Three Arc 10 EA changes in **one recompile/redeploy**, aligning sizing + daily-DD + news to FundedNext's actual rules. **v3.0.2 signal/exit logic is untouched** — only sizing, the daily-DD anchor, and the news filter (plus their comments/spec) change. Total-DD path and the floor input are untouched.

### FIX 1 — Sizing off the static initial balance
`ArcComputeLots` / `ArcPlaceEntry` now take a `base_equity` parameter, threaded from the `.mq5` call site as `Initial_Equity_Floor` (the static $100k floor) rather than reading floating `ACCOUNT_EQUITY`. `risk_amount = base_equity × risk_pct`, so risk-per-trade is constant regardless of current equity — matching FundedNext's static DD limits and removing procyclical breach-risk-scaling. A `[ARC10] sizing …` journal line is emitted on every entry proving the static basis. No `ACCOUNT_EQUITY` read remains in any sizing path.

### FIX 2 — Daily-DD anchor to the static floor
FundedNext's daily loss limit is a **fixed % of the INITIAL balance**, not of day-start equity (help article 8019811). The old day-start-equity anchor was dangerous on growth: once equity rose past ~$111k the EA's 4.5%-of-day-start trigger exceeded the fixed $4,500 dollar limit, so the EA believed it had room while actually breaching. The daily anchor is now `g_arc_eq_total_floor` (the static floor), set once at init and **never re-snapshotted at EET rollover** — rollover now resets only the per-day entry-halt flag. Header comments rewritten to document the new anchor and *why* (so it is not reverted as a bug). Behaviour is identical at $100k start; the fix's value appears only once equity moves off initial.

### FIX 3 — News blackout widened to ±5min, entries **and** exits
`News_Window_Sec` default `120 → 300`. New `ArcNewsInBlackout()` defers the EA's own discretionary closes (TP1 partial, queued trail/time close) while inside the ±5min high-impact window, per the FundedNext profit-split rule (article 10701685: a trade opened OR closed in-window has only 40% of in-window profit credited, losses 100%). **Risk-governor close-alls and broker-side SL fills are NOT gated** and always fire for safety; deferred exits stay queued and fire on the first tick after the window clears. The entry side already delays past the event — the wider window covers both sides.

## Touchpoints
- `deployment/ea/include/PositionManager.mqh` — `base_equity` param + sizing audit log (FIX 1)
- `deployment/ea/include/EquityGuards.mqh` — static daily anchor, no rollover re-snapshot, rewritten comments (FIX 2)
- `deployment/ea/include/NewsFilter.mqh` — `ArcNewsInBlackout()` + header (FIX 3)
- `deployment/ea/Arc10_DLR_Sidecar_EA.mq5` — call-site wiring, `News_Window_Sec=300`, exit-blackout gating (FIX 1 + 3)
- `tests/ea/scenarios/scenarios.json` — s6/s18/s19 brought in line with the new window + static anchor

## Note on the dispatch's "PositionManager.mqh:190" call site
The probe labelled the `ArcPlaceEntry` call site as `PositionManager.mqh:190`. It is actually `Arc10_DLR_Sidecar_EA.mq5:190` (`ArcAttemptEntry`) — the line number matched, the filename did not. That is where `Initial_Equity_Floor` is in scope, exactly as the dispatch intended; the param is threaded through both `ArcComputeLots` and `ArcPlaceEntry` as specified.

## Verification
- `tests/ea` Python scenario suite: **23/23 pass** (scenario JSON valid, 19 scenarios, titles unique).
- MQL5 cannot be compiled headlessly here — **recompile both terminals (FundedNext + 5ers) in MetaEditor after merge** and confirm on a test attach:
  - `equity init: floor=100000.00 source=input` still fires (floor logic untouched).
  - `[ARC10] sizing …: base_equity=100000.00 … basis=static-initial` — sizing off 100000, not current equity.
  - `[ARC10] daily-DD anchor: static_floor=100000.00 … source=init-static-floor`; rollover logs `held static=100000.00`.
  - Total-DD path unchanged (governors 7%/8% of floor).
  - News ±5min defers entries+exits around a high-impact event; governor close-alls still fire in-window.

## Out-of-scope stale-doc note (not changed)
`deployment/ea/.../phase_1_build_intent.md §8` (referenced in NewsFilter header) still describes the ±120s window, and any lingering OPEN-001 narrative describing the daily re-snapshot is now superseded by FIX 2. Flagging rather than editing to keep this PR scoped to the sanctioned EA change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
