### PR TITLE
Docs: NAVIGATION router + EA_REFERENCE card + README staleness fix

### DIFF
--- a/EA_REFERENCE.md
+++ b/EA_REFERENCE.md
@@ -1,0 +1,130 @@
+# EA_REFERENCE — Arc 10 DLR Sidecar EA: parameters + deployment card
+
+> Single reference for the live EA's full parameter surface, per-broker overrides, and the
+> attach / verify / recompile procedure. **Source of truth for the inputs is the committed
+> EA — [`deployment/ea/Arc10_DLR_Sidecar_EA.mq5`](./deployment/ea/Arc10_DLR_Sidecar_EA.mq5)
+> lines 32–57.** Per-broker values trace to [`BROKER_RULES.md`](./BROKER_RULES.md) and
+> [`arc_10/03_deployment/`](./arc_10/03_deployment/). Where a 5ers value is unconfirmed it is
+> marked **TBD-VERIFY** — do not guess it.
+>
+> Architecture: the EA is a *thin* executor. Signal logic lives in the Python sidecar
+> ([`deployment/sidecar/`](./deployment/sidecar/)); the EA polls signal envelopes, validates
+> schema + `config_hash`, applies news / equity governors, places entries, runs the
+> `sl_partial_close_1r_runner_trail` exit policy, and writes audit telemetry.
+
+---
+
+## 1. All 26 EA inputs
+
+Defaults below are the **source defaults** (the EA ships UTC / 5ers-native; the FundedNext
+account overrides several — see §2). Verified against `Arc10_DLR_Sidecar_EA.mq5:32–57`.
+
+| # | Input | Type | Default (source) | What it does / notes |
+|---|---|---|---|---|
+| 1 | `Risk_Per_Trade` | double | `0.0043` | Risk per trade as a fraction. Sized **fixed-initial** (1R = `Risk_Per_Trade × Initial_Equity_Floor`, constant per trade — FIX 1). Deployed operating value is **0.0040** (0.40%); source default `0.0043` is the UTC r_safe. |
+| 2 | `Initial_Equity_Floor` | double | `0` | Operator-set **static** total-DD anchor and sizing base. **`0` = unset → fail-loud halt** (OPEN-001). MUST be set per account (§2). Survives nothing — re-set after any recompile/reinstall (§5). |
+| 3 | `Total_DD_Halt_Pct` | double | `0.07` | Total-DD halt threshold (7%): stop new entries. |
+| 4 | `Total_DD_CloseAll_Pct` | double | `0.08` | Total-DD close-all threshold (8%): flatten. Safety margin under the 10% broker MLL. |
+| 5 | `Daily_DD_Halt_Pct` | double | `0.035` | Daily-DD halt threshold (3.5%): stop new entries today. |
+| 6 | `Daily_DD_CloseAll_Pct` | double | `0.045` | Daily-DD close-all threshold (4.5%). Safety margin under the 5% broker daily limit. |
+| 7 | `Daily_DD_Basis` | enum `ArcDailyDdBasis` | `DAILY_DD_BASIS_INITIAL` | Daily-DD denominator. `INITIAL` = fixed % of initial (FundedNext); `DAY_START` = % of day-start equity (5ers). **Daily window ALWAYS resets at EET rollover** regardless of basis (FIX 2b). The non-resetting `static_noreset` mode is quarantined — never deployed. |
+| 8 | `Time_Exit_Bars` | int | `240` | H4 bars held before the time-based exit fires. |
+| 9 | `SL_ATR_Multiplier_Expected` | double | `3.5` | Parity-check only — verifies the sidecar's SL distance matches; does not size the SL itself. |
+| 10 | `Sidecar_Inbox_Dir` | string | `Arc10\signals_out` | Where the EA polls for signal-envelope JSON. |
+| 11 | `Sidecar_Processed_Dir` | string | `Arc10\signals_processed` | Move target for successfully-entered signals. |
+| 12 | `Sidecar_Failed_Dir` | string | `Arc10\signals_failed` | Move target for rejected signals. |
+| 13 | `Sidecar_Heartbeat_Path` | string | `Arc10\sidecar.heartbeat` | Sidecar staleness-check file the EA reads. |
+| 14 | `Ea_Heartbeat_Path` | string | `Arc10\ea.heartbeat` | EA heartbeat output (watchdog reads it). |
+| 15 | `Ea_Positions_Path` | string | `Arc10\ea_positions.json` | Position-state persistence for crash recovery. |
+| 16 | `Trade_Log_Path` | string | `Arc10\trade_log.csv` | Audit trade log. |
+| 17 | `Sidecar_Heartbeat_Max_Age_Sec` | int | `600` | Max sidecar heartbeat age (10 min) before the EA halts entries. |
+| 18 | `Expected_Config_Hash` | string | `""` (empty) | SHA-256 of the sidecar's locked config subset. **Fill at deploy** — validates the EA and sidecar agree on the strategy config. |
+| 19 | `News_Calendar_URL` | string | `ARC10_NEWS_DEFAULT_URL` | ForexFactory weekly XML calendar URL (must be in MT5's WebRequest whitelist). |
+| 20 | `Enable_News_Filter` | bool | `true` | Master switch for the news blackout logic. |
+| 21 | `News_Window_Sec` | int | `300` | ±N s high-impact blackout (FIX 3 = ±5 min on FundedNext). Entries delayed past the window; non-forced exits deferred within it. |
+| 22 | `News_Delay_Buffer_Sec` | int | `5` | Buffer after a news event before an entry is allowed. |
+| 23 | `News_Delay_Max_Sec` | int | `3600` | Max time a news-delayed signal is held (1 h) before it is discarded. |
+| 24 | `News_Refresh_Sec` | int | `14400` | Calendar refresh interval (4 h). |
+| 25 | `Magic_Number` | long | `1010202601` | Trade magic identifier. Source default `1010202601` is the **5ers/UTC** value; FundedNext overrides to `1010202602` (§2). |
+| 26 | `Signal_Poll_Min_Interval_Sec` | int | `5` | Minimum interval between signal polls in `OnTick`. |
+
+---
+
+## 2. Per-broker override table (the must-set-correctly inputs)
+
+Everything not listed here uses the §1 source default on both accounts.
+
+| Input | FundedNext | The5ers |
+|---|---|---|
+| `Initial_Equity_Floor` | `100000` | `10000` |
+| `Risk_Per_Trade` | `0.0040` | **TBD-VERIFY** (KH-24 runs 1.0% = `0.01` live per CLAUDE.md; confirm the deployed Arc-10 value before relying on it) |
+| `Daily_DD_Basis` | `INITIAL` | `DAY_START` |
+| `News_Window_Sec` | `300` | `120` |
+| `Magic_Number` | `1010202602` | `1010202601` |
+| `Convention` | `5ers_eet` (EET) | `utc` |
+
+Notes (from [`BROKER_RULES.md`](./BROKER_RULES.md)):
+- `Convention` is the engine's EET-aggregation convention name (PR #189 / Amendment 6), set on
+  the sidecar side; it is not an EA `input`. FundedNext selects the EET broker trading day;
+  5ers runs the KH-24 anchor under `utc` for byte-identity.
+- **FundedNext daily basis = `INITIAL`, resetting** (5% of initial = fixed $/day, window resets
+  00:00 EET — per FundedNext help article #8019811, the authority over inconsistent live-chat
+  answers). This matches the #254 canonical fixed-initial backtest (`daily_ref="initial"`).
+- All 5ers cells marked **TBD-VERIFY** must be confirmed against current 5ers documentation
+  before any 5ers-specific input depends on them.
+
+---
+
+## 3. Setup / attach procedure
+
+1. **Pull `main`** on the VPS so the EA + includes + sidecar are current.
+2. **Place the EA files** so MetaTrader sees them: copy `deployment/ea/Arc10_DLR_Sidecar_EA.mq5`
+   and the `deployment/ea/include/*.mqh` files into the terminal's `MQL5/Experts/` tree
+   (preserving the `include/` subfolder). See [`arc_10/03_deployment/04_vps_setup_guide.md`](./arc_10/03_deployment/04_vps_setup_guide.md).
+3. **Recompile** the EA in MetaEditor (**F7**) — once per terminal. Confirm 0 errors.
+4. **Whitelist** `News_Calendar_URL`'s host in MT5 → Tools → Options → Expert Advisors → Allow WebRequest.
+5. **Set inputs** per §2 for the account this terminal trades. **Set `Initial_Equity_Floor`**
+   (non-zero) and **`Expected_Config_Hash`** (from the sidecar config) — both are required.
+6. **Attach** the EA to a chart and **enable Algo Trading**.
+7. Start / confirm the sidecar service (NSSM) and watchdog — see
+   [`arc_10/03_deployment/`](./arc_10/03_deployment/) and `deployment/ops/`.
+
+---
+
+## 4. Verification journal lines (confirm on attach)
+
+On a correct attach, the Experts log shows these `[ARC10] …` lines (strings quoted from the
+committed source). Confirm each:
+
+- **Floor accepted:** `[ARC10] equity init: floor=<N> source=input`
+  (`deployment/ea/include/EquityGuards.mqh:173`). If you instead see
+  `[ARC10] ERROR FLOOR_FAIL: Initial_Equity_Floor=… implausible` /
+  `equity init: floor=… source=sentinel-fail` (`EquityGuards.mqh:165–167`), the floor is
+  unset/implausible → **fail-loud halt** (OPEN-001). Set `Initial_Equity_Floor` and reattach.
+- **Daily-DD basis + reset:** `[ARC10] daily-DD basis=<INITIAL|DAY_START> reset=daily`
+  (`EquityGuards.mqh:196`). At each EET rollover:
+  `[ARC10] eet-rollover: daily-DD reset day_start_equity=… basis=… eet_day_utc=…`
+  (`EquityGuards.mqh:229`).
+- **Sizing (on first trade):** `[ARC10] sizing <pair>: base_equity=<floor> risk_pct=<r> risk_amount=…`
+  (`deployment/ea/include/PositionManager.mqh:212`) — `base_equity` must equal
+  `Initial_Equity_Floor` (static-initial sizing, FIX 1), **not** current account equity.
+- **Recovery (on restart):** `[ARC10] recovery complete: <N> positions reconstructed`
+  (`deployment/ea/include/RecoveryManager.mqh:166`) — N must match open positions.
+
+---
+
+## 5. Recompile / reinstall attestation checklist
+
+`Initial_Equity_Floor` is an EA **input**, not persisted state — a recompile, VPS reinstall, or
+snapshot rollback wipes it back to `0` (→ fail-loud halt). After ANY of those:
+
+- [ ] Re-set `Initial_Equity_Floor` to the correct per-account value (§2).
+- [ ] Re-set `Expected_Config_Hash` if the sidecar config changed.
+- [ ] Confirm all four §4 journal lines (floor `source=input`, basis + `reset=daily`, sizing
+      `base_equity=<floor>`, recovery count).
+- [ ] Confirm `Magic_Number` matches the account (§2) so recovery binds the right positions.
+
+---
+
+*Inputs verified against `deployment/ea/Arc10_DLR_Sidecar_EA.mq5` (26 inputs, lines 32–57).
+Cross-linked from [`NAVIGATION.md`](./NAVIGATION.md) and `arc_10/03_deployment/`.*

--- a/NAVIGATION.md
+++ b/NAVIGATION.md
@@ -1,0 +1,46 @@
+# NAVIGATION — Repo Front Door (route by intent)
+
+> The single intent-router for this repo. Find what you're trying to do below, read the
+> listed docs **in order**. Everything else is reachable from these.
+> For full project context and locked philosophy, read **[`CLAUDE.md`](./CLAUDE.md)** first.
+
+**What this project is:** a research-first FX trading system. A long-only 4H trend system
+(**KH-24**) and the **Arc 10 v3.0.2** DLR system are live; the L_PROTOCOL v3.0 overseer runs
+research arcs through five gates-as-rankings steps plus a lazy Step 6 causal audit. WFO
+worst-fold at Step 5 is the only deployment gate.
+
+---
+
+## Intent map
+
+| I want to… | Read, in order |
+|---|---|
+| **Start a new arc** | [`ARC_RUN_TEMPLATE.md`](./ARC_RUN_TEMPLATE.md) (self-run spec — copy, fill blanks) → [`L_PROTOCOL.md`](./L_PROTOCOL.md) (methodology + Amendment 8 defaults) → [`BROKER_RULES.md`](./BROKER_RULES.md) (constraints). Supply only the signal idea + any non-default settings; everything else = Amendment 8 defaults. |
+| **Understand / validate Arc 10** | [`arc_10/START_HERE.md`](./arc_10/START_HERE.md) → [`arc_10/02_validation/07_canonical_wfo.md`](./arc_10/02_validation/07_canonical_wfo.md) (canonical numbers; source of truth). |
+| **Deploy / set up the EA** | [`EA_REFERENCE.md`](./EA_REFERENCE.md) (every EA input + per-broker overrides + attach/verify) → [`arc_10/03_deployment/`](./arc_10/03_deployment/) (per-broker setup, VPS, config artifacts). |
+| **Run live health / monitoring** | [`arc_10/04_runbook/01_daily_health_check.md`](./arc_10/04_runbook/01_daily_health_check.md) → [`arc_10/04_runbook/`](./arc_10/04_runbook/) (weekly/Sunday checks, restart, incident response, emergency kill, kill criteria). |
+| **Question a number / "where did X come from"** | [`arc_10/02_validation/07_canonical_wfo.md`](./arc_10/02_validation/07_canonical_wfo.md) + the `_final_canonical/` CSVs at [`results/l_arc_10_v3.0.2_final_canonical/`](./results/l_arc_10_v3.0.2_final_canonical/) (`matrix.csv`, `per_fold.csv`, `governor_log.csv`). |
+| **Look up broker rules / per-account settings** | [`BROKER_RULES.md`](./BROKER_RULES.md). |
+| **See what's been tried / failed (don't repeat it)** | [`ARC_HISTORY.md`](./ARC_HISTORY.md) (frozen pre-v3.0 record) + [`docs/SHELVED_ARCS.md`](./docs/SHELVED_ARCS.md) (parked threads + reopen criteria) + [`ARC_TRACKER.md`](./ARC_TRACKER.md) (closed-arc verdicts, auto-managed). |
+| **Deep-dive the methodology** | [`L_PROTOCOL.md`](./L_PROTOCOL.md) (v3.0 + Amendments 1–8 inline). |
+| **Understand the engine internals** | [`docs/BACKTESTER_ARCHITECTURE.md`](./docs/BACKTESTER_ARCHITECTURE.md) + [`docs/PROTOCOL_RUNTIME.md`](./docs/PROTOCOL_RUNTIME.md). |
+| **Touch the live KH-24 system** | [`docs/KH24_SYSTEM_LOCK.md`](./docs/KH24_SYSTEM_LOCK.md) (locked — out of scope for forward research without an explicit modification phase). |
+| **Know current phase / in-flight work** | [`TODO.md`](./TODO.md) + [`WORKFLOW.md`](./WORKFLOW.md) (conventions, dispatch pattern, branch strategy). |
+
+---
+
+## Active vs reference
+
+- **Active / canonical:** Arc 10 v3.0.2 (DLR) is the deployed live system (FundedNext, 0.40%);
+  its canonical gate is [`results/l_arc_10_v3.0.2_final_canonical/`](./results/l_arc_10_v3.0.2_final_canonical/)
+  (fixed-initial sizing + `daily_ref=initial`-resetting — matches the live EA post-FIX-2b).
+  KH-24 is the other live system. `arc_10/` is the complete, self-contained suite for it.
+- **Reference only (not active):** the failed arcs (Arcs 5 / 7 / 8 / 11, both discovery folders)
+  and the six superseded Arc 10 result folders (`l_arc_10`, `l_arc_10_v3.0.2`,
+  `_canonical`, `_canonical_compound`, `_ea_faithful`, `_utc_rerun`) are retained for
+  reference — each carries a SUPERSEDED banner pointing forward to `_final_canonical`. Do not
+  cite their numbers as current.
+
+---
+
+*Front door only — it routes, it does not duplicate. When a target doc moves, fix the link here.*

