### PR TITLE
Arc 10 v3.0.2 WFO: align backtester daily_ref to deployed EA FIX 2b (resetting daily-DD)

### DIFF
--- a/scripts/l_arc_10_v3_0_2_governed/_validate_daily_ref.py
+++ b/scripts/l_arc_10_v3_0_2_governed/_validate_daily_ref.py
@@ -1,0 +1,164 @@
+"""Logic validation for the EA-aligned daily_ref modes (no frame data required).
+
+The sha-05dea9 frame (trade_paths.parquet + H4_5ers_eet cache) is not in the tree,
+so the full canonical WFO can't be run here. This drives the REAL simulators
+(governed_wfo.simulate_fold, whole_period_dd.daily_dd_from_trace, daily_anchors) on
+synthetic schedules in the exact `sched` format build_schedules emits, proving:
+  1. static_noreset FREEZES (daily governor halts every bar once a fold dips 3.5%
+     below initial → recovery entries skipped) — the F5/F6 artifact.
+  2. initial-resetting does NOT freeze (daily window resets each EET day → entries
+     resume → fold recovers to positive). This is the FundedNext-EA behaviour.
+  3. daily_ref default is "initial"; static_noreset warns; unknown mode raises.
+  4. daily_anchors() and daily_dd_from_trace() math is correct for all three modes.
+  5. Governors-OFF curve/DD is IDENTICAL across all daily_ref modes → the daily-basis
+     change cannot touch the governors-off path, so the 9.22% reconstruction gate
+     (governors-off, zero-cost) is byte-identical to before.
+  6. Determinism: two identical runs produce identical results.
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "l_arc_10_v3_0_2_governed"))
+
+import governed_wfo as gw  # noqa: E402
+import whole_period_dd as wp  # noqa: E402
+
+gw.R_BASE = 0.005  # 1R = 0.5% (Arc 10 r_base)
+RB = gw.R_BASE
+
+
+def _mk(e, x, close_r, realized_r, base="EUR", quote="USD"):
+    """One synthetic trade schedule (close-mark series in R; mae == close here)."""
+    close = np.asarray(close_r, dtype=float)
+    return dict(e=e, x=x, close=close, mae=close.copy(),
+                realized=float(realized_r), base=base, quote=quote)
+
+
+def build_freeze_fold():
+    """A fold that locks an ~4% loss on day 1, then offers +1R recovery entries on
+    a NON-first bar of each later day. Two bars per day; entries on bar 1 (so the
+    new-day halt-reset doesn't auto-admit them). 6 days, 2 bars each → 12 bars."""
+    n_days, bars_per_day = 6, 2
+    clock = pd.date_range("2014-01-01", periods=n_days * bars_per_day, freq="12h", tz="UTC")
+    day_key = pd.DatetimeIndex([ts.normalize() for ts in clock])
+    sched = {}
+    # day 0: big loser, enters bar 0 exits bar 1, realizes -8R -> equity 1+0.005*-8=0.96
+    sched[0] = _mk(e=0, x=1, close_r=[-4.0, -8.0], realized_r=-8.0)
+    # days 1..5: recovery entry on the 2nd bar of the day (odd positions), +1R same bar
+    tid = 1
+    for d in range(1, n_days):
+        p = d * bars_per_day + 1  # second bar of the day
+        sched[tid] = _mk(e=p, x=p, close_r=[1.0], realized_r=1.0)
+        tid += 1
+    tids = sorted(sched)
+    return tids, sched, day_key, clock
+
+
+def run(daily_ref, governed=True, trigger_mark="close"):
+    tids, sched, day_key, clock = build_freeze_fold()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # silence the static_noreset warning here
+        return gw.simulate_fold(tids, sched, day_key, clock, governed=governed,
+                                total_ref="static", daily_ref=daily_ref,
+                                trigger_mark=trigger_mark)
+
+
+def main() -> int:
+    ok = True
+
+    def check(name, cond, detail=""):
+        nonlocal ok
+        ok = ok and bool(cond)
+        print(f"  [{'PASS' if cond else 'FAIL'}] {name}" + (f" - {detail}" if detail else ""))
+
+    print("=== 1/2. Freeze vs reset (the F5/F6 artifact) ===")
+    fr = run("static_noreset")
+    ini = run("initial")
+    ds = run("day_start")
+    n_skip_fr = sum(1 for _t, g in fr["skipped"] if g in ("daily_halt", "daily_close_all"))
+    n_skip_ini = sum(1 for _t, g in ini["skipped"] if g in ("daily_halt", "daily_close_all"))
+    print(f"  static_noreset: final_eq={fr['final_equity']:.4f} "
+          f"daily-skipped-entries={n_skip_fr} fires={len(fr['fires'])}")
+    print(f"  initial       : final_eq={ini['final_equity']:.4f} "
+          f"daily-skipped-entries={n_skip_ini} fires={len(ini['fires'])}")
+    print(f"  day_start     : final_eq={ds['final_equity']:.4f} "
+          f"daily-skipped-entries={n_skip_ini and '' or ''}{sum(1 for _t,g in ds['skipped'] if g in ('daily_halt','daily_close_all'))}")
+    check("static_noreset FREEZES (recovery entries skipped by daily halt)", n_skip_fr >= 4,
+          f"{n_skip_fr} skipped")
+    check("initial does NOT freeze (recovery entries admitted)", n_skip_ini == 0,
+          f"{n_skip_ini} skipped")
+    check("initial recovers above the locked-loss equity (static_noreset stays frozen)",
+          ini["final_equity"] > fr["final_equity"],
+          f"initial {ini['final_equity']:.4f} > static_noreset {fr['final_equity']:.4f}")
+    check("initial ~ day_start when equity ~ initial (both near-1.0 per-fold)",
+          abs(ini["final_equity"] - ds["final_equity"]) < 1e-9,
+          f"initial {ini['final_equity']:.6f} vs day_start {ds['final_equity']:.6f}")
+
+    print("=== 3. Mode plumbing (default / warn / raise) ===")
+    import inspect
+    sig = inspect.signature(gw.simulate_fold)
+    check("simulate_fold default daily_ref == 'initial'",
+          sig.parameters["daily_ref"].default == "initial")
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        gw.check_daily_ref("static_noreset")
+        check("static_noreset emits a warning", len(w) == 1 and "freeze" in str(w[0].message).lower())
+    raised = False
+    try:
+        gw.check_daily_ref("bogus")
+    except ValueError:
+        raised = True
+    check("unknown daily_ref raises ValueError", raised)
+
+    print("=== 4. daily_anchors() + daily_dd_from_trace() math ===")
+    check("anchors initial  -> (day_start, 1.0)", gw.daily_anchors("initial", 0.96) == (0.96, 1.0))
+    check("anchors day_start -> (day_start, day_start)", gw.daily_anchors("day_start", 0.96) == (0.96, 0.96))
+    check("anchors static_noreset -> (1.0, 1.0)", gw.daily_anchors("static_noreset", 0.96) == (1.0, 1.0))
+    # synthetic trace: one EET day, day-start numerator 0.96, intraday low 0.93.
+    # slot3 carries the numerator anchor (0.96 for initial/day_start, 1.0 for s_nr).
+    dk = pd.DatetimeIndex([pd.Timestamp("2014-06-01", tz="UTC")] * 3)
+    tr_init = [(0, 0.96, 0.96, 0.96, ()), (1, 0.93, 0.96, 0.96, ()), (2, 0.95, 0.96, 0.96, ())]
+    d_init = wp.daily_dd_from_trace(tr_init, dk, daily_ref="initial")
+    d_dstart = wp.daily_dd_from_trace(tr_init, dk, daily_ref="day_start")
+    # initial: (0.96-0.93)/1.0 = 0.03 ; day_start: (0.96-0.93)/0.96 = 0.03125
+    check("trace daily DD initial = (0.96-0.93)/1.0 = 0.03",
+          abs(max(d_init.values()) - 0.03) < 1e-9, f"{max(d_init.values()):.6f}")
+    check("trace daily DD day_start = (0.96-0.93)/0.96 = 0.03125",
+          abs(max(d_dstart.values()) - 0.03 / 0.96) < 1e-9, f"{max(d_dstart.values()):.6f}")
+
+    print("=== 5. Governors-OFF invariance (the 9.22%-gate proxy) ===")
+    off_init = run("initial", governed=False)
+    off_snr = run("static_noreset", governed=False)
+    off_ds = run("day_start", governed=False)
+    same_curve = (np.array_equal(off_init["dd_trailing"], off_snr["dd_trailing"])
+                  and abs(off_init["dd_trailing"] - off_ds["dd_trailing"]) < 1e-15
+                  and abs(off_init["final_equity"] - off_snr["final_equity"]) < 1e-15
+                  and abs(off_init["final_equity"] - off_ds["final_equity"]) < 1e-15
+                  and abs(off_init["roi"] - off_snr["roi"]) < 1e-15)
+    check("governors-OFF: final_eq / dd_trailing / roi IDENTICAL across all daily_ref",
+          same_curve,
+          f"dd_trailing={off_init['dd_trailing']:.6f} (init=snr=ds), "
+          f"final_eq={off_init['final_equity']:.6f}")
+
+    print("=== 6. Determinism (two identical runs) ===")
+    a = run("initial")
+    b = run("initial")
+    det = (abs(a["final_equity"] - b["final_equity"]) < 1e-15
+           and abs(a["roi"] - b["roi"]) < 1e-15
+           and a["fires"] == b["fires"] and a["skipped"] == b["skipped"])
+    check("two identical 'initial' runs are bit-identical", det)
+
+    print("\n" + ("ALL CHECKS PASSED" if ok else "*** SOME CHECKS FAILED ***"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/l_arc_10_v3_0_2_governed/canonical_wfo.py
+++ b/scripts/l_arc_10_v3_0_2_governed/canonical_wfo.py
@@ -256,12 +256,17 @@ def main() -> int:
         # ----- continuous view (compound; no fold reset) -----
         for gov in ("off", "on"):
             governed = gov == "on"
+            # Continuous floor = 16y no-reset compounding curve → daily_ref="day_start"
+            # (%/day vs the day's equity); a fixed-$/day "initial" basis would
+            # spuriously breach once the curve banks a multi-x buffer. The per-fold
+            # canonical view above uses simulate_fold's "initial" default (near-1.0).
             run = wp.simulate_continuous(
                 D["allt"], D["sched_cost"], D["day_key"], D["clock"],
                 governed=governed, total_ref="static", compound=True,
+                daily_ref="day_start",
             )
             cont_raw[(risk, gov)] = run
-            day_dd = wp.daily_dd_from_trace(run["trace"], D["day_key"])
+            day_dd = wp.daily_dd_from_trace(run["trace"], D["day_key"], daily_ref="day_start")
             cells[(risk, gov, "continuous")] = dict(
                 worst_roi=continuous_roi(run, D["sched_cost"], D["allt"], D["clock"]),
                 mean_roi=float("nan"),  # one curve — no per-fold mean
@@ -273,6 +278,7 @@ def main() -> int:
         cont_trail[risk] = wp.simulate_continuous(
             D["allt"], D["sched_cost"], D["day_key"], D["clock"],
             governed=True, total_ref="trailing", compound=True,
+            daily_ref="day_start",
         )
         print(
             f"[risk {risk * 100:.2f}%] per-fold(gov) trailing "

--- a/scripts/l_arc_10_v3_0_2_governed/canonical_wfo_compound.py
+++ b/scripts/l_arc_10_v3_0_2_governed/canonical_wfo_compound.py
@@ -92,15 +92,19 @@ def run_fold(tids, D, *, governed, is_2026=False):
 
     ROI = compound return over the fold; full-year folds annualised over their own
     ~1y span (= annual return), 2026 reported RAW (not annualised)."""
+    # Per-fold / per-year reset (equity starts 1.0, compounds within ~1y) → daily_ref
+    # ="initial" = the EA-faithful FundedNext fixed-$/day basis (equity stays near
+    # 1.0, so initial ≈ day_start). daily_dd_from_trace reports on the same basis.
     run = wp.simulate_continuous(
         tids, D["sched_cost"], D["day_key"], D["clock"],
         governed=governed, total_ref="static", compound=True,
+        daily_ref="initial",
     )
     e_ps = [D["sched_cost"][t]["e"] for t in tids]
     span = (D["clock"][max(e_ps)] - D["clock"][min(e_ps)]).total_seconds() / (365.25 * 86400.0)
     raw = float(run["e_bal_final"] - 1.0)
     roi = raw if is_2026 else float(gw.annualise(run["e_bal_final"], span))
-    day_dd = wp.daily_dd_from_trace(run["trace"], D["day_key"])
+    day_dd = wp.daily_dd_from_trace(run["trace"], D["day_key"], daily_ref="initial")
     return dict(
         n=len(tids), roi=roi, raw=raw, span=float(span),
         trailing_dd=float(run["dd_trailing"]), from_initial_dd=float(run["dd_static"]),

--- a/scripts/l_arc_10_v3_0_2_governed/canonical_wfo_ea_faithful.py
+++ b/scripts/l_arc_10_v3_0_2_governed/canonical_wfo_ea_faithful.py
@@ -81,14 +81,18 @@ DAILY_HALT, DAILY_CLOSE, TOTAL_HALT, TOTAL_KILL = 0.035, 0.045, 0.07, 0.08
 # ONLY the per-entry sizing differs: mult = rb × equity_INCL_FLOATING, not rb × e_bal).
 # ───────────────────────────────────────────────────────────────────────────
 def simulate_floating(tids, sched, day_key, clock, *, rb, governed, total_ref,
-                      daily_ref="static", trigger_mark="close"):
-    # daily_ref in {"static","day_start"} sets the DAILY-DD anchor (mirrors
-    # total_ref's static option, for the daily window). "static" (DEFAULT) =
-    # fixed initial (1.0): daily DD = (1.0 - intraday_low)/1.0, matching
-    # FundedNext (daily limit = a fixed % of initial) and the live EA fix.
-    # "day_start" = re-captured day-start equity (prior behaviour). The daily
-    # governors fire off this anchor, and slot 3 of the trace carries it so
-    # whole_period_dd.daily_dd_from_trace reports the same reference.
+                      daily_ref="initial", trigger_mark="close"):
+    # daily_ref in gw.DAILY_REF_MODES sets the DAILY-DD basis — EA-faithful
+    # (EquityGuards.mqh FIX 2b), with the daily window RESETTING each EET day:
+    #   "initial" (DEFAULT, FundedNext) = (day-start equity − intraday low) / FIXED
+    #     initial (1.0) — a fixed $/day budget; numerator resets daily. The
+    #     canonical gate basis matching the deployed EA's INITIAL basis.
+    #   "day_start" (5ers) = vs the re-captured day-start equity; resets daily.
+    #   "static_noreset" (QUARANTINED) = the OLD non-resetting freeze basis (warns).
+    # The daily governors fire off this basis, and slot 3 of the trace carries the
+    # daily NUMERATOR anchor so whole_period_dd.daily_dd_from_trace reports the same
+    # reference. See gw.daily_anchors().
+    gw.check_daily_ref(daily_ref)
     e_min = min(sched[t]["e"] for t in tids)
     x_max = max(sched[t]["x"] for t in tids)
     entries: dict = {}
@@ -121,7 +125,7 @@ def simulate_floating(tids, sched, day_key, clock, *, rb, governed, total_ref,
             day = d
             daily_halt = daily_closed = False
             day_start = prev_float
-        daily_anchor = 1.0 if daily_ref == "static" else day_start
+        daily_num, daily_den = gw.daily_anchors(daily_ref, day_start)
 
         # ── ENTRIES: EA-faithful floating-equity sizing ──
         for tid in entries.get(p, []):
@@ -141,8 +145,8 @@ def simulate_floating(tids, sched, day_key, clock, *, rb, governed, total_ref,
         close_eq = book("close")
         peak_ref = 1.0 if total_ref == "static" else peak_float
         total_dd = (peak_ref - trig) / peak_ref
-        daily_dd = (daily_anchor - trig) / daily_anchor
-        trace.append((p, float(close_eq), float(e_bal), float(daily_anchor), tuple(open_t)))
+        daily_dd = (daily_num - trig) / daily_den
+        trace.append((p, float(close_eq), float(e_bal), float(daily_num), tuple(open_t)))
 
         if governed and not killed and total_dd >= TOTAL_KILL:
             e_bal += wp._flat(open_t, mult, sched, p, flattened, "total_close_all", trigger_mark)
@@ -210,13 +214,16 @@ def holdout_year_tids(D):
 
 
 def run_fold(tids, D, *, rb, governed, is_2026=False):
+    # CANONICAL FundedNext basis: daily_ref="initial" (fixed-$/day, resets each EET
+    # day) = the deployed EA's INITIAL basis. daily_dd_from_trace reports on the same.
     run = simulate_floating(tids, D["sched_cost"], D["day_key"], D["clock"],
-                            rb=rb, governed=governed, total_ref="static")
+                            rb=rb, governed=governed, total_ref="static",
+                            daily_ref="initial")
     e_ps = [D["sched_cost"][t]["e"] for t in tids]
     span = (D["clock"][max(e_ps)] - D["clock"][min(e_ps)]).total_seconds() / (365.25 * 86400.0)
     raw = float(run["e_bal_final"] - 1.0)
     roi = raw if is_2026 else float(gw.annualise(run["e_bal_final"], span))
-    day_dd = wp.daily_dd_from_trace(run["trace"], D["day_key"])
+    day_dd = wp.daily_dd_from_trace(run["trace"], D["day_key"], daily_ref="initial")
     return dict(
         n=len(tids), roi=roi, raw=raw, span=float(span),
         trailing_dd=float(run["dd_trailing"]), from_initial_dd=float(run["dd_static"]),
@@ -349,7 +356,8 @@ def write_summary(search_res, holdout_res, matrix, D):
         "re-read per entry) to MEASURE the procyclical concurrency tail vs the fixed-initial "
         "basis. Reconstruction (`build_schedules`, open-book marks, `_flat`) reused verbatim; "
         "only the per-entry sizing differs from the compound run (floating equity vs closed "
-        "`e_bal`). Daily DD on the static (fixed-initial) anchor by default. v3.0.2 LOCKED; "
+        "`e_bal`). Daily DD on the EA-faithful `initial` basis (fixed-$/day, daily window "
+        "resets each EET day = deployed EA INITIAL basis). v3.0.2 LOCKED; "
         "governors EA-faithful, not tuned. Costs ON (cell 5); r_base {0.40%,0.50%}; EET; "
         "frame sha `05dea9…9ee58a`; deterministic; PR-gated.\n"
     )

--- a/scripts/l_arc_10_v3_0_2_governed/fundednext_floating.py
+++ b/scripts/l_arc_10_v3_0_2_governed/fundednext_floating.py
@@ -158,9 +158,10 @@ def main() -> int:
     # configs: (cost_label, sched) x (gov_label, kw)
     scheds = {"zerocost": sched_raw, "costed": sched_cost}
     # Superseded diagnostic: pin daily_ref="day_start" so this run keeps its
-    # original day-start daily-DD anchor (process_trace reads trace slot 3 as
-    # literal day-start equity). The canonical/EA runs use the new static
-    # default; this legacy diagnostic is preserved byte-for-byte.
+    # original day-start daily-DD anchor (process_trace reads trace slot 3 as the
+    # day-start numerator anchor, which equals day-start equity for day_start mode).
+    # The canonical/EA runs use the new `initial` default (FundedNext fixed-$/day,
+    # resets each EET day); this legacy diagnostic is preserved byte-for-byte.
     govs = {
         "off": dict(governed=False, total_ref="static", daily_ref="day_start"),
         "gov_static": dict(governed=True, total_ref="static", daily_ref="day_start"),

--- a/scripts/l_arc_10_v3_0_2_governed/governed_wfo.py
+++ b/scripts/l_arc_10_v3_0_2_governed/governed_wfo.py
@@ -50,17 +50,26 @@ floating-equity path (`canonical_wfo_ea_faithful.simulate_floating`) is now
 REFERENCE-ONLY (the procyclical comparison), not the canonical gate.
 
 CANONICAL RUN DEFINITION (after the FundedNext-alignment edits): a canonical WFO
-= fixed-initial sizing + `daily_ref="static"` (daily DD vs the fixed initial =
-the FundedNext daily basis) + `total_ref="trailing"` (the planning anchor:
-"safe from wherever we begin") REPORTED ALONGSIDE `total_ref="static"` (what
-FundedNext actually enforces from-initial), governed (3.5/4.5 daily, 7/8 total),
-cell-5 costs, EET. `total_ref` logic is unchanged by these edits — both
-references are already produced.
+= fixed-initial sizing + `daily_ref="initial"` (EA-faithful FundedNext daily
+basis: daily DD = (day-start equity − intraday low) vs a FIXED initial denom, the
+daily window RESETTING each EET day — mirrors EquityGuards.mqh FIX 2b) +
+`total_ref="trailing"` (the planning anchor: "safe from wherever we begin")
+REPORTED ALONGSIDE `total_ref="static"` (what FundedNext actually enforces
+from-initial), governed (3.5/4.5 daily, 7/8 total), cell-5 costs, EET. `total_ref`
+logic is unchanged by these edits — both references are already produced.
+
+The OLD `daily_ref="static"` (anchor fixed at initial AND never reset → daily DD
+== total-from-initial → daily governor freezes a fold permanently once it dips
+3.5% below initial: the F5/F6 −5.99%/−5.45% freeze artifact) is NON-PHYSICAL and
+has been quarantined as `daily_ref="static_noreset"` (warns; never the default,
+never canonical). FundedNext resets the daily window every day — the bug was the
+missing reset, not the basis.
 """
 
 from __future__ import annotations
 
 import sys
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -88,6 +97,49 @@ TOTAL_KILL = 0.08
 
 # prior (ungoverned, per-trade-sequential) deployment gate — SUPERSEDED
 PRIOR = dict(mean_roi=0.4987, worst_roi=0.2246, worst_dd=0.0780)
+
+# Daily-DD basis names, aligned to the deployed EA's `Daily_DD_Basis` (FIX 2b).
+DAILY_REF_MODES = ("initial", "day_start", "static_noreset")
+
+
+def check_daily_ref(daily_ref: str) -> None:
+    """Validate a daily-DD basis name (call once at sim entry).
+
+    Raises on an unknown name; warns LOUDLY if the quarantined non-resetting basis
+    is selected, so a future run cannot pick it by accident."""
+    if daily_ref not in DAILY_REF_MODES:
+        raise ValueError(f"daily_ref must be one of {DAILY_REF_MODES}, got {daily_ref!r}")
+    if daily_ref == "static_noreset":
+        warnings.warn(
+            "daily_ref='static_noreset' is the NON-RESETTING daily-DD basis that "
+            "produced the F5/F6 freeze artifact (daily DD measured cumulatively from "
+            "the fixed initial, never reset, so the daily governor halts a fold "
+            "permanently once it dips 3.5% below initial). It is NON-PHYSICAL and NOT "
+            "deploy-faithful — the live EA (EquityGuards.mqh FIX 2b) resets the daily "
+            "window every EET day. Do NOT use it for a canonical/governed gate run.",
+            stacklevel=2,
+        )
+
+
+def daily_anchors(daily_ref: str, day_start_eq: float) -> tuple[float, float]:
+    """(numerator_anchor, denominator) for the daily-DD basis — EA-faithful (FIX 2b).
+
+    daily DD = (numerator_anchor − intraday_equity) / denominator. The numerator
+    RESETS each EET day to the day-start equity for both physical bases (mandatory,
+    like the EA); only the denominator differs:
+      * "initial"  (FundedNext, CANONICAL DEFAULT): denom = fixed initial (1.0) — a
+        fixed $/day budget; numerator = day-start equity (resets daily).
+      * "day_start" (5ers): denom = day-start equity — a fixed %/day budget;
+        numerator = day-start equity (resets daily).
+      * "static_noreset" (QUARANTINED): numerator = fixed initial (1.0), never
+        resets → daily DD == total-from-initial → the freeze artifact; denom = 1.0.
+    When equity ≈ initial (per-fold reset) initial ≈ day_start (fixed-$ ≈ %-of-day-
+    start); they diverge once a buffer is banked."""
+    if daily_ref == "static_noreset":
+        return 1.0, 1.0
+    if daily_ref == "initial":
+        return day_start_eq, 1.0
+    return day_start_eq, day_start_eq  # day_start
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -180,21 +232,24 @@ def simulate_fold(
     *,
     governed: bool,
     total_ref: str,
-    daily_ref: str = "static",
+    daily_ref: str = "initial",
     trigger_mark: str = "close",
     trace: list | None = None,
 ):
     """Event-driven portfolio sim over one fold's trades. Returns metrics + logs.
 
     total_ref in {"static","trailing"} sets the total-DD reference for governors
-    3 & 4. daily_ref in {"static","day_start"} sets the DAILY-DD anchor for the
-    daily governors (3.5% halt / 4.5% close-all) and the reported daily DD:
-      * "static" (DEFAULT) — anchor = the fixed initial (1.0). Daily DD =
-        (1.0 - intraday_low)/1.0. Matches FundedNext (daily limit = a fixed % of
-        the initial balance) and the live EA fix. Mirrors total_ref's static
-        option but for the daily window.
-      * "day_start" — anchor = re-captured day-start equity (the prior
-        behaviour), retained for reference/comparison.
+    3 & 4. daily_ref in DAILY_REF_MODES sets the DAILY-DD basis for the daily
+    governors (3.5% halt / 4.5% close-all) and the reported daily DD — EA-faithful
+    (EquityGuards.mqh FIX 2b), with the daily window RESETTING each EET day:
+      * "initial" (DEFAULT, FundedNext) — daily DD = (day-start equity − intraday
+        low) / FIXED initial (1.0): a fixed $/day budget; numerator resets daily.
+        This is the deployed EA's INITIAL basis and the canonical gate default.
+      * "day_start" (5ers) — daily DD vs the re-captured day-start equity; resets
+        daily.
+      * "static_noreset" (QUARANTINED) — the OLD non-resetting basis (anchor fixed
+        at initial, never reset → freeze artifact). Warns; never canonical.
+    See daily_anchors() for the (numerator, denominator) per basis.
     Per-fold reset to INITIAL=1.0; equity in account multiples (1R contributes
     R_BASE).
 
@@ -212,6 +267,7 @@ def simulate_fold(
     for the trigger comparison varies with trigger_mark."""
     if not tids:
         return None
+    check_daily_ref(daily_ref)
     e_min = min(sched[t]["e"] for t in tids)
     x_max = max(sched[t]["x"] for t in tids)
     entries = {}
@@ -241,10 +297,12 @@ def simulate_fold(
             day = d
             daily_halt = daily_closed = False
             day_start_eq = prev_close_eq
-        # daily-DD anchor: "static" = fixed initial (FundedNext daily limit = a
-        # fixed % of initial; the live EA fix); "day_start" = re-captured
-        # day-start equity (legacy reference). Mirrors total_ref's static option.
-        daily_anchor = 1.0 if daily_ref == "static" else day_start_eq
+        # daily-DD basis (EA FIX 2b): both physical bases RESET each EET day
+        # (numerator = day-start equity); only the denom differs. "initial" =
+        # fixed initial denom (FundedNext fixed-$/day, canonical default);
+        # "day_start" = day-start denom (5ers); "static_noreset" = the quarantined
+        # non-resetting freeze basis (numerator fixed at 1.0). See daily_anchors().
+        daily_num, daily_den = daily_anchors(daily_ref, day_start_eq)
 
         # 1. entries
         for tid in entries.get(p, []):
@@ -273,13 +331,14 @@ def simulate_fold(
         close_eq = book("close")
         ref = 1.0 if total_ref == "static" else total_peak
         total_dd = (ref - trig_eq) / ref
-        daily_dd = (daily_anchor - trig_eq) / daily_anchor
+        daily_dd = (daily_num - trig_eq) / daily_den
         daily_dd_intrabar_max = max(daily_dd_intrabar_max, daily_dd)
-        daily_dd_close_max = max(daily_dd_close_max, (daily_anchor - close_eq) / daily_anchor)
+        daily_dd_close_max = max(daily_dd_close_max, (daily_num - close_eq) / daily_den)
         if trace is not None:  # per-bar diagnostics (pre-flatten open book); slot 3
-            # carries the daily anchor so daily_dd_from_trace reports the same
-            # reference the governors fired on.
-            trace.append((p, float(close_eq), float(realized), float(daily_anchor), tuple(open_t)))
+            # carries the daily NUMERATOR anchor (day-start equity for the resetting
+            # bases; 1.0 for static_noreset) so daily_dd_from_trace / process_trace
+            # report the same reference the governors fired on.
+            trace.append((p, float(close_eq), float(realized), float(daily_num), tuple(open_t)))
 
         # 3. governor actions (severity order); flatten at the trigger mark
         if governed and not killed and total_dd >= TOTAL_KILL:

--- a/scripts/l_arc_10_v3_0_2_governed/whole_period_dd.py
+++ b/scripts/l_arc_10_v3_0_2_governed/whole_period_dd.py
@@ -69,13 +69,21 @@ def simulate_continuous(
     governed: bool,
     total_ref: str,
     compound: bool,
+    daily_ref: str = "initial",
     trigger_mark: str = "close",
 ):
     """One unbroken governed portfolio path over `tids` (no fold reset).
 
     compound=True: each trade's account contribution is scaled by the running
     realised balance at its entry (mult = R_BASE * E_bal_entry). compound=False:
-    mult = R_BASE always (linear)."""
+    mult = R_BASE always (linear).
+
+    daily_ref in gw.DAILY_REF_MODES sets the DAILY-DD basis (EA-faithful FIX 2b;
+    daily window resets each EET day): "initial" (FundedNext fixed-$/day, default),
+    "day_start" (5ers %/day — the natural unit for a compounding no-reset curve),
+    "static_noreset" (quarantined freeze basis). Total governors (total_ref) are
+    unchanged. See gw.daily_anchors()."""
+    gw.check_daily_ref(daily_ref)
     e_min = min(sched[t]["e"] for t in tids)
     x_max = max(sched[t]["x"] for t in tids)
     entries = {}
@@ -125,12 +133,13 @@ def simulate_continuous(
             mult[tid] = (RB * e_bal) if compound else RB
             open_t[tid] = True
 
+        daily_num, daily_den = gw.daily_anchors(daily_ref, day_start)
         trig = book(trigger_mark)
         close_eq = book("close")
         peak_ref = 1.0 if total_ref == "static" else peak_float
         total_dd = (peak_ref - trig) / peak_ref
-        daily_dd = (day_start - trig) / day_start
-        trace.append((p, float(close_eq), float(e_bal), float(day_start), tuple(open_t)))
+        daily_dd = (daily_num - trig) / daily_den
+        trace.append((p, float(close_eq), float(e_bal), float(daily_num), tuple(open_t)))
 
         if governed and not killed and total_dd >= TOTAL_KILL:
             e_bal += _flat(open_t, mult, sched, p, flattened, "total_close_all", trigger_mark)
@@ -272,15 +281,21 @@ def time_underwater(curve, bars, clock):
     return frac, longest_days
 
 
-def daily_dd_from_trace(trace, day_key):
+def daily_dd_from_trace(trace, day_key, daily_ref="initial"):
+    """Per-EET-day max daily DD from a sim trace. Slot 3 carries the daily
+    NUMERATOR anchor (day-start equity for the resetting bases; 1.0 for
+    static_noreset). The denominator matches the basis — mirroring the in-sim daily
+    governor: fixed initial (1.0) for "initial"/"static_noreset", day-start equity
+    for "day_start"."""
     by_day = {}
-    for p, close_eq, e_bal, day_start, open_tids in trace:
-        by_day.setdefault(day_key[p], []).append((close_eq, day_start))
+    for p, close_eq, e_bal, daily_num, open_tids in trace:
+        by_day.setdefault(day_key[p], []).append((close_eq, daily_num))
     out = {}
     for d, rows in by_day.items():
-        ds = rows[0][1]
+        num_anchor = rows[0][1]  # day-start numerator anchor
         lo = min(r[0] for r in rows)
-        out[d] = max(0.0, (ds - lo) / ds)
+        den = num_anchor if daily_ref == "day_start" else 1.0
+        out[d] = max(0.0, (num_anchor - lo) / den)
     return out
 
 
@@ -303,6 +318,11 @@ def main() -> int:
     allt = sorted(meta["trade_id"])
     holdt = sorted(meta[meta.fold == 12]["trade_id"])
 
+    # daily_ref="day_start" for this 16y NO-RESET curve: on a compounding curve that
+    # banks a multi-x buffer, the EA's fixed-$/day "initial" basis would spuriously
+    # breach the daily limit on normal moves once equity ≫ 1.0 (a fixed $ is a tiny %
+    # of a grown account). day_start (%/day vs the day's equity) is the physical unit
+    # here; the per-fold/per-year-reset canonical runs use "initial" (near-1.0 equity).
     runs = {}
     for lab, kw in {
         "off_compound": dict(governed=False, total_ref="static", compound=True),
@@ -311,10 +331,11 @@ def main() -> int:
         "off_linear": dict(governed=False, total_ref="static", compound=False),
         "static_linear": dict(governed=True, total_ref="static", compound=False),
     }.items():
-        runs[lab] = simulate_continuous(allt, schedc, day_key, clock, **kw)
+        runs[lab] = simulate_continuous(allt, schedc, day_key, clock, daily_ref="day_start", **kw)
     # holdout standalone (linear, governors-off) cross-check vs prior 6.56%
     ho_lin = simulate_continuous(
-        holdt, schedc, day_key, clock, governed=False, total_ref="static", compound=False
+        holdt, schedc, day_key, clock, governed=False, total_ref="static",
+        compound=False, daily_ref="day_start",
     )
 
     print(


### PR DESCRIPTION
## Summary

Aligns the backtester's daily-DD logic to the **now-deployed EA (`EquityGuards.mqh` FIX 2b)**. The EA's daily DD basis is selectable (`INITIAL` | `DAY_START`) and **resets at EET rollover for both bases** (mandatory). The backtester's old `daily_ref="static"` was the **non-resetting** version — anchor fixed at initial *and* never reset, so daily DD `== total-from-initial` and the daily governor froze a fold permanently once it dipped 3.5% below initial (the **−5.99% / −5.45% F5/F6 freeze artifact**). That basis is non-physical and was never deploy-faithful.

This **gates the final canonical WFO** — that run must not be executed until this lands (and the frame is regenerated, see below).

## The fix — `daily_ref` modes mirror the EA's `Daily_DD_Basis`

Daily reset is now **intrinsic to both physical bases** (numerator resets to day-start equity each EET day; only the denominator differs):

| mode | numerator | denominator | meaning |
|---|---|---|---|
| **`initial`** (NEW canonical default, FundedNext) | day-start eq (resets) | fixed initial `1.0` | fixed-$/day budget |
| `day_start` (5ers) | day-start eq (resets) | day-start eq | fixed-%/day budget |
| `static_noreset` (QUARANTINED) | fixed `1.0` (never resets) | `1.0` | the freeze artifact |

`static_noreset` warns loudly via `check_daily_ref()`, is never the default, and an unknown mode raises. **`total_ref` / total-DD path untouched** (7/8 governors stay static-from-initial). Daily governors now reference the resetting daily basis, mirroring the EA.

## Changes (daily-DD anchor/reset logic + mode names only; v3.0.2 signal/exit/cost LOCKED)

- **`governed_wfo.py`** — `DAILY_REF_MODES`, `check_daily_ref()`, `daily_anchors() -> (num, den)`; `simulate_fold` default `"static"` → `"initial"`, single anchor split into numerator/denominator, trace slot 3 now carries the daily **numerator** anchor.
- **`canonical_wfo_ea_faithful.py`** (the EA-faithful canonical gate) — `simulate_floating` default → `"initial"`; `run_fold` pins `daily_ref="initial"` on the sim and the trace report.
- **`whole_period_dd.py`** — `simulate_continuous` gains `daily_ref`; `daily_dd_from_trace` gains `daily_ref` (denominator per basis). 16y no-reset callers pinned to `"day_start"` (a fixed-$/day `initial` basis would spuriously breach once the compounding curve banks a multi-x buffer).
- **`canonical_wfo.py`** continuous view → `"day_start"`; **`canonical_wfo_compound.py`** per-fold → `"initial"` (near-1.0 equity == EA fixed-$).
- **`fundednext_floating.py`** — stale comment fixed; still pinned `day_start`, byte-identical.

## Validation

⚠️ The sha-`05dea9` frame (`trade_paths.parquet`) and the `H4_5ers_eet` cache are **absent from the tree** (consistent with the project memory note dated 2026-05-31), so the full canonical WFO **cannot be run here**. Instead `_validate_daily_ref.py` drives the **real** simulators (`simulate_fold`, `daily_anchors`, `daily_dd_from_trace`) on synthetic schedules in the exact `build_schedules` format — **ALL CHECKS PASS**:

- **static_noreset FREEZES** (recovery entries skipped, equity stuck at the locked loss) while **`initial`-resetting does NOT** (entries resume → recovers); `initial` ≈ `day_start` when equity ≈ initial.
- default is `"initial"`; `static_noreset` warns; unknown mode raises.
- `daily_anchors` + `daily_dd_from_trace` math correct for all three modes.
- **governors-OFF curve / DD / ROI IDENTICAL across all `daily_ref`** → the daily-basis change cannot touch the governors-off path, so the **9.22% reconstruction gate** (governors-off, zero-cost) is byte-identical to before.
- two-run determinism.

**Next step (out of scope here):** regenerate the frame from raw HistData + sha-gate, then re-run the canonical WFO. Expectation per dispatch: under `initial`-resetting at 0.40% gov-ON, **F5 (2014) / F6 (2015) no longer freeze** and return positive (the `day_start` counterfactual gave F5 +28.91% / F6 +20.77%, 0 fires; `initial`-resetting at ~initial equity is near-identical since fixed-$ ≈ %-of-day-start when equity ≈ initial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)