### PR TITLE
Fix Part D: SL-honest heavy_ml labels (in-tree bars_to_1r_mfe producer + hard_sl tie-break)

### DIFF
--- a/FIX_PART_D_HEAVYML_LABELS_REPORT.md
+++ b/FIX_PART_D_HEAVYML_LABELS_REPORT.md
@@ -1,0 +1,160 @@
+# FIX PART D — heavy_ml label provenance + same-bar tie-break — **RESOLVED**
+
+> Closes the two open items in `HONEST_ENGINE_SWEEP.md` Part D (the FLAG).
+> heavy_ml's training labels are now SL-honest and provably in-tree, so the
+> path is safe to UN-quarantine for discovery.
+>
+> Date: 2026-06-03 · Engine state: clean-base reset (fast replay retired 2026-06-02)
+
+---
+
+## What the sweep found (Part D = FLAG)
+
+1. **FLAG-D1 — provenance gap.** `bars_to_1r_mfe` (the meta-label + survival
+   target input) was *read* by `core/heavy_ml_probe` but **produced nowhere
+   in-tree**, so any pool fed to heavy_ml had to be enriched out-of-tree —
+   honesty unverifiable, possibly a retired-replay frame.
+2. **FLAG-D2 — same-bar tie-break bug.** The label compared `exit_reason`
+   against the literal `"sl"`, but the pool simulators emit `"hard_sl"` with
+   no normalization. A same-bar (+1R-high **and** SL-low) trade therefore
+   resolved to `y = 1` (**WIN**) — the Arc-10 defect (same-bar → win)
+   reincarnated in label space.
+
+---
+
+## The fix
+
+### D.1 — honest, in-tree `bars_to_1r_mfe` producer
+
+New leaf module **`core/sim/honest_label.py`** — `reached_1r_before_sl(...)`
+walks the actual forward bars with **take-the-loss ordering** (the hard stop
+is checked BEFORE +1R on every bar), so "+1R reached before SL" is true ONLY
+if +1R landed on a bar **strictly before** any stop breach; a same-bar
++1R/SL bar resolves SL-first and is **not** a reach:
+
+```python
+def reached_1r_before_sl(*, high_bid, low_bid, entry_idx, exit_off,
+                         entry_price, sl_price, sl_distance,
+                         exit_at_bar_open=False, r_threshold=ONE_R):
+    if not math.isfinite(sl_distance) or sl_distance <= 0:
+        return float("nan")
+    last = exit_off - 1 if exit_at_bar_open else exit_off
+    for off in range(0, last + 1):
+        bidx = entry_idx + off
+        lo = float(low_bid[bidx])
+        if off > 0 and math.isfinite(lo) and lo <= sl_price:
+            return float("nan")          # stop breach before any qualifying +1R
+        hi = float(high_bid[bidx])
+        if math.isfinite(hi) and (hi - entry_price) / sl_distance >= r_threshold:
+            return float(off)            # +1R on a non-stop bar => strictly before SL
+    return float("nan")
+```
+
+It is now **called by both pool simulators**, so the column is a native part
+of the Step-1 pool (`pool.parquet`) that heavy_ml loads — no out-of-tree
+enrichment, fully reproducible:
+
+- `core/arc/arc_pool_builder.py:281` — the documented heavy_ml pool source
+  (`run_probe.py --pool .../step_1/pool.parquet`).
+- `core/discovery/pool_simulator.py:331` — the discovery pool source.
+
+### D.2 — same-bar tie-break normalization (take-the-loss in label space)
+
+`core/sim/honest_label.is_stop_loss_exit()` recognises every stop spelling a
+producer emits — `{"sl", "hard_sl", "stop_loss", "stop"}`, case-insensitive.
+Both label builders now resolve a same-bar +1R/SL tie to a **LOSS** for any
+of these. The builders moved to a new sklearn-free module
+**`core/heavy_ml_probe/labels.py`** (`build_meta_label_target`,
+`build_survival_target`), re-exported from `meta_labeling.py` / `survival.py`
+so every existing import is unchanged. The decoupling lets the regression
+test pin the *real* label functions in CI's minimal (numpy/pandas) env.
+
+With the honest producer in place the `bars_to_1r_mfe == bars_held` + stop
+case can no longer arise for an intrabar stop (the producer never registers
++1R on the stop bar), so D.2 is belt-and-braces: the label agrees with the
+engine even if the column is ever sourced elsewhere.
+
+---
+
+## Validation (per dispatch)
+
+### Old vs new label — constructed same-bar +1R/SL trade
+
+Trade: `bars_to_1r_mfe == bars_held == 5`, `exit_reason == "hard_sl"` (a bar
+whose high hit +1R **and** whose low hit the stop).
+
+| | comparison | label |
+|---|---|---|
+| **OLD** (`exit_reason == "sl"`) | `"hard_sl" == "sl"` → `False` | `y = 1` → **WIN (bug)** |
+| **NEW** (`is_stop_loss_exit`) | `is_stop_loss_exit("hard_sl")` → `True` | `y = 0` → **LOSS (correct)** |
+
+End-to-end through the real simulator (no hand-set columns), a same-bar tie
+trade exits `hard_sl` with raw `mfe_r >= 1.0` (the high *did* touch +1R
+intrabar) yet honest `bars_to_1r_mfe = NaN` → `build_meta_label_target → 0`,
+`build_survival_target event → 0`. Pinned by
+`tests/heavy_ml/test_label_take_the_loss.py::test_chain_same_bar_tie_simulator_to_label_is_loss`
+and `::test_sim_same_bar_tie_nan_despite_raw_mfe_touching_1r`.
+
+### Producer is in-tree + reproducible
+
+`bars_to_1r_mfe` is now **written** by `reached_1r_before_sl` at
+`core/arc/arc_pool_builder.py:281` and `core/discovery/pool_simulator.py:331`
+(declared in the pool schema at `arc_pool_builder.py:425` and
+`pool_simulator.py` `TradeRow`). Deterministic, standard-library walk —
+provenance is the function + the bar data, nothing external.
+
+### No replay/precomputed frame on the label path (grep)
+
+```
+grep -rniE "realized_r|_3p5|B_exit|simulate_path|np\.load|\.npy" \
+     core/heavy_ml_probe/ core/sim/honest_label.py \
+     core/discovery/pool_simulator.py core/arc/arc_pool_builder.py
+→ (no matches)
+```
+
+The only `read_parquet` on the path is `pipeline.load_pool` reading the
+**in-tree** Step-1 pool. The `realised_r` name in `meta_labeling.threshold_sweep`
+is the kept/dropped mean-R **diagnostic** built from the honest `final_r`
+column (the sweep itself classified this as honest), not a label input. The
+`mfe_so_far_r` path column is a diagnostic and is **not** read by the label
+builders (which consume only `bars_to_1r_mfe` / `bars_held` / `exit_reason` /
+`final_r`).
+
+### Tests — green
+
+- **`tests/heavy_ml/test_label_take_the_loss.py`** — 18 cases, **CI-gated,
+  not research-marked**, numpy/pandas only. Proven minimal-env safe: all its
+  imports resolve with `sklearn` / `flaml` / `joblib` / `statsmodels` / `scipy`
+  blocked (none load). Covers producer (before / after / same-bar / never),
+  producer-through-real-simulator (engine bar indices), the real label
+  functions, and the old-vs-new bug demonstration.
+- `tests/heavy_ml_probe/test_meta_labeling.py` + `test_survival.py` — extended
+  with `hard_sl` same-bar cases (real builders, via the re-export path).
+- `tests/protocol_runtime/test_arc_pool_builder.py` + `tests/discovery/test_pool_simulator.py`
+  — assert the emitted `bars_to_1r_mfe` is SL-honest.
+- **Full non-research suite (CI parity):** `1649 passed, 294 skipped, 0 failed`.
+- ruff clean on every changed/new file.
+
+### Guards unchanged
+
+heavy_ml's causal-lineage gate (`core/heavy_ml_probe/causal_lineage.py`) and
+holdout-guard (`core/heavy_ml_probe/automl.py`) are **not modified** — they
+defend against feature lineage / lookahead, not label dishonesty. This fix is
+the missing label-honesty defense; it composes with them.
+
+---
+
+## Definition of done
+
+- [x] `bars_to_1r_mfe` + the reach-1R-before-SL label have an honest, in-tree,
+      reproducible producer sourced from the SL-honest forward walk
+      (`core/sim/honest_label.reached_1r_before_sl`, called by both simulators).
+- [x] Same-bar tie-break labels a +1R/SL `hard_sl` trade as a **LOSS**
+      (`is_stop_loss_exit` normalization).
+- [x] Regression test committed, CI-gated (minimal-env safe), green.
+- [x] Old-vs-new label shown on the bug case (win → loss).
+- [x] Grep confirms no replay-frame label source.
+
+**heavy_ml is safe to UN-quarantine for discovery** on label-honesty grounds.
+(Part C — broker-cost wiring on the gate path — remains a separate, open
+blocker tracked in `HONEST_ENGINE_SWEEP.md`.)

--- a/HONEST_ENGINE_SWEEP.md
+++ b/HONEST_ENGINE_SWEEP.md
@@ -15,7 +15,7 @@
 
 1. **(Part C) Mandatory broker costs are not applied on ANY gate-scoring path.** The 1.5× spread stress, $5/lot commission, and 0.5 pip × n_fills slippage primitives exist (`core/sim/costs/`) but are never called by the driver, the fold runners, the architectures, or the gates. They were post-hoc R-adjustments wired to the now-retired `simulate_path` replay and are orphaned. Today every gate verdict is scored on **raw HistData bid/ask spread only (1.0×), zero commission, zero slippage**. Re-wire (or re-establish) the deployment-gate cost application before the engine produces a PASS verdict.
 
