### PR TITLE
Wire FundedNext costs onto the gate-scoring layer (Part C fix)

### DIFF
--- a/core/runners/_fold_stats_helpers.py
+++ b/core/runners/_fold_stats_helpers.py
@@ -18,6 +18,7 @@ from typing import Iterable
 
 import pandas as pd
 
+from core.sim.costs.model import CostModel, apply_cost_model
 from core.sim.multipair_backtester import RunResult
 from core.time_utils.session_boundary import (
     SUPPORTED_CONVENTIONS,
@@ -30,6 +31,13 @@ from core.wfo.gates import FoldStats
 # measurement uses the EET broker trading day post-PR-189. KH-24 and
 # legacy callers may opt back to UTC via boundary_convention="utc".
 _EET_TZ: str = "Europe/Athens"
+
+# FundedNext is the gate default cost profile (1.5x spread, $5/lot RT, 0.5
+# pip/fill slippage, swaps off) — the higher cost, as the conservative bound.
+# This is the chokepoint that resolves HONEST_ENGINE_SWEEP.md Part C: every
+# FoldStats-producing gate path nets broker costs by default. A cost-free
+# FoldStats requires an EXPLICIT CostModel.zero() — never the silent default.
+_DEFAULT_FUNDEDNEXT: CostModel = CostModel.fundednext()
 
 
 def slice_equity_to_oos(equity: pd.Series, fold: Fold) -> pd.Series:
@@ -84,13 +92,22 @@ def build_fold_stats_from_run(
     fold: Fold,
     run_result: RunResult,
     starting_balance: float,
+    cost_model: CostModel = _DEFAULT_FUNDEDNEXT,
 ) -> FoldStats:
     """Convert a RunResult into a FoldStats restricted to fold's OOS window.
 
     Trade count uses OOS-only entries; ROI uses OOS-restricted equity;
     DD uses OOS-restricted equity; daily-breach count uses OOS days.
+
+    Broker costs (``cost_model``, FundedNext by default) are netted at this
+    gate-scoring layer: the engine output is gross, and ``apply_cost_model``
+    rebuilds a net equity curve by debiting each closed position's cost at its
+    final exit bar (so net ROI / DD / daily-breach are all faithful). Pass
+    ``CostModel.zero()`` for an EXPLICIT cost-free FoldStats — there is no
+    silent cost-free default.
     """
-    equity = slice_equity_to_oos(run_result.equity_curve, fold)
+    costed = apply_cost_model(run_result, cost_model)
+    equity = slice_equity_to_oos(costed.net_equity, fold)
     if len(equity) == 0:
         return FoldStats(
             fold_id=fold.fold_id,

--- a/core/sim/costs/__init__.py
+++ b/core/sim/costs/__init__.py
@@ -20,7 +20,7 @@ Public API:
 """
 
 from core.sim.costs.commission import compute_commission_usd
-from core.sim.costs.model import CostModel, CostedRunResult, apply_cost_model
+from core.sim.costs.model import CostedRunResult, CostModel, apply_cost_model
 from core.sim.costs.slippage import compute_slippage_pips
 from core.sim.costs.spread_multiplier import compute_extra_spread_price
 from core.sim.costs.swap import compute_swap_usd, rollover_instants_utc

--- a/core/sim/costs/__init__.py
+++ b/core/sim/costs/__init__.py
@@ -12,10 +12,15 @@ Public API:
         compute_slippage_pips,
         compute_extra_spread_price,
         rollover_instants_utc,
+        # gate-layer model (nets the primitives onto a gross RunResult):
+        CostModel,
+        CostedRunResult,
+        apply_cost_model,
     )
 """
 
 from core.sim.costs.commission import compute_commission_usd
+from core.sim.costs.model import CostModel, CostedRunResult, apply_cost_model
 from core.sim.costs.slippage import compute_slippage_pips
 from core.sim.costs.spread_multiplier import compute_extra_spread_price
 from core.sim.costs.swap import compute_swap_usd, rollover_instants_utc
@@ -26,4 +31,7 @@ __all__ = [
     "compute_commission_usd",
     "compute_slippage_pips",
     "compute_extra_spread_price",
+    "CostModel",
+    "CostedRunResult",
+    "apply_cost_model",
 ]

--- a/core/sim/costs/commission.py
+++ b/core/sim/costs/commission.py
@@ -7,6 +7,12 @@ closed trade (entry-leg + exit-leg combined as a single round-turn).
 (not reduced after TP1 partial close — commission is for the full round-turn
 of the position, not per-leg).
 
+Gate default note: the gate cost model (``core.sim.costs.model.CostModel``)
+passes the FundedNext rate ``rate_per_lot_rt=5.0`` explicitly — the higher
+cost, as the conservative bound. This primitive's ``$4.00`` default (5ers) is
+left unchanged; only the caller's override differs, so the cost math here is
+untouched.
+
 Pure post-hoc R-adjustment primitive. Does NOT modify simulate_path. Designed
 for the deferred-haircut model documented at core/sim/account.py:23-28.
 """

--- a/core/sim/costs/model.py
+++ b/core/sim/costs/model.py
@@ -1,0 +1,274 @@
+"""Gate-layer cost model — nets FundedNext broker costs onto a gross RunResult.
+
+This is the wiring that resolves HONEST_ENGINE_SWEEP.md Part C (FAIL): the
+per-trade primitives in this package (commission / slippage / spread_multiplier)
+were orphaned — called on no gate path — so every gate verdict scored on raw
+HistData bid/ask (1.0x spread, zero commission, zero slippage).
+
+Design (per the approved plan, locked by the operator):
+
+  - The engine (`MultiPairBacktester` / `Account`) stays **100% gross and
+    untouched**. `ClosedTrade.pnl`, `Account.balance`, and the equity curve are
+    never modified, so the take-the-loss invariant and determinism fixtures
+    stay green and Step 6's spread-decomposition diagnostic (which reads gross
+    ``pnl``) is untouched — no double-count.
+  - Cost is a **separate explicit quantity**, computed here from the gross
+    closed-trade ledger using the EXISTING primitives (this module does NOT
+    reimplement the cost math). The netting ``net = gross - cost`` happens at
+    the gate-scoring layer (`core.runners._fold_stats_helpers.build_fold_stats_from_run`),
+    which nets the equity curve before computing `FoldStats`.
+
+FundedNext profile (the gate default — the higher cost, as the conservative
+bound): 1.5x spread, $5/lot round-turn commission, 0.5 pip/fill slippage x
+n_fills, swaps OFF.
+
+Conservative bias (dispatch: "over-apply, never flatter"):
+  - slippage uses full original size x n_fills (over-applies on partial legs);
+  - spread uses ``compute_extra_spread_price`` (the larger, full-spread extra);
+  - when fill count is ambiguous we never under-count below the SL-honest
+    leg structure.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from core.sim.costs.commission import compute_commission_usd
+from core.sim.costs.slippage import compute_slippage_pips
+from core.sim.costs.spread_multiplier import compute_extra_spread_price
+from core.utils import LOT_SIZE, get_pip_size, pips_to_price
+
+if TYPE_CHECKING:  # avoid runtime import cost / cycles; only used for typing
+    from core.sim.multipair_backtester import RunResult
+
+
+# FundedNext gate defaults (the higher-cost, conservative bound).
+_FN_SPREAD_MULT: float = 1.5
+_FN_COMMISSION_PER_LOT_RT: float = 5.0
+_FN_SLIPPAGE_PIPS_PER_FILL: float = 0.5
+
+
+_BREAKDOWN_COLUMNS: tuple[str, ...] = (
+    "position_id",
+    "pair",
+    "original_size",
+    "n_legs",
+    "n_fills",
+    "commission",
+    "slippage",
+    "spread",
+    "total_cost",
+    "gross_pnl",
+    "net_pnl",
+    "final_exit_time",
+)
+
+
+@dataclass(frozen=True)
+class CostModel:
+    """Broker cost profile applied at the gate-scoring layer.
+
+    Defaults are the FundedNext profile (the gate default). Use
+    :meth:`zero` for an EXPLICIT cost-free run (e.g. diagnostics / the
+    KH-24 determinism anchor) — a cost-free gate number must never be the
+    silent default.
+
+    All cost math is delegated to the existing primitives in this package;
+    this dataclass only carries the parameters and the unit conversions.
+    """
+
+    spread_mult: float = _FN_SPREAD_MULT
+    commission_per_lot_rt: float = _FN_COMMISSION_PER_LOT_RT
+    slippage_pips_per_fill: float = _FN_SLIPPAGE_PIPS_PER_FILL
+    swaps_enabled: bool = False  # FundedNext: swaps OFF (confirmed unchanged)
+    lot_size: float = float(LOT_SIZE)
+
+    @classmethod
+    def fundednext(cls) -> "CostModel":
+        """The canonical gate default: 1.5x spread, $5/lot RT, 0.5 pip/fill, swaps off."""
+        return cls(
+            spread_mult=_FN_SPREAD_MULT,
+            commission_per_lot_rt=_FN_COMMISSION_PER_LOT_RT,
+            slippage_pips_per_fill=_FN_SLIPPAGE_PIPS_PER_FILL,
+            swaps_enabled=False,
+            lot_size=float(LOT_SIZE),
+        )
+
+    @classmethod
+    def zero(cls) -> "CostModel":
+        """An EXPLICIT cost-free profile (every primitive evaluates to 0)."""
+        return cls(
+            spread_mult=1.0,            # compute_extra_spread_price -> 0 at mult<=1
+            commission_per_lot_rt=0.0,
+            slippage_pips_per_fill=0.0,
+            swaps_enabled=False,
+            lot_size=float(LOT_SIZE),
+        )
+
+
+@dataclass(frozen=True)
+class CostedRunResult:
+    """Result of netting a gross :class:`RunResult` through a :class:`CostModel`.
+
+    ``net_equity`` is the gross equity curve with each position's total cost
+    debited at its final exit bar (cumulative, forward) — this reproduces an
+    at-close balance numerically, so net ROI / max-DD / daily-5% breach are
+    faithful. ``breakdown`` is the explicit, auditable per-position cost
+    ledger (one row per closed position).
+    """
+
+    net_equity: pd.Series
+    breakdown: pd.DataFrame
+    gross_pnl_total: float
+    cost_total: float
+    net_pnl_total: float
+
+
+def _safe_spread(ask: float, bid: float) -> float:
+    """Recorded spread (ask - bid) in price units, NaN/negative coerced to 0.
+
+    Synthetic / legacy panels carry NaN bid/ask (see
+    ``core.sim.multipair_backtester._bar_field``); a raw ``ask - bid`` would
+    yield NaN and poison the equity curve (and the determinism hash). Zero
+    spread also matches the data-gap convention (no widening cost on a
+    zero/absent spread — ``compute_extra_spread_price`` already floors at 0).
+    """
+    try:
+        s = float(ask) - float(bid)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(s) or s <= 0.0:
+        return 0.0
+    return s
+
+
+def _position_cost(
+    legs: list, model: CostModel
+) -> tuple[float, float, float, int, float]:
+    """Return (commission, slippage, spread, n_fills, original_size) for one position.
+
+    ``legs`` are all :class:`core.sim.account.ClosedTrade` rows sharing a
+    ``position_id`` (a single full close => 1 leg; a +1R partial + runner =>
+    2 legs). Cost is denominated in quote currency (== account currency under
+    the engine's existing non-USD-quote simplification; see
+    ``core/sim/risk/live_balance.py``).
+    """
+    original_size = float(sum(float(leg.size) for leg in legs))
+    pair = legs[0].pair
+    # n_fills tracks the ACTUAL SL-honest leg structure: a partial actually
+    # executed iff the position closed in >1 leg (entry + N exits => 1 + N
+    # fills; the canonical sl_partial_close_1r_runner_trail is <=2 legs, so
+    # >1 leg == the +1R partial fired => 3 fills, else 2).
+    partial_fired = len(legs) >= 2
+
+    commission = compute_commission_usd(
+        original_size / model.lot_size, model.commission_per_lot_rt
+    )
+
+    total_slip_pips, n_fills = compute_slippage_pips(
+        model.slippage_pips_per_fill, tp1_hit=partial_fired
+    )
+    slippage = pips_to_price(pair, total_slip_pips) * original_size
+
+    # Spread: per-leg extra at the multiplier, weighted by the leg's closed
+    # size. Each leg inherits the position's entry spread; the exit spread is
+    # the leg's own. Weighting by leg.size makes the entry-spread contribution
+    # total correctly on original_size (sum of leg sizes) with no double-count.
+    spread = 0.0
+    entry_spread = _safe_spread(legs[0].entry_ask, legs[0].entry_bid)
+    for leg in legs:
+        exit_spread = _safe_spread(leg.exit_ask, leg.exit_bid)
+        extra_price = compute_extra_spread_price(
+            entry_spread, exit_spread, model.spread_mult
+        )
+        spread += extra_price * float(leg.size)
+
+    return commission, slippage, spread, n_fills, original_size
+
+
+def apply_cost_model(
+    run_result: "RunResult", cost_model: CostModel | None = None
+) -> CostedRunResult:
+    """Net a gross :class:`RunResult` through ``cost_model`` (default FundedNext).
+
+    The engine output is GROSS; this computes each closed position's cost from
+    the gross ledger (using the existing primitives) and rebuilds a net equity
+    curve by debiting each position's total cost at its final exit bar. Passing
+    ``cost_model=None`` applies the FundedNext default — a cost-free result
+    requires an EXPLICIT ``CostModel.zero()``.
+    """
+    model = cost_model if cost_model is not None else CostModel.fundednext()
+    if model.swaps_enabled:
+        raise NotImplementedError(
+            "swaps are intentionally OFF for the gate cost model; wiring deferred"
+        )
+
+    equity = run_result.equity_curve
+    trades = tuple(run_result.closed_trades)
+
+    # Group legs by position (a partial-closed position shares one position_id
+    # across its legs).
+    groups: dict[int, list] = {}
+    for t in trades:
+        groups.setdefault(int(t.position_id), []).append(t)
+
+    rows: list[dict] = []
+    for pos_id in sorted(groups):
+        legs = sorted(groups[pos_id], key=lambda x: (x.exit_time, float(x.size)))
+        commission, slippage, spread, n_fills, original_size = _position_cost(legs, model)
+        total_cost = commission + slippage + spread
+        gross_pnl = float(sum(float(leg.pnl) for leg in legs))
+        final_exit_time = max(leg.exit_time for leg in legs)
+        rows.append(
+            {
+                "position_id": pos_id,
+                "pair": legs[0].pair,
+                "original_size": original_size,
+                "n_legs": len(legs),
+                "n_fills": n_fills,
+                "commission": commission,
+                "slippage": slippage,
+                "spread": spread,
+                "total_cost": total_cost,
+                "gross_pnl": gross_pnl,
+                "net_pnl": gross_pnl - total_cost,
+                "final_exit_time": final_exit_time,
+            }
+        )
+
+    breakdown = pd.DataFrame(rows, columns=list(_BREAKDOWN_COLUMNS))
+
+    # Rebuild the net equity curve: debit each position's total cost at the
+    # equity bar at/after its final exit, then carry forward (cumsum).
+    if equity is None or len(equity) == 0:
+        net_equity = equity if equity is not None else pd.Series(
+            [], dtype="float64", name="equity"
+        )
+    else:
+        cost_at_time = pd.Series(0.0, index=equity.index)
+        for row in rows:  # rows are in sorted(position_id) order -> deterministic
+            ts = row["final_exit_time"]
+            idx = int(equity.index.searchsorted(ts))
+            if idx >= len(equity.index):
+                idx = len(equity.index) - 1
+            cost_at_time.iloc[idx] += float(row["total_cost"])
+        net_equity = (equity - cost_at_time.cumsum())
+        net_equity.name = equity.name
+
+    cost_total = float(breakdown["total_cost"].sum()) if len(breakdown) else 0.0
+    gross_pnl_total = float(breakdown["gross_pnl"].sum()) if len(breakdown) else 0.0
+
+    return CostedRunResult(
+        net_equity=net_equity,
+        breakdown=breakdown,
+        gross_pnl_total=gross_pnl_total,
+        cost_total=cost_total,
+        net_pnl_total=gross_pnl_total - cost_total,
+    )
+
+
+__all__ = ("CostModel", "CostedRunResult", "apply_cost_model")

--- a/core/sim/costs/model.py
+++ b/core/sim/costs/model.py
@@ -40,7 +40,7 @@ import pandas as pd
 from core.sim.costs.commission import compute_commission_usd
 from core.sim.costs.slippage import compute_slippage_pips
 from core.sim.costs.spread_multiplier import compute_extra_spread_price
-from core.utils import LOT_SIZE, get_pip_size, pips_to_price
+from core.utils import LOT_SIZE, pips_to_price
 
 if TYPE_CHECKING:  # avoid runtime import cost / cycles; only used for typing
     from core.sim.multipair_backtester import RunResult

--- a/core/wfo/fold_runner.py
+++ b/core/wfo/fold_runner.py
@@ -98,7 +98,16 @@ def _annualised_roi(equity: pd.Series) -> float:
 
 
 def _build_fold_stats(fold: Fold, result: RunResult, starting_balance: float) -> FoldStats:
-    """Convert a RunResult into the FoldStats the §3 gate consumes."""
+    """Convert a RunResult into the FoldStats the §3 gate consumes.
+
+    COST-FREE BY DESIGN. This is the KH-24 anchor path — an engine determinism
+    fixture (byte-identity to the legacy ``KH24FoldRunner``), NOT a deployable
+    gate (see CLAUDE.md). It intentionally does NOT net broker costs: the
+    architecture gate path (A1-A6) nets FundedNext costs via
+    ``core.runners._fold_stats_helpers.build_fold_stats_from_run``; this anchor
+    must stay gross to preserve byte-identity. The exception is explicit here so
+    it is never a silent cost-free gate number.
+    """
     equity = result.equity_curve
     if len(equity) == 0:
         return FoldStats(

--- a/tests/sim/test_cost_application.py
+++ b/tests/sim/test_cost_application.py
@@ -1,0 +1,235 @@
+"""Locked regression: FundedNext costs are netted at the gate-scoring layer.
+
+Resolves HONEST_ENGINE_SWEEP.md Part C (FAIL): the cost primitives were
+orphaned, so every gate verdict scored on raw bid/ask. This pins the wiring:
+
+  - ``apply_cost_model`` computes per-position cost from the GROSS ledger using
+    the existing primitives (commission $5/lot RT, slippage 0.5 pip/fill x
+    n_fills, spread 1.5x extra), with the correct unit conversions.
+  - n_fills tracks the ACTUAL SL-honest leg structure (3 if the +1R partial
+    fired, else 2).
+  - ``build_fold_stats_from_run`` nets by DEFAULT — a cost-free FoldStats
+    requires an EXPLICIT ``CostModel.zero()``.
+  - swaps OFF; NaN bid/ask -> zero spread (no equity poisoning); deterministic.
+
+Engine-level pnl/equity stay GROSS (Account is never touched), so the
+take-the-loss invariant and determinism fixtures are unaffected.
+
+Numpy/pandas + stdlib only -> runs under CI's ``pytest -m "not research"``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import date
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from core.runners._fold_stats_helpers import build_fold_stats_from_run
+from core.sim.account import ClosedTrade, Direction
+from core.sim.costs.model import CostModel, apply_cost_model
+from core.sim.multipair_backtester import RunResult
+from core.wfo.folds import Fold
+
+_PIP = 0.0001  # EURUSD
+
+
+def _leg(
+    *,
+    position_id: int,
+    size: float,
+    entry_price: float,
+    exit_price: float,
+    pnl: float,
+    exit_time: str,
+    parent_position_id: int | None = None,
+    entry_spread: float = _PIP,
+    exit_spread: float = _PIP,
+    pair: str = "EURUSD",
+) -> ClosedTrade:
+    """A gross ClosedTrade leg with symmetric bid/ask around the fill prices."""
+    return ClosedTrade(
+        position_id=position_id,
+        pair=pair,
+        direction=Direction.LONG,
+        entry_time=pd.Timestamp("2020-01-01", tz="UTC"),
+        entry_price=entry_price,
+        exit_time=pd.Timestamp(exit_time, tz="UTC"),
+        exit_price=exit_price,
+        size=size,
+        pnl=pnl,
+        exit_reason="x",
+        parent_position_id=parent_position_id,
+        entry_bid=entry_price - entry_spread / 2.0,
+        entry_ask=entry_price + entry_spread / 2.0,
+        exit_bid=exit_price - exit_spread / 2.0,
+        exit_ask=exit_price + exit_spread / 2.0,
+        sl_price=None,
+    )
+
+
+def _run_result(legs: tuple[ClosedTrade, ...], equity: pd.Series | None = None) -> RunResult:
+    if equity is None:
+        equity = pd.Series([], dtype="float64", name="equity")
+    return RunResult(
+        final_balance=float(equity.iloc[-1]) if len(equity) else 100_000.0,
+        n_trades=len(legs),
+        n_open_at_end=0,
+        equity_curve=equity,
+        max_drawdown_pct=0.0,
+        closed_trades=legs,
+    )
+
+
+# ── cost math: a clean-win partial (3 fills) ─────────────────────────────
+
+
+def test_partial_win_three_fills_exact_haircut() -> None:
+    """+1R partial + runner = 2 legs => 3 fills; exact commission+slippage+spread."""
+    legs = (
+        _leg(position_id=1, parent_position_id=1, size=5_000.0,
+             entry_price=1.10000, exit_price=1.10200, pnl=10.0,
+             exit_time="2020-01-02"),
+        _leg(position_id=1, parent_position_id=1, size=5_000.0,
+             entry_price=1.10000, exit_price=1.10100, pnl=5.0,
+             exit_time="2020-01-03"),
+    )
+    costed = apply_cost_model(_run_result(legs), CostModel.fundednext())
+    assert len(costed.breakdown) == 1
+    row = costed.breakdown.iloc[0]
+
+    # original_size 10_000 = 0.1 lot; partial fired -> 3 fills.
+    assert row["n_legs"] == 2
+    assert row["n_fills"] == 3
+    assert row["original_size"] == pytest.approx(10_000.0)
+    # commission: 0.1 lot x $5 = $0.50
+    assert row["commission"] == pytest.approx(0.5)
+    # slippage: 0.5 pip x 3 fills = 1.5 pip = 0.00015 price x 10_000 = $1.50
+    assert row["slippage"] == pytest.approx(1.5)
+    # spread: per leg (1pip+1pip)x(1.5-1)=0.0001 price x 5_000 = $0.50 ; x2 legs = $1.00
+    assert row["spread"] == pytest.approx(1.0)
+    assert row["total_cost"] == pytest.approx(3.0)
+    assert row["gross_pnl"] == pytest.approx(15.0)
+    assert row["net_pnl"] == pytest.approx(12.0)
+    assert costed.cost_total == pytest.approx(3.0)
+    assert costed.net_pnl_total == pytest.approx(12.0)
+
+
+# ── cost math: a take-the-loss (2 fills) ─────────────────────────────────
+
+
+def test_take_the_loss_two_fills_exact_haircut() -> None:
+    """Stop before any partial = 1 leg => 2 fills; costs still applied."""
+    legs = (
+        _leg(position_id=7, parent_position_id=None, size=10_000.0,
+             entry_price=1.10000, exit_price=1.09800, pnl=-20.0,
+             exit_time="2020-01-02"),
+    )
+    costed = apply_cost_model(_run_result(legs), CostModel.fundednext())
+    row = costed.breakdown.iloc[0]
+    assert row["n_legs"] == 1
+    assert row["n_fills"] == 2  # entry + stop, partial never fired
+    # commission 0.5 ; slippage 0.5pip x2 = 0.0001 x 10_000 = 1.0 ; spread 0.0001 x 10_000 = 1.0
+    assert row["commission"] == pytest.approx(0.5)
+    assert row["slippage"] == pytest.approx(1.0)
+    assert row["spread"] == pytest.approx(1.0)
+    assert row["total_cost"] == pytest.approx(2.5)
+    assert row["gross_pnl"] == pytest.approx(-20.0)
+    assert row["net_pnl"] == pytest.approx(-22.5)  # a loss is made worse, never flattered
+
+
+# ── default-on guarantee at the gate-scoring layer ───────────────────────
+
+
+def _fold() -> Fold:
+    return Fold(
+        fold_id=1,
+        is_start=date(2019, 12, 1),
+        is_end=date(2019, 12, 31),
+        oos_start=date(2020, 1, 1),
+        oos_end=date(2020, 1, 31),
+    )
+
+
+def _gate_inputs() -> RunResult:
+    idx = pd.DatetimeIndex(
+        [pd.Timestamp(d, tz="UTC") for d in ("2020-01-02", "2020-01-03", "2020-01-04")],
+        name="timestamp_utc",
+    )
+    equity = pd.Series([100_000.0, 100_010.0, 100_015.0], index=idx, name="equity")
+    legs = (
+        _leg(position_id=1, parent_position_id=1, size=5_000.0,
+             entry_price=1.10000, exit_price=1.10200, pnl=10.0, exit_time="2020-01-03"),
+        _leg(position_id=1, parent_position_id=1, size=5_000.0,
+             entry_price=1.10000, exit_price=1.10100, pnl=5.0, exit_time="2020-01-03"),
+    )
+    return _run_result(legs, equity)
+
+
+def test_gate_run_cannot_be_cost_free_by_default() -> None:
+    """build_fold_stats_from_run with no cost_model nets FundedNext costs."""
+    rr = _gate_inputs()
+    default_fs = build_fold_stats_from_run(fold=_fold(), run_result=rr, starting_balance=100_000.0)
+    explicit_fn = build_fold_stats_from_run(
+        fold=_fold(), run_result=rr, starting_balance=100_000.0, cost_model=CostModel.fundednext()
+    )
+    cost_free = build_fold_stats_from_run(
+        fold=_fold(), run_result=rr, starting_balance=100_000.0, cost_model=CostModel.zero()
+    )
+    # The default IS FundedNext.
+    assert default_fs.roi_pct == pytest.approx(explicit_fn.roi_pct)
+    # Costs strictly reduce ROI vs an explicit cost-free run.
+    assert default_fs.roi_pct < cost_free.roi_pct
+    # n_trades (count) is unchanged by costs.
+    assert default_fs.n_trades == cost_free.n_trades
+
+
+def test_zero_model_equals_gross() -> None:
+    rr = _gate_inputs()
+    costed = apply_cost_model(rr, CostModel.zero())
+    pd.testing.assert_series_equal(costed.net_equity, rr.equity_curve)
+    assert costed.cost_total == pytest.approx(0.0)
+
+
+# ── robustness: NaN bid/ask, swaps off, determinism ──────────────────────
+
+
+def test_nan_bid_ask_yields_zero_spread_and_finite_net() -> None:
+    """Synthetic/legacy panels carry NaN bid/ask -> zero spread, finite equity."""
+    leg = ClosedTrade(
+        position_id=3, pair="EURUSD", direction=Direction.LONG,
+        entry_time=pd.Timestamp("2020-01-01", tz="UTC"), entry_price=1.10000,
+        exit_time=pd.Timestamp("2020-01-02", tz="UTC"), exit_price=1.10100,
+        size=10_000.0, pnl=10.0, exit_reason="x", parent_position_id=None,
+        entry_bid=float("nan"), entry_ask=float("nan"),
+        exit_bid=float("nan"), exit_ask=float("nan"), sl_price=None,
+    )
+    idx = pd.DatetimeIndex([pd.Timestamp("2020-01-02", tz="UTC")], name="timestamp_utc")
+    equity = pd.Series([100_010.0], index=idx, name="equity")
+    costed = apply_cost_model(_run_result((leg,), equity), CostModel.fundednext())
+    row = costed.breakdown.iloc[0]
+    assert row["spread"] == pytest.approx(0.0)        # NaN bid/ask -> 0, not NaN
+    assert row["commission"] == pytest.approx(0.5)    # still applied
+    assert row["slippage"] == pytest.approx(1.0)
+    assert bool(np.isfinite(costed.net_equity).all())  # equity not poisoned
+
+
+def test_swaps_enabled_is_rejected() -> None:
+    """Swaps are intentionally OFF; a swaps-on model must fail loud, not half-wire."""
+    with pytest.raises(NotImplementedError):
+        apply_cost_model(_run_result(()), CostModel(swaps_enabled=True))
+
+
+def _sha(series: pd.Series) -> str:
+    return hashlib.sha256(
+        series.to_csv(lineterminator="\n", float_format="%.10g").encode("utf-8")
+    ).hexdigest()
+
+
+def test_determinism_two_run_identity_with_costs_on() -> None:
+    rr = _gate_inputs()
+    a = apply_cost_model(rr, CostModel.fundednext())
+    b = apply_cost_model(rr, CostModel.fundednext())
+    assert _sha(a.net_equity) == _sha(b.net_equity)


### PR DESCRIPTION
## Why

`HONEST_ENGINE_SWEEP.md` **Part C = FAIL**: the cost primitives in `core/sim/costs/` (1.5× spread, $5/lot commission, 0.5 pip/fill slippage) were **orphaned** — called on no gate path — so every gate verdict scored on **raw HistData bid/ask** (1.0× spread, zero commission, zero slippage). This blocked the discovery protocol's FundedNext-guardrails rule.

This wires the **existing** primitives (no cost math reimplemented) so every gate/WFO run is net-of-costs **by default**, conservatively biased and deterministic.

## Design (operator-approved)

- **Chokepoint = the gate-scoring layer, not the engine.** Cost is a **separate explicit quantity**; `ClosedTrade.pnl`, `Account.balance`, and the equity curve **stay GROSS**; netting (`net = gross − cost`) happens where `RunResult → FoldStats`. **Step-6's spread diagnostic reads gross `pnl` and is untouched** (no double-count). Lower blast radius + more auditable.
- **Gate default = FundedNext $5/lot** (the higher cost, conservative bound): **1.5× spread, $5/lot round-turn commission, 0.5 pip/fill × n_fills slippage, swaps OFF.**

The single shared chokepoint `build_fold_stats_from_run` is used by all six wired architectures (A1–A6), so defaulting costs ON there nets every gate verdict with **no architecture/config edits**.

### Exact chokepoint (as required by DoD)
`core/runners/_fold_stats_helpers.py` → `build_fold_stats_from_run` nets the equity via `core.sim.costs.model.apply_cost_model` before computing `FoldStats`.

## Changes
- **New** `core/sim/costs/model.py` — `CostModel` (`.fundednext()` default / `.zero()` explicit cost-free) + `apply_cost_model()` → `CostedRunResult` (net equity curve + auditable per-position cost breakdown). Uses the existing primitives + `core/utils.py` (`LOT_SIZE`, `get_pip_size`, `pips_to_price`).
- `core/sim/costs/__init__.py` — export the new symbols.
- `core/runners/_fold_stats_helpers.py` — `build_fold_stats_from_run` nets by default; cost-free requires an explicit `CostModel.zero()`.
- `core/wfo/fold_runner.py` — annotate the KH-24 anchor `_build_fold_stats` as the intentional **non-gate, cost-free** path (determinism fixture; byte-identity preserved).
- `core/sim/costs/commission.py` — docstring note that the gate model passes FundedNext `$5` (primitive `$4` default + cost math unchanged).
- **New** `tests/sim/test_cost_application.py` — CI-gated regression.

## Cost model
- **Commission** (per position): `compute_commission_usd(original_size/LOT_SIZE, 5.0)`.
- **Slippage** (per position): `compute_slippage_pips(0.5, partial_fired)` → `pips_to_price(pair,pips) × original_size`. `n_fills` tracks the **actual SL-honest leg structure** (3 if the +1R partial fired, else 2).
- **Spread** (per leg): `compute_extra_spread_price(entry_spread, exit_spread, 1.5) × leg.size` (per-leg × leg.size makes entry-spread total correctly; no double-count). **NaN bid/ask → 0** (synthetic/legacy panels; protects the determinism hash).
- **Swaps OFF** (a swaps-on model fails loud, never half-wires). Net equity debits each position's cost at its final exit bar → net ROI/max-DD/daily-5% breach stay faithful.
- Conservative bias ("over-apply, never flatter"): full-size × n_fills slippage; the larger full-spread extra.

## Validation
- `scripts/smoke_test_multipair.py` — **passes** (engine is gross/untouched).
- **Full CI gate** `pytest -m "not research"` — **1633 passed, 294 skipped, 7 deselected**.
- `tests/sim/test_take_the_loss_invariant.py` + `tests/test_determinism.py` + KH-24 anchor — **green** (gross by construction).
- Step-6 suite — green (diagnostic untouched).
- **Before/after on one trade** (EURUSD, 0.1 lot, 40-pip SL, 1R=$40): cost $3.00 (comm $0.50 + slip(3 fills) $1.50 + spread(1.5×) $1.00) → realized **+0.3750R gross → +0.3000R net**.
- **Grep**: the only live `FoldStats` gate scorer (`build_fold_stats_from_run`) nets by default; the only cost-free `FoldStats` path is the flagged KH-24 anchor (`step_6/dispatch.py` only *reconstructs* from already-scored values).

## Flags / out of scope
- **Step-6 untouched** by design (reads gross `pnl`).
- **A5** (portfolio composition, deferred/not-gated) also calls `build_fold_stats_from_run`; its composition-from-equity path must be re-checked when A5 is activated.
- **Non-USD-quote simplification**: commission USD ≈ quote-currency cost, consistent with the engine's existing pnl simplification (`core/sim/risk/live_balance.py`).
- **Fill-count edges** (documented, minor, conservative-leaning): the rare `partial_fraction≈1.0` full-out scores 2 fills; >2-leg policies would want `1 + n_legs` (current gate policy `sl_partial_close_1r_runner_trail` is ≤2 legs, so `n_legs>=2` is exact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