--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 A research-first FX trading system targeting prop-firm requirements (5ers) with WFO-validated edge.
 
+> **New here? Start at [`NAVIGATION.md`](./NAVIGATION.md)** — the intent-router that maps what
+> you're trying to do (start an arc / deploy the EA / question a number / …) to the exact docs.
+
 ---
 
 ## Current State
 
-- **Live systems:** **Arc 10 v3.0.2** (DLR signal) — deployed on FundedNext ($100k Challenge, EET) at **0.40%** operating risk; PASS-DEPLOYABLE under the canonical EA-faithful gate. **KH-24** — running on Contabo VPS / 5ers MT5 broker feed, gate-passing, +1.92% worst-fold ROI / 6.37% worst-fold DD across 7 OOS folds. Live state + canonical Arc 10 numbers → [`arc_10/START_HERE.md`](./arc_10/START_HERE.md) + [`arc_10/02_validation/07_canonical_wfo.md`](./arc_10/02_validation/07_canonical_wfo.md).
-- **Active methodology:** `L_PROTOCOL.md` v3.0 + Amendments 1-6 (locked). Five steps as rankings; WFO at Step 5 is the only deployment gate; Step 6 causal-audit framework auto-dispatches on Top-1 PASS candidate.
+- **Live systems:** **Arc 10 v3.0.2** (DLR signal) — deployed on FundedNext ($100k Challenge, EET) at **0.40%** operating risk; PASS-DEPLOYABLE under the canonical **fixed-initial** gate ([`results/l_arc_10_v3.0.2_final_canonical/`](./results/l_arc_10_v3.0.2_final_canonical/) — fixed-initial sizing + `daily_ref=initial`-resetting, matching the live EA post-FIX-2b; worst-fold ROI 13.77% / mean 28.85% / trailing DD 7.73% / daily 4.06%). The earlier EA-faithful floating-equity run is retained as a reference only. **KH-24** — running on Contabo VPS / 5ers MT5 broker feed, gate-passing, +1.92% worst-fold ROI / 6.37% worst-fold DD across 7 OOS folds. Live state + canonical Arc 10 numbers → [`arc_10/START_HERE.md`](./arc_10/START_HERE.md) + [`arc_10/02_validation/07_canonical_wfo.md`](./arc_10/02_validation/07_canonical_wfo.md).
+- **Active methodology:** `L_PROTOCOL.md` v3.0 + Amendments 1-8 (locked) — Amendment 7 = portfolio-level DD gating + both-DD-references reporting; Amendment 8 = standing run-basis defaults (fixed-initial sizing, `daily_ref=initial`-resetting) + provenance stamp + decorrelation gate. Five steps as rankings; WFO at Step 5 is the only deployment gate; Step 6 causal-audit framework auto-dispatches on Top-1 PASS candidate.
 - **v3.0 engine:** post-Phase-1-engine-build sprint (8 PRs: #185 / #186 / #188 / #189 / #193 / #194 / #195 / #197). Steps 1–5 + Step 6 framework wired end-to-end. Architectures A1, A2, A3, A4, A6 operational; A5 deferred until ≥ 1 VIABLE candidate. Signal parity (mid features + 5ers EET aggregation + worst-case fills) merged.
 - **Data layer:** HistData M1 bid+ask, 28 pairs, 2010-2026 (52 GB tick + 18 GB M1 derived; verified 2026-05-21).
 - **Research status:** Phase 1 Wave 1 is **CLOSED** — Arc 10 PASS-DEPLOYABLE → deployed at 0.40%; Arcs 5 / 7 / 8 / 11 FAIL. The PASS-DEPLOYABLE survivor goal is **achieved**. Forward research (Wave 2 + Phase 2) is **PARKED** behind the deployment pivot; reopenable if Arc 10 fails its live kill criteria.
@@ -82,7 +85,7 @@ Canonical reads — everything else is reachable from these six:
 
 | File | When to read |
 | --- | --- |
-| `L_PROTOCOL.md` | Methodology of record. First read for any forward research work. Locked v3.0 + Amendments 1-6 inline. |
+| `L_PROTOCOL.md` | Methodology of record. First read for any forward research work. Locked v3.0 + Amendments 1-8 inline. |
 | `TODO.md` | Live operational tracker — current phase, in-flight PRs, standing items. Update at major state transitions. |
 | `ARC_TRACKER.md` | Auto-managed arc state via `scripts/update_tracker_from_closure.py`. Read-only for chat. |
 | `CLAUDE.md` | First-read context for AI assistants. Locked philosophy + KH-24 spec + permanently-eliminated list. |


### PR DESCRIPTION
## What

Three doc-only changes to make the repo a self-directing baseline. No code, no moves, no archiving, no branch ops.

1. **`NAVIGATION.md`** (new, root) — the intent-router the repo lacked. Maps task → exact docs in read order: start a new arc, validate Arc 10, deploy the EA, run live health, question a number, broker rules, failed-arc history, methodology deep-dive, engine internals, KH-24. Every linked path verified to resolve.
2. **`EA_REFERENCE.md`** (new, root) — single EA parameter + deployment card consolidating knowledge previously scattered across `BROKER_RULES.md` + `arc_10/03_deployment/`. All **26 EA inputs** (verified against `deployment/ea/Arc10_DLR_Sidecar_EA.mq5:32-57`) with defaults/ranges, the per-broker override table, attach/verify procedure, journal verification lines (quoted from committed source), and a recompile-attest checklist. 5ers `Risk_Per_Trade` left **TBD-VERIFY**.
3. **`README.md`** — targeted staleness fix only:
   - `Amendments 1-6` → `Amendments 1-8` (both occurrences)
   - canonical "EA-faithful gate" → fixed-initial `_final_canonical` (floating relabelled as reference); added the canonical numbers (worst 13.77 / mean 28.85 / trailing 7.73 / daily 4.06)
   - added a `NAVIGATION.md` front-door pointer

## Verification

- `NAVIGATION.md`, `EA_REFERENCE.md` exist.
- `git grep "Amendments 1-6" / "EA-faithful gate" README.md` → 0 matches.
- `EA_REFERENCE.md` §1 has exactly 26 numbered input rows; per-broker `Daily_DD_Basis` / `INITIAL` / `DAY_START` table present.
- All 22 path links in `NAVIGATION.md` resolve (`Test-Path` each → OK).
- EA input defaults cross-checked against the live `.mq5` source.

Deferred (separate pass, needs importer/link checks): relocating the 8 root `*_intent.md`, root `.py` modules, `EA/`/`MQL5/` strays, archiving superseded result folders, branch pruning, `REPO_INVENTORY.md` refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