-2. **(Part D) heavy_ml's training labels cannot be proven honest, and carry a latent take-the-loss bug-class.** The `bars_to_1r_mfe` label is computed *nowhere* in `core/` or `scripts/` (only read), so its provenance is unverifiable. Separately, the label same-bar tie-break compares `exit_reason` against `"sl"` while the pool builders emit `"hard_sl"` with no normalization — so a same-bar (+1R high AND SL low) trade would be labelled a **win**, exactly the Arc-10 defect re-entering in label space. Latent today (no in-tree producer of `bars_to_1r_mfe`) but a live trap the moment heavy_ml is wired for discovery.
+2. **(Part D) heavy_ml's training labels cannot be proven honest, and carry a latent take-the-loss bug-class.** ✅ **RESOLVED 2026-06-03** ([`FIX_PART_D_HEAVYML_LABELS_REPORT.md`](FIX_PART_D_HEAVYML_LABELS_REPORT.md)). The `bars_to_1r_mfe` label is computed *nowhere* in `core/` or `scripts/` (only read), so its provenance is unverifiable. Separately, the label same-bar tie-break compares `exit_reason` against `"sl"` while the pool builders emit `"hard_sl"` with no normalization — so a same-bar (+1R high AND SL low) trade would be labelled a **win**, exactly the Arc-10 defect re-entering in label space. *Fix:* `bars_to_1r_mfe` now has an in-tree, reproducible producer (`core/sim/honest_label.reached_1r_before_sl`) called by both pool simulators, and the tie-break normalizes every stop spelling (`is_stop_loss_exit`) so a `hard_sl` same-bar tie is a **LOSS**; CI-gated regression added.
 
 **What IS sound:** the trade-by-trade SL/exit accounting (Part A — take-the-loss invariant holds, now pinned by 5 regression cases), no-lookahead / ex-ante construction (Part B), and determinism (Part E). The engine's *mechanics* are honest; what is missing is **(C) cost realism on the gate path** and **(D) provenance + correctness of the ML training labels** that feed the A2/A4/A6 architectures.
 
@@ -24,7 +24,7 @@
 | **A** | Take-the-loss invariant | **PASS** (fixture committed, CI-green) |
 | **B** | No lookahead / ex-ante populations | **PASS** (one watch-item) |
 | **C** | Cost + rule fidelity (FundedNext) | **FAIL** (spread 1.5× / commission / slippage not wired) |
-| **D** | heavy_ml label contamination | **FLAG** (provenance unverifiable + bug-class tie-break) |
+| **D** | heavy_ml label contamination | **RESOLVED** (2026-06-03; was FLAG) — in-tree producer + `hard_sl`-aware tie-break, see [`FIX_PART_D_HEAVYML_LABELS_REPORT.md`](FIX_PART_D_HEAVYML_LABELS_REPORT.md) |
 | **E** | Determinism + reconstruction | **PASS** (one FLAG: no full-data anchor in CI) |
 
 ---
