### PR TITLE
Short-side enablement (GATED canonical-core — do not self-merge)

### DIFF
--- a/HONEST_ENGINE_SWEEP.md
+++ b/HONEST_ENGINE_SWEEP.md
@@ -188,3 +188,32 @@ The two blockers this report flagged were subsequently resolved by operator-appr
 Empirical confirmation this pass: the 35 honesty-critical cases (`test_take_the_loss_invariant`, `test_cost_application`, `test_label_take_the_loss`, `test_determinism`) pass, and the full CI suite `pytest -m "not research"` is green — **1656 passed, 294 skipped, 7 deselected** (no collateral regression from the cost wiring on the shared chokepoint).
 
 **Final top verdict: `MultiPairBacktester` is honest end-to-end and safe as the sole gate engine.** Residual non-blocking items remain as written: Part B's cross-pair `SUSPECT` features (excluded by the causal-lineage gate, flagged for the Step-6 cross-pair audit) and Part E's absence of an automated full-data A1-vs-legacy anchor in CI.
+
+---
+
+## SHORT-SIDE RE-READ ADDENDUM — 2026-06-05
+
+Scope: the short-side enablement PR (`feature/short-side-enablement`, per
+[`discovery/SHORTS_ENABLEMENT_PROBE.md`](discovery/SHORTS_ENABLEMENT_PROBE.md))
+exercises the engine's already-symmetric short path for the first time. The
+sweep is re-read for shorts; the dispatch requires **Part C** (FundedNext cost
+netting symmetric on short legs) and **Part D** (the direction-aware
+`reached_1r_before_sl` is the label producer of record) to read **SAFE**. Longs
+are byte-identical (default `Direction.LONG` everywhere; `tests/test_determinism.py`
+and the A1-vs-legacy anchor green), so this addendum only adds the short
+mirror — no prior verdict changes.
+
+| Part | Short-side re-read (2026-06-05) |
+|------|--------------------------------|
+| **A** Take-the-loss | **SAFE (short)** — `tests/sim/test_take_the_loss_invariant.py` gained a 5-case `Direction.SHORT` mirror (every fixture the reflection of its long counterpart around entry). The dispatch case — a short stop ABOVE entry breached on the SAME bar its +1R partial BELOW entry would fire → SL-first → full −1R, partial suppressed — is `test_short_same_bar_stop_and_partial_is_sl_first_minus_1r`. Short SL fires on `high_ask >= sl` (`core/sim/fill.py:78`); the SL-first `_check_exits`→partial ordering is shared, not re-authored. |
+| **C** FundedNext costs | **SAFE (short)** — the cost model is direction-agnostic (size + bid/ask spread only; `core/sim/costs/*`). `tests/sim/test_cost_application.py::test_short_leg_costs_match_long_leg_exactly` pins commission / slippage / spread / total identical on a SHORT leg vs the otherwise-identical LONG leg; `test_short_partial_win_three_fills_symmetric` pins the 3-fill partial haircut. Costs still only ever subtract — a short's gross win is reduced, never inflated. |
+| **D** labels | **SAFE (short)** — `core/sim/honest_label.reached_1r_before_sl` is now direction-aware (short: favourable = `low_ask` below entry, stop = `high_ask` above SL) and remains the in-tree producer of record, called by **both** Step-1 pool producers on the short branch. The same-bar +1R/SL tie still resolves SL-first → NaN → LOSS for shorts (`tests/sim/test_short_enablement.py::test_short_label_same_bar_plus1r_and_sl_is_nan`, plus the full producer suite). The two producers are cross-checked to agree trade-for-trade on a losing short (`test_two_producers_agree_on_a_losing_short`, with a long control). |
+| **E** Determinism | **SAFE** — longs byte-identical (two-run sha + serial-vs-parallel green, A1 anchor green); the short path adds no RNG / time / unordered iteration. No committed short fixtures exist yet (no short arc has opened), so there is nothing to regenerate; short fixture/sha generation happens when a short arc is dispatched. |
+
+**Short-side verdict: the honest-engine sweep reads SAFE for shorts.** The
+35 honesty-critical cases plus the new short mirror (`test_take_the_loss_invariant`
+short cases, `test_cost_application` short cases, `test_short_enablement`,
+`test_label_take_the_loss`, `test_determinism`) pass under `pytest -m "not research"`.
+Caveat, unchanged from the long verdict: Part B's cross-pair `SUSPECT` features
+remain causal-lineage-gated, and no short discovery arc may open until this PR is
+merged (it is human-gated canonical core; deployable-system count stays 0).

--- a/configs/arc_discovery_01.yaml
+++ b/configs/arc_discovery_01.yaml
@@ -15,6 +15,9 @@ arc:
   sub_protocol: signal_discovery_probe
   tf_mode: locked
   tf: H1   # H1 primary. Rationale: L-arc convention; KH-24 deploys on H4 so discovery on H1 keeps signals orthogonal.
+  # Load-bearing as of short-side enablement: a run parses this via
+  # core.sim.account.parse_direction -> DiscoveryExitConfig.direction
+  # (long_only is an accepted alias for Direction.LONG). A short arc sets `short`.
   direction: long_only
 
 search:

--- a/configs/arc_discovery_02.yaml
+++ b/configs/arc_discovery_02.yaml
@@ -23,6 +23,9 @@ arc:
   sub_protocol: signal_discovery_probe
   tf_mode: locked
   tf: H4   # AMENDED — chat decision 1
+  # Load-bearing as of short-side enablement: a run parses this via
+  # core.sim.account.parse_direction -> DiscoveryExitConfig.direction
+  # (long_only is an accepted alias for Direction.LONG). A short arc sets `short`.
   direction: long_only
 
 search:

--- a/core/arc/arc_pool_builder.py
+++ b/core/arc/arc_pool_builder.py
@@ -49,7 +49,8 @@ from core.arc.signal_protocol import (
     SignalModule,
     validate_panels,
 )
-from core.sim.fill import long_entry_fill_price
+from core.sim.account import Direction
+from core.sim.fill import long_entry_fill_price, short_entry_fill_price
 from core.sim.honest_label import reached_1r_before_sl
 from core.sim.panel import Panel
 
@@ -119,22 +120,27 @@ def _simulate_pair_pool(
 ) -> tuple[list[dict], list[dict], int]:
     """Apply the signal to one pair and return (trades, paths, next_trade_id).
 
-    The simulation:
+    The simulation (mirrored by ``state.direction``; LONG default):
       - Signal fires at bar N close (state.signal_mask).
-      - Entry at bar N+1 open using core.sim.fill.long_entry_fill_price.
-      - SL at signal-bar close_ask − sl_atr_mult × ATR (proxy for true
-        post-fill anchor; matches v3 KH-24 convention).
+      - Entry at bar N+1 open. Long fills at ``open_ask``
+        (``long_entry_fill_price``); short fills at ``open_bid``
+        (``short_entry_fill_price``).
+      - SL anchored at the signal bar. Long: ``close_ask − sl_atr_mult ×
+        ATR`` (below entry). Short: ``close_bid + sl_atr_mult × ATR`` (above
+        entry). ``sl_distance`` is the positive entry↔SL gap either way.
       - Forward-window scan: each bar from N+1 .. min(N+1+hold_bars, end)
-        emits close_r / mfe_so_far_r / mae_so_far_r relative to entry +
-        SL distance.
-      - Exit on: hard SL hit (high_bid for short / low_bid for long
-        falls past SL), time-cap (bar N+1+hold_bars open), or
-        additional_gates falling false (signal-inherent exit).
+        emits close_r / mfe_so_far_r / mae_so_far_r in R relative to entry.
+        Long tracks the bid side (it exits at the bid); short tracks the ask
+        side (it buys back at the ask), matching ``core.sim.fill``.
+      - Exit on: hard SL hit (long: ``low_bid ≤ sl``; short: ``high_ask ≥
+        sl``) or time-cap (bar N+1+hold_bars).
 
-    Only long-side simulation is implemented at v3.0 launch; short
-    handling is structurally trivial but not exercised by any registry
-    signal. Short signals raise NotImplementedError if signal mask sets
-    direction to short (the SignalModule contract is long-only at v3.0).
+    Direction comes from ``state.direction`` (``PerPairSignalState``); a
+    long signal (the default) is byte-identical to the pre-short builder —
+    the short branches are reached only when a short signal module sets
+    ``Direction.SHORT``. The ``final_r`` sign and the SL-honest +1R-before-SL
+    label are both mirrored so a short's realised R and take-the-loss
+    provenance are computed in the short's own frame.
     """
     trades: list[dict] = []
     paths: list[dict] = []