@@ -103,7 +103,9 @@ Half-spread cost IS paid implicitly (entries at ask, exits at bid via `core/sim/
 
 ---
 
-## PART D — heavy_ml LABEL-CONTAMINATION — **FLAG**
+## PART D — heavy_ml LABEL-CONTAMINATION — **FLAG → RESOLVED (2026-06-03)**
+
+> **RESOLVED.** Both vectors below are fixed — see [`FIX_PART_D_HEAVYML_LABELS_REPORT.md`](FIX_PART_D_HEAVYML_LABELS_REPORT.md). FLAG-D1: `bars_to_1r_mfe` now has an in-tree, reproducible producer ([`core/sim/honest_label.reached_1r_before_sl`](core/sim/honest_label.py)) called by both pool simulators. FLAG-D2: the same-bar tie-break normalizes every stop spelling via `is_stop_loss_exit`, so a `hard_sl` +1R/SL tie labels as a **LOSS**. CI-gated regression at [`tests/heavy_ml/test_label_take_the_loss.py`](tests/heavy_ml/test_label_take_the_loss.py). The original finding is preserved below.
 
 Central question — are heavy_ml's labels honest-engine-derived or replay-derived? **Classification: FLAG — CANNOT VERIFY, plus a latent bug-class.**
 

--- a/core/arc/arc_pool_builder.py
+++ b/core/arc/arc_pool_builder.py
@@ -50,6 +50,7 @@ from core.arc.signal_protocol import (
     validate_panels,
 )
 from core.sim.fill import long_entry_fill_price
+from core.sim.honest_label import reached_1r_before_sl
 from core.sim.panel import Panel
 
 
@@ -169,6 +170,7 @@ def _simulate_pair_pool(
 
     df_close_ask = df["close_ask"].values
     df_low_bid = df["low_bid"].values
+    df_high_bid = df["high_bid"].values
     df_close_bid = df["close_bid"].values
     # Per-bar bid+ask quotes for the Step 6 §6.3 spread-decomposition
     # diagnostic. Captured at fill sites only (entry-bar open / exit-bar
@@ -270,6 +272,22 @@ def _simulate_pair_pool(
             exit_ask_q = _q(df_open_ask, exit_idx)
 
         final_r = (exit_price - entry_price) / sl_distance
+        # SL-honest meta-label provenance: the first forward offset at which
+        # the trade reached +1R MFE STRICTLY BEFORE its hard stop (take-the-
+        # loss ordering; same-bar +1R/SL → NaN). Both exits here are open
+        # through the resolved bar (hard_sl intrabar at sl_price, time_exit
+        # at the bar close), so the exit bar is included in the scan. This is
+        # the in-tree producer that closes HONEST_ENGINE_SWEEP.md FLAG-D1.
+        bars_to_1r_mfe = reached_1r_before_sl(
+            high_bid=df_high_bid,
+            low_bid=df_low_bid,
+            entry_idx=entry_idx,
+            exit_off=int(bars_held),
+            entry_price=entry_price,
+            sl_price=sl_price,
+            sl_distance=sl_distance,
+            exit_at_bar_open=False,
+        )
         trades.append(
             {
                 "pair": pair,
@@ -286,6 +304,7 @@ def _simulate_pair_pool(
                 "final_r": float(final_r),
                 "mfe_r": float(mfe_r),
                 "mae_r": float(mae_r),
+                "bars_to_1r_mfe": bars_to_1r_mfe,
                 "entry_bid": entry_bid_q,
                 "entry_ask": entry_ask_q,
                 "exit_bid": exit_bid_q,
@@ -400,6 +419,10 @@ _TRADES_COLUMNS = (
     "pair", "trade_id", "signal_time", "entry_time", "entry_price",
     "atr_at_signal", "sl_at_entry_price", "exit_time", "exit_price",
     "exit_reason", "bars_held", "final_r", "mfe_r", "mae_r",
+    # SL-honest meta-label provenance (HONEST_ENGINE_SWEEP.md Part D): first
+    # forward offset reaching +1R strictly before the hard stop, NaN if
+    # never. Produced by core.sim.honest_label.reached_1r_before_sl.
+    "bars_to_1r_mfe",
     # Bid+ask at entry-bar open and exit-bar open (close for intra-bar
     # SL hits) per the Step 6 §6.3 spread-decomposition diagnostic.
     "entry_bid", "entry_ask", "exit_bid", "exit_ask",

--- a/core/discovery/pool_simulator.py
+++ b/core/discovery/pool_simulator.py
@@ -39,6 +39,13 @@ import numpy as np
 import pandas as pd
 
 from core.sim.fill import long_entry_fill_price
+from core.sim.honest_label import reached_1r_before_sl
+
+# Exit reasons whose fill lands at the OPEN of the exit bar (queued
+# next-bar-open fills): that bar's intrabar high is unreachable, so the
+# +1R producer scan stops one bar earlier. Intrabar / at-close exits
+# ("hard_sl", "end_of_data") leave the trade open through the bar.
+_OPEN_FILL_EXIT_REASONS: frozenset[str] = frozenset({"trail", "time_exit"})
 
 
 @dataclass(frozen=True)
@@ -80,6 +87,10 @@ class TradeRow:
     mfe_r: float
     mae_r: float
     activated_trail: bool
+    # SL-honest meta-label provenance (HONEST_ENGINE_SWEEP.md Part D): first
+    # forward offset reaching +1R strictly before the hard stop (take-the-
+    # loss; same-bar +1R/SL → NaN). NaN if +1R never reached before SL.
+    bars_to_1r_mfe: float = float("nan")
 
     def to_dict(self) -> dict:
         return {
@@ -98,6 +109,7 @@ class TradeRow:
             "mfe_r": self.mfe_r,
             "mae_r": self.mae_r,
             "activated_trail": self.activated_trail,
+            "bars_to_1r_mfe": self.bars_to_1r_mfe,
         }
 
 
@@ -311,6 +323,22 @@ def simulate_pair_pool(
 
         final_r = (exit_price - entry_price) / sl_distance
 
+        # SL-honest meta-label provenance: first forward offset reaching +1R
+        # STRICTLY before the hard stop (take-the-loss; same-bar +1R/SL →
+        # NaN). Trail / time exits fill at the next bar's open, so that bar's
+        # high is excluded; hard_sl / end_of_data leave the trade open
+        # through the resolved bar. Closes HONEST_ENGINE_SWEEP.md FLAG-D1.
+        bars_to_1r_mfe = reached_1r_before_sl(
+            high_bid=high_bid,
+            low_bid=low_bid,
+            entry_idx=entry_idx,
+            exit_off=int(bars_held),
+            entry_price=entry_price,
+            sl_price=sl_price,
+            sl_distance=sl_distance,
+            exit_at_bar_open=(str(exit_reason) in _OPEN_FILL_EXIT_REASONS),
+        )
+
         trades.append(
             TradeRow(
                 pair=pair,
@@ -328,6 +356,7 @@ def simulate_pair_pool(
                 mfe_r=float(mfe_r),
                 mae_r=float(mae_r),
                 activated_trail=trail_armed,
+                bars_to_1r_mfe=bars_to_1r_mfe,
             )
         )
         tid += 1

--- a/core/heavy_ml_probe/labels.py
+++ b/core/heavy_ml_probe/labels.py
@@ -1,0 +1,305 @@
+"""SL-honest training-label construction for heavy_ml_probe.
+
+This is the dependency-light home (numpy / pandas + the standard-library
+:mod:`core.sim.honest_label` primitives) for the two heavy_ml training
+targets:
+
+  * :func:`build_meta_label_target` — binary "reached +1R MFE strictly
+    before SL / time-exit" (meta-labeling, PR-C).
+  * :func:`build_survival_target` — ``(duration, event)`` for Cox PH, the
+    same +1R event modelled as time-to-event with SL / time-exit censoring
+    (PR-D).
+
+It was split out of ``meta_labeling.py`` / ``survival.py`` (which keep the
+sklearn / joblib / statsmodels machinery) for two reasons the honest-engine
+sweep made load-bearing:
+
+  1. **Label honesty is independent of the model machinery.** The
+     contamination risk the sweep flagged (``HONEST_ENGINE_SWEEP.md`` Part
+     D) lives entirely in label construction, not in AutoML / Cox PH. Both
+     builders re-export from their original modules, so existing imports are
+     unchanged.
+  2. **The take-the-loss regression test must run in CI's minimal env.**
+     Importing the real builders here pulls only numpy / pandas, so the
+     CI-gated test pins the *actual* label functions without sklearn /
+     flaml present.
+
+The same-bar tie-break is delegated to
+:func:`core.sim.honest_label.is_stop_loss_exit`, which recognises every
+stop-loss spelling a pool producer emits (``"hard_sl"`` from the
+simulators, ``"sl"`` / ``"stop_loss"`` legacy). This closes the
+``"hard_sl"`` vs ``"sl"`` mismatch the sweep found: a same-bar +1R/SL trade
+now resolves to a LOSS regardless of the producer's ``exit_reason`` string —
+the take-the-loss invariant in label space.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from core.sim.honest_label import ONE_R, is_stop_loss_exit
+
+# Locked target name + +1R threshold per ``docs/sub_protocols/heavy_ml_probe.md``.
+META_LABEL_TARGET_COL: str = "y_meta_label"
+DEFAULT_MFE_R_THRESHOLD: float = ONE_R  # +1R; locked at 1.0
+
+# Backwards-compatible scalar anchor for the SL tie-break. Matching is done
+# by :func:`core.sim.honest_label.is_stop_loss_exit` (which also recognises
+# ``"hard_sl"`` / ``"stop_loss"``); this constant is retained for callers
+# that pass an explicit ``sl_exit_reason`` and for the public API surface.
+SL_EXIT_REASON: str = "sl"
+
+
+class PoolSchemaError(ValueError):
+    """Raised when the input pool is missing columns required for label
+    target construction. Schema mismatches HALT loudly — they are NOT
+    papered over (``docs/sub_protocols/heavy_ml_probe.md`` §1).
+    """
+
+
+# Columns the meta-labeling stage requires on the input pool. The
+# classifier-pipeline stage adds ``entry_time`` + ``trade_id`` on top.
+REQUIRED_POOL_COLUMNS: tuple[str, ...] = (
+    "bars_to_1r_mfe",   # int, NaN if MFE never reached +1R before SL
+    "bars_held",        # int, total bars trade was open (= bars_to_close)
+    "exit_reason",      # str, e.g. "hard_sl" | "time_exit" | "trail" | ...
+    "final_r",          # float, realised R-multiple at close (for kept/dropped means)
+)
+
+# Survival consumes a subset of the meta-label schema (``final_r`` is not
+# required). Kept separate so future schema drift can fork cleanly.
+SURVIVAL_REQUIRED_POOL_COLUMNS: tuple[str, ...] = (
+    "bars_to_1r_mfe",
+    "bars_held",
+    "exit_reason",
+)
+
+
+def _validate_pool_schema(
+    pool: pd.DataFrame, required: tuple[str, ...], *, target: str
+) -> None:
+    """HALT loud on missing columns (``docs/sub_protocols/heavy_ml_probe.md`` §1)."""
+    missing = [c for c in required if c not in pool.columns]
+    if missing:
+        raise PoolSchemaError(
+            f"{target} target requires pool columns {sorted(required)}; "
+            f"missing: {sorted(missing)} — pool has: {sorted(pool.columns)[:20]}"
+            + ("..." if len(pool.columns) > 20 else "")
+        )
+
+
+def _is_sl_tie(exit_reason: object, sl_exit_reason: str) -> bool:
+    """Same-bar tie-break predicate: True → the +1R/SL same-bar trade is a
+    LOSS. Recognises every canonical stop-loss spelling
+    (:func:`core.sim.honest_label.is_stop_loss_exit`) plus any explicit
+    ``sl_exit_reason`` a caller passes (case-insensitive)."""
+    if is_stop_loss_exit(exit_reason):
+        return True
+    if exit_reason is None:
+        return False
+    return str(exit_reason).strip().lower() == str(sl_exit_reason).strip().lower()
+
+
+# ── Meta-label target (binary) ───────────────────────────────────────
+
+
+def build_meta_label_target(
+    pool: pd.DataFrame,
+    *,
+    mfe_r_threshold: float = DEFAULT_MFE_R_THRESHOLD,
+    sl_exit_reason: str = SL_EXIT_REASON,
+) -> np.ndarray:
+    """Construct the binary meta-label target over ``pool``.
+
+    The target is binary:
+
+      1 = trade reached +1R MFE STRICTLY BEFORE SL hit OR time-exit
+      0 = otherwise
+
+    expressed over the pool columns:
+
+      * ``bars_to_1r_mfe`` is NaN      → 0  (never reached +1R before SL)
+      * ``bars_to_1r_mfe <  bars_held`` → 1  (reached strictly before close)
+      * ``bars_to_1r_mfe == bars_held``:
+            stop-loss ``exit_reason``  → 0  (same-bar tie, SL-first)
+            any other exit reason      → 1  (reached +1R same bar as a
+                                              non-adverse close)
+      * ``bars_to_1r_mfe >  bars_held`` → 0  (defensive; shouldn't happen)
+
+    The same-bar tie-break is take-the-loss: a stop-loss ``exit_reason``
+    (``"hard_sl"`` / ``"sl"`` / ``"stop_loss"`` — see
+    :func:`core.sim.honest_label.is_stop_loss_exit`) makes the tie a LOSS.
+    With the honest ``bars_to_1r_mfe`` producer
+    (:func:`core.sim.honest_label.reached_1r_before_sl`) the ``== bars_held``
+    + stop case cannot arise for an intrabar stop (the producer never
+    registers +1R on the stop bar), so this branch is belt-and-braces: the
+    label agrees with the engine even if the column is sourced elsewhere.
+
+    Parameters
+    ----------
+    pool
+        Must contain :data:`REQUIRED_POOL_COLUMNS`.
+    mfe_r_threshold
+        Multiple of R that defines the favourable event. Default 1.0;
+        non-1.0 is rejected (production pools carry ``bars_to_1r_mfe`` only).
+    sl_exit_reason
+        Explicit stop-loss ``exit_reason`` anchor (case-insensitive),
+        accepted in addition to the canonical stop spellings.
+
+    Returns
+    -------
+    ``np.ndarray`` of shape ``(len(pool),)`` with values in ``{0, 1}`` in
+    the same row order as ``pool``.
+
+    Raises
+    ------
+    PoolSchemaError
+        If any required column is missing.
+    ValueError
+        If ``bars_held`` has NaN values, or ``mfe_r_threshold != 1.0``.
+    """
+    _validate_pool_schema(pool, REQUIRED_POOL_COLUMNS, target="meta-label")
+    bars_to_1r = pool["bars_to_1r_mfe"]
+    bars_held = pool["bars_held"]
+    exit_reason = pool["exit_reason"].astype(str)
+
+    if bars_held.isna().any():
+        raise ValueError(
+            "meta-label target: bars_held column has NaN values; this is "
+            "structurally inconsistent (every closed trade has a known "
+            "duration). Inspect pool integrity."
+        )
+
+    # The bars_to_1r_mfe column already reflects the +1R event in production
+    # pools. Non-1.0 sensitivity analyses must pre-compute an equivalent
+    # column upstream rather than silently reusing the +1R column.
+    if not np.isclose(mfe_r_threshold, 1.0):
+        raise ValueError(
+            f"mfe_r_threshold={mfe_r_threshold} != 1.0 not supported in "
+            f"production; pools carry `bars_to_1r_mfe` only. To run a "
+            f"sensitivity analysis with a different threshold, pre-compute "
+            f"the equivalent column upstream + pass via a future "
+            f"`bars_to_event_col` override (not yet implemented)."
+        )
+
+    n = len(pool)
+    y = np.zeros(n, dtype=int)
+
+    reached = bars_to_1r.notna().values
+    bars_1r_arr = bars_to_1r.values
+    bars_held_arr = bars_held.values
+    exit_arr = exit_reason.values
+
+    for i in range(n):
+        if not reached[i]:
+            y[i] = 0
+            continue
+        b1r = float(bars_1r_arr[i])
+        bh = float(bars_held_arr[i])
+        if b1r < bh:
+            y[i] = 1
+        elif b1r == bh:
+            # Same-bar tie: SL-first (take-the-loss) → LOSS.
+            y[i] = 0 if _is_sl_tie(exit_arr[i], sl_exit_reason) else 1
+        else:
+            # bars_to_1r_mfe > bars_held: defensive — shouldn't happen.
+            y[i] = 0
+    return y
+
+
+# ── Survival target (duration, event) ────────────────────────────────
+
+
+def build_survival_target(
+    pool: pd.DataFrame,
+    *,
+    sl_exit_reason: str = SL_EXIT_REASON,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Construct ``(duration, event)`` for Cox PH.
+
+      * ``event[i] = 1`` if trade ``i`` reached +1R MFE strictly before SL
+        hit or time-exit; ``0`` otherwise (censored at the close bar).
+      * ``duration[i]`` = bars to first of ``{+1R MFE, SL hit, time-exit}``.
+
+    Same-bar tie-break (identical to :func:`build_meta_label_target`):
+
+      * ``bars_to_1r_mfe`` is NaN       → event=0, duration=bars_held
+      * ``bars_to_1r_mfe <  bars_held``  → event=1, duration=bars_to_1r_mfe
+      * ``bars_to_1r_mfe == bars_held``:
+            stop-loss ``exit_reason``   → event=0 (SL-first), duration=bars_held
+            otherwise                   → event=1, duration=bars_to_1r_mfe
+      * ``bars_to_1r_mfe >  bars_held``  → event=0 (defensive), duration=bars_held
+
+    Returns
+    -------
+    duration : np.ndarray[int]
+        Time-to-first-event in bars (always >= 1; 0-bar trades clipped to 1
+        so Cox PH stays well-defined).
+    event : np.ndarray[int]
+        Binary event indicator.
+
+    Raises
+    ------
+    PoolSchemaError
+        If any required column is missing.
+    ValueError
+        If ``bars_held`` has NaN values.
+    """
+    _validate_pool_schema(pool, SURVIVAL_REQUIRED_POOL_COLUMNS, target="survival")
+    bars_to_1r = pool["bars_to_1r_mfe"]
+    bars_held = pool["bars_held"]
+    exit_reason = pool["exit_reason"].astype(str)
+
+    if bars_held.isna().any():
+        raise ValueError(
+            "survival target: bars_held column has NaN values; "
+            "every closed trade must have a known duration."
+        )
+
+    n = len(pool)
+    event = np.zeros(n, dtype=int)
+    duration = np.zeros(n, dtype=int)
+
+    reached = bars_to_1r.notna().values
+    b1r = bars_to_1r.values
+    bh = bars_held.values
+    er = exit_reason.values
+
+    for i in range(n):
+        held_i = int(bh[i])
+        if not reached[i]:
+            event[i] = 0
+            duration[i] = held_i
+            continue
+        first_r = float(b1r[i])
+        if first_r < held_i:
+            event[i] = 1
+            duration[i] = int(first_r)
+        elif first_r == held_i:
+            if _is_sl_tie(er[i], sl_exit_reason):
+                event[i] = 0      # SL-wins tie-break
+                duration[i] = held_i
+            else:
+                event[i] = 1      # +1R on same bar as non-adverse close
+                duration[i] = held_i
+        else:
+            # Defensive — shouldn't happen on consistent pool data.
+            event[i] = 0
+            duration[i] = held_i
+
+    # Cox PH requires duration > 0 — clip any 0-duration entries to 1.
+    duration = np.maximum(duration, 1)
+    return duration, event
+
+
+__all__ = (
+    "DEFAULT_MFE_R_THRESHOLD",
+    "META_LABEL_TARGET_COL",
+    "REQUIRED_POOL_COLUMNS",
+    "SURVIVAL_REQUIRED_POOL_COLUMNS",
+    "SL_EXIT_REASON",
+    "PoolSchemaError",
+    "build_meta_label_target",
+    "build_survival_target",
+)

--- a/core/heavy_ml_probe/meta_labeling.py
+++ b/core/heavy_ml_probe/meta_labeling.py
@@ -75,141 +75,24 @@ from core.heavy_ml_probe.automl import (
     run_automl,
 )
 from core.heavy_ml_probe.io import sha256_file
-
-# Locked target name + threshold sweep grid per dispatch §3.
-META_LABEL_TARGET_COL: str = "y_meta_label"
-DEFAULT_THRESHOLD_SWEEP: tuple[float, ...] = (0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80)
-DEFAULT_MFE_R_THRESHOLD: float = 1.0  # +1R per dispatch §1
-
-
-class PoolSchemaError(ValueError):
-    """Raised when the input pool is missing columns required for
-    meta-label target construction. Per dispatch §1 (last paragraph),
-    schema mismatches HALT loudly — they are NOT papered over.
-    """
-
-
-# Columns the meta-labeling stage requires on the input pool. The
-# classifier-pipeline stage adds ``entry_time`` + ``trade_id`` (already
-# required by PR-B's ``run_automl``) on top of these.
-REQUIRED_POOL_COLUMNS: tuple[str, ...] = (
-    "bars_to_1r_mfe",   # int, NaN if MFE never reached +1R
-    "bars_held",        # int, total bars trade was open (= bars_to_close)
-    "exit_reason",      # str, e.g. "sl" | "time_exit" | "tp" | ...
-    "final_r",          # float, realised R-multiple at close (for kept/dropped means)
+from core.heavy_ml_probe.labels import (
+    DEFAULT_MFE_R_THRESHOLD,
+    META_LABEL_TARGET_COL,
+    REQUIRED_POOL_COLUMNS,
+    SL_EXIT_REASON,
+    PoolSchemaError,
+    _validate_pool_schema,
+    build_meta_label_target,
 )
 
-# Exit-reason value that triggers the same-bar SL tie-break. Lowercased
-# during comparison so producer drift between ``SL`` / ``Sl`` / ``sl``
-# is absorbed.
-SL_EXIT_REASON: str = "sl"
-
-
-# ── Target construction ──────────────────────────────────────────────
-
-
-def _validate_pool_schema(pool: pd.DataFrame) -> None:
-    """Per dispatch §1 last paragraph: HALT loud on missing columns."""
-    missing = [c for c in REQUIRED_POOL_COLUMNS if c not in pool.columns]
-    if missing:
-        raise PoolSchemaError(
-            f"meta-label target requires pool columns {sorted(REQUIRED_POOL_COLUMNS)}; "
-            f"missing: {sorted(missing)} — pool has: {sorted(pool.columns)[:20]}"
-            + ("..." if len(pool.columns) > 20 else "")
-        )
-
-
-def build_meta_label_target(
-    pool: pd.DataFrame,
-    *,
-    mfe_r_threshold: float = DEFAULT_MFE_R_THRESHOLD,
-    sl_exit_reason: str = SL_EXIT_REASON,
-) -> np.ndarray:
-    """Construct the binary meta-label target over ``pool``.
-
-    Parameters
-    ----------
-    pool
-        Must contain :data:`REQUIRED_POOL_COLUMNS`.
-    mfe_r_threshold
-        Multiple of R that defines the favourable event. Default 1.0
-        per dispatch §1. Exposed for sensitivity probes.
-    sl_exit_reason
-        Exit-reason string that triggers the same-bar tie-break per
-        dispatch §1. Case-insensitive at comparison time.
-
-    Returns
-    -------
-    ``np.ndarray`` of shape ``(len(pool),)`` with values in ``{0, 1}``
-    in the same row order as ``pool``.
-
-    Raises
-    ------
-    PoolSchemaError
-        If any required column is missing.
-    ValueError
-        If a per-trade record has missing ``bars_held`` (defensive — the
-        pool should always have this).
-
-    Notes
-    -----
-    The ``mfe_r_threshold`` parameter is non-default *only* for
-    sensitivity analyses; production runs MUST use 1.0 per spec. The
-    threshold value is recorded in the meta-label manifest so audits
-    can detect non-spec overrides.
-    """
-    _validate_pool_schema(pool)
-    bars_to_1r = pool["bars_to_1r_mfe"]
-    bars_held = pool["bars_held"]
-    exit_reason = pool["exit_reason"].astype(str).str.lower()
-
-    if bars_held.isna().any():
-        raise ValueError(
-            "meta-label target: bars_held column has NaN values; this is "
-            "structurally inconsistent (every closed trade has a known "
-            "duration). Inspect pool integrity."
-        )
-
-    # The mfe_r_threshold parameter is recorded but the bars_to_1r_mfe
-    # column already reflects the +1R event in production pools. For
-    # non-1.0 sensitivity analyses, callers must pre-compute the
-    # equivalent ``bars_to_<threshold>r_mfe`` column. PR-C surfaces a
-    # ValueError in that case rather than silently using the wrong
-    # column.
-    if not np.isclose(mfe_r_threshold, 1.0):
-        raise ValueError(
-            f"mfe_r_threshold={mfe_r_threshold} != 1.0 not supported in "
-            f"PR-C; production pools carry `bars_to_1r_mfe` only. To run "
-            f"a sensitivity analysis with a different threshold, pre-compute "
-            f"the equivalent column upstream + pass via a future "
-            f"`bars_to_event_col` override (not yet implemented)."
-        )
-
-    n = len(pool)
-    y = np.zeros(n, dtype=int)
-
-    # Vectorised branches:
-    reached = bars_to_1r.notna().values
-    bars_1r_arr = bars_to_1r.values
-    bars_held_arr = bars_held.values
-    exit_arr = exit_reason.values
-    sl_lower = sl_exit_reason.lower()
-
-    for i in range(n):
-        if not reached[i]:
-            y[i] = 0
-            continue
-        b1r = float(bars_1r_arr[i])
-        bh = float(bars_held_arr[i])
-        if b1r < bh:
-            y[i] = 1
-        elif b1r == bh:
-            # Same-bar tie: SL wins (conservative).
-            y[i] = 0 if exit_arr[i] == sl_lower else 1
-        else:
-            # bars_to_1r_mfe > bars_held: defensive — shouldn't happen.
-            y[i] = 0
-    return y
+# Locked threshold-sweep grid per dispatch §3 (meta-label specific). The
+# target name, +1R threshold, required-column schema, the SL tie-break
+# anchor, ``PoolSchemaError`` and ``build_meta_label_target`` itself now
+# live in the sklearn-free ``core.heavy_ml_probe.labels`` module (imported
+# above, re-exported via ``__all__``) so label honesty — including the
+# take-the-loss same-bar tie-break — can be tested in CI's minimal env
+# without the AutoML / joblib machinery present.
+DEFAULT_THRESHOLD_SWEEP: tuple[float, ...] = (0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80)
 
 
 # ── Threshold sweep ──────────────────────────────────────────────────
@@ -529,7 +412,7 @@ def run_meta_labeling(
         If ``used_features`` is empty (propagated).
     """
     # 1. Schema validation up-front
-    _validate_pool_schema(pool)
+    _validate_pool_schema(pool, REQUIRED_POOL_COLUMNS, target="meta-label")
     if final_r_col not in pool.columns:
         raise PoolSchemaError(
             f"meta-labeling threshold sweep requires {final_r_col!r} column "

--- a/core/heavy_ml_probe/survival.py
+++ b/core/heavy_ml_probe/survival.py
@@ -75,23 +75,23 @@ from core.heavy_ml_probe.automl import (
     _select_used_features,
 )
 from core.heavy_ml_probe.io import sha256_file
-from core.heavy_ml_probe.meta_labeling import (
-    SL_EXIT_REASON,
+from core.heavy_ml_probe.labels import (
+    SURVIVAL_REQUIRED_POOL_COLUMNS,
     PoolSchemaError,
+    _validate_pool_schema,
+    build_survival_target,
 )
 from core.heavy_ml_probe.metrics import concordance
 
 # Locked threshold per dispatch §3. Cox PH is unstable below this n.
 MIN_N_WARN: int = 200
 
-# Survival target consumes a subset of the meta-label schema (final_r
-# not required). Kept as a separate constant so future schema drift
-# can fork cleanly.
-SURVIVAL_REQUIRED_POOL_COLUMNS: tuple[str, ...] = (
-    "bars_to_1r_mfe",
-    "bars_held",
-    "exit_reason",
-)
+# ``SURVIVAL_REQUIRED_POOL_COLUMNS`` + ``build_survival_target`` + the
+# take-the-loss same-bar tie-break now live in the sklearn-free
+# ``core.heavy_ml_probe.labels`` module (imported above, re-exported via
+# ``__all__``). The survival event/duration construction shares its +1R-MFE
+# definition and SL/time-exit censoring with the meta-label, including the
+# ``"hard_sl"``-aware tie-break.
 
 
 # ── Result types ─────────────────────────────────────────────────────
@@ -136,112 +136,6 @@ class SurvivalResult:
     statsmodels_version: str
     skip_reason: str = "ok"
     classifier_manifest_path: Path | None = None
-
-
-# ── Target construction ──────────────────────────────────────────────
-
-
-def _validate_pool_schema(pool: pd.DataFrame) -> None:
-    """HALT loud on missing columns. Mirrors PR-C convention."""
-    missing = [c for c in SURVIVAL_REQUIRED_POOL_COLUMNS if c not in pool.columns]
-    if missing:
-        raise PoolSchemaError(
-            f"survival target requires pool columns "
-            f"{sorted(SURVIVAL_REQUIRED_POOL_COLUMNS)}; "
-            f"missing: {sorted(missing)} — pool has: "
-            f"{sorted(pool.columns)[:20]}"
-            + ("..." if len(pool.columns) > 20 else "")
-        )
-
-
-def build_survival_target(
-    pool: pd.DataFrame,
-    *,
-    sl_exit_reason: str = SL_EXIT_REASON,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Construct ``(duration, event)`` for Cox PH.
-
-    Per dispatch §3:
-
-      * ``event[i] = 1`` if trade ``i`` reached +1R MFE strictly before
-        SL hit or time-exit (i.e. it's a real event).
-      * ``event[i] = 0`` otherwise (censored at the close bar).
-      * ``duration[i]`` = bars to first of ``{+1R MFE, SL hit, time-exit}``.
-
-    Same-bar tie-break (mirrors PR-C ``build_meta_label_target``):
-
-      * ``bars_to_1r_mfe is NaN`` → event=0, duration=bars_held
-      * ``bars_to_1r_mfe <  bars_held`` → event=1, duration=bars_to_1r_mfe
-      * ``bars_to_1r_mfe == bars_held``:
-            ``exit_reason == "sl"`` → event=0 (SL wins same-bar tie),
-                duration=bars_held
-            otherwise              → event=1 (reached +1R same bar as
-                non-adverse close), duration=bars_to_1r_mfe
-      * ``bars_to_1r_mfe >  bars_held`` → event=0 (defensive; shouldn't
-        happen on consistent data), duration=bars_held
-
-    Returns
-    -------
-    duration : np.ndarray[int] of shape (len(pool),)
-        Time-to-first-event in bars. Always positive.
-    event : np.ndarray[int] of shape (len(pool),)
-        Binary event indicator.
-
-    Raises
-    ------
-    PoolSchemaError
-        If any required column is missing.
-    ValueError
-        If ``bars_held`` has NaN values (data integrity guard).
-    """
-    _validate_pool_schema(pool)
-    bars_to_1r = pool["bars_to_1r_mfe"]
-    bars_held = pool["bars_held"]
-    exit_reason = pool["exit_reason"].astype(str).str.lower()
-
-    if bars_held.isna().any():
-        raise ValueError(
-            "survival target: bars_held column has NaN values; "
-            "every closed trade must have a known duration."
-        )
-
-    n = len(pool)
-    event = np.zeros(n, dtype=int)
-    duration = np.zeros(n, dtype=int)
-    sl_lower = sl_exit_reason.lower()
-
-    reached = bars_to_1r.notna().values
-    b1r = bars_to_1r.values
-    bh = bars_held.values
-    er = exit_reason.values
-
-    for i in range(n):
-        held_i = int(bh[i])
-        if not reached[i]:
-            event[i] = 0
-            duration[i] = held_i
-            continue
-        first_r = float(b1r[i])
-        if first_r < held_i:
-            event[i] = 1
-            duration[i] = int(first_r)
-        elif first_r == held_i:
-            if er[i] == sl_lower:
-                event[i] = 0      # SL-wins tie-break
-                duration[i] = held_i
-            else:
-                event[i] = 1      # +1R on same bar as non-adverse close
-                duration[i] = held_i
-        else:
-            # Defensive — shouldn't happen on consistent pool data.
-            event[i] = 0
-            duration[i] = held_i
-
-    # Cox PH requires duration > 0 — clip any 0-duration entries to 1
-    # (trades that closed on bar 0 are degenerate; clipping preserves
-    # them in the dataset without breaking the fit).
-    duration = np.maximum(duration, 1)
-    return duration, event
 
 
 # ── Internal: PHReg fit + concordance ─────────────────────────────────
@@ -613,7 +507,7 @@ def run_survival(
             "lineage gate rejected every feature — cannot fit Cox PH on an "
             "empty design matrix"
         )
-    _validate_pool_schema(pool)
+    _validate_pool_schema(pool, SURVIVAL_REQUIRED_POOL_COLUMNS, target="survival")
     if trade_id_col not in pool.columns:
         raise PoolSchemaError(
             f"survival requires {trade_id_col!r} column for fold-result "

--- a/core/sim/honest_label.py
+++ b/core/sim/honest_label.py
@@ -1,0 +1,157 @@
+"""Take-the-loss label primitives — the SL-honest producer of record.
+
+This module is the in-tree, reproducible source for the heavy_ml training
+label ``bars_to_1r_mfe`` and the "reached +1R before SL" event. It exists
+because the honest-engine sweep (``HONEST_ENGINE_SWEEP.md`` Part D) found
+that label honest-ness was *unverifiable*: ``bars_to_1r_mfe`` was consumed
+by ``core/heavy_ml_probe`` but produced nowhere in-tree, and the same-bar
+tie-break compared against ``"sl"`` while the pool simulators emit
+``"hard_sl"`` — so a trade that hit +1R and its stop on the SAME bar would
+be labelled a WIN. That is the Arc-10 defect (same-bar resolves to a win)
+reincarnated in label space.
+
+The fix has two halves, both live here:
+
+  * :func:`reached_1r_before_sl` — walks the actual forward bars with
+    **take-the-loss ordering** (the hard stop is evaluated BEFORE +1R on
+    every bar), so "reached +1R before SL" is true ONLY if +1R was reached
+    on a bar STRICTLY BEFORE any stop breach. A same-bar +1R-high / SL-low
+    trade resolves SL-first and is NOT a reach (returns ``NaN``). This is
+    the canonical ``bars_to_1r_mfe`` producer the pool simulators call.
+
+  * :func:`is_stop_loss_exit` — normalises every stop-loss spelling a pool
+    producer might emit (``"hard_sl"`` from the simulators, ``"sl"`` /
+    ``"stop_loss"`` from legacy/label callers) so the label tie-break
+    resolves a same-bar +1R/SL trade to a LOSS regardless of the producer's
+    ``exit_reason`` string. This is the take-the-loss invariant in label
+    space, mirroring the engine's ``sl_first=True`` resolution
+    (``core/sim/multipair_backtester.py``) and the trade-level invariant
+    pinned by ``tests/sim/test_take_the_loss_invariant.py``.
+
+Dependency-light by design (standard library only): the pool simulators in
+``core/sim`` and ``core/discovery`` and the label builders in
+``core/heavy_ml_probe`` all import from here, and the CI-gated regression
+test runs in the minimal numpy/pandas environment without pulling sklearn /
+joblib / statsmodels.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+# The favourable event is "+1R MFE". By construction the initial stop sits
+# exactly 1R below entry (``sl_distance == 1R``), so the trade reaches +1R
+# when its high is one ``sl_distance`` above entry: ``(high - entry) /
+# sl_distance >= 1.0``. Locked at 1.0 — the meta-label refuses any other
+# threshold (see ``core/heavy_ml_probe/labels.build_meta_label_target``).
+ONE_R: float = 1.0
+
+# Every ``exit_reason`` spelling that denotes a hard stop-loss hit. The arc
+# and discovery pool simulators emit ``"hard_sl"``; legacy / hand-built
+# label callers (and the existing regression fixtures) use ``"sl"``;
+# ``"stop_loss"`` / ``"stop"`` are accepted defensively. ALL of these make a
+# same-bar +1R/SL tie resolve to a LOSS (take-the-loss).
+SL_EXIT_REASONS: frozenset[str] = frozenset({"sl", "hard_sl", "stop_loss", "stop"})
+
+
+def is_stop_loss_exit(exit_reason: object) -> bool:
+    """True if ``exit_reason`` denotes a hard stop-loss hit.
+
+    Case-insensitive and whitespace-trimmed, so producer drift between
+    ``"SL"`` / ``"Sl"`` / ``"hard_sl"`` is absorbed. Used by the meta-label
+    and survival tie-breaks: a same-bar +1R/SL trade with any stop-loss
+    ``exit_reason`` is a LOSS, never a win. ``None`` / non-string inputs are
+    treated as non-stop (return ``False``) rather than raising — the schema
+    guard upstream is responsible for required-column validation.
+    """
+    if exit_reason is None:
+        return False
+    return str(exit_reason).strip().lower() in SL_EXIT_REASONS
+
+
+def reached_1r_before_sl(
+    *,
+    high_bid: Sequence[float],
+    low_bid: Sequence[float],
+    entry_idx: int,
+    exit_off: int,
+    entry_price: float,
+    sl_price: float,
+    sl_distance: float,
+    exit_at_bar_open: bool = False,
+    r_threshold: float = ONE_R,
+) -> float:
+    """Honest ``bars_to_1r_mfe`` via a take-the-loss forward bar walk.
+
+    Walks bar offsets ``0 .. exit_off`` (``bidx = entry_idx + off``) and
+    returns the FIRST offset at which the trade's high reaches
+    ``+r_threshold`` R, counted with take-the-loss ordering:
+
+      * On every bar with ``off > 0`` the hard stop is checked FIRST — if
+        the bar's ``low_bid`` breaches ``sl_price`` the walk ends and the
+        bar is NOT eligible to register +1R. A same-bar (+1R high AND SL
+        low) trade therefore resolves SL-first → +1R was NOT reached first →
+        result is ``NaN`` (unless a STRICTLY earlier bar already reached
+        +1R). This is exactly the engine's same-bar SL-first resolution,
+        applied to the label.
+      * A bar that does not breach the stop is eligible: if its high reaches
+        ``+r_threshold`` R the offset is returned immediately (it is, by the
+        walk order, strictly before any stop breach).
+
+    Parameters
+    ----------
+    high_bid, low_bid
+        Per-bar intrabar extremes for the whole pair, indexed by absolute
+        bar index (the simulator's native arrays). Only indices
+        ``entry_idx .. entry_idx + exit_off`` are read.
+    entry_idx
+        Absolute index of the entry bar (forward offset 0).
+    exit_off
+        ``bars_held`` — the forward offset of the trade's exit bar.
+    entry_price, sl_price, sl_distance
+        Entry fill, stop price, and ``entry_price - sl_price`` (== 1R).
+    exit_at_bar_open
+        Set when the trade leaves at the OPEN of the exit bar (e.g. a queued
+        trail / time exit filled next-bar-open): that bar's intrabar high is
+        unreachable, so the scan stops at ``exit_off - 1``. Leave ``False``
+        when the trade is open through the exit bar (intrabar stop, at-close
+        time exit, end-of-data), so the exit bar's high is included.
+    r_threshold
+        Favourable-event multiple. Default :data:`ONE_R` (1.0).
+
+    Returns
+    -------
+    float
+        The first qualifying offset as a float, or ``float('nan')`` if +1R
+        is never reached strictly before a stop breach.
+
+    Notes
+    -----
+    Pure / deterministic / standard-library only. The walk re-derives the
+    stop breach from ``sl_price`` rather than trusting a precomputed exit
+    offset, so the label cannot inherit a stale or replay-sourced value —
+    its provenance is this function plus the bar data.
+    """
+    if not math.isfinite(sl_distance) or sl_distance <= 0:
+        return float("nan")
+    last = exit_off - 1 if exit_at_bar_open else exit_off
+    for off in range(0, last + 1):
+        bidx = entry_idx + off
+        lo = float(low_bid[bidx])
+        # Take-the-loss: stop is checked before +1R. A stop breach ends the
+        # walk; this bar can never register +1R (same-bar tie → SL wins).
+        if off > 0 and math.isfinite(lo) and lo <= sl_price:
+            return float("nan")
+        hi = float(high_bid[bidx])
+        if math.isfinite(hi) and (hi - entry_price) / sl_distance >= r_threshold:
+            return float(off)
+    return float("nan")
+
+
+__all__ = (
+    "ONE_R",
+    "SL_EXIT_REASONS",
+    "is_stop_loss_exit",
+    "reached_1r_before_sl",
+)

--- a/tests/discovery/test_pool_simulator.py
+++ b/tests/discovery/test_pool_simulator.py
@@ -204,3 +204,36 @@ def test_warmup_excludes_early_signals():
     atr = _atr(df.index, 1.0)
     trades, _, _, _ = simulate_pair_pool("EURUSD", df, trigger, atr, _cfg(warmup=5))
     assert trades == []
+
+
+# ── SL-honest bars_to_1r_mfe producer (HONEST_ENGINE_SWEEP.md Part D) ───
+
+
+def test_bars_to_1r_mfe_same_bar_tie_is_nan_despite_mfe():
+    """A bar whose high reaches +1R (102.0) AND whose low breaches the stop
+    (98.0) resolves SL-first: raw mfe_r touches +1R but bars_to_1r_mfe is
+    NaN (take-the-loss). entry 100.0, sl 98.0, sl_distance 2.0 = 1R."""
+    df = _ohlc([
+        {"ts": "2020-01-01T00", "open_ask": 99.0, "high_bid": 100.0, "low_bid": 98.5, "close_bid": 99.0},
+        {"ts": "2020-01-01T01", "open_ask": 100.0, "high_bid": 100.5, "low_bid": 99.5, "close_bid": 100.2},
+        {"ts": "2020-01-01T02", "open_ask": 100.1, "high_bid": 102.5, "low_bid": 97.5, "close_bid": 98.6},
+    ])
+    t = simulate_pair_pool("EURUSD", df, _signal_at(df.index, 0), _atr(df.index, 1.0), _cfg())[0][0]
+    assert t.exit_reason == "hard_sl"
+    assert t.mfe_r >= 1.0                      # raw excursion touched +1R
+    assert np.isnan(t.bars_to_1r_mfe)          # honest: not reached before SL
+
+
+def test_bars_to_1r_mfe_reached_before_sl_offset():
+    """+1R reached at forward offset 1 (no stop that bar); stop at offset 2.
+    bars_to_1r_mfe == 1 < bars_held == 2."""
+    df = _ohlc([
+        {"ts": "2020-01-01T00", "open_ask": 99.0, "high_bid": 100.0, "low_bid": 98.5, "close_bid": 99.0},
+        {"ts": "2020-01-01T01", "open_ask": 100.0, "high_bid": 100.5, "low_bid": 99.5, "close_bid": 100.2},
+        {"ts": "2020-01-01T02", "open_ask": 100.1, "high_bid": 102.5, "low_bid": 99.5, "close_bid": 101.0},
+        {"ts": "2020-01-01T03", "open_ask": 101.0, "high_bid": 101.5, "low_bid": 97.5, "close_bid": 98.0},
+    ])
+    t = simulate_pair_pool("EURUSD", df, _signal_at(df.index, 0), _atr(df.index, 1.0), _cfg())[0][0]
+    assert t.exit_reason == "hard_sl"
+    assert t.bars_held == 2
+    assert t.bars_to_1r_mfe == 1.0

--- a/tests/heavy_ml/test_label_take_the_loss.py
+++ b/tests/heavy_ml/test_label_take_the_loss.py
@@ -1,0 +1,334 @@
+"""CI-gated regression: the take-the-loss invariant in LABEL space.
+
+The engine pins take-the-loss at the trade level
+(``tests/sim/test_take_the_loss_invariant.py``): a stop breach at or before
+the +1R partial bar is −1R, and a same-bar +1R/SL trade resolves SL-first —
+ambiguity never resolves to a win. This file pins the SAME invariant for the
+heavy_ml training label, closing ``HONEST_ENGINE_SWEEP.md`` Part D:
+
+  * **FLAG-D1 (provenance).** ``bars_to_1r_mfe`` had no in-tree producer.
+    It now has one — :func:`core.sim.honest_label.reached_1r_before_sl` —
+    exercised here directly AND end-to-end through the real discovery pool
+    simulator, so the label's bar indices come from the SL-honest forward
+    walk and nothing else.
+  * **FLAG-D2 (tie-break bug).** The label compared ``exit_reason`` against
+    ``"sl"`` while the simulators emit ``"hard_sl"``, so a same-bar
+    (+1R-high AND SL-low) trade was labelled a WIN. It is now a LOSS.
+
+Design constraint: this module imports ONLY numpy / pandas (+ the
+standard-library producer and the sklearn-free
+``core.heavy_ml_probe.labels``), so it runs under CI's minimal
+``pytest -m "not research"`` env exactly like the engine fixture — unlike
+``tests/heavy_ml_probe/*`` which ``importorskip("flaml")`` and are skipped
+there.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+
+from core.discovery.pool_simulator import DiscoveryExitConfig, simulate_pair_pool
+from core.heavy_ml_probe.labels import (
+    build_meta_label_target,
+    build_survival_target,
+)
+from core.sim.honest_label import (
+    ONE_R,
+    SL_EXIT_REASONS,
+    is_stop_loss_exit,
+    reached_1r_before_sl,
+)
+
+# ── synthetic-OHLC helpers (mirror tests/discovery/test_pool_simulator) ──
+
+
+def _ohlc(rows: list[dict]) -> pd.DataFrame:
+    idx = pd.DatetimeIndex(
+        [pd.Timestamp(r["ts"], tz="UTC") for r in rows], name="timestamp_utc"
+    )
+    return pd.DataFrame(
+        {
+            "open_bid": [r.get("open_bid", r["open_ask"]) for r in rows],
+            "high_bid": [r["high_bid"] for r in rows],
+            "low_bid": [r["low_bid"] for r in rows],
+            "close_bid": [r["close_bid"] for r in rows],
+            "open_ask": [r["open_ask"] for r in rows],
+            "high_ask": [r.get("high_ask", r["high_bid"]) for r in rows],
+            "low_ask": [r.get("low_ask", r["low_bid"]) for r in rows],
+            "close_ask": [r.get("close_ask", r["close_bid"]) for r in rows],
+            "volume": [1.0] * len(rows),
+            "spread_close": [
+                r.get("close_ask", r["close_bid"]) - r["close_bid"] for r in rows
+            ],
+            "bid_ask_data_quality": ["ok"] * len(rows),
+        },
+        index=idx,
+    )
+
+
+def _cfg() -> DiscoveryExitConfig:
+    # sl_mult=2, atr=1 → sl_distance = 2.0 = 1R; +1R level = entry + 2.0.
+    # trail arms at close >= entry + 4xATR (deliberately out of reach in
+    # these fixtures so only SL / +1R drive the outcome).
+    return DiscoveryExitConfig(
+        initial_sl_atr_mult=2.0,
+        trail_activation_atr_mult=4.0,
+        trail_distance_atr_mult=2.0,
+        primary_tf_warmup_bars=0,
+    )
+
+
+def _sig(idx: pd.DatetimeIndex) -> pd.Series:
+    arr = np.zeros(len(idx), dtype=bool)
+    arr[0] = True  # signal at bar 0 → entry at bar 1 (offset 0)
+    return pd.Series(arr, index=idx)
+
+
+def _atr(idx: pd.DatetimeIndex, value: float = 1.0) -> pd.Series:
+    return pd.Series([value] * len(idx), index=idx, dtype="float64")
+
+
+def _one_trade(df: pd.DataFrame):
+    trades, _, _, _ = simulate_pair_pool("EURUSD", df, _sig(df.index), _atr(df.index), _cfg())
+    assert len(trades) == 1
+    return trades[0]
+
+
+def _meta_label(bars_to_1r_mfe, bars_held, exit_reason, final_r=0.0) -> int:
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": bars_to_1r_mfe,
+        "bars_held": float(bars_held),
+        "exit_reason": exit_reason,
+        "final_r": final_r,
+    }])
+    return int(build_meta_label_target(pool)[0])
+
+
+def _survival_event(bars_to_1r_mfe, bars_held, exit_reason) -> int:
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": bars_to_1r_mfe,
+        "bars_held": float(bars_held),
+        "exit_reason": exit_reason,
+    }])
+    _, event = build_survival_target(pool)
+    return int(event[0])
+
+
+# ── 1. Producer unit (the honest bars_to_1r_mfe walk) ───────────────────
+
+
+def test_producer_reaches_strictly_before_sl():
+    """High reaches +1R at offset 2; stop breaches at offset 4 → offset 2."""
+    high = [100.0, 101.0, 102.0, 101.0, 101.0]   # off2 high == entry+1R
+    low = [99.5, 99.5, 99.5, 99.5, 97.5]          # off4 low <= sl
+    got = reached_1r_before_sl(
+        high_bid=high, low_bid=low, entry_idx=0, exit_off=4,
+        entry_price=100.0, sl_price=98.0, sl_distance=2.0,
+    )
+    assert got == 2.0
+
+
+def test_producer_sl_strictly_before_reach_is_nan():
+    """Stop breaches at offset 2 before any +1R (which only comes at 4)."""
+    high = [100.0, 100.5, 100.5, 100.5, 103.0]
+    low = [99.5, 99.5, 97.5, 99.5, 99.5]          # off2 low <= sl (first)
+    got = reached_1r_before_sl(
+        high_bid=high, low_bid=low, entry_idx=0, exit_off=2,
+        entry_price=100.0, sl_price=98.0, sl_distance=2.0,
+    )
+    assert math.isnan(got)
+
+
+def test_producer_same_bar_plus1r_and_sl_is_nan():
+    """THE BUG CASE — a bar whose high reaches +1R AND whose low breaches
+    the stop resolves SL-first: +1R was NOT reached first → NaN."""
+    high = [100.0, 100.5, 102.5]   # off2 high >= entry+1R (102.0)
+    low = [99.5, 99.5, 97.5]       # off2 low <= sl (98.0) — same bar
+    got = reached_1r_before_sl(
+        high_bid=high, low_bid=low, entry_idx=0, exit_off=2,
+        entry_price=100.0, sl_price=98.0, sl_distance=2.0,
+    )
+    assert math.isnan(got), "same-bar +1R/SL must NOT register a +1R reach"
+
+
+def test_producer_never_reached_is_nan():
+    high = [100.0, 100.5, 101.0, 101.5]   # never hits +1R (102.0)
+    low = [99.5, 99.5, 99.5, 99.5]        # never breaches sl
+    got = reached_1r_before_sl(
+        high_bid=high, low_bid=low, entry_idx=0, exit_off=3,
+        entry_price=100.0, sl_price=98.0, sl_distance=2.0,
+    )
+    assert math.isnan(got)
+
+
+def test_producer_reach_on_at_close_exit_bar_is_included():
+    """+1R first reached ON the exit bar; the trade is open through it
+    (at-close / intrabar exit) → the exit bar counts."""
+    high = [100.0, 101.0, 102.0]   # off2 == exit bar reaches +1R
+    low = [99.5, 99.5, 99.5]
+    got = reached_1r_before_sl(
+        high_bid=high, low_bid=low, entry_idx=0, exit_off=2,
+        entry_price=100.0, sl_price=98.0, sl_distance=2.0,
+        exit_at_bar_open=False,
+    )
+    assert got == 2.0
+
+
+def test_producer_reach_on_open_fill_exit_bar_is_excluded():
+    """Same bars, but the trade left at the OPEN of the exit bar (queued
+    trail/time fill) → that bar's high is unreachable → NaN."""
+    high = [100.0, 101.0, 102.0]
+    low = [99.5, 99.5, 99.5]
+    got = reached_1r_before_sl(
+        high_bid=high, low_bid=low, entry_idx=0, exit_off=2,
+        entry_price=100.0, sl_price=98.0, sl_distance=2.0,
+        exit_at_bar_open=True,
+    )
+    assert math.isnan(got)
+
+
+def test_producer_one_r_constant_is_unit():
+    assert ONE_R == 1.0
+
+
+# ── 2. Producer through the REAL simulator (engine bar indices) ─────────
+
+
+def test_sim_same_bar_tie_nan_despite_raw_mfe_touching_1r():
+    """End-to-end: a same-bar (+1R-high AND SL-low) trade exits hard_sl with
+    raw mfe_r >= 1.0 (the high DID touch +1R intrabar) yet honest
+    bars_to_1r_mfe is NaN — exactly the divergence the fix introduces."""
+    df = _ohlc([
+        {"ts": "2020-01-01T00", "open_ask": 99.0, "high_bid": 100.0, "low_bid": 98.5, "close_bid": 99.0},
+        {"ts": "2020-01-01T01", "open_ask": 100.0, "high_bid": 100.5, "low_bid": 99.5, "close_bid": 100.2},
+        # off1: high 102.5 (>= +1R 102.0) AND low 97.5 (<= sl 98.0) — tie.
+        {"ts": "2020-01-01T02", "open_ask": 100.1, "high_bid": 102.5, "low_bid": 97.5, "close_bid": 98.6},
+    ])
+    t = _one_trade(df)
+    assert t.exit_reason == "hard_sl"
+    assert t.mfe_r >= 1.0          # raw excursion touched +1R on the SL bar
+    assert math.isnan(t.bars_to_1r_mfe)   # honest label says: not reached first
+    # And the label built from this trade is a LOSS.
+    assert _meta_label(t.bars_to_1r_mfe, t.bars_held, t.exit_reason, t.final_r) == 0
+
+
+def test_sim_reach_before_sl_records_offset():
+    """+1R at forward offset 1, stop at offset 2 → bars_to_1r_mfe == 1."""
+    df = _ohlc([
+        {"ts": "2020-01-01T00", "open_ask": 99.0, "high_bid": 100.0, "low_bid": 98.5, "close_bid": 99.0},
+        {"ts": "2020-01-01T01", "open_ask": 100.0, "high_bid": 100.5, "low_bid": 99.5, "close_bid": 100.2},
+        # off1: high 102.5 reaches +1R, low 99.5 (no stop)
+        {"ts": "2020-01-01T02", "open_ask": 100.1, "high_bid": 102.5, "low_bid": 99.5, "close_bid": 101.0},
+        # off2: low 97.5 breaches stop
+        {"ts": "2020-01-01T03", "open_ask": 101.0, "high_bid": 101.5, "low_bid": 97.5, "close_bid": 98.0},
+    ])
+    t = _one_trade(df)
+    assert t.exit_reason == "hard_sl"
+    assert t.bars_held == 2
+    assert t.bars_to_1r_mfe == 1.0
+    # Reached +1R strictly before the stop → meta label = win.
+    assert _meta_label(t.bars_to_1r_mfe, t.bars_held, t.exit_reason, t.final_r) == 1
+
+
+def test_sim_sl_before_reach_is_nan():
+    """Stop at offset 1 before any +1R → NaN → loss."""
+    df = _ohlc([
+        {"ts": "2020-01-01T00", "open_ask": 99.0, "high_bid": 100.0, "low_bid": 98.5, "close_bid": 99.0},
+        {"ts": "2020-01-01T01", "open_ask": 100.0, "high_bid": 100.5, "low_bid": 99.5, "close_bid": 100.2},
+        # off1: low 97.5 breaches stop; high 101.0 never reached +1R
+        {"ts": "2020-01-01T02", "open_ask": 100.1, "high_bid": 101.0, "low_bid": 97.5, "close_bid": 98.0},
+        # later +1R must NOT resurrect the trade
+        {"ts": "2020-01-01T03", "open_ask": 98.0, "high_bid": 103.0, "low_bid": 97.9, "close_bid": 102.5},
+    ])
+    t = _one_trade(df)
+    assert t.exit_reason == "hard_sl"
+    assert t.bars_held == 1
+    assert math.isnan(t.bars_to_1r_mfe)
+    assert _meta_label(t.bars_to_1r_mfe, t.bars_held, t.exit_reason, t.final_r) == 0
+
+
+# ── 3. The REAL label functions (sklearn-free import) ───────────────────
+
+
+def test_meta_label_reach_before_sl_is_win():
+    assert _meta_label(2.0, 10.0, "hard_sl", final_r=-1.0) == 1
+
+
+def test_meta_label_sl_before_reach_is_loss():
+    assert _meta_label(float("nan"), 10.0, "hard_sl", final_r=-1.0) == 0
+
+
+def test_meta_label_same_bar_hard_sl_is_loss():
+    """The dispatch bug case: bars_to_1r_mfe == bars_held with a hard_sl
+    exit MUST label 0 (LOSS), not 1."""
+    assert _meta_label(5.0, 5.0, "hard_sl", final_r=-1.0) == 0
+
+
+def test_meta_label_same_bar_non_adverse_is_win():
+    """+1R on the same bar as a benign time exit is still a +1R reach."""
+    assert _meta_label(5.0, 5.0, "time_exit", final_r=1.0) == 1
+
+
+def test_survival_event_mirrors_meta_label():
+    assert _survival_event(2.0, 10.0, "hard_sl") == 1     # reached before
+    assert _survival_event(float("nan"), 10.0, "hard_sl") == 0  # never
+    assert _survival_event(5.0, 5.0, "hard_sl") == 0      # same-bar → censored
+    assert _survival_event(5.0, 5.0, "time_exit") == 1    # same-bar benign
+
+
+# ── 4. Old-vs-new: prove the bug is fixed at the contract boundary ──────
+
+
+def test_same_bar_hard_sl_old_vs_new_label():
+    """OLD logic compared exit_reason against the literal "sl"; the
+    simulators emit "hard_sl", so the same-bar tie slipped through as a WIN.
+    NEW logic normalises via is_stop_loss_exit → LOSS."""
+    old_is_sl = ("hard_sl".lower() == "sl")          # the buggy comparison
+    new_is_sl = is_stop_loss_exit("hard_sl")          # the fix
+    assert old_is_sl is False, "documents the old bug: hard_sl != sl"
+    assert new_is_sl is True, "fix: hard_sl is recognised as a stop"
+
+    # Old label on the same-bar tie would have been 1 (win); the real
+    # builder now returns 0 (loss).
+    old_label = 0 if old_is_sl else 1
+    new_label = _meta_label(5.0, 5.0, "hard_sl", final_r=-1.0)
+    assert old_label == 1          # bug: win
+    assert new_label == 0          # fixed: loss
+    assert old_label != new_label
+
+
+def test_is_stop_loss_exit_recognises_all_stop_spellings():
+    for r in ("sl", "SL", "Sl", "hard_sl", "HARD_SL", " hard_sl ", "stop_loss", "stop"):
+        assert is_stop_loss_exit(r) is True, r
+    for r in ("time_exit", "trail", "tp", "end_of_data", "", None):
+        assert is_stop_loss_exit(r) is False, r
+    # Every simulator stop spelling is covered by the canonical set.
+    assert {"sl", "hard_sl"} <= SL_EXIT_REASONS
+
+
+# ── 5. Full chain: simulator → pool → real label (no hand-set columns) ──
+
+
+def test_chain_same_bar_tie_simulator_to_label_is_loss():
+    """The complete provenance path: a same-bar tie trade produced by the
+    real simulator, fed (verbatim) into the real meta-label builder, is a
+    LOSS — no hand-authored bars_to_1r_mfe anywhere."""
+    df = _ohlc([
+        {"ts": "2020-01-01T00", "open_ask": 99.0, "high_bid": 100.0, "low_bid": 98.5, "close_bid": 99.0},
+        {"ts": "2020-01-01T01", "open_ask": 100.0, "high_bid": 100.5, "low_bid": 99.5, "close_bid": 100.2},
+        {"ts": "2020-01-01T02", "open_ask": 100.1, "high_bid": 102.5, "low_bid": 97.5, "close_bid": 98.6},
+    ])
+    t = _one_trade(df)
+    row = t.to_dict()
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": row["bars_to_1r_mfe"],
+        "bars_held": float(row["bars_held"]),
+        "exit_reason": row["exit_reason"],
+        "final_r": row["final_r"],
+    }])
+    assert build_meta_label_target(pool).tolist() == [0]
+    _, event = build_survival_target(pool)
+    assert event.tolist() == [0]

--- a/tests/heavy_ml_probe/test_meta_labeling.py
+++ b/tests/heavy_ml_probe/test_meta_labeling.py
@@ -227,17 +227,31 @@ def test_target_case_insensitive_sl_exit_reason():
         assert y.tolist() == [0], f"exit_reason={er!r} should trigger SL tie-break"
 
 
+def test_target_same_bar_hard_sl_is_loss():
+    """HONEST_ENGINE_SWEEP.md FLAG-D2 regression: the pool simulators emit
+    ``exit_reason='hard_sl'`` (not ``'sl'``). A same-bar +1R/SL tie with a
+    ``hard_sl`` exit MUST label 0 (LOSS) — the old ``== 'sl'`` compare let it
+    through as a WIN."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 5.0, "bars_held": 5.0,
+        "exit_reason": "hard_sl", "final_r": -1.0,
+    }])
+    assert build_meta_label_target(pool).tolist() == [0]
+
+
 def test_target_vectorised_over_pool():
-    """Mixed cases vectorise correctly."""
+    """Mixed cases vectorise correctly — incl. the producer-native
+    ``hard_sl`` spelling alongside the legacy ``sl``."""
     pool = pd.DataFrame([
         {"bars_to_1r_mfe": 2.0, "bars_held": 5.0, "exit_reason": "tp", "final_r": 2.0},          # 1
         {"bars_to_1r_mfe": np.nan, "bars_held": 10.0, "exit_reason": "sl", "final_r": -1.0},      # 0
         {"bars_to_1r_mfe": 5.0, "bars_held": 5.0, "exit_reason": "sl", "final_r": -1.0},          # 0 (tie + SL)
+        {"bars_to_1r_mfe": 5.0, "bars_held": 5.0, "exit_reason": "hard_sl", "final_r": -1.0},     # 0 (tie + hard_sl)
         {"bars_to_1r_mfe": 5.0, "bars_held": 5.0, "exit_reason": "time_exit", "final_r": 1.0},    # 1 (tie + non-SL)
         {"bars_to_1r_mfe": np.nan, "bars_held": 30.0, "exit_reason": "time_exit", "final_r": 0.3},  # 0
     ])
     y = build_meta_label_target(pool)
-    assert y.tolist() == [1, 0, 0, 1, 0]
+    assert y.tolist() == [1, 0, 0, 0, 1, 0]
 
 
 def test_target_halts_loud_on_missing_column():

--- a/tests/heavy_ml_probe/test_survival.py
+++ b/tests/heavy_ml_probe/test_survival.py
@@ -92,6 +92,18 @@ def test_target_same_bar_sl_tie_censored():
     assert e.tolist() == [0]
 
 
+def test_target_same_bar_hard_sl_censored():
+    """HONEST_ENGINE_SWEEP.md FLAG-D2: the simulators emit ``'hard_sl'``.
+    A same-bar +1R/SL tie with a ``hard_sl`` exit is SL-first → event=0
+    (censored), not a spurious event=1."""
+    pool = pd.DataFrame([{
+        "bars_to_1r_mfe": 5.0, "bars_held": 5.0, "exit_reason": "hard_sl",
+    }])
+    d, e = build_survival_target(pool)
+    assert d.tolist() == [5]
+    assert e.tolist() == [0]
+
+
 def test_target_same_bar_non_sl_event():
     """+1R and time-exit on same bar (not SL) → event=1 (reached before
     non-adverse close)."""

--- a/tests/protocol_runtime/test_arc_pool_builder.py
+++ b/tests/protocol_runtime/test_arc_pool_builder.py
@@ -62,8 +62,6 @@ def test_bars_to_1r_mfe_is_sl_honest() -> None:
     where set it is (a) <= bars_held and (b) backed by mfe_r >= 1.0 (the
     high genuinely reached +1R); a same-bar +1R/SL trade leaves it NaN even
     though raw mfe_r touched +1R. See core.sim.honest_label."""
-    import numpy as np
-
     pool = _run_builder()
     df = pool.trades
     assert "bars_to_1r_mfe" in df.columns

--- a/tests/protocol_runtime/test_arc_pool_builder.py
+++ b/tests/protocol_runtime/test_arc_pool_builder.py
@@ -51,5 +51,28 @@ def test_pool_schema_columns() -> None:
         "pair", "trade_id", "signal_time", "entry_time", "entry_price",
         "atr_at_signal", "sl_at_entry_price", "exit_time", "exit_price",
         "exit_reason", "bars_held", "final_r", "mfe_r", "mae_r",
+        # SL-honest meta-label provenance (HONEST_ENGINE_SWEEP.md Part D).
+        "bars_to_1r_mfe",
     }
     assert set(pool.trades.columns) >= expected
+
+
+def test_bars_to_1r_mfe_is_sl_honest() -> None:
+    """The emitted bars_to_1r_mfe is the take-the-loss producer's output:
+    where set it is (a) <= bars_held and (b) backed by mfe_r >= 1.0 (the
+    high genuinely reached +1R); a same-bar +1R/SL trade leaves it NaN even
+    though raw mfe_r touched +1R. See core.sim.honest_label."""
+    import numpy as np
+
+    pool = _run_builder()
+    df = pool.trades
+    assert "bars_to_1r_mfe" in df.columns
+    reached = df["bars_to_1r_mfe"].notna()
+    # Every honest +1R reach must be at/within the holding window.
+    assert bool((df.loc[reached, "bars_to_1r_mfe"] <= df.loc[reached, "bars_held"]).all())
+    # And must be corroborated by the raw excursion having touched +1R.
+    assert bool((df.loc[reached, "mfe_r"] >= 1.0 - 1e-9).all())
+    # A hard_sl trade may have raw mfe_r >= 1.0 yet NaN bars_to_1r_mfe (the
+    # +1R high landed on the stop bar → take-the-loss says "not reached").
+    # The reverse — a set bars_to_1r_mfe whose mfe_r < 1R — must never occur.
+    assert not bool(((df["bars_to_1r_mfe"].notna()) & (df["mfe_r"] < 1.0 - 1e-9)).any())


### PR DESCRIPTION
## Objective

Closes the two open items in **`HONEST_ENGINE_SWEEP.md` Part D** (the FLAG) — heavy_ml's training labels were a re-contamination vector (the Arc-10 take-the-loss defect reincarnated in label space). Full writeup: [`FIX_PART_D_HEAVYML_LABELS_REPORT.md`](FIX_PART_D_HEAVYML_LABELS_REPORT.md).

## What was wrong

1. **FLAG-D1 (provenance):** `bars_to_1r_mfe` (the meta-label + survival target input) was *read* by `core/heavy_ml_probe` but **produced nowhere in-tree** — honesty unverifiable, possibly a retired-replay frame.
2. **FLAG-D2 (tie-break bug):** the label compared `exit_reason` against `"sl"`, but both pool simulators emit `"hard_sl"` with no normalization — so a same-bar (+1R-high **and** SL-low) trade was labelled a **WIN**.

## The fix

- **New `core/sim/honest_label.py`** (stdlib-only leaf): `reached_1r_before_sl(...)` walks the forward bars with **take-the-loss ordering** (hard stop checked before +1R; same-bar +1R/SL → `NaN`). Now called by **both** pool simulators (`arc_pool_builder.py`, `discovery/pool_simulator.py`), so `bars_to_1r_mfe` is a native, reproducible column of the Step-1 pool that heavy_ml loads. Also `is_stop_loss_exit()` normalizes `{sl, hard_sl, stop_loss, stop}`.
- **New `core/heavy_ml_probe/labels.py`** (numpy/pandas only): `build_meta_label_target` + `build_survival_target` moved here and now resolve a same-bar `hard_sl` tie to a **LOSS**. Re-exported from `meta_labeling.py` / `survival.py` — every existing import is unchanged. The decoupling lets the regression test pin the *real* label functions in CI's minimal env.

## Validation

| | old (`== "sl"`) | new (`is_stop_loss_exit`) |
|---|---|---|
| same-bar `hard_sl` +1R/SL | `False` → label **1 (WIN, bug)** | `True` → label **0 (LOSS)** |

- **New CI-gated test** `tests/heavy_ml/test_label_take_the_loss.py` (18 cases, **not** research-marked, numpy/pandas only) — proven importable with `sklearn`/`flaml`/`joblib`/`statsmodels`/`scipy` blocked, so it actually gates in CI's minimal env (unlike the `importorskip("flaml")` heavy_ml_probe suite, which skips there). Covers producer (before/after/same-bar/never), producer-through-real-simulator (engine bar indices), the real label builders, and the old-vs-new bug demonstration.
- Extended `test_meta_labeling.py` / `test_survival.py` (`hard_sl` cases) + `test_arc_pool_builder.py` / `test_pool_simulator.py` (emitted column is SL-honest).
- Grep confirms **no replay/precomputed frame** on the label path.
- **Full non-research suite (CI parity): 1649 passed, 294 skipped, 0 failed.** ruff clean.
- causal-lineage gate + holdout guard **unchanged** (they don't defend against label dishonesty — this does).

heavy_ml is safe to **un-quarantine for discovery** on label-honesty grounds. Part C (broker-cost wiring on the gate path) remains a separate, open blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)