@@ -168,10 +174,25 @@ def _simulate_pair_pool(
     n = len(df)
     warmup = max(cfg.primary_tf_warmup_bars, 0)
 
+    direction = state.direction
+    is_long = direction is Direction.LONG
+
     df_close_ask = df["close_ask"].values
     df_low_bid = df["low_bid"].values
     df_high_bid = df["high_bid"].values
     df_close_bid = df["close_bid"].values
+    # Ask-side intrabar extremes — needed only for short trades (a short is
+    # stopped on the ASK rising to SL and bought back on the ASK falling, per
+    # core.sim.fill). Extracted only when the signal is short so existing
+    # long arcs / synthetic long fixtures without ask columns are untouched.
+    if not is_long:
+        if "high_ask" not in df.columns or "low_ask" not in df.columns:
+            raise ValueError(
+                "short arc-pool simulation requires high_ask/low_ask columns; "
+                f"pair {pair!r} panel has {sorted(df.columns)[:12]}"
+            )
+        df_high_ask = df["high_ask"].values
+        df_low_ask = df["low_ask"].values
     # Per-bar bid+ask quotes for the Step 6 §6.3 spread-decomposition
     # diagnostic. Captured at fill sites only (entry-bar open / exit-bar
     # open). The diagnostic skips trades with NaN bid/ask gracefully.
@@ -198,15 +219,21 @@ def _simulate_pair_pool(
         atr = float(atr_arr[s])
         if not np.isfinite(atr) or atr <= 0:
             continue
-        # Entry fill at next-bar open_ask
+        # Entry fill at next-bar open. Long buys the ask; short sells the bid.
         entry_bar = df.iloc[entry_idx]
-        entry_price = float(long_entry_fill_price(entry_bar))
-        # SL anchored to signal-bar close_ask (consistent with current v3 KH-24)
-        sl_anchor = float(df_close_ask[s])
-        sl_price = sl_anchor - cfg.sl_atr_mult * atr
+        if is_long:
+            entry_price = float(long_entry_fill_price(entry_bar))
+            # SL anchored to signal-bar close_ask (consistent with v3 KH-24).
+            sl_anchor = float(df_close_ask[s])
+            sl_price = sl_anchor - cfg.sl_atr_mult * atr
+        else:
+            entry_price = float(short_entry_fill_price(entry_bar))
+            # Mirror: anchor to signal-bar close_bid, stop ABOVE entry.
+            sl_anchor = float(df_close_bid[s])
+            sl_price = sl_anchor + cfg.sl_atr_mult * atr
         if sl_price <= 0 or not np.isfinite(sl_price):
             continue
-        sl_distance = entry_price - sl_price
+        sl_distance = (entry_price - sl_price) if is_long else (sl_price - entry_price)
         if sl_distance <= 0:
             continue
         # Entry-bar bid+ask quotes at open (long entry fills at open_ask;
@@ -226,16 +253,33 @@ def _simulate_pair_pool(
         bars_held = 0
         for off in range(0, max_off + 1):
             bidx = entry_idx + off
-            bar_low = float(df_low_bid[bidx])
-            bar_close_bid = float(df_close_bid[bidx])
-            close_r = (bar_close_bid - entry_price) / sl_distance
-            # Intra-bar excursions in R
-            bar_min_r = (bar_low - entry_price) / sl_distance
-            mae_r = min(mae_r, bar_min_r)
-            mfe_so_far_high = (
-                float(df["high_bid"].iat[bidx]) - entry_price
-            ) / sl_distance
-            mfe_r = max(mfe_r, mfe_so_far_high)
+            if is_long:
+                bar_low = float(df_low_bid[bidx])
+                bar_close_bid = float(df_close_bid[bidx])
+                close_r = (bar_close_bid - entry_price) / sl_distance
+                # Intra-bar excursions in R
+                bar_min_r = (bar_low - entry_price) / sl_distance
+                mae_r = min(mae_r, bar_min_r)
+                mfe_so_far_high = (
+                    float(df["high_bid"].iat[bidx]) - entry_price
+                ) / sl_distance
+                mfe_r = max(mfe_r, mfe_so_far_high)
+                # SL check (long): low_bid <= sl_price
+                stop_hit = bar_low <= sl_price
+            else:
+                # Short mirror: track the ask side (buy-back), stop ABOVE entry.
+                bar_high = float(df_high_ask[bidx])
+                bar_close_ask = float(df_close_ask[bidx])
+                close_r = (entry_price - bar_close_ask) / sl_distance
+                # Adverse excursion = price rising; favourable = price falling.
+                bar_min_r = (entry_price - bar_high) / sl_distance
+                mae_r = min(mae_r, bar_min_r)
+                mfe_so_far_low = (
+                    entry_price - float(df_low_ask[bidx])
+                ) / sl_distance
+                mfe_r = max(mfe_r, mfe_so_far_low)
+                # SL check (short): high_ask >= sl_price
+                stop_hit = bar_high >= sl_price
             path_rows.append(
                 {
                     "trade_id": tid,
@@ -246,18 +290,20 @@ def _simulate_pair_pool(
                     "mae_so_far_r": mae_r,
                 }
             )
-            # SL check (long): low_bid <= sl_price
-            if off > 0 and bar_low <= sl_price:
+            if off > 0 and stop_hit:
                 exit_idx = bidx
                 exit_reason = "hard_sl"
                 exit_price = sl_price
                 bars_held = off
                 break
         if exit_idx is None:
-            # Time exit at the end of the forward window
+            # Time exit at the end of the forward window (long exits at the
+            # bid, short buys back at the ask).
             exit_idx = entry_idx + max_off
             exit_reason = "time_exit"
-            exit_price = float(df_close_bid[exit_idx])
+            exit_price = (
+                float(df_close_bid[exit_idx]) if is_long else float(df_close_ask[exit_idx])
+            )
             bars_held = max_off
 
         # Exit-bar bid+ask quotes — open quotes for time exits (mirrors the
@@ -271,23 +317,41 @@ def _simulate_pair_pool(
             exit_bid_q = _q(df_open_bid, exit_idx)
             exit_ask_q = _q(df_open_ask, exit_idx)
 
-        final_r = (exit_price - entry_price) / sl_distance
+        final_r = (
+            (exit_price - entry_price) if is_long else (entry_price - exit_price)
+        ) / sl_distance
         # SL-honest meta-label provenance: the first forward offset at which
         # the trade reached +1R MFE STRICTLY BEFORE its hard stop (take-the-
         # loss ordering; same-bar +1R/SL → NaN). Both exits here are open
         # through the resolved bar (hard_sl intrabar at sl_price, time_exit
         # at the bar close), so the exit bar is included in the scan. This is
         # the in-tree producer that closes HONEST_ENGINE_SWEEP.md FLAG-D1.
-        bars_to_1r_mfe = reached_1r_before_sl(
-            high_bid=df_high_bid,
-            low_bid=df_low_bid,
-            entry_idx=entry_idx,
-            exit_off=int(bars_held),
-            entry_price=entry_price,
-            sl_price=sl_price,
-            sl_distance=sl_distance,
-            exit_at_bar_open=False,
-        )
+        # Short mirrors on the ask side (stop above entry, favourable down).
+        if is_long:
+            bars_to_1r_mfe = reached_1r_before_sl(
+                high_bid=df_high_bid,
+                low_bid=df_low_bid,
+                entry_idx=entry_idx,
+                exit_off=int(bars_held),
+                entry_price=entry_price,
+                sl_price=sl_price,
+                sl_distance=sl_distance,
+                exit_at_bar_open=False,
+            )
+        else:
+            bars_to_1r_mfe = reached_1r_before_sl(
+                high_bid=df_high_bid,
+                low_bid=df_low_bid,
+                high_ask=df_high_ask,
+                low_ask=df_low_ask,
+                direction="short",
+                entry_idx=entry_idx,
+                exit_off=int(bars_held),
+                entry_price=entry_price,
+                sl_price=sl_price,
+                sl_distance=sl_distance,
+                exit_at_bar_open=False,
+            )
         trades.append(
             {
                 "pair": pair,

--- a/core/arc/signal_protocol.py
+++ b/core/arc/signal_protocol.py
@@ -34,6 +34,7 @@ from typing import Mapping, Protocol, runtime_checkable
 
 import pandas as pd
 
+from core.sim.account import Direction
 from core.sim.exit_hooks import ExitPredicate
 from core.sim.panel import Panel
 
@@ -58,6 +59,14 @@ class PerPairSignalState:
     the primary TF and per-trade path emission — Step 1's path builder
     uses it to slice forward windows correctly. For most signal modules
     this is the primary TF's index unchanged.
+
+    ``direction`` is the side the signal trades (LONG default). It is the
+    single source of truth that flows into the Step-1 pool bar-walk
+    (``arc_pool_builder._simulate_pair_pool``) and the Step-5 architecture
+    Order emission, so a short signal module sets ``Direction.SHORT`` here
+    and every entry / SL / MFE-MAE / final_r computation mirrors. Default
+    ``Direction.LONG`` keeps every existing long signal byte-identical (the
+    column is not serialised into the pool sha; longs are unaffected).
     """
 
     signal_mask: pd.Series  # bool, indexed by primary-TF timestamp
@@ -65,16 +74,26 @@ class PerPairSignalState:
     additional_gates: Mapping[str, pd.Series] = field(default_factory=dict)
     exit_predicate: ExitPredicate | None = None
     path_feature_anchor: pd.Index | None = None
+    direction: Direction = Direction.LONG
 
 
 @dataclass(frozen=True)
 class SignalEvaluation:
-    """Output of :meth:`SignalModule.evaluate` — what arc-pool-builder consumes."""
+    """Output of :meth:`SignalModule.evaluate` — what arc-pool-builder consumes.
+
+    ``direction`` is the arc-level declared side (LONG default), surfaced
+    here for convenience so a consumer that holds only the evaluation (not a
+    per-pair state) can read the side. The authoritative per-trade source
+    remains ``PerPairSignalState.direction``; an arc whose pairs all trade
+    one side sets both to the same value. Default ``Direction.LONG`` keeps
+    existing long signals byte-identical.
+    """
 
     primary_tf: str
     per_pair: Mapping[str, PerPairSignalState]
     signal_name: str
     causal_lineage: str  # "clean" | "suspect" | "unverified"
+    direction: Direction = Direction.LONG
 
 
 @runtime_checkable

--- a/core/architectures/a1_system_level_filter.py
+++ b/core/architectures/a1_system_level_filter.py
@@ -186,6 +186,7 @@ def _build_a1_strategy(
 
     # Reindex per-pair series onto the fold-sliced primary panel
     series_cache: dict[str, dict[str, pd.Series]] = {}
+    directions: dict[str, Direction] = {}
     for pair, state in per_pair.items():
         df = primary_panel.pair_dfs.get(pair)
         if df is None:
@@ -196,6 +197,7 @@ def _build_a1_strategy(
         for k, v in state.additional_gates.items():
             gates[k] = v.reindex(df.index).fillna(False).astype(bool)
         series_cache[pair] = {"mask": mask, "atr": atr, **gates}
+        directions[pair] = state.direction
 
     def strategy(
         t: pd.Timestamp,
@@ -229,15 +231,22 @@ def _build_a1_strategy(
                 )
                 if not _evaluate_filter_rules(cfg.filter_rules, feats):
                     continue
-            # ATR + entry proxy
+            # ATR + entry proxy (mirrored by the signal's direction). Long
+            # anchors to close_ask and stops below; short anchors to close_bid
+            # and stops above. risk_size uses abs(entry-sl) so it is side-safe.
             atr = float(cached["atr"].loc[t])
             if not (atr > 0):
                 continue
             bar = snapshot.get(pair)
             if bar is None:
                 continue
-            entry_proxy = float(bar["close_ask"])
-            sl_price = entry_proxy - cfg.sl_atr_mult * atr
+            direction = directions.get(pair, Direction.LONG)
+            if direction is Direction.LONG:
+                entry_proxy = float(bar["close_ask"])
+                sl_price = entry_proxy - cfg.sl_atr_mult * atr
+            else:
+                entry_proxy = float(bar["close_bid"])
+                sl_price = entry_proxy + cfg.sl_atr_mult * atr
             if sl_price <= 0:
                 continue
             size = risk.risk_size(
@@ -246,7 +255,7 @@ def _build_a1_strategy(
             orders.append(
                 Order(
                     pair=pair,
-                    direction=Direction.LONG,
+                    direction=direction,
                     size=size,
                     sl_price=sl_price,
                     tp_price=None,

--- a/core/architectures/a2_classifier_filter.py
+++ b/core/architectures/a2_classifier_filter.py
@@ -83,6 +83,7 @@ def _build_a2_strategy(
     per_pair = signal_eval.per_pair
 
     series_cache: dict[str, dict[str, pd.Series]] = {}
+    directions: dict[str, Direction] = {}
     for pair, state in per_pair.items():
         df = primary_panel.pair_dfs.get(pair)
         if df is None:
@@ -94,6 +95,7 @@ def _build_a2_strategy(
             for k, v in state.additional_gates.items()
         }
         series_cache[pair] = {"mask": mask, "atr": atr, **gates}
+        directions[pair] = state.direction
 
     feat_keys = cfg.classifier_feature_order
 
@@ -137,8 +139,14 @@ def _build_a2_strategy(
             bar = snapshot.get(pair)
             if bar is None:
                 continue
-            entry_proxy = float(bar["close_ask"])
-            sl_price = entry_proxy - cfg.sl_atr_mult * atr
+            # Entry proxy mirrored by the signal's direction (see A1).
+            direction = directions.get(pair, Direction.LONG)
+            if direction is Direction.LONG:
+                entry_proxy = float(bar["close_ask"])
+                sl_price = entry_proxy - cfg.sl_atr_mult * atr
+            else:
+                entry_proxy = float(bar["close_bid"])
+                sl_price = entry_proxy + cfg.sl_atr_mult * atr
             if sl_price <= 0:
                 continue
             size = risk.risk_size(
@@ -146,7 +154,7 @@ def _build_a2_strategy(
             )
             orders.append(Order(
                 pair=pair,
-                direction=Direction.LONG,
+                direction=direction,
                 size=size,
                 sl_price=sl_price,
                 tp_price=None,

--- a/core/architectures/a3_pipeline_de.py
+++ b/core/architectures/a3_pipeline_de.py
@@ -107,14 +107,23 @@ def _path_features_so_far(
     n_defer: int,
     sl_anchor_price: float,
     sl_distance: float,
+    direction: Direction = Direction.LONG,
 ) -> dict[str, float]:
     """Compute path-so-far features at bar (signal_idx + n_defer).
 
     The simulator treats bar signal_idx+1 as the would-be entry; we
     compute path-so-far relative to that "tentative entry price" =
-    open_ask(signal_idx+1). The classifier decides at signal_idx +
-    n_defer whether the path-so-far features admit entry at
-    signal_idx + n_defer + 1.
+    open_ask(signal_idx+1) for a long / open_bid for a short. The
+    classifier decides at signal_idx + n_defer whether the path-so-far
+    features admit entry at signal_idx + n_defer + 1.
+
+    The features are computed in the TRADE's own frame, so they carry the
+    same meaning for either side: ``mfe_so_far_r`` is the best favourable
+    excursion (price up for a long, down for a short), ``mae_so_far_r`` the
+    worst adverse one, ``close_r`` the signed progress. ``direction=LONG``
+    (default) is byte-identical to the pre-short helper (``sgn=1.0`` and the
+    bid-side arrays); ``direction=SHORT`` mirrors onto the ask side with the
+    sign flipped.
 
     Returns a dict matching PATH_FEATURE_KEYS. Bars used: from
     signal_idx+1 up to signal_idx+n_defer (inclusive).
@@ -124,18 +133,26 @@ def _path_features_so_far(
     n = len(pair_df)
     if entry_idx >= n or decide_idx >= n:
         return {k: float("nan") for k in PATH_FEATURE_KEYS}
-    entry_price = float(pair_df["open_ask"].iat[entry_idx])
-    closes_bid = pair_df["close_bid"].values
-    highs_bid = pair_df["high_bid"].values
-    lows_bid = pair_df["low_bid"].values
+    if direction is Direction.LONG:
+        entry_price = float(pair_df["open_ask"].iat[entry_idx])
+        closes = pair_df["close_bid"].values
+        favs = pair_df["high_bid"].values   # favourable extreme (price up)
+        advs = pair_df["low_bid"].values    # adverse extreme (price down)
+        sgn = 1.0
+    else:
+        entry_price = float(pair_df["open_bid"].iat[entry_idx])
+        closes = pair_df["close_ask"].values
+        favs = pair_df["low_ask"].values    # favourable extreme (price down)
+        advs = pair_df["high_ask"].values   # adverse extreme (price up)
+        sgn = -1.0
     # close_r at each held bar
     close_r_series: list[float] = []
     mfe_so_far = 0.0
     mae_so_far = 0.0
     for bidx in range(entry_idx, decide_idx + 1):
-        close_r = (closes_bid[bidx] - entry_price) / sl_distance
-        mfe_bar = (highs_bid[bidx] - entry_price) / sl_distance
-        mae_bar = (lows_bid[bidx] - entry_price) / sl_distance
+        close_r = sgn * (closes[bidx] - entry_price) / sl_distance
+        mfe_bar = sgn * (favs[bidx] - entry_price) / sl_distance
+        mae_bar = sgn * (advs[bidx] - entry_price) / sl_distance
         if mfe_bar > mfe_so_far:
             mfe_so_far = mfe_bar
         if mae_bar < mae_so_far:
@@ -147,7 +164,7 @@ def _path_features_so_far(
     prev_mfe = None
     running_mfe = 0.0
     for bidx in range(entry_idx, decide_idx + 1):
-        m = (highs_bid[bidx] - entry_price) / sl_distance
+        m = sgn * (favs[bidx] - entry_price) / sl_distance
         if m > running_mfe:
             running_mfe = m
             if prev_mfe is not None and running_mfe > prev_mfe:
@@ -196,6 +213,7 @@ def _build_a3_strategy(
     per_pair = signal_eval.per_pair
 
     series_cache: dict[str, dict[str, pd.Series]] = {}
+    directions: dict[str, Direction] = {}
     for pair, state in per_pair.items():
         df = primary_panel.pair_dfs.get(pair)
         if df is None:
@@ -207,6 +225,7 @@ def _build_a3_strategy(
             for k, v in state.additional_gates.items()
         }
         series_cache[pair] = {"mask": mask, "atr": atr, **gates}
+        directions[pair] = state.direction
 
     n_defer = cfg.n_defer
 
@@ -240,10 +259,18 @@ def _build_a3_strategy(
             atr = float(cached["atr"].iloc[signal_bar_idx])
             if not (atr > 0):
                 continue
-            # Tentative entry price + SL (computed once at signal bar)
-            entry_proxy = float(df["close_ask"].iat[signal_bar_idx])
-            sl_price = entry_proxy - cfg.sl_atr_mult * atr
-            sl_distance = entry_proxy - sl_price
+            direction = directions.get(pair, Direction.LONG)
+            # Tentative entry price + SL (computed once at signal bar),
+            # mirrored by direction (long anchors close_ask / stop below;
+            # short anchors close_bid / stop above). sl_distance via abs keeps
+            # the long value identical and is positive for a short.
+            if direction is Direction.LONG:
+                entry_proxy = float(df["close_ask"].iat[signal_bar_idx])
+                sl_price = entry_proxy - cfg.sl_atr_mult * atr
+            else:
+                entry_proxy = float(df["close_bid"].iat[signal_bar_idx])
+                sl_price = entry_proxy + cfg.sl_atr_mult * atr
+            sl_distance = abs(entry_proxy - sl_price)
             if sl_distance <= 0:
                 continue
             # Build classifier feature vector
@@ -255,7 +282,7 @@ def _build_a3_strategy(
             if entry_feats is None:
                 continue
             path_feats = _path_features_so_far(
-                df, signal_bar_idx, n_defer, entry_proxy, sl_distance
+                df, signal_bar_idx, n_defer, entry_proxy, sl_distance, direction
             )
             combined = {**entry_feats, **path_feats}
             admit, _proba = predict_admit(
@@ -268,11 +295,16 @@ def _build_a3_strategy(
             bar_now = snapshot.get(pair)
             if bar_now is None:
                 continue
-            # Use current bar's close_ask as the *re-anchored* entry proxy
-            # so the order fills at this bar's next-bar open. This matches
-            # "wait N bars, then enter at next-bar open" semantics.
-            new_entry_proxy = float(bar_now["close_ask"])
-            new_sl_price = new_entry_proxy - cfg.sl_atr_mult * atr
+            # Use the current bar's close as the *re-anchored* entry proxy so
+            # the order fills at this bar's next-bar open. This matches "wait N
+            # bars, then enter at next-bar open" semantics. Mirrored by
+            # direction (long close_ask / stop below; short close_bid / above).
+            if direction is Direction.LONG:
+                new_entry_proxy = float(bar_now["close_ask"])
+                new_sl_price = new_entry_proxy - cfg.sl_atr_mult * atr
+            else:
+                new_entry_proxy = float(bar_now["close_bid"])
+                new_sl_price = new_entry_proxy + cfg.sl_atr_mult * atr
             if new_sl_price <= 0:
                 continue
             size = risk.risk_size(
@@ -283,7 +315,7 @@ def _build_a3_strategy(
             )
             orders.append(Order(
                 pair=pair,
-                direction=Direction.LONG,
+                direction=direction,
                 size=size,
                 sl_price=new_sl_price,
                 tp_price=None,

--- a/core/architectures/a4_pipeline_d_exits.py
+++ b/core/architectures/a4_pipeline_d_exits.py
@@ -116,7 +116,7 @@ class _A4ExitPredicate:
     def __call__(
         self, position: Position, snapshot: dict[str, pd.Series | None], t: pd.Timestamp
     ) -> ExitDecision | None:
-        if position.pair != self.pair or position.direction is not Direction.LONG:
+        if position.pair != self.pair:
             return None
         # Recover signal_time = bar preceding entry_time on this pair
         entry_ts = pd.Timestamp(position.entry_time)
@@ -136,10 +136,13 @@ class _A4ExitPredicate:
         entry_idx = int(idx_arr[0])
         if t_idx < entry_idx:
             return None
-        sl_distance = float(position.entry_price) - float(position.sl_price or 0)
+        # abs() keeps the long value identical (stop below entry) and is the
+        # positive entry↔SL gap for a short (stop above entry).
+        sl_distance = abs(float(position.entry_price) - float(position.sl_price or 0))
         if sl_distance <= 0:
             return None
-        # Re-use the same path-so-far computation as A3
+        # Re-use the same path-so-far computation as A3 (direction-aware so a
+        # short's path features are computed in the short's own frame).
         from core.architectures.a3_pipeline_de import _path_features_so_far
         path_feats = _path_features_so_far(
             self.pair_df,
@@ -147,6 +150,7 @@ class _A4ExitPredicate:
             n_defer=t_idx - sig_idx,
             sl_anchor_price=float(position.entry_price),
             sl_distance=sl_distance,
+            direction=position.direction,
         )
         combined = {**entry_feats, **path_feats}
         admit, proba = predict_admit(
@@ -156,11 +160,17 @@ class _A4ExitPredicate:
         # classifier predicts P(final_r > 0). High proba = let it run.
         # Low proba = exit.
         if proba < self.exit_threshold:
-            # fill_price is recorded but the driver's PR-E.1.6 path
-            # discards it and fills at next-bar open_bid (long exits).
-            # Provide a sane value anyway for any consumer that reads it.
+            # fill_price is recorded but the driver's PR-E.1.6 path discards it
+            # and fills at next-bar open (open_bid for a long exit, open_ask for
+            # a short). Provide a sane value anyway for any consumer that reads
+            # it (long marks at the bid, short buys back at the ask).
             bar = snapshot.get(self.pair)
-            fp = float(bar["close_bid"]) if bar is not None else float(position.entry_price)
+            if bar is None:
+                fp = float(position.entry_price)
+            elif position.direction is Direction.LONG:
+                fp = float(bar["close_bid"])
+            else:
+                fp = float(bar["close_ask"])
             return ExitDecision(fill_price=fp, exit_reason="pipeline_d_exit")
         return None
 

--- a/core/architectures/a6_meta_labeling.py
+++ b/core/architectures/a6_meta_labeling.py
@@ -95,6 +95,7 @@ def _build_a6_strategy(
     primary_panel = panels[signal_eval.primary_tf]
     per_pair = signal_eval.per_pair
     series_cache: dict[str, dict[str, pd.Series]] = {}
+    directions: dict[str, Direction] = {}
     for pair, state in per_pair.items():
         df = primary_panel.pair_dfs.get(pair)
         if df is None:
@@ -106,6 +107,7 @@ def _build_a6_strategy(
             for k, v in state.additional_gates.items()
         }
         series_cache[pair] = {"mask": mask, "atr": atr, **gates}
+        directions[pair] = state.direction
 
     feat_keys = cfg.classifier_feature_order
 
@@ -149,8 +151,14 @@ def _build_a6_strategy(
             bar = snapshot.get(pair)
             if bar is None:
                 continue
-            entry_proxy = float(bar["close_ask"])
-            sl_price = entry_proxy - cfg.sl_atr_mult * atr
+            # Entry proxy mirrored by the signal's direction (see A1).
+            direction = directions.get(pair, Direction.LONG)
+            if direction is Direction.LONG:
+                entry_proxy = float(bar["close_ask"])
+                sl_price = entry_proxy - cfg.sl_atr_mult * atr
+            else:
+                entry_proxy = float(bar["close_bid"])
+                sl_price = entry_proxy + cfg.sl_atr_mult * atr
             if sl_price <= 0:
                 continue
             base_size = risk.risk_size(
@@ -158,7 +166,7 @@ def _build_a6_strategy(
             )
             orders.append(Order(
                 pair=pair,
-                direction=Direction.LONG,
+                direction=direction,
                 size=base_size,
                 sl_price=sl_price,
                 tp_price=None,

--- a/core/discovery/pool_simulator.py
+++ b/core/discovery/pool_simulator.py
@@ -6,22 +6,29 @@ activation at +2.0R close-based + trail 2.0xATR + no time exit). Returns
 per-trade R-multiples plus aggregate path geometry for downstream
 metric computation.
 
-Exit semantics (long-only, matches dispatch §Override 2 + chat decision 1):
+Exit semantics (LONG default; mirrored by ``DiscoveryExitConfig.direction``):
 
-  * Entry         : bar N+1 open_ask  (next-bar open after signal bar N close)
-  * Initial SL    : entry - 2.0 * ATR(14)_at_signal_bar (anchored at entry)
+  * Entry         : bar N+1 open. Long fills at open_ask; short at open_bid.
+  * Initial SL    : long entry - 2.0*ATR (below); short entry + 2.0*ATR (above).
                     1R = 2.0 * ATR (SL distance equals 1R by construction)
-  * Hard SL hit   : intra-bar low_bid <= sl_price  -> fill at sl_price
-  * Trail arm     : bar close_bid >= entry + 4.0 * ATR  (= entry + 2.0R)
-                    On the arming bar, trail level = close_bid - 2.0 * ATR
-  * Trail ratchet : on each subsequent bar's close_bid:
-                      new_trail = max(prev_trail, close_bid - 2.0 * ATR)
-                    (ratchet-only; never lowers)
-  * Trail hit     : bar close_bid <= current_trail
-                    Exit at NEXT bar open_bid (KH-24 pattern; if no next
-                    bar exists, exit at this bar's close_bid)
+  * Hard SL hit   : long intra-bar low_bid <= sl; short high_ask >= sl
+                    -> fill at sl_price
+  * Trail arm     : long close_bid >= entry + 4.0*ATR (= +2.0R); short
+                    close_ask <= entry - 4.0*ATR. On the arming bar, trail
+                    level = close ∓ 2.0*ATR (long below close, short above).
+  * Trail ratchet : on each subsequent bar's close (close_bid long /
+                    close_ask short): long new_trail = max(prev, close-2.0*ATR);
+                    short new_trail = min(prev, close+2.0*ATR). Ratchet-only —
+                    never moves against the trade.
+  * Trail hit     : long close_bid <= trail; short close_ask >= trail.
+                    Exit at NEXT bar open (open_bid long / open_ask short;
+                    if no next bar exists, exit at this bar's close).
   * Time exit     : NONE — trade runs to end of data if neither SL nor
                     trail fires
+
+Short trades track the ASK side (where a short is stopped / bought back),
+matching ``core.sim.fill``; longs track the BID side, byte-identically to
+the pre-short simulator (direction defaults LONG).
 
 If a trade reaches the end of its pair's data without either trigger,
 it's marked ``exit_reason='end_of_data'`` and exited at the last
@@ -38,7 +45,8 @@ from dataclasses import dataclass
 import numpy as np
 import pandas as pd
 
-from core.sim.fill import long_entry_fill_price
+from core.sim.account import Direction
+from core.sim.fill import long_entry_fill_price, short_entry_fill_price
 from core.sim.honest_label import reached_1r_before_sl
 
 # Exit reasons whose fill lands at the OPEN of the exit bar (queued
@@ -66,6 +74,12 @@ class DiscoveryExitConfig:
     trail_distance_atr_mult: float = 2.0     # ratchet at close - 2.0xATR
     primary_tf_warmup_bars: int = 100        # ATR/Kijun warmup
     time_exit_bars: int | None = None        # Amendment A — None == no time exit
+    # Trade side for this discovery arc. LONG default keeps every existing
+    # arc byte-identical; a short discovery arc sets Direction.SHORT (the
+    # load-bearing target of the configs' ``direction:`` key, parsed via
+    # ``core.sim.account.parse_direction``). The simulator mirrors entry /
+    # SL / trail / final_r / +1R-before-SL label by this field.
+    direction: Direction = Direction.LONG
 
 
 @dataclass(frozen=True)
@@ -181,13 +195,37 @@ def simulate_pair_pool(
     mask_arr = trigger_mask.to_numpy(dtype=bool, copy=False)
     atr_arr = atr_series.to_numpy(dtype="float64", copy=False)
 
-    # Entry fill goes through long_entry_fill_price(pair_df.iloc[...]) — open_ask
-    # is read from the bar row directly, not from a precomputed array. The other
-    # series are extracted as numpy arrays for the per-bar inner loop.
+    direction = cfg.direction
+    is_long = direction is Direction.LONG
+
+    # Entry fill goes through {long,short}_entry_fill_price(pair_df.iloc[...]) —
+    # the open is read from the bar row directly, not a precomputed array. The
+    # other series are extracted as numpy arrays for the per-bar inner loop.
     open_bid = pair_df["open_bid"].to_numpy(dtype="float64", copy=False)
     low_bid = pair_df["low_bid"].to_numpy(dtype="float64", copy=False)
     high_bid = pair_df["high_bid"].to_numpy(dtype="float64", copy=False)
     close_bid = pair_df["close_bid"].to_numpy(dtype="float64", copy=False)
+    # Ask-side arrays — needed only for short trades (stop / buy-back on the
+    # ask). Extracted only when short so existing long fixtures without ask
+    # columns are untouched.
+    if is_long:
+        open_ask = low_ask = high_ask = close_ask = None
+    else:
+        for _col in ("open_ask", "high_ask", "low_ask", "close_ask"):
+            if _col not in pair_df.columns:
+                raise ValueError(
+                    f"short discovery simulation requires {_col}; pair {pair!r} "
+                    f"panel has {sorted(pair_df.columns)[:12]}"
+                )
+        open_ask = pair_df["open_ask"].to_numpy(dtype="float64", copy=False)
+        low_ask = pair_df["low_ask"].to_numpy(dtype="float64", copy=False)
+        high_ask = pair_df["high_ask"].to_numpy(dtype="float64", copy=False)
+        close_ask = pair_df["close_ask"].to_numpy(dtype="float64", copy=False)
+    # Direction-selected fill / close arrays: long exits at the bid, short
+    # buys back at the ask. For long these alias the bid arrays exactly, so
+    # the long bar-walk reads identical values to the pre-short simulator.
+    exit_open = open_bid if is_long else open_ask
+    close_arr = close_bid if is_long else close_ask
     index_arr = pair_df.index
 
     n = len(pair_df)
@@ -217,15 +255,24 @@ def simulate_pair_pool(
         if not np.isfinite(atr) or atr <= 0.0:
             continue
 
-        # Entry @ next-bar open_ask
-        entry_price = float(long_entry_fill_price(pair_df.iloc[entry_idx]))
+        # Entry @ next-bar open. Long buys the ask; short sells the bid.
+        entry_bar = pair_df.iloc[entry_idx]
+        if is_long:
+            entry_price = float(long_entry_fill_price(entry_bar))
+        else:
+            entry_price = float(short_entry_fill_price(entry_bar))
         if not np.isfinite(entry_price) or entry_price <= 0.0:
             continue
-        sl_price = entry_price - sl_mult * atr
+        if is_long:
+            sl_price = entry_price - sl_mult * atr
+            trail_activation_close = entry_price + trail_arm_mult * atr
+        else:
+            # Mirror: stop ABOVE entry; trail arms once price drops +2R below.
+            sl_price = entry_price + sl_mult * atr
+            trail_activation_close = entry_price - trail_arm_mult * atr
         if sl_price <= 0.0 or not np.isfinite(sl_price):
             continue
-        sl_distance = entry_price - sl_price       # == sl_mult * atr by construction
-        trail_activation_close = entry_price + trail_arm_mult * atr
+        sl_distance = abs(entry_price - sl_price)  # == sl_mult * atr by construction
         trail_distance = trail_dist_mult * atr
 
         # State machine
@@ -246,7 +293,7 @@ def simulate_pair_pool(
 
             # Priority 1: deferred trail exit queued from the previous bar's close.
             if pending_trail_exit:
-                fill = float(open_bid[bidx])
+                fill = float(exit_open[bidx])
                 if np.isfinite(fill):
                     exit_idx = bidx
                     exit_reason = "trail"
@@ -262,7 +309,7 @@ def simulate_pair_pool(
             # downstream R is purely from the open_bid fill on the cap-anniversary
             # bar. KH-24 forward-window convention; 240 at 4H = 40 calendar days.
             if time_exit_bars is not None and off == time_exit_bars:
-                fill = float(open_bid[bidx])
+                fill = float(exit_open[bidx])
                 if np.isfinite(fill):
                     exit_idx = bidx
                     exit_reason = "time_exit"
@@ -272,34 +319,60 @@ def simulate_pair_pool(
                 # If open_bid is NaN (data gap on the exit bar), fall through —
                 # the SL/trail/end-of-data branches will catch it.
 
-            # mfe / mae update using this bar's high_bid / low_bid in R-units.
-            bar_high = float(high_bid[bidx])
-            bar_low = float(low_bid[bidx])
-            if np.isfinite(bar_high):
-                mfe_r = max(mfe_r, (bar_high - entry_price) / sl_distance)
-            if np.isfinite(bar_low):
-                mae_r = min(mae_r, (bar_low - entry_price) / sl_distance)
+            # mfe / mae update in R-units + hard-SL extreme (direction-mirrored).
+            if is_long:
+                # Long tracks bid extremes; stop fires on low_bid <= sl.
+                bar_high = float(high_bid[bidx])
+                bar_low = float(low_bid[bidx])
+                if np.isfinite(bar_high):
+                    mfe_r = max(mfe_r, (bar_high - entry_price) / sl_distance)
+                if np.isfinite(bar_low):
+                    mae_r = min(mae_r, (bar_low - entry_price) / sl_distance)
+                stop_hit = np.isfinite(bar_low) and bar_low <= sl_price
+            else:
+                # Short tracks ask extremes; favourable = price falling
+                # (low_ask), adverse = price rising (high_ask); stop fires on
+                # high_ask >= sl.
+                bar_high = float(high_ask[bidx])
+                bar_low = float(low_ask[bidx])
+                if np.isfinite(bar_low):
+                    mfe_r = max(mfe_r, (entry_price - bar_low) / sl_distance)
+                if np.isfinite(bar_high):
+                    mae_r = min(mae_r, (entry_price - bar_high) / sl_distance)
+                stop_hit = np.isfinite(bar_high) and bar_high >= sl_price
 
-            # Priority 2: hard SL — intra-bar low_bid <= sl_price.
-            if off > 0 and np.isfinite(bar_low) and bar_low <= sl_price:
+            # Priority 2: hard SL.
+            if off > 0 and stop_hit:
                 exit_idx = bidx
                 exit_reason = "hard_sl"
                 exit_price = sl_price
                 bars_held = off
                 break
 
-            # Priority 3: trail logic at bar close.
-            bar_close = float(close_bid[bidx])
+            # Priority 3: trail logic at bar close (close_bid long / close_ask
+            # short). Long arms once close climbs +2R and trails BELOW; short
+            # arms once close drops +2R and trails ABOVE (ratchet-only either
+            # way — the trail never moves against the trade).
+            bar_close = float(close_arr[bidx])
             if not np.isfinite(bar_close):
                 continue
-            if not trail_armed and bar_close >= trail_activation_close:
-                trail_armed = True
-                trail_price = bar_close - trail_distance
-            elif trail_armed:
-                trail_price = max(trail_price, bar_close - trail_distance)
+            if is_long:
+                if not trail_armed and bar_close >= trail_activation_close:
+                    trail_armed = True
+                    trail_price = bar_close - trail_distance
+                elif trail_armed:
+                    trail_price = max(trail_price, bar_close - trail_distance)
+                trail_hit = trail_armed and bar_close <= trail_price
+            else:
+                if not trail_armed and bar_close <= trail_activation_close:
+                    trail_armed = True
+                    trail_price = bar_close + trail_distance
+                elif trail_armed:
+                    trail_price = min(trail_price, bar_close + trail_distance)
+                trail_hit = trail_armed and bar_close >= trail_price
 
-            if trail_armed and bar_close <= trail_price:
-                # Trail hit at bar close -> exit at next-bar open_bid.
+            if trail_hit:
+                # Trail hit at bar close -> exit at next-bar open.
                 pending_trail_exit = True
                 # If this IS the last bar, fall through to end-of-data branch.
                 if bidx == n - 1:
@@ -311,9 +384,10 @@ def simulate_pair_pool(
                     break
 
         if exit_idx is None:
-            # Reached end of data without SL or trail firing.
+            # Reached end of data without SL or trail firing (long exits at the
+            # last close_bid; short buys back at the last close_ask).
             exit_idx = n - 1
-            last_close = float(close_bid[exit_idx])
+            last_close = float(close_arr[exit_idx])
             if not np.isfinite(last_close):
                 # Skip degenerate trade — no usable exit price.
                 continue
@@ -321,23 +395,41 @@ def simulate_pair_pool(
             exit_price = last_close
             bars_held = exit_idx - entry_idx
 
-        final_r = (exit_price - entry_price) / sl_distance
+        final_r = (
+            (exit_price - entry_price) if is_long else (entry_price - exit_price)
+        ) / sl_distance
 
         # SL-honest meta-label provenance: first forward offset reaching +1R
         # STRICTLY before the hard stop (take-the-loss; same-bar +1R/SL →
         # NaN). Trail / time exits fill at the next bar's open, so that bar's
-        # high is excluded; hard_sl / end_of_data leave the trade open
+        # extreme is excluded; hard_sl / end_of_data leave the trade open
         # through the resolved bar. Closes HONEST_ENGINE_SWEEP.md FLAG-D1.
-        bars_to_1r_mfe = reached_1r_before_sl(
-            high_bid=high_bid,
-            low_bid=low_bid,
-            entry_idx=entry_idx,
-            exit_off=int(bars_held),
-            entry_price=entry_price,
-            sl_price=sl_price,
-            sl_distance=sl_distance,
-            exit_at_bar_open=(str(exit_reason) in _OPEN_FILL_EXIT_REASONS),
-        )
+        # Short mirrors on the ask side (stop above entry, favourable down).
+        if is_long:
+            bars_to_1r_mfe = reached_1r_before_sl(
+                high_bid=high_bid,
+                low_bid=low_bid,
+                entry_idx=entry_idx,
+                exit_off=int(bars_held),
+                entry_price=entry_price,
+                sl_price=sl_price,
+                sl_distance=sl_distance,
+                exit_at_bar_open=(str(exit_reason) in _OPEN_FILL_EXIT_REASONS),
+            )
+        else:
+            bars_to_1r_mfe = reached_1r_before_sl(
+                high_bid=high_bid,
+                low_bid=low_bid,
+                high_ask=high_ask,
+                low_ask=low_ask,
+                direction="short",
+                entry_idx=entry_idx,
+                exit_off=int(bars_held),
+                entry_price=entry_price,
+                sl_price=sl_price,
+                sl_distance=sl_distance,
+                exit_at_bar_open=(str(exit_reason) in _OPEN_FILL_EXIT_REASONS),
+            )
 
         trades.append(
             TradeRow(

--- a/core/sim/account.py
+++ b/core/sim/account.py
@@ -67,6 +67,46 @@ class Direction(Enum):
         return 1 if self is Direction.LONG else -1
 
 
+# Accepted spellings for the discovery/arc ``direction:`` config key. The
+# legacy discovery YAMLs wrote ``long_only`` (documentary); ``long`` is the
+# canonical value going forward. A short arc sets ``short``.
+_LONG_SPELLINGS: frozenset[str] = frozenset({"long", "long_only"})
+_SHORT_SPELLINGS: frozenset[str] = frozenset({"short", "short_only"})
+
+
+def parse_direction(raw: object, *, default: "Direction | None" = Direction.LONG) -> "Direction":
+    """Map a config ``direction:`` value to a :class:`Direction`.
+
+    This is the load-bearing parser for the discovery/arc ``direction:`` key
+    (today inert in ``configs/arc_discovery_*.yaml`` — no loader read it). A
+    discovery/arc run turns its YAML side into the apparatus by calling this
+    and passing the result to ``DiscoveryExitConfig(direction=...)`` /
+    ``ArcConfig(direction=...)`` / the signal module's emitted
+    ``PerPairSignalState.direction``.
+
+    Accepts (case-insensitive, whitespace-trimmed): ``long`` / ``long_only``
+    → :attr:`Direction.LONG`; ``short`` / ``short_only`` → :attr:`Direction.SHORT`.
+    ``None`` / missing returns ``default`` (LONG) so an absent key preserves
+    the long default. Any other value raises ``ValueError`` (a typo'd side is
+    a loud failure, never a silent long).
+    """
+    if raw is None:
+        if default is None:
+            raise ValueError("direction is required (no default)")
+        return default
+    if isinstance(raw, Direction):
+        return raw
+    s = str(raw).strip().lower()
+    if s in _LONG_SPELLINGS:
+        return Direction.LONG
+    if s in _SHORT_SPELLINGS:
+        return Direction.SHORT
+    raise ValueError(
+        f"unrecognised direction {raw!r}; expected one of "
+        f"{sorted(_LONG_SPELLINGS | _SHORT_SPELLINGS)}"
+    )
+
+
 @dataclass(frozen=True)
 class Position:
     """Open position record. Immutable once opened.

--- a/core/sim/honest_label.py
+++ b/core/sim/honest_label.py
@@ -81,44 +81,68 @@ def reached_1r_before_sl(
     sl_distance: float,
     exit_at_bar_open: bool = False,
     r_threshold: float = ONE_R,
+    direction: str = "long",
+    high_ask: Sequence[float] | None = None,
+    low_ask: Sequence[float] | None = None,
 ) -> float:
     """Honest ``bars_to_1r_mfe`` via a take-the-loss forward bar walk.
 
     Walks bar offsets ``0 .. exit_off`` (``bidx = entry_idx + off``) and
-    returns the FIRST offset at which the trade's high reaches
-    ``+r_threshold`` R, counted with take-the-loss ordering:
+    returns the FIRST offset at which the trade reaches ``+r_threshold`` R in
+    its favour, counted with take-the-loss ordering:
 
-      * On every bar with ``off > 0`` the hard stop is checked FIRST — if
-        the bar's ``low_bid`` breaches ``sl_price`` the walk ends and the
-        bar is NOT eligible to register +1R. A same-bar (+1R high AND SL
-        low) trade therefore resolves SL-first → +1R was NOT reached first →
-        result is ``NaN`` (unless a STRICTLY earlier bar already reached
-        +1R). This is exactly the engine's same-bar SL-first resolution,
-        applied to the label.
-      * A bar that does not breach the stop is eligible: if its high reaches
-        ``+r_threshold`` R the offset is returned immediately (it is, by the
-        walk order, strictly before any stop breach).
+      * On every bar with ``off > 0`` the hard stop is checked FIRST — if the
+        bar's adverse extreme breaches ``sl_price`` the walk ends and the bar
+        is NOT eligible to register +1R. A same-bar (+1R AND SL) trade
+        therefore resolves SL-first → +1R was NOT reached first → result is
+        ``NaN`` (unless a STRICTLY earlier bar already reached +1R). This is
+        exactly the engine's same-bar SL-first resolution, applied to the
+        label.
+      * A bar that does not breach the stop is eligible: if its favourable
+        extreme reaches ``+r_threshold`` R the offset is returned immediately
+        (it is, by the walk order, strictly before any stop breach).
+
+    Direction-symmetric (the take-the-loss invariant in label space, both
+    sides — the Arc-10 defect surface):
+
+      * ``direction="long"`` (default): the favourable extreme is the bar
+        ``high_bid`` (price up: ``(high - entry) / sl_distance``) and the
+        stop fires when ``low_bid <= sl_price`` (the stop sits BELOW entry).
+        Long callers pass only ``high_bid`` / ``low_bid`` — byte-identical to
+        the pre-short signature.
+      * ``direction="short"``: the favourable extreme is the bar ``low_ask``
+        (price down: ``(entry - low_ask) / sl_distance``) and the stop fires
+        when ``high_ask >= sl_price`` (the stop sits ABOVE entry). Short
+        callers MUST pass ``high_ask`` + ``low_ask`` (the ask side is where a
+        short is stopped / bought back, matching ``core.sim.fill``'s short
+        predicates); ``high_bid`` / ``low_bid`` are ignored for a short.
 
     Parameters
     ----------
     high_bid, low_bid
-        Per-bar intrabar extremes for the whole pair, indexed by absolute
-        bar index (the simulator's native arrays). Only indices
+        Per-bar intrabar bid extremes (the long side's favourable / stop
+        arrays), indexed by absolute bar index. Only indices
         ``entry_idx .. entry_idx + exit_off`` are read.
     entry_idx
         Absolute index of the entry bar (forward offset 0).
     exit_off
         ``bars_held`` — the forward offset of the trade's exit bar.
     entry_price, sl_price, sl_distance
-        Entry fill, stop price, and ``entry_price - sl_price`` (== 1R).
+        Entry fill, stop price, and ``abs(entry_price - sl_price)`` (== 1R).
     exit_at_bar_open
         Set when the trade leaves at the OPEN of the exit bar (e.g. a queued
-        trail / time exit filled next-bar-open): that bar's intrabar high is
-        unreachable, so the scan stops at ``exit_off - 1``. Leave ``False``
+        trail / time exit filled next-bar-open): that bar's intrabar extreme
+        is unreachable, so the scan stops at ``exit_off - 1``. Leave ``False``
         when the trade is open through the exit bar (intrabar stop, at-close
-        time exit, end-of-data), so the exit bar's high is included.
+        time exit, end-of-data), so the exit bar is included.
     r_threshold
         Favourable-event multiple. Default :data:`ONE_R` (1.0).
+    direction
+        ``"long"`` (default) or ``"short"``. Selects the favourable / stop
+        geometry above.
+    high_ask, low_ask
+        Per-bar intrabar ask extremes — REQUIRED for ``direction="short"``,
+        ignored for ``direction="long"``.
 
     Returns
     -------
@@ -135,16 +159,39 @@ def reached_1r_before_sl(
     """
     if not math.isfinite(sl_distance) or sl_distance <= 0:
         return float("nan")
+    side = str(direction).strip().lower()
+    if side not in ("long", "short"):
+        raise ValueError(f"direction must be 'long' or 'short'; got {direction!r}")
     last = exit_off - 1 if exit_at_bar_open else exit_off
+
+    if side == "long":
+        for off in range(0, last + 1):
+            bidx = entry_idx + off
+            lo = float(low_bid[bidx])
+            # Take-the-loss: stop is checked before +1R. A stop breach ends
+            # the walk; this bar can never register +1R (same-bar tie → SL).
+            if off > 0 and math.isfinite(lo) and lo <= sl_price:
+                return float("nan")
+            hi = float(high_bid[bidx])
+            if math.isfinite(hi) and (hi - entry_price) / sl_distance >= r_threshold:
+                return float(off)
+        return float("nan")
+
+    # short — mirror geometry on the ask side (stop ABOVE entry, favourable
+    # is price falling). Same take-the-loss ordering: the stop is evaluated
+    # FIRST so a same-bar (+1R-low AND SL-high) trade resolves SL-first → NaN.
+    if high_ask is None or low_ask is None:
+        raise ValueError(
+            "direction='short' requires high_ask and low_ask arrays "
+            "(the ask side is where a short is stopped / bought back)"
+        )
     for off in range(0, last + 1):
         bidx = entry_idx + off
-        lo = float(low_bid[bidx])
-        # Take-the-loss: stop is checked before +1R. A stop breach ends the
-        # walk; this bar can never register +1R (same-bar tie → SL wins).
-        if off > 0 and math.isfinite(lo) and lo <= sl_price:
+        hi = float(high_ask[bidx])
+        if off > 0 and math.isfinite(hi) and hi >= sl_price:
             return float("nan")
-        hi = float(high_bid[bidx])
-        if math.isfinite(hi) and (hi - entry_price) / sl_distance >= r_threshold:
+        lo = float(low_ask[bidx])
+        if math.isfinite(lo) and (entry_price - lo) / sl_distance >= r_threshold:
             return float(off)
     return float("nan")
 

--- a/core/sim/multipair_backtester.py
+++ b/core/sim/multipair_backtester.py
@@ -382,7 +382,13 @@ class MultiPairBacktester:
                 entry_bid=entry_bid_q,
                 entry_ask=entry_ask_q,
             )
-            # Auto-register trail if the order carries an ATR + manager is set
+            # Auto-register trail if the order carries an ATR + manager is set.
+            # The LONG gate is intentional: the legacy KH-24 ``TrailManager`` is
+            # long-only (``core/sim/trailing_stop.py`` raises for a short, and
+            # is deferred per the short-enablement spec item #9). A SHORT order
+            # therefore skips this KH-24-style trail and trails instead via the
+            # canonical, already-symmetric ``sl_plus_trailing_atr`` exit policy
+            # (Order.exit_policy), which the exit-policy manager drives below.
             if (
                 self.trail_manager is not None
                 and order.atr_at_entry is not None

--- a/discovery/tools/observe_long_capture.py
+++ b/discovery/tools/observe_long_capture.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from core.features._helpers import wilder_atr, mid_high, mid_low, mid_close
+from core.features._helpers import mid_close, mid_high, mid_low, wilder_atr
 from core.sim.honest_label import reached_1r_before_sl
 
 

--- a/discovery/tools/observe_long_capture.py
+++ b/discovery/tools/observe_long_capture.py
@@ -43,20 +43,29 @@ def observe_long_capture(
     drift_bars: int | None = None,
     warmup: int = 100,
     restrict: dict[str, np.ndarray] | None = None,
+    direction: str = "long",
 ) -> pd.DataFrame:
-    """Per-bar hypothetical-long honest capture + forward drift across every pair.
+    """Per-bar hypothetical honest capture + forward drift across every pair.
+
+    Despite the historical name, this is direction-aware: ``direction="long"``
+    (default) is byte-identical to the original long lens; ``direction="short"``
+    mirrors every site (entry = next-bar ``open_bid``; SL = signal-bar
+    ``close_bid`` + sl_mult·ATR, ABOVE entry; capture via the short
+    +1R-before-SL label on the ask side; drift sign flipped so a falling price
+    reads as positive forward drift). Still CHARACTERIZATION ONLY — not a gate.
 
     Parameters
     ----------
     panel : Panel — the primary-TF panel (uses each pair's bars).
-    sl_mult : SL = signal-bar close_ask − sl_mult·ATR (default 2.0, matching the pool).
+    sl_mult : SL = signal-bar close ∓ sl_mult·ATR (default 2.0, matching the pool).
     hold : forward bars scanned for the +1R-before-SL label.
     drift_bars : if set, also compute forward `drift_bars`-bar mid-close drift in ATR
-        (gross). If None, ``fwd_drift_atr`` is NaN.
+        (gross, signed by direction). If None, ``fwd_drift_atr`` is NaN.
     warmup : skip the first ``warmup`` bars per pair (ATR/feature stabilization).
     restrict : optional {pair -> bool ndarray aligned to that pair's bars} to compute
         only on selected bars (efficient for sparse conditions, e.g. week-opens). None =
         every bar.
+    direction : ``"long"`` (default) or ``"short"``.
 
     Returns
     -------
@@ -64,17 +73,27 @@ def observe_long_capture(
     evaluated bar with a finite ATR and a fillable next bar. Take-the-loss honest;
     gross; CHARACTERIZATION ONLY (see module docstring).
     """
+    side = str(direction).strip().lower()
+    if side not in ("long", "short"):
+        raise ValueError(f"direction must be 'long' or 'short'; got {direction!r}")
+    is_long = side == "long"
     rows = []
     for pair in sorted(panel.pairs):
         df = panel.pair_dfs[pair]
         atr = wilder_atr(mid_high(df), mid_low(df), mid_close(df), 14).shift(1).values
         mc = mid_close(df).values
-        open_ask = df["open_ask"].values
-        close_ask = df["close_ask"].values
-        high_bid = df["high_bid"].values
-        low_bid = df["low_bid"].values
         idx = df.index
         n = len(df)
+        if is_long:
+            open_ask = df["open_ask"].values
+            close_ask = df["close_ask"].values
+            high_bid = df["high_bid"].values
+            low_bid = df["low_bid"].values
+        else:
+            open_bid = df["open_bid"].values
+            close_bid = df["close_bid"].values
+            high_ask = df["high_ask"].values
+            low_ask = df["low_ask"].values
         sel = restrict.get(pair) if restrict is not None else None
         for t in range(max(warmup, 0), n - 1):
             if sel is not None and not sel[t]:
@@ -82,19 +101,32 @@ def observe_long_capture(
             a = atr[t]
             if not np.isfinite(a) or a <= 0:
                 continue
-            entry = float(open_ask[t + 1])
-            sl = float(close_ask[t]) - sl_mult * a
-            sl_dist = entry - sl
+            if is_long:
+                entry = float(open_ask[t + 1])
+                sl = float(close_ask[t]) - sl_mult * a
+                sl_dist = entry - sl
+            else:
+                entry = float(open_bid[t + 1])
+                sl = float(close_bid[t]) + sl_mult * a
+                sl_dist = sl - entry
             if sl_dist <= 0 or not np.isfinite(sl_dist):
                 continue
             exit_off = min(hold, n - 1 - (t + 1))
-            res = reached_1r_before_sl(
-                high_bid=high_bid, low_bid=low_bid, entry_idx=t + 1, exit_off=exit_off,
-                entry_price=entry, sl_price=sl, sl_distance=sl_dist, exit_at_bar_open=False,
-            )
+            if is_long:
+                res = reached_1r_before_sl(
+                    high_bid=high_bid, low_bid=low_bid, entry_idx=t + 1, exit_off=exit_off,
+                    entry_price=entry, sl_price=sl, sl_distance=sl_dist, exit_at_bar_open=False,
+                )
+            else:
+                res = reached_1r_before_sl(
+                    high_bid=high_ask, low_bid=low_ask, high_ask=high_ask, low_ask=low_ask,
+                    direction="short", entry_idx=t + 1, exit_off=exit_off,
+                    entry_price=entry, sl_price=sl, sl_distance=sl_dist, exit_at_bar_open=False,
+                )
             drift = float("nan")
             if drift_bars is not None:
-                drift = (float(mc[min(t + drift_bars, n - 1)]) - entry) / a
+                fwd = float(mc[min(t + drift_bars, n - 1)])
+                drift = ((fwd - entry) if is_long else (entry - fwd)) / a
             rows.append({
                 "pair": pair, "signal_time": idx[t],
                 "capture": 1 if np.isfinite(res) else 0,

--- a/tests/sim/test_cost_application.py
+++ b/tests/sim/test_cost_application.py
@@ -48,12 +48,13 @@ def _leg(
     entry_spread: float = _PIP,
     exit_spread: float = _PIP,
     pair: str = "EURUSD",
+    direction: Direction = Direction.LONG,
 ) -> ClosedTrade:
     """A gross ClosedTrade leg with symmetric bid/ask around the fill prices."""
     return ClosedTrade(
         position_id=position_id,
         pair=pair,
-        direction=Direction.LONG,
+        direction=direction,
         entry_time=pd.Timestamp("2020-01-01", tz="UTC"),
         entry_price=entry_price,
         exit_time=pd.Timestamp(exit_time, tz="UTC"),
@@ -138,6 +139,57 @@ def test_take_the_loss_two_fills_exact_haircut() -> None:
     assert row["total_cost"] == pytest.approx(2.5)
     assert row["gross_pnl"] == pytest.approx(-20.0)
     assert row["net_pnl"] == pytest.approx(-22.5)  # a loss is made worse, never flattered
+
+
+# ── short legs: costs are direction-agnostic (symmetric haircut) ─────────
+
+
+def test_short_leg_costs_match_long_leg_exactly() -> None:
+    """FundedNext costs depend only on size + bid/ask spread, never on side.
+    A SHORT leg must incur exactly the same commission / slippage / spread
+    haircut as the otherwise-identical LONG leg (cost-model symmetry — part of
+    the short-enablement gate: HONEST_ENGINE_SWEEP.md Part C on short legs)."""
+    long_leg = _leg(
+        position_id=1, parent_position_id=None, size=10_000.0,
+        entry_price=1.10000, exit_price=1.09800, pnl=-20.0,
+        exit_time="2020-01-02", direction=Direction.LONG,
+    )
+    # Same magnitudes, opposite side: a short that moved +20 in its favour.
+    short_leg = _leg(
+        position_id=2, parent_position_id=None, size=10_000.0,
+        entry_price=1.10000, exit_price=1.09800, pnl=20.0,
+        exit_time="2020-01-02", direction=Direction.SHORT,
+    )
+    long_row = apply_cost_model(_run_result((long_leg,)), CostModel.fundednext()).breakdown.iloc[0]
+    short_row = apply_cost_model(_run_result((short_leg,)), CostModel.fundednext()).breakdown.iloc[0]
+    # The cost columns are identical regardless of direction.
+    for col in ("commission", "slippage", "spread", "total_cost", "n_fills", "n_legs"):
+        assert short_row[col] == pytest.approx(long_row[col]), col
+    # Concretely: commission 0.5, slippage 1.0, spread 1.0 => 2.5 (entry+stop, 2 fills).
+    assert short_row["total_cost"] == pytest.approx(2.5)
+    # Costs always WORSEN the result: a short's gross win is reduced, never inflated.
+    assert short_row["net_pnl"] == pytest.approx(short_row["gross_pnl"] - 2.5)
+    assert short_row["net_pnl"] < short_row["gross_pnl"]
+
+
+def test_short_partial_win_three_fills_symmetric() -> None:
+    """A short +1R partial + runner (2 legs => 3 fills) pays the same haircut as
+    the long partial-win fixture."""
+    legs = (
+        _leg(position_id=1, parent_position_id=1, size=5_000.0,
+             entry_price=1.10000, exit_price=1.09800, pnl=10.0,
+             exit_time="2020-01-02", direction=Direction.SHORT),
+        _leg(position_id=1, parent_position_id=1, size=5_000.0,
+             entry_price=1.10000, exit_price=1.09900, pnl=5.0,
+             exit_time="2020-01-03", direction=Direction.SHORT),
+    )
+    row = apply_cost_model(_run_result(legs), CostModel.fundednext()).breakdown.iloc[0]
+    assert row["n_legs"] == 2
+    assert row["n_fills"] == 3
+    assert row["commission"] == pytest.approx(0.5)
+    assert row["slippage"] == pytest.approx(1.5)
+    assert row["spread"] == pytest.approx(1.0)
+    assert row["total_cost"] == pytest.approx(3.0)
 
 
 # ── default-on guarantee at the gate-scoring layer ───────────────────────

--- a/tests/sim/test_short_enablement.py
+++ b/tests/sim/test_short_enablement.py
@@ -1,0 +1,246 @@
+"""Short-side enablement: label producer, two-producer parity, config parse.
+
+Pins the Step-1 / label-space half of the short-enablement spec
+(``discovery/SHORTS_ENABLEMENT_PROBE.md``). The engine-level take-the-loss
+short mirror lives in ``tests/sim/test_take_the_loss_invariant.py`` and the
+cost symmetry in ``tests/sim/test_cost_application.py``; this file covers:
+
+  1. :func:`core.sim.honest_label.reached_1r_before_sl` SHORT branch — the
+     take-the-loss invariant in label space, mirrored (stop ABOVE entry on the
+     ask, favourable = price falling). Same-bar +1R/SL resolves SL-first → NaN.
+  2. **Two-producer parity** — the spec requires the two Step-1 pool producers
+     (``core.arc.arc_pool_builder`` and ``core.discovery.pool_simulator``) to
+     agree trade-for-trade on a short. A losing short that hits its hard stop
+     must come out identical (entry / SL / exit / final_r / bars_held / label)
+     from both bar-walks. A long control proves the harness is non-trivial.
+  3. :func:`core.sim.account.parse_direction` — the load-bearing parser for the
+     configs' ``direction:`` key.
+
+Numpy / pandas + stdlib only → runs under CI's ``pytest -m "not research"``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from core.arc.arc_pool_builder import ArcPoolConfig, _simulate_pair_pool
+from core.arc.signal_protocol import PerPairSignalState
+from core.discovery.pool_simulator import DiscoveryExitConfig, simulate_pair_pool
+from core.sim.account import Direction, parse_direction
+from core.sim.honest_label import reached_1r_before_sl
+
+
+# ── 1. honest label — SHORT branch (take-the-loss in label space) ───────────
+#
+# entry=100, stop ABOVE at 102 (sl_distance=2 == 1R), +1R favourable level = 98.
+# Short stop fires on high_ask >= 102; favourable on low_ask <= 98.
+
+
+def test_short_label_reach_strictly_before_sl():
+    """low_ask hits +1R (<=98) at offset 2; high_ask breaches 102 at offset 4."""
+    high_ask = [100.0, 100.5, 100.5, 100.5, 102.5]   # off4 breaches stop
+    low_ask = [100.0, 99.5, 98.0, 99.0, 99.0]         # off2 reaches +1R (==98)
+    got = reached_1r_before_sl(
+        high_bid=high_ask, low_bid=low_ask, high_ask=high_ask, low_ask=low_ask,
+        direction="short", entry_idx=0, exit_off=4,
+        entry_price=100.0, sl_price=102.0, sl_distance=2.0,
+    )
+    assert got == 2.0
+
+
+def test_short_label_sl_strictly_before_reach_is_nan():
+    """high_ask breaches the stop at offset 2 before any +1R (only at 4)."""
+    high_ask = [100.0, 100.5, 102.5, 100.5, 100.5]    # off2 breaches stop first
+    low_ask = [100.0, 99.5, 99.5, 99.5, 97.0]
+    got = reached_1r_before_sl(
+        high_bid=high_ask, low_bid=low_ask, high_ask=high_ask, low_ask=low_ask,
+        direction="short", entry_idx=0, exit_off=2,
+        entry_price=100.0, sl_price=102.0, sl_distance=2.0,
+    )
+    assert math.isnan(got)
+
+
+def test_short_label_same_bar_plus1r_and_sl_is_nan():
+    """THE bug case, mirrored: a bar whose low_ask reaches +1R AND whose
+    high_ask breaches the stop resolves SL-first → NaN."""
+    high_ask = [100.0, 100.5, 102.5]   # off2 high_ask >= 102 (stop)
+    low_ask = [100.0, 99.5, 98.0]      # off2 low_ask <= 98 (+1R) — same bar
+    got = reached_1r_before_sl(
+        high_bid=high_ask, low_bid=low_ask, high_ask=high_ask, low_ask=low_ask,
+        direction="short", entry_idx=0, exit_off=2,
+        entry_price=100.0, sl_price=102.0, sl_distance=2.0,
+    )
+    assert math.isnan(got), "same-bar +1R/SL must NOT register a +1R reach"
+
+
+def test_short_label_never_reached_is_nan():
+    high_ask = [100.0, 100.5, 101.0, 101.5]
+    low_ask = [100.0, 99.5, 99.0, 98.5]   # never reaches +1R (98.0)
+    got = reached_1r_before_sl(
+        high_bid=high_ask, low_bid=low_ask, high_ask=high_ask, low_ask=low_ask,
+        direction="short", entry_idx=0, exit_off=3,
+        entry_price=100.0, sl_price=102.0, sl_distance=2.0,
+    )
+    assert math.isnan(got)
+
+
+def test_short_label_requires_ask_arrays():
+    with pytest.raises(ValueError, match="requires high_ask and low_ask"):
+        reached_1r_before_sl(
+            high_bid=[100.0, 101.0], low_bid=[99.0, 98.0],
+            direction="short", entry_idx=0, exit_off=1,
+            entry_price=100.0, sl_price=102.0, sl_distance=2.0,
+        )
+
+
+# ── 2. two-producer parity (the spec cross-check) ───────────────────────────
+
+
+def _df(rows: list[dict]) -> pd.DataFrame:
+    idx = pd.DatetimeIndex(
+        [pd.Timestamp("2020-01-01", tz="UTC") + pd.Timedelta(hours=4 * i) for i in range(len(rows))],
+        name="timestamp_utc",
+    )
+    return pd.DataFrame(rows, index=idx)
+
+
+def _run_both(rows: list[dict], direction: Direction):
+    """Run the SAME pair through both Step-1 pool producers and return
+    (arc_trade_dict, pool_traderow). The fixtures hold close==open at the
+    signal/entry bars so the two SL anchors (arc: signal-bar close; pool:
+    entry price) coincide — isolating the bar-walk geometry under test."""
+    df = _df(rows)
+    mask = pd.Series([i == 0 for i in range(len(rows))], index=df.index)
+    atr = pd.Series([1.0] * len(rows), index=df.index, dtype="float64")
+
+    state = PerPairSignalState(signal_mask=mask, atr=atr, direction=direction)
+    arc_cfg = ArcPoolConfig(arc_name="t", sl_atr_mult=2.0, hold_bars=240, primary_tf_warmup_bars=0)
+    arc_trades, _paths, _nid = _simulate_pair_pool("EURUSD", df, state, arc_cfg, 1)
+    assert len(arc_trades) == 1, arc_trades
+
+    disc_cfg = DiscoveryExitConfig(
+        initial_sl_atr_mult=2.0, trail_activation_atr_mult=4.0,
+        trail_distance_atr_mult=2.0, primary_tf_warmup_bars=0, direction=direction,
+    )
+    pool_trades, _n, _it, _ab = simulate_pair_pool("EURUSD", df, mask, atr, disc_cfg)
+    assert len(pool_trades) == 1, pool_trades
+    return arc_trades[0], pool_trades[0]
+
+
+# A losing SHORT: enters at open_bid=100, price rises into the stop at 102.
+_SHORT_STOP_ROWS = [
+    # bar0 signal: close==100 both sides (== entry, so the SL anchors coincide)
+    dict(open_bid=99.9, open_ask=99.9, high_bid=100.1, high_ask=100.1,
+         low_bid=99.8, low_ask=99.8, close_bid=100.0, close_ask=100.0),
+    # bar1 entry: open==100; no stop this bar
+    dict(open_bid=100.0, open_ask=100.0, high_bid=100.5, high_ask=100.5,
+         low_bid=99.5, low_ask=99.5, close_bid=100.2, close_ask=100.2),
+    # bar2: high_ask 102.5 >= sl 102 -> hard_sl at 102
+    dict(open_bid=100.5, open_ask=100.5, high_bid=102.5, high_ask=102.5,
+         low_bid=100.0, low_ask=100.0, close_bid=101.5, close_ask=101.5),
+    # bar3 filler
+    dict(open_bid=101.5, open_ask=101.5, high_bid=101.6, high_ask=101.6,
+         low_bid=101.0, low_ask=101.0, close_bid=101.2, close_ask=101.2),
+]
+
+# A losing LONG control: enters at open_ask=100, price falls into the stop at 98.
+_LONG_STOP_ROWS = [
+    dict(open_bid=100.1, open_ask=100.1, high_bid=100.2, high_ask=100.2,
+         low_bid=99.9, low_ask=99.9, close_bid=100.0, close_ask=100.0),
+    dict(open_bid=100.0, open_ask=100.0, high_bid=100.5, high_ask=100.5,
+         low_bid=99.5, low_ask=99.5, close_bid=99.8, close_ask=99.8),
+    # bar2: low_bid 97.5 <= sl 98 -> hard_sl at 98
+    dict(open_bid=99.5, open_ask=99.5, high_bid=100.0, high_ask=100.0,
+         low_bid=97.5, low_ask=97.5, close_bid=98.5, close_ask=98.5),
+    dict(open_bid=98.5, open_ask=98.5, high_bid=99.0, high_ask=99.0,
+         low_bid=98.4, low_ask=98.4, close_bid=98.6, close_ask=98.6),
+]
+
+
+def _assert_producers_agree(arc: dict, pool, *, entry, sl, final_r):
+    assert arc["entry_price"] == pytest.approx(entry)
+    assert pool.entry_price == pytest.approx(entry)
+    assert arc["sl_at_entry_price"] == pytest.approx(sl)
+    assert pool.sl_at_entry_price == pytest.approx(sl)
+    assert arc["exit_reason"] == "hard_sl"
+    assert pool.exit_reason == "hard_sl"
+    assert arc["exit_price"] == pytest.approx(sl)
+    assert pool.exit_price == pytest.approx(sl)
+    assert arc["final_r"] == pytest.approx(final_r)
+    assert pool.final_r == pytest.approx(final_r)
+    assert arc["bars_held"] == pool.bars_held
+    # The +1R-before-SL label agrees (never reached on a losing trade → NaN).
+    assert math.isnan(arc["bars_to_1r_mfe"]) and math.isnan(pool.bars_to_1r_mfe)
+
+
+def test_two_producers_agree_on_a_losing_short():
+    """The spec cross-check: both Step-1 producers agree trade-for-trade on a
+    short that hits its hard stop (stop ABOVE entry, exit at the SL, -1R)."""
+    arc, pool = _run_both(_SHORT_STOP_ROWS, Direction.SHORT)
+    _assert_producers_agree(arc, pool, entry=100.0, sl=102.0, final_r=-1.0)
+    assert arc["bars_held"] == 1
+
+
+def test_two_producers_agree_on_a_losing_long_control():
+    """Control: the same harness on a LONG also agrees — so the short parity
+    above is a real cross-check, not a vacuous pass."""
+    arc, pool = _run_both(_LONG_STOP_ROWS, Direction.LONG)
+    _assert_producers_agree(arc, pool, entry=100.0, sl=98.0, final_r=-1.0)
+    assert arc["bars_held"] == 1
+
+
+def test_short_final_r_sign_is_mirrored():
+    """A short that falls in its favour books a POSITIVE final_r in both
+    producers (sign mirrored, not a long-signed negative)."""
+    rows = [
+        dict(open_bid=99.9, open_ask=99.9, high_bid=100.1, high_ask=100.1,
+             low_bid=99.8, low_ask=99.8, close_bid=100.0, close_ask=100.0),
+        dict(open_bid=100.0, open_ask=100.0, high_bid=100.2, high_ask=100.2,
+             low_bid=99.0, low_ask=99.0, close_bid=99.5, close_ask=99.5),
+        # price falls; no stop (high_ask 99.8 < 102). time/hold or eod exit below.
+        dict(open_bid=99.0, open_ask=99.0, high_bid=99.8, high_ask=99.8,
+             low_bid=97.0, low_ask=97.0, close_bid=97.5, close_ask=97.5),
+    ]
+    df = _df(rows)
+    mask = pd.Series([True, False, False], index=df.index)
+    atr = pd.Series([1.0, 1.0, 1.0], index=df.index, dtype="float64")
+    state = PerPairSignalState(signal_mask=mask, atr=atr, direction=Direction.SHORT)
+    cfg = ArcPoolConfig(arc_name="t", sl_atr_mult=2.0, hold_bars=240, primary_tf_warmup_bars=0)
+    trades, _p, _n = _simulate_pair_pool("EURUSD", df, state, cfg, 1)
+    assert len(trades) == 1
+    # entry 100, exits at end of window on close_ask=97.5 -> (100-97.5)/2 = +1.25R
+    assert trades[0]["final_r"] == pytest.approx((100.0 - 97.5) / 2.0)
+    assert trades[0]["final_r"] > 0.0
+
+
+# ── 3. parse_direction (load-bearing config key) ────────────────────────────
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("long", Direction.LONG),
+    ("long_only", Direction.LONG),
+    ("LONG", Direction.LONG),
+    (" Long ", Direction.LONG),
+    ("short", Direction.SHORT),
+    ("short_only", Direction.SHORT),
+    ("SHORT", Direction.SHORT),
+    (Direction.SHORT, Direction.SHORT),
+    (Direction.LONG, Direction.LONG),
+    (None, Direction.LONG),   # absent key -> long default
+])
+def test_parse_direction_accepts(raw, expected):
+    assert parse_direction(raw) is expected
+
+
+def test_parse_direction_rejects_typo():
+    with pytest.raises(ValueError, match="unrecognised direction"):
+        parse_direction("lonng")
+
+
+def test_parse_direction_required_when_default_none():
+    with pytest.raises(ValueError, match="required"):
+        parse_direction(None, default=None)

--- a/tests/sim/test_short_enablement.py
+++ b/tests/sim/test_short_enablement.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import math
 
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -32,7 +31,6 @@ from core.arc.signal_protocol import PerPairSignalState
 from core.discovery.pool_simulator import DiscoveryExitConfig, simulate_pair_pool
 from core.sim.account import Direction, parse_direction
 from core.sim.honest_label import reached_1r_before_sl
-
 
 # ── 1. honest label — SHORT branch (take-the-loss in label space) ───────────
 #

--- a/tests/sim/test_take_the_loss_invariant.py
+++ b/tests/sim/test_take_the_loss_invariant.py
@@ -210,3 +210,165 @@ def test_stop_after_partial_books_partial_plus_runner_minus_1r() -> None:
     assert partial.exit_price == pytest.approx(_ENTRY + _R)
     assert runner.exit_price == pytest.approx(_SL)
     assert (runner.exit_price - runner.entry_price) / _R == pytest.approx(-1.0)
+
+
+# ── Direction.SHORT mirror (short-side enablement) ──────────────────────────
+#
+# The SAME take-the-loss invariant, mirrored for a short: the stop sits ABOVE
+# entry and the +1R partial BELOW it. Every fixture below is the corresponding
+# long fixture reflected around the entry (p' = 2*_ENTRY - p, with high<->low
+# swapped), so a green short test is a direct proof of long/short symmetry on
+# the SOLE gate engine. Short entry fills at open_bid; the stop fires on
+# high_ask >= sl (core.sim.fill.short_sl_triggered), still SL-first.
+
+_SL_SHORT = 1.102  # entry + 1R (stop ABOVE entry); short +1R partial = 1.098.
+
+
+def _one_shot_short(t_target: str, **order_kwargs) -> StrategyFn:
+    target = pd.Timestamp(t_target, tz="UTC")
+    emitted = {"done": False}
+
+    def strategy(t, snapshot, account):
+        if emitted["done"] or t != target:
+            return []
+        emitted["done"] = True
+        return [Order(pair="EURUSD", direction=Direction.SHORT, size=10_000.0, **order_kwargs)]
+
+    return strategy
+
+
+def _run_short(rows: list[dict]):
+    panel = _make_panel(rows)
+    acct = Account(
+        starting_balance=100_000.0,
+        exposure=ExposureRules(max_concurrent_per_pair=1),
+    )
+    strategy = _one_shot_short(
+        "2026-01-01 00:00",
+        sl_price=_SL_SHORT,
+        atr_at_entry=0.001,
+        sl_atr_mult=2.0,
+        exit_policy="sl_partial_close_1r_runner_trail",
+    )
+    bt = MultiPairBacktester(
+        panel=panel, account=acct, strategy=strategy,
+        exit_policy_manager=ExitPolicyManager(),
+    )
+    return bt.run()
+
+
+def _assert_single_minus_1r_stop_short(result, *, exit_bar: str) -> None:
+    legs = list(result.closed_trades)
+    assert len(legs) == 1, f"expected one full -1R short stop leg, got {legs}"
+    leg = legs[0]
+    assert leg.direction == Direction.SHORT
+    assert leg.exit_reason == "stop_loss"
+    assert leg.parent_position_id is None, "partial must NOT have fired"
+    assert leg.size == pytest.approx(10_000.0), "full position must close"
+    assert leg.exit_price == pytest.approx(_SL_SHORT)
+    assert leg.entry_price == pytest.approx(_ENTRY)
+    # Short realised R = (entry - exit) / 1R == -1.0 exactly.
+    assert (leg.entry_price - leg.exit_price) / _R == pytest.approx(-1.0)
+    # A short stop is a loss, never flattered: pnl = -size * 1R.
+    assert leg.pnl == pytest.approx(-10_000.0 * _R)  # -20.0
+    assert leg.exit_time == pd.Timestamp(exit_bar, tz="UTC")
+
+
+def test_short_stop_before_partial_bar_is_minus_1r() -> None:
+    """Short stop (above entry) breaches STRICTLY BEFORE +1R is reached -> -1R."""
+    result = _run_short([
+        _bar("2026-01-01 00:00", o=1.101, h=1.102, lo=1.100, c=1.101),
+        # entry fills here at open=1.100 (short sells the bid)
+        _bar("2026-01-01 01:00", o=1.100, h=1.101, lo=1.099, c=1.100),
+        # stop breach (high>=1.102); low 1.0995 never reaches +1R (1.098)
+        _bar("2026-01-01 02:00", o=1.100, h=1.102, lo=1.0995, c=1.101),
+        _bar("2026-01-01 03:00", o=1.101, h=1.101, lo=1.100, c=1.101),
+    ])
+    _assert_single_minus_1r_stop_short(result, exit_bar="2026-01-01 02:00")
+
+
+def test_short_same_bar_stop_and_partial_is_sl_first_minus_1r() -> None:
+    """THE dispatch case: a short whose stop ABOVE entry is breached on the
+    SAME bar its +1R partial BELOW entry would fire -> SL-first -> full -1R,
+    the partial never fires."""
+    result = _run_short([
+        _bar("2026-01-01 00:00", o=1.101, h=1.102, lo=1.100, c=1.101),
+        _bar("2026-01-01 01:00", o=1.100, h=1.101, lo=1.099, c=1.100),
+        # high 1.103 (>=SL 1.102) AND low 1.098 (=+1R) on the SAME bar
+        _bar("2026-01-01 02:00", o=1.100, h=1.103, lo=1.098, c=1.101),
+        _bar("2026-01-01 03:00", o=1.101, h=1.101, lo=1.100, c=1.101),
+    ])
+    _assert_single_minus_1r_stop_short(result, exit_bar="2026-01-01 02:00")
+
+
+def test_short_stop_then_recover_is_still_minus_1r() -> None:
+    """Short stop breaches on bar 02:00; a later bar dropping past +1R must
+    NOT resurrect the already-closed trade (the Arc-10 bug class, mirrored)."""
+    result = _run_short([
+        _bar("2026-01-01 00:00", o=1.101, h=1.102, lo=1.100, c=1.101),
+        _bar("2026-01-01 01:00", o=1.100, h=1.101, lo=1.099, c=1.100),
+        # stop breach (high 1.103 >= SL 1.102); low 1.0995 never hits +1R
+        _bar("2026-01-01 02:00", o=1.100, h=1.103, lo=1.0995, c=1.101),
+        # full recovery PAST +1R (low 1.097) — must NOT resurrect the trade
+        _bar("2026-01-01 03:00", o=1.099, h=1.099, lo=1.097, c=1.097),
+        _bar("2026-01-01 04:00", o=1.097, h=1.098, lo=1.096, c=1.097),
+    ])
+    _assert_single_minus_1r_stop_short(result, exit_bar="2026-01-01 02:00")
+
+
+def test_short_clean_win_partial_then_runner_trail_books_a_win() -> None:
+    """No stop ever touched: short +1R partial fires (50% at 1.098), the runner
+    trails (trough + 1R) to a profit. The mirror of the long clean win — two
+    profitable legs, NO stop_loss leg."""
+    result = _run_short([
+        _bar("2026-01-01 00:00", o=1.101, h=1.102, lo=1.100, c=1.101),
+        # entry fills at open=1.100; no stop, no +1R yet
+        _bar("2026-01-01 01:00", o=1.100, h=1.1005, lo=1.099, c=1.0992),
+        # +1R partial fires intra-bar (low 1.097 <= 1.098); high 1.0995 < SL
+        _bar("2026-01-01 02:00", o=1.099, h=1.0995, lo=1.097, c=1.0975),
+        # runner trails out: trough 1.097 -> trail level 1.099; close_ask
+        # 1.0995 >= 1.099 AND strictly after the tp1 bar -> queue full close
+        _bar("2026-01-01 03:00", o=1.098, h=1.100, lo=1.0975, c=1.0995),
+        # runner fills at next-bar open_ask = 1.0995
+        _bar("2026-01-01 04:00", o=1.0995, h=1.100, lo=1.099, c=1.0995),
+    ])
+    legs = list(result.closed_trades)
+    assert len(legs) == 2, f"expected partial + runner legs, got {legs}"
+    assert all(leg.direction == Direction.SHORT for leg in legs)
+    assert all(leg.parent_position_id is not None for leg in legs)
+    assert {leg.exit_reason for leg in legs} == {"partial_close_1r", "runner_trail_stop"}
+    assert all(leg.exit_reason != "stop_loss" for leg in legs)
+    partial = next(leg for leg in legs if leg.exit_reason == "partial_close_1r")
+    runner = next(leg for leg in legs if leg.exit_reason == "runner_trail_stop")
+    assert partial.size == pytest.approx(5_000.0)
+    assert runner.size == pytest.approx(5_000.0)
+    assert partial.exit_price == pytest.approx(_ENTRY - _R)  # short +1R level (below)
+    assert partial.pnl > 0.0
+    assert runner.pnl > 0.0
+    assert (partial.pnl + runner.pnl) > 0.0  # a genuine, honestly-booked short win
+
+
+def test_short_stop_after_partial_books_partial_plus_runner_minus_1r() -> None:
+    """Short +1R partial banks 50% at 1.098; the runner is later stopped at the
+    SL above entry (-1R on the runner half). Mirror of the long counterpart."""
+    result = _run_short([
+        _bar("2026-01-01 00:00", o=1.101, h=1.102, lo=1.100, c=1.101),
+        _bar("2026-01-01 01:00", o=1.100, h=1.1005, lo=1.099, c=1.0992),
+        # +1R partial fires (low 1.097 <= 1.098); no stop this bar
+        _bar("2026-01-01 02:00", o=1.099, h=1.0995, lo=1.097, c=1.0975),
+        # runner stop: high 1.103 >= SL 1.102 -> runner closes at SL (-1R)
+        _bar("2026-01-01 03:00", o=1.099, h=1.103, lo=1.0985, c=1.102),
+        _bar("2026-01-01 04:00", o=1.102, h=1.102, lo=1.101, c=1.102),
+    ])
+    legs = list(result.closed_trades)
+    assert len(legs) == 2, f"expected partial + runner-stop legs, got {legs}"
+    assert all(leg.direction == Direction.SHORT for leg in legs)
+    assert all(leg.parent_position_id is not None for leg in legs)
+    partial = next(leg for leg in legs if leg.exit_reason == "partial_close_1r")
+    runner = next(leg for leg in legs if leg.exit_reason == "stop_loss")
+    assert partial.size == pytest.approx(5_000.0)
+    assert runner.size == pytest.approx(5_000.0)
+    # Partial banked +1R on its half; runner realised exactly -1R on its half.
+    assert partial.exit_price == pytest.approx(_ENTRY - _R)
+    assert runner.exit_price == pytest.approx(_SL_SHORT)
+    assert (runner.entry_price - runner.exit_price) / _R == pytest.approx(-1.0)


### PR DESCRIPTION
## ⛔ DO NOT MERGE without operator review — gated canonical-core change

Implements short-side support per [`discovery/SHORTS_ENABLEMENT_PROBE.md`](discovery/SHORTS_ENABLEMENT_PROBE.md) (the authoritative spec). The v3 **scoring engine was already short-symmetric** (`Account`, `fill`, the 6 exit policies, the cost model, the `MultiPairBacktester` SL-first bar-walk); this PR threads an optional `direction` (default `LONG`) through the long-locked **Step-1 apparatus + architecture entry layer** and **exercises/pins** the short path. It does **not** re-author any bar-walk / cost / take-the-loss geometry — only mirrors and tests it.

**Existing long behaviour is byte-identical** (default `LONG` everywhere; determinism test + A1-vs-legacy anchor green). **No short discovery arc is opened.** Deployable-system count stays **0**.

## Change-list status (probe Q3)

| # | Item | Status |
|---|------|--------|
| 1 | `signal_protocol.py` — `direction` on `PerPairSignalState`+`SignalEvaluation` (default LONG); false `NotImplementedError` docstring in `arc_pool_builder` corrected | ✅ done |
| 2 ⚠ | `arc_pool_builder._simulate_pair_pool` — dispatch entry (`short_entry_fill_price`), SL (`entry + k·ATR`), stop scan (`high_ask ≥ sl`), MFE/MAE sign, `final_r` | ✅ done |
| 3 ⚠ | `discovery/pool_simulator` — `DiscoveryExitConfig.direction` + full trail-machine mirror; **two-producer cross-check** added | ✅ done |
| 4 ⚠ | `honest_label.reached_1r_before_sl` — `direction` param + ask-side short branch (take-the-loss in label space; same-bar +1R/SL → NaN) | ✅ done |
| 5 | `observe_long_capture` — direction-aware capture/drift | ✅ done |
| 6 | `architectures/a1,a2,a3,a6` — read signal `direction`, emit `Order(direction=…)`, mirror entry-SL; `a4` filter generalized; shared `_path_features_so_far` direction-aware (`sgn=1.0` keeps long bit-identical) | ✅ done |
| 7 | `multipair_backtester:386-390` — trail auto-register LONG gate kept **intentional** (KH-24 `TrailManager` is long-only; shorts trail via the canonical symmetric `sl_plus_trailing_atr` policy), documented | ✅ done |
| 8 | `core/sim/account.parse_direction` + `configs/arc_discovery_0{1,2}.yaml` — discovery `direction:` key now **load-bearing** (was inert) | ✅ done |
| 9 | `trailing_stop.py` / `kijun_d1.py` KH-24 long guards | ⏸ **deferred** (untouched — only needed if a short arc reuses KH-24's `TrailManager`/`kijun_d1`) |

**Untouched because already short-symmetric:** `core/sim/account.py`, `core/sim/fill.py`, the 6 `core/sim/exit_policies/`, `core/sim/costs/*`, and the `MultiPairBacktester` fill-dispatch + SL-first ordering.

## Gate results (mandatory — part of this PR, before any short arc)

- **SHORT take-the-loss test — PASS.** `tests/sim/test_take_the_loss_invariant.py` gained a 5-case `Direction.SHORT` mirror (each fixture the reflection of its long counterpart around entry). The dispatch-required case — a short stop **above** entry breached on the **same bar** its +1R partial **below** entry would fire → SL-first → full −1R, partial suppressed — is `test_short_same_bar_stop_and_partial_is_sl_first_minus_1r`. **10 passed (5 long + 5 short).**
- **Cost-model short test — PASS.** `tests/sim/test_cost_application.py::test_short_leg_costs_match_long_leg_exactly` + `test_short_partial_win_three_fills_symmetric` pin commission/slippage/spread identical on a short leg; costs only ever subtract.
- **Two-producer parity — PASS.** `tests/sim/test_short_enablement.py::test_two_producers_agree_on_a_losing_short` (with a long control) — both Step-1 producers agree trade-for-trade on a losing short.
- **Determinism — PASS.** `tests/test_determinism.py` two-run + serial-vs-parallel byte identity green; A1-vs-legacy byte-identity anchor green. Longs unchanged → no fixture/sha regen needed; no short fixtures committed yet (no short arc).
- **Honest-engine sweep (Parts C & D) — reads SAFE for shorts.** Cost netting is direction-agnostic (Part C); the new direction-aware `reached_1r_before_sl` is the label producer of record (Part D). Documented in the `HONEST_ENGINE_SWEEP.md` short-side re-read addendum.

**Full `pytest -m "not research"`: 1694 passed, 294 skipped, 7 deselected (8m19s).**

## Reviewer notes
- Byte-identity strategy: long expressions are kept **verbatim** inside `if is_long:` branches; short is the mirror. The two `abs()` / `sgn=1.0` reformulations are identity-preserving for longs (proven green by the determinism test + A1 anchor + the full long suite).
- A short arc may open **only after** this PR is merged AND the sweep re-reads SAFE — both satisfied here, pending your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
