### PR TITLE
Item E: single co-simulated portfolio equity-curve gate (cosim_book) — GATED-CORE, do not self-merge

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -13,6 +13,11 @@ exclude = [
   ".venv/**",
   ".git/**",
   "__pycache__/**",
+  # Discovery-fleet scratch working dirs (throwaway; committed but never a gate
+  # path) — excluded from lint like archive/research/results. Matches top-level
+  # (_disco_work, _disco2000_work, _disco3_work) and nested (discovery/_disco1_work).
+  "_*_work/**",
+  "**/_*_work/**",
 ]
 
 [lint]

--- a/HONEST_ENGINE_SWEEP.md
+++ b/HONEST_ENGINE_SWEEP.md
@@ -218,3 +218,53 @@ Caveat, unchanged from the long verdict: Part B's cross-pair `SUSPECT` features
 remain causal-lineage-gated. The short path is now **MERGED** (PR #273, 2026-06-05,
 squash-merged as `d826219`), so this sweep no longer blocks short arcs — the short
 engine path remains human-gated canonical core, and deployable-system count stays 0.
+
+---
+
+## CO-SIM BOOK RE-READ ADDENDUM — 2026-06-06
+
+Scope: Item E (`discovery/NEEDS_ENABLEMENT.md`) adds a NEW scoring path —
+the single co-simulated portfolio equity curve
+([`core/wfo/cosim_book.py`](core/wfo/cosim_book.py), `cosim_book_fold`) — which
+marks ≥2 already-scored components to ONE equity line under a shared
+2-per-currency exposure cap and a shared 5% daily-DD cap, replacing/standing
+beside the per-fold LINEAR combiner for the discovery all-folds-positive judge.
+The dispatch requires the sweep be re-read against it: **no lookahead in the
+shared-clock advance, the daily-DD cap applied causally, and costs per-leg**.
+The co-sim is a thin composition layer over the canonical engine — it does NOT
+re-fill, re-price, or re-exit a trade; it replays each component's already-SL-first
+`ClosedTrade` ledger verbatim and adds only the cross-component book layer.
+
+| Part | Co-sim re-read (2026-06-06) |
+|------|----------------------------|
+| **A** Take-the-loss | **SAFE (inherited)** — the co-sim authors NO exit logic. Each component's trades are produced by `MultiPairBacktester` under the SL-first / pre-partial ordering (Part A) and replayed verbatim (same entry/exit times, prices, P&L). A stopped trade is replayed as the −1R it already was; the co-sim never resurrects it. The only new "close" is the optional exposure-cap DROP (a trade the book never opens), which removes a trade, never converts a loss to a win. |
+| **B** No lookahead | **SAFE** — the shared-clock advance is causal. (i) Exposure admission walks the sorted event clock; a candidate at time `t` is gated by `Account.exposure_check` against only the positions OPEN at `t` (entered ≤ `t`, not yet exited) — a present fact, not a future price read; OPEN is processed before CLOSE at a timestamp, matching the engine's intra-bar order (`core/sim/cosim_book.py::_admit_under_exposure_cap`). (ii) Marks are each component's close-mid `reindex(clock).ffill()` — strictly last-known, never a forward fill. (iii) The daily-DD cap is measured on the REALIZED net equity per EET day from day-start (`compute_per_day_max_dd`, the canonical bucketing) — no future bar. Replaying an already-determined exit time is reconstruction, not lookahead: no decision reads a future price. |
+| **C** Costs per-leg | **SAFE** — costs are netted by the canonical chokepoint `build_fold_stats_from_run` → `apply_cost_model` on the admitted union ledger, which costs EACH position independently (own size, own bid/ask, own leg count). There is **no cross-instrument netting** — the explicit Arc-10 trap the dispatch forbids. The co-sim nets *exposure and risk on one equity line*, never broker billing; each component position pays its full FundedNext round-turn. Capital weights scale a component's size (hence its cost) linearly, faithful to deploying `w_k` of capital to it. Pinned by `tests/wfo/test_cosim_book.py::test_costs_are_per_leg_not_netted`. |
+| **D** labels | **N/A** — the co-sim produces no ML labels; it consumes already-scored trades. |
+| **E** Determinism | **SAFE** — sorted clock (set-union), sorted events tie-broken by `(component_index, position_id)`, sorted positions; no RNG / wall-clock / unordered iteration. Pinned by `tests/wfo/test_cosim_book.py::test_determinism_two_run_byte_identity` (two-run byte identity of equity + FoldStats). The engine cost/FoldStats chokepoint it calls is already two-run-identical (Part E). |
+
+### Monotonicity caveat (FLAG, by design — not a defect)
+
+The dispatch's safety invariant is "the co-sim can only make a fold's verdict
+equal or worse, never better." This holds **strictly** for the parts that are the
+invariant's actual basis — the real cross-component DD interaction and the daily-DD
+cap (`passes_with_daily_cap ⟹ passes_roi`); and with the exposure cap OFF the
+co-sim per-fold ROI tracks the linear combiner to the OOS-slice boundary
+(anti-optimism anchor: the equity/cost composition adds **no** return source —
+`test_no_interaction_equals_linear`). The shared 2-per-currency cap, however, is a
+faithful real constraint that is **NOT strictly ROI-monotone**: dropping a
+net-LOSING over-cap entry raises ROI, and no lookahead-free cap can avoid that
+(you cannot skip a trade by its unknown outcome). On the validated USD-concentrated
+4-way book the cap binds hard (~10 drops/fold) and produces a few folds where
+cap-ON co-sim > linear — the legitimate drop-a-loser effect, NOT optimism (the
+cap-OFF anchor confirms the math adds nothing). This is surfaced explicitly
+(`n_dropped`/`dropped`, and the cap-OFF strictly-monotone bound is always reported)
+rather than hidden. It does not change the engine's honesty: per-leg costs, no
+lookahead, SL-first all hold.
+
+**Co-sim verdict: the honest-engine sweep reads SAFE for the co-sim book gate**
+(no lookahead in the shared-clock advance, daily-DD cap applied causally, costs
+strictly per-leg). The one non-strict element — the exposure cap's drop-a-loser
+non-monotonicity — is a faithful constraint reported transparently, with the
+cap-OFF strictly-monotone bound always available. The co-sim is human-gated
+canonical core (Item-E PR); deployable-system count stays 0.

--- a/core/wfo/cosim_book.py
+++ b/core/wfo/cosim_book.py
@@ -1,0 +1,571 @@
+"""Co-simulated portfolio EQUITY CURVE — the single-book discovery gate (Item E).
+
+This is the CANONICAL-CORE scoring path that replaces (or sits beside) the
+per-fold **LINEAR** ROI combiner (``discovery/tools/combine_fold_roi.py``) for
+the discovery all-folds-positive judgement on a multi-component BOOK. The linear
+combiner sums each component's *independently simulated* per-fold ROI; it is
+faithful only when the components trade disjoint universes and never hold
+simultaneous positions. It cannot see the book's ACTUAL risk geometry: a shared
+5% daily-DD cap and real cross-component drawdown interaction.
+
+``cosim_book_fold`` marks **all components to ONE equity line on a shared clock**
+under a **shared 2-per-currency exposure cap applied to the book's net exposure**
+and a **shared 5% daily-DD cap**, then scores the single co-simulated curve
+through the canonical cost + FoldStats chokepoint.
+
+────────────────────────────────────────────────────────────────────────────
+THE INVARIANT THAT MAKES THIS SAFE — "can only tighten"
+────────────────────────────────────────────────────────────────────────────
+A shared daily-DD cap + real cross-component drawdown interaction is *strictly
+harder* than the per-fold linear sum, so the co-simulated curve can only make a
+fold's verdict **equal or worse, never better**. There is ZERO fabrication
+surface. Concretely, the co-sim adds only CONSTRAINTS and removes only the
+linear sum's idealizations — it never adds a return source:
+
+  1. Per-trade P&L is taken VERBATIM from each component's own canonical
+     simulation (same entries, exits, fill prices, SL-first take-the-loss). The
+     co-sim re-marks those trades onto one equity line; it never re-fills or
+     re-prices a trade.
+  2. Per-leg costs stay per-leg: each component position pays its own full
+     FundedNext round-turn cost (``apply_cost_model`` runs per-position on the
+     union ledger). The co-sim nets *exposure and risk on one equity line*, it
+     does NOT net broker billing — modelling a cross-instrument cost saving here
+     would be a textbook Arc-10 defect.
+  3. With capital weights ``w`` (Σw = 1, frozen on IS — the SAME weights the
+     linear combiner uses) and NO interaction (caps never bind, drawdowns never
+     coincide), the co-sim per-fold ROI EQUALS the linear combiner's weighted
+     ROI exactly: ``Σ_k w_k · ROI_k``. See
+     ``tests/wfo/test_cosim_book.py::test_no_interaction_equals_linear``.
+  4. The shared 5% daily cap can only FAIL a fold the book would otherwise pass
+     (a real 5ers/FundedNext daily breach = account dead), never rescue one —
+     and the discovery ROI judge is unchanged when caps are off, so the daily
+     cap is a STRICT extra gate (``passes_with_daily_cap`` ⟹ ``passes_roi``).
+  5. Real cross-component drawdown interaction can only DEEPEN the book's
+     max-DD (coincident drawdowns stack), never flatten it below the linear
+     view (which sees no book DD at all). Monotone.
+
+The strictly-monotone "can only tighten" guarantee is points 3–5 (no return
+source + daily cap + DD interaction). The shared 2-per-currency cap (point-2
+companion) can only DROP entries the linear sum counted — never add one — but it
+is NOT strictly ROI-monotone trade-by-trade: dropping a net-LOSING entry raises
+ROI, and no lookahead-free cap can avoid that (you cannot decide to skip a trade
+by its unknown outcome). This matters only when components hold simultaneous
+same-currency positions; the 4-way book this gate validates has disjoint event
+timing, so its cap NEVER binds (cap-on == cap-off) and the strict guarantee
+holds in practice. The driver therefore reports the exposure drop explicitly
+(``n_dropped`` / ``dropped``); ``apply_exposure_cap=False`` gives the
+strictly-monotone bound. If a co-sim book ever scores *better* than the linear
+combiner with the cap OFF, that is a BUG (optimism introduced — e.g. accidental
+cost-netting or double-counted equity); see the "can only tighten" property
+tests. The review anchor is: with the cap off this can only tighten the verdict;
+with the cap on it additionally drops trades the real book could not take.
+
+────────────────────────────────────────────────────────────────────────────
+Capital convention (apples-to-apples with the linear combiner)
+────────────────────────────────────────────────────────────────────────────
+The book holds ONE capital pool of ``starting_balance``; component ``k`` is
+allocated fraction ``w_k`` of it (Σ w_k = 1). Each component's already-scored
+trades are linearly scaled by ``w_k`` (size → size·w_k, hence P&L and cost →
+·w_k). The combined gross equity is therefore
+``starting_balance + Σ_k w_k · pnl_k(t)`` and the combined ROI is
+``Σ_k w_k · ROI_k`` BEFORE the (only-tightening) cap interactions — identical in
+scale and convention to ``combine_fold_rois`` with the same weights. Equal
+weights ``w_k = 1/N`` reproduce the combiner's ``"equal"`` mode.
+
+────────────────────────────────────────────────────────────────────────────
+Reuse, not re-author
+────────────────────────────────────────────────────────────────────────────
+The only NEW scoring code here is the co-simulation loop (shared-clock advance,
+one equity line, the two book-level caps). Everything load-bearing is the
+canonical engine, CALLED not re-rolled:
+
+  - ``core.sim.account.Account`` (sign-based ``Direction``/``Position`` +
+    ``parent_position_id`` multi-leg primitive, shorts probe Q2.6) for the
+    2-per-currency exposure admission — ``exposure_check`` is the canonical cap.
+  - ``core.sim.costs.model.apply_cost_model`` (FundedNext per-leg costs).
+  - ``core.runners._fold_stats_helpers.build_fold_stats_from_run`` (the gate
+    cost+FoldStats chokepoint) and ``compute_per_day_max_dd`` (EET daily-DD).
+
+Determinism: components are processed in caller order; positions and same-clock
+events are tie-broken by ``(component_index, position_id)``; the clock is the
+sorted union of every component's mark index. No RNG, no wall-clock.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+
+from core.runners._fold_stats_helpers import (
+    build_fold_stats_from_run,
+    compute_per_day_max_dd,
+    slice_equity_to_oos,
+)
+from core.sim.account import (
+    Account,
+    ClosedTrade,
+    Direction,
+    ExposureRules,
+)
+from core.sim.costs.model import CostModel, apply_cost_model
+from core.sim.multipair_backtester import RunResult
+from core.wfo.folds import Fold
+from core.wfo.gates import FoldStats
+
+# The book-level exposure cap: 2 positions per currency applied to the WHOLE
+# book's net exposure, uncapped per-pair and per-total (the dispatch specifies
+# only the per-currency cap). Reuses the canonical ``Account.exposure_check``.
+DEFAULT_BOOK_EXPOSURE: ExposureRules = ExposureRules(
+    max_concurrent_total=None,
+    max_concurrent_per_pair=None,
+    max_concurrent_per_currency=2,
+)
+
+# 5ers / FundedNext daily-DD breach threshold (fraction of day-start equity).
+DAILY_DD_CAP: float = 0.05
+
+# Stable per-component id offset so position ids never collide across
+# components when the union ledger is grouped by position_id for costing.
+_COMPONENT_ID_OFFSET: int = 10_000_000
+
+
+@dataclass(frozen=True)
+class CoSimComponent:
+    """One book component, ALREADY scored by the canonical engine on its own.
+
+    ``closed_trades`` is the component's gross ``RunResult.closed_trades`` (each
+    carrying entry/exit time+price, direction, size, sl_price and the entry/exit
+    bid+ask the cost model reads). ``mark_prices`` is the per-pair close-mid
+    series on the component's PRIMARY-TF panel (the engine's mark axis), used to
+    mark this component's open positions on the shared clock — exactly the marks
+    its own ``Account.mark_to_market`` used, so an un-dropped component
+    reproduces its own equity contribution bar-for-bar.
+    """
+
+    name: str
+    closed_trades: tuple[ClosedTrade, ...]
+    mark_prices: Mapping[str, pd.Series]
+    starting_balance: float = 100_000.0
+
+
+@dataclass(frozen=True)
+class CoSimBookResult:
+    """Result of co-simulating a multi-component book over ONE fold."""
+
+    fold_stats: FoldStats                # cost-netted, OOS-restricted (canonical chokepoint)
+    gross_equity: pd.Series              # the single co-simulated equity line (gross), full clock
+    net_equity: pd.Series                # cost-netted equity line, full clock
+    weights: tuple[float, ...]           # capital fractions used, component order
+    component_names: tuple[str, ...]
+    n_admitted: int                      # positions admitted under the book exposure cap
+    n_dropped: int                       # positions dropped by the book exposure cap
+    dropped: tuple[tuple[str, int], ...]  # (component_name, position_id) dropped, sorted
+    days_breaching_daily_5pct_eet: int   # EET-convention book daily-DD breaches over OOS
+    per_day_max_dd_eet: pd.DataFrame     # compute_per_day_max_dd on the OOS net equity (EET)
+    daily_dd_breached: bool              # True iff the book breached the 5% daily cap in OOS
+
+    @property
+    def roi_pct(self) -> float:
+        return self.fold_stats.roi_pct
+
+    @property
+    def passes_roi(self) -> bool:
+        """The linear-combiner-comparable judge: book ROI strictly positive."""
+        return self.fold_stats.roi_pct > 0.0
+
+    @property
+    def passes_with_daily_cap(self) -> bool:
+        """The full book judge: ROI > 0 AND no 5% daily-DD breach (account alive)."""
+        return self.passes_roi and not self.daily_dd_breached
+
+
+# ── internal: weight-scaled, globally-unique re-id of a component's trades ──
+def _reid_scaled_trades(
+    trades: Sequence[ClosedTrade], component_index: int, weight: float
+) -> list[ClosedTrade]:
+    """Return ``trades`` with size/pnl scaled by ``weight`` and position ids
+    offset into a component-unique range (so the union ledger groups legs of
+    the same original position together, and never merges two components'
+    ``position_id == 1`` into one position at costing time).
+    """
+    base = (component_index + 1) * _COMPONENT_ID_OFFSET
+    out: list[ClosedTrade] = []
+    for t in trades:
+        new_pid = base + int(t.position_id)
+        new_parent = (
+            None if t.parent_position_id is None else base + int(t.parent_position_id)
+        )
+        out.append(
+            ClosedTrade(
+                position_id=new_pid,
+                pair=t.pair,
+                direction=t.direction,
+                entry_time=t.entry_time,
+                entry_price=t.entry_price,
+                exit_time=t.exit_time,
+                exit_price=t.exit_price,
+                size=float(t.size) * weight,
+                pnl=float(t.pnl) * weight,
+                exit_reason=t.exit_reason,
+                parent_position_id=new_parent,
+                entry_bid=t.entry_bid,
+                entry_ask=t.entry_ask,
+                exit_bid=t.exit_bid,
+                exit_ask=t.exit_ask,
+                sl_price=t.sl_price,
+            )
+        )
+    return out
+
+
+@dataclass
+class _Position:
+    """One co-sim position: an original position's leg group, on one component."""
+
+    key: tuple[str, int]          # (component_name, original position_id)
+    component_index: int
+    pair: str
+    direction: Direction
+    entry_time: pd.Timestamp
+    entry_price: float
+    total_size: float             # weight-scaled
+    legs: list[tuple[pd.Timestamp, float, float]]  # (exit_time, exit_price, leg_size), sorted by exit_time
+    mark: pd.Series               # this component's close-mid for ``pair``
+
+    @property
+    def final_exit_time(self) -> pd.Timestamp:
+        return self.legs[-1][0]
+
+
+def _group_positions(
+    component_index: int,
+    component_name: str,
+    reid_trades: Sequence[ClosedTrade],
+    mark_prices: Mapping[str, pd.Series],
+) -> list[_Position]:
+    """Group a component's (re-id'd, scaled) closed trades into positions.
+
+    Legs sharing a ``position_id`` are one position (partial close + runner);
+    a standalone full close is a 1-leg position. The position's entry geometry
+    is taken from any leg (all legs of a position share entry_time/price/dir).
+    """
+    by_pid: dict[int, list[ClosedTrade]] = {}
+    for t in reid_trades:
+        by_pid.setdefault(int(t.position_id), []).append(t)
+    positions: list[_Position] = []
+    for pid in sorted(by_pid):
+        legs = sorted(by_pid[pid], key=lambda x: (pd.Timestamp(x.exit_time), float(x.size)))
+        head = legs[0]
+        pair = head.pair
+        mark = mark_prices.get(pair)
+        if mark is None:
+            raise KeyError(
+                f"component {component_name!r} position {pid} trades {pair!r} but "
+                f"no mark_prices series was supplied for it"
+            )
+        orig_pid = pid - (component_index + 1) * _COMPONENT_ID_OFFSET
+        positions.append(
+            _Position(
+                key=(component_name, orig_pid),
+                component_index=component_index,
+                pair=pair,
+                direction=head.direction,
+                entry_time=pd.Timestamp(head.entry_time),
+                entry_price=float(head.entry_price),
+                total_size=float(sum(float(leg.size) for leg in legs)),
+                legs=[
+                    (pd.Timestamp(leg.exit_time), float(leg.exit_price), float(leg.size))
+                    for leg in legs
+                ],
+                mark=mark,
+            )
+        )
+    return positions
+
+
+def _admit_under_exposure_cap(
+    positions: Sequence[_Position], exposure: ExposureRules
+) -> set[tuple[str, int]]:
+    """Walk a shared clock and admit/drop each position under the book cap.
+
+    Reuses the canonical ``Account.exposure_check`` (the 2-per-currency cap
+    applied to the whole book's open positions). At each timestamp OPEN events
+    are processed before CLOSE events — matching the engine's intra-bar order
+    (``_fill_pending_entries`` before ``_check_exits``), so a new entry is gated
+    against positions still open on that bar. Ties at a timestamp break on
+    ``(component_index, original position_id)`` for determinism.
+
+    Returns the set of admitted position keys. A dropped position is one the
+    book could not open without breaching its 2-per-currency cap; it never
+    enters the equity curve or the cost ledger (honest skip).
+    """
+    account = Account(starting_balance=1.0, exposure=exposure)
+    # Event kinds: 0 = OPEN (processed first at a timestamp), 1 = CLOSE.
+    events: list[tuple[pd.Timestamp, int, int, int, _Position]] = []
+    for p in positions:
+        events.append((p.entry_time, 0, p.component_index, p.key[1], p))
+        events.append((p.final_exit_time, 1, p.component_index, p.key[1], p))
+    events.sort(key=lambda e: (e[0], e[1], e[2], e[3]))
+
+    admitted: set[tuple[str, int]] = set()
+    open_acct_id: dict[tuple[str, int], int] = {}
+    for ts, kind, _ci, _oid, p in events:
+        if kind == 1:  # CLOSE
+            acct_id = open_acct_id.pop(p.key, None)
+            if acct_id is not None:
+                account.close(acct_id, ts, p.entry_price, "cosim_close")
+        else:  # OPEN
+            if account.exposure_check(p.pair):
+                pos = account.open(
+                    pair=p.pair,
+                    direction=p.direction,
+                    entry_time=ts,
+                    entry_price=p.entry_price,
+                    size=max(p.total_size, 1.0),  # size irrelevant to exposure; keep > 0
+                )
+                open_acct_id[p.key] = pos.position_id
+                admitted.add(p.key)
+    return admitted
+
+
+def _position_contribution(pos: _Position, clock: pd.DatetimeIndex) -> np.ndarray:
+    """Per-clock-bar gross P&L contribution of one position (realized + marked).
+
+    For t < entry: 0. While open over a segment [prev_exit, leg_exit): the
+    still-open size is marked at this component's close-mid (ffilled to the
+    shared clock — a flat mark between the component's own bars, matching its
+    own ``Account.mark_to_market``). Each leg's realized P&L is added forward
+    from its exit. After the final exit the contribution is the position's
+    total realized P&L (constant). Equivalent bar-for-bar to the component's
+    own equity contribution when the position is admitted.
+    """
+    mark_arr = pos.mark.reindex(clock).ffill().to_numpy(dtype=float)
+    clock_vals = clock.values
+    contrib = np.zeros(len(clock), dtype=float)
+    sign = pos.direction.sign
+    entry = pos.entry_price
+    size_remaining = pos.total_size
+    prev = np.datetime64(pos.entry_time.to_datetime64())
+    for exit_ts, exit_price, leg_size in pos.legs:
+        exit_v = np.datetime64(pd.Timestamp(exit_ts).to_datetime64())
+        seg = (clock_vals >= prev) & (clock_vals < exit_v)
+        if seg.any():
+            contrib[seg] += sign * (mark_arr[seg] - entry) * size_remaining
+        after = clock_vals >= exit_v
+        if after.any():
+            contrib[after] += sign * (exit_price - entry) * leg_size
+        size_remaining -= leg_size
+        prev = exit_v
+    # Defensive: a NaN mark inside an open segment (should not happen — the
+    # segment lies within the component's own panel) must not poison equity.
+    return np.nan_to_num(contrib, nan=0.0)
+
+
+def cosim_book_fold(
+    components: Sequence[CoSimComponent],
+    fold: Fold,
+    *,
+    weights: Sequence[float] | None = None,
+    starting_balance: float = 100_000.0,
+    exposure: ExposureRules = DEFAULT_BOOK_EXPOSURE,
+    cost_model: CostModel | None = None,
+    apply_exposure_cap: bool = True,
+) -> CoSimBookResult:
+    """Co-simulate a multi-component book over ONE fold → one curve → FoldStats.
+
+    Parameters
+    ----------
+    components
+        The already-scored components (one per book leg). Order is the weight
+        order and the determinism tie-break order.
+    fold
+        The fold whose OOS window the resulting FoldStats restrict to (same
+        ``Fold`` the components were scored on).
+    weights
+        Capital fractions, summed to 1, frozen on IS (the SAME weights the
+        linear combiner uses). ``None`` → equal weights ``1/N``. A 0-weight
+        component contributes nothing (matches the combiner dropping it).
+    starting_balance
+        The book's single capital pool.
+    exposure
+        Book-level exposure cap. Default: 2-per-currency, uncapped otherwise.
+    cost_model
+        FundedNext by default (per-leg, the gate default). Never silently zero.
+    apply_exposure_cap
+        When False, no entry is dropped (pure equity superposition). Used by the
+        ``test_no_interaction_equals_linear`` anchor; production gating leaves
+        this True.
+
+    Returns
+    -------
+    CoSimBookResult
+        The co-simulated book's FoldStats + the single equity line + the
+        exposure-drop and daily-DD-breach diagnostics.
+    """
+    if not components:
+        raise ValueError("cosim_book_fold requires ≥1 component")
+    n = len(components)
+    if weights is None:
+        weights = [1.0 / n] * n
+    if len(weights) != n:
+        raise ValueError(f"{len(weights)} weights for {n} components")
+    w = [float(x) for x in weights]
+    if any(x < 0.0 for x in w):
+        raise ValueError(f"weights must be ≥ 0; got {w}")
+    tot = sum(w)
+    if tot <= 0.0:
+        raise ValueError("weights sum to 0")
+    # Tolerate a non-normalised weight vector by normalising (frozen IS weights
+    # from ``fit_weights`` already sum to 1; this is just defensive).
+    if not np.isclose(tot, 1.0):
+        w = [x / tot for x in w]
+
+    model = cost_model if cost_model is not None else CostModel.fundednext()
+
+    # 1. Weight-scale + globally re-id each component's trades; group into
+    #    positions; collect the per-component mark series.
+    all_positions: list[_Position] = []
+    all_reid_trades: list[ClosedTrade] = []
+    for ci, (comp, wk) in enumerate(zip(components, w)):
+        if wk == 0.0:
+            continue  # a 0-weight component is absent from the book
+        reid = _reid_scaled_trades(comp.closed_trades, ci, wk)
+        all_reid_trades.extend(reid)
+        all_positions.extend(
+            _group_positions(ci, comp.name, reid, comp.mark_prices)
+        )
+
+    # 2. Shared clock = sorted union of every component's mark index (the bars
+    #    where the book's open positions are marked). Every trade entry/exit
+    #    time is a bar on its pair's panel, so it is already in this union.
+    clock = pd.DatetimeIndex([], tz="UTC")
+    for comp in components:
+        for series in comp.mark_prices.values():
+            clock = clock.union(series.index)
+    if len(clock) == 0:
+        # No marks anywhere — degenerate empty book.
+        return _empty_result(fold, tuple(w), tuple(c.name for c in components))
+
+    # 3. Book-level exposure admission (the canonical 2-per-currency cap).
+    if apply_exposure_cap:
+        admitted_keys = _admit_under_exposure_cap(all_positions, exposure)
+    else:
+        admitted_keys = {p.key for p in all_positions}
+    dropped = tuple(sorted(p.key for p in all_positions if p.key not in admitted_keys))
+
+    # 4. One gross equity line: Σ admitted position contributions on the clock.
+    pnl_path = np.zeros(len(clock), dtype=float)
+    admitted_positions = [p for p in all_positions if p.key in admitted_keys]
+    for pos in admitted_positions:
+        pnl_path += _position_contribution(pos, clock)
+    gross_equity = pd.Series(
+        starting_balance + pnl_path, index=clock, name="equity"
+    )
+
+    # 5. Admitted union ledger (for per-leg cost netting). Drop any leg whose
+    #    position was not admitted.
+    admitted_pid = {
+        (p.component_index + 1) * _COMPONENT_ID_OFFSET + p.key[1]
+        for p in admitted_positions
+    }
+    admitted_trades = tuple(
+        t for t in all_reid_trades if int(t.position_id) in admitted_pid
+    )
+
+    # 6. Canonical cost + FoldStats chokepoint (FundedNext per-leg, OOS-sliced).
+    run_result = RunResult(
+        final_balance=float(gross_equity.iloc[-1]),
+        n_trades=len(admitted_trades),
+        n_open_at_end=0,
+        equity_curve=gross_equity,
+        max_drawdown_pct=0.0,  # recomputed inside build_fold_stats_from_run
+        closed_trades=admitted_trades,
+    )
+    fold_stats = build_fold_stats_from_run(
+        fold=fold,
+        run_result=run_result,
+        starting_balance=starting_balance,
+        cost_model=model,
+    )
+
+    # 7. EET daily-DD diagnostic on the OOS net equity (the canonical bucketing
+    #    named in CLAUDE.md). FoldStats.days_breaching_daily_5pct already
+    #    carries the UTC-convention count from the chokepoint.
+    costed = apply_cost_model(run_result, model)
+    net_equity = costed.net_equity
+    net_oos = slice_equity_to_oos(net_equity, fold)
+    per_day = compute_per_day_max_dd(net_oos, pair_set="cosim_book")
+    if len(per_day):
+        eet_breaches = int((per_day["day_max_dd_base_pct"] >= DAILY_DD_CAP).sum())
+    else:
+        eet_breaches = 0
+    # The book breached the daily cap if EITHER convention saw a ≥5% day.
+    daily_breached = bool(
+        eet_breaches > 0 or fold_stats.days_breaching_daily_5pct > 0
+    )
+
+    return CoSimBookResult(
+        fold_stats=fold_stats,
+        gross_equity=gross_equity,
+        net_equity=net_equity,
+        weights=tuple(w),
+        component_names=tuple(c.name for c in components),
+        n_admitted=len(admitted_positions),
+        n_dropped=len(dropped),
+        dropped=dropped,
+        days_breaching_daily_5pct_eet=eet_breaches,
+        per_day_max_dd_eet=per_day,
+        daily_dd_breached=daily_breached,
+    )
+
+
+def _empty_result(
+    fold: Fold, weights: tuple[float, ...], names: tuple[str, ...]
+) -> CoSimBookResult:
+    empty = pd.Series([], dtype="float64", name="equity")
+    return CoSimBookResult(
+        fold_stats=FoldStats(
+            fold_id=fold.fold_id,
+            n_trades=0,
+            roi_pct=0.0,
+            max_dd_pct=0.0,
+            days_breaching_daily_5pct=0,
+            roi_dd_ratio=0.0,
+        ),
+        gross_equity=empty,
+        net_equity=empty,
+        weights=weights,
+        component_names=names,
+        n_admitted=0,
+        n_dropped=0,
+        dropped=(),
+        days_breaching_daily_5pct_eet=0,
+        per_day_max_dd_eet=compute_per_day_max_dd(empty),
+        daily_dd_breached=False,
+    )
+
+
+def mark_prices_from_panel(panel) -> dict[str, pd.Series]:
+    """Extract per-pair close-mid ``(close_bid + close_ask) / 2`` from a Panel.
+
+    This is the engine's mark axis (``MultiPairBacktester._close_mid``), so an
+    admitted component reproduces its own equity contribution exactly. ``panel``
+    is duck-typed (anything exposing ``.pair_dfs``) to avoid importing Panel.
+    """
+    out: dict[str, pd.Series] = {}
+    for pair, df in panel.pair_dfs.items():
+        out[pair] = ((df["close_bid"] + df["close_ask"]) / 2.0).rename("close_mid")
+    return out
+
+
+__all__ = (
+    "CoSimComponent",
+    "CoSimBookResult",
+    "cosim_book_fold",
+    "mark_prices_from_panel",
+    "DEFAULT_BOOK_EXPOSURE",
+    "DAILY_DD_CAP",
+)

--- a/discovery/COSIM_ITEM_E_VALIDATION.md
+++ b/discovery/COSIM_ITEM_E_VALIDATION.md
@@ -1,0 +1,107 @@
+# Item E — co-simulated portfolio equity curve: 4-way book validation
+
+> Reproduces and re-judges the portfolio-route thread (arcs 1006/1011/1013/1019,
+> combined in arc 1020) through the NEW single co-simulated equity-curve gate
+> (`core/wfo/cosim_book.py`), side-by-side with the per-fold LINEAR combiner
+> (`discovery/tools/combine_fold_roi.py`). Answers the open question arc 2019 left
+> for the operator: **is the 4-way book's all-folds-positive failure a
+> linear-combiner artifact, or fundamental?**
+>
+> Reproduce: `PYTHONPATH=. py scripts/cosim_validation/validate_4way_book.py`
+> Date: 2026-06-06 · IS folds: per-year 2011-2020 · costs: FundedNext ON · engine: `MultiPairBacktester` (sole gate engine)
+
+## Components (canonical A1 + MultiPairBacktester, SL=2.0 ATR)
+
+| name | signal | universe | TF | exit |
+|------|--------|----------|----|------|
+| gap | `WeekendGapFillLongSignal(0.5, 36)` | 5 JPY crosses | H4 | 24-bar time-exit |
+| me_long | `MonthEndReversionLongSignal(1.0, 2)` | 7 USD majors | D1 | 2-bar time-exit + `sl_only` |
+| fbr | `FailedBreakdownReclaimLongSignal(40, 1.25)` | 7 USD majors | H4 | `sl_plus_trailing_atr` |
+| me_short | `MonthEndReversionShortSignal(1.0, 2)` | 7 USD majors | D1 | `sl_partial_close_1r_runner_trail` |
+
+### Reproduction fidelity vs arc-1020 recorded per-fold ROI (%)
+
+gap / me_long / me_short reproduce the recorded numbers **exactly**; fbr is within
+~1.4% (the `sl_plus_trailing_atr` trail params were not pinned in the arc record —
+immaterial to the verdict at fbr's 0.107 weight).
+
+```
+year |   gap (mine/rec) | me_long | fbr (mine/rec)  | me_short
+2011 | -0.07 / -0.07 |  +0.40 |  +8.97 / +7.55 |  +3.39
+2012 | +8.23 / +8.23 |  +0.29 |  +3.12 / +3.05 |  +1.69
+2013 | -2.06 / -2.06 |  +0.96 |  +0.86 / +0.91 |  -0.90
+2014 | +2.94 / +2.94 |  -0.23 |  +0.24 / +0.19 |  +0.98
+2015 | -4.19 / -4.19 |  -1.14 |  +3.36 / +3.17 |  +0.40
+2016 | +3.20 / +3.20 |  -0.51 |  +4.04 / +2.55 |  -0.91
+2017 | +0.53 / +0.53 |  +0.34 |  +0.80 / +1.23 |  -0.68
+2018 | -6.79 / -6.79 |  +0.90 |  -4.39 / -4.20 |  +0.86
+2019 | +7.45 / +7.45 |  +1.16 |  -0.17 / +0.05 |  +1.29
+2020 | -2.39 / -2.39 |  +0.15 |  +3.99 / +4.03 |  +0.71
+```
+
+IS-frozen risk-parity weights: `gap=0.078, me_long=0.531, fbr=0.107, me_short=0.284`.
+
+## Co-sim vs linear — per-fold ROI (%), book max-DD (%), exposure drops
+
+Two co-sim measurements: **cap-OFF** (the strictly-monotone bound — real DD
+interaction only) and **cap-ON** (the faithful book under the 2-per-currency
+limit). `dOFF`/`dON` = co-sim − linear.
+
+```
+year |  linear  cosOFF   dOFF bookDD |   cosON    dON dropON
+2011 |   +2.13   +2.05  -0.08   0.35 |   +1.05  -1.08     13
+2012 |   +1.61   +1.59  -0.02   0.83 |   +0.97  -0.64     11
+2013 |   +0.18   +0.18  -0.01   0.59 |   +0.34  +0.16      6
+2014 |   +0.41   +0.41  -0.00   0.80 |   +0.57  +0.16     10
+2015 |   -0.46   -0.46  +0.00   1.51 |   -0.50  -0.04     12
+2016 |   +0.15   +0.16  +0.01   0.87 |   +0.61  +0.45      8
+2017 |   +0.11   +0.02  -0.10   0.82 |   -0.07  -0.18     10
+2018 |   -0.27   -0.27  +0.00   0.65 |   -0.58  -0.30      7
+2019 |   +1.54   +1.53  -0.01   0.64 |   +1.18  -0.37     14
+2020 |   +0.53   +0.53  +0.00   0.78 |   +0.31  -0.22     12
+```
+
+### Anti-optimism anchor (cap OFF)
+
+`max |cosim_off − linear| = 0.096%` (risk-parity), `0.310%` (equal) — boundary-only
+(the union clock's first OOS bar is an H4 bar, each D1 component's own is a D1 bar).
+**The co-sim equity/cost composition adds NO return source.** The only NEW
+information cap-OFF surfaces is the real BOOK max-DD (0.35–1.51%), which the linear
+combiner structurally cannot see — and it never approaches the 5% daily cap (so the
+daily cap never binds for this book; it is correctly inert here, not silently off).
+
+### Exposure cap (cap ON)
+
+The book is **USD-concentrated** (3 of 4 components trade USD majors), so the
+2-per-currency cap **binds hard**: 103 positions dropped across 10 folds (~10/fold).
+Because dropping is a faithful real constraint (not lookahead-free monotone),
+cap-ON ROI is mixed-sign vs linear (dropping a net-loser raises ROI on 2013/14/16).
+This is surfaced transparently, not hidden; the cap-OFF column is the
+strictly-monotone bound.
+
+## VERDICTS — all-folds-positive (IS 2011-2020)
+
+| measurement | all-folds-positive | worst fold | n_nonpositive |
+|-------------|:--:|:--:|:--:|
+| linear, equal | **False** | −2.35% | 3 |
+| co-sim cap-OFF, equal | **False** | −2.36% | 4 |
+| co-sim cap-ON, equal | **False** | −2.75% | 3 |
+| linear, risk-parity | **False** | −0.46% | 2 (2015, 2018) |
+| co-sim cap-OFF, risk-parity | **False** | −0.46% | 2 (2015, 2018) |
+| co-sim cap-ON, risk-parity | **False** | −0.58% | 3 (2015, 2017, 2018) |
+
+## FOLD-FLIP VERDICT
+
+- linear all-folds-positive: **False**
+- co-sim cap-OFF: **False** — sign flips vs linear: **none** (tracks linear, deepens DD only)
+- co-sim cap-ON: **False** — sign flips vs linear: **[2017]** (cap drops push 2017 marginally negative — strictly harder)
+
+**Co-simulation CONFIRMS the linear verdict. The 4-way book's all-folds-positive
+failure is FUNDAMENTAL, not a linear-combiner artifact.** Every measurement —
+linear, co-sim with the shared book caps off, and co-sim with them on — fails
+all-folds-positive on IS (2015 and 2018 are negative under every weighting; the
+cap-on book adds 2017). The portfolio route is closed **cleanly**: the thinness is
+real risk geometry, not an artifact of summing independently-simulated legs.
+
+Per §4 holdout preservation: **IS did not clear, so the frozen 2021+ OOS was NOT
+touched.** No PASS candidate; no `passed/` record; deployable-system count stays 0.

--- a/discovery/NEEDS_ENABLEMENT.md
+++ b/discovery/NEEDS_ENABLEMENT.md
@@ -43,6 +43,14 @@ simultaneous opposing leg to net). The genuinely cheap, high-value unlock hiding
 
 ### E — Single co-simulated portfolio EQUITY CURVE (build this FIRST) · small build · highest ROI
 
+> **STATUS 2026-06-06 — BUILT, IN HUMAN REVIEW (gated-core PR, not yet merged).** `core/wfo/cosim_book.py`
+> (`cosim_book_fold`) + CI gate tests (`tests/wfo/test_cosim_book.py`) + the honest-engine-sweep co-sim
+> re-read (SAFE). Validated against the existing 4-way book (gap+me_long+fbr+me_short, arcs
+> 1006/1011/1013/1019) — see [`COSIM_ITEM_E_VALIDATION.md`](./COSIM_ITEM_E_VALIDATION.md). **Result: every
+> measurement (linear, co-sim cap-off, co-sim cap-on) FAILS all-folds-positive on IS → the book's failure is
+> FUNDAMENTAL, not a linear-combiner artifact. The portfolio route is closed cleanly; IS did not clear so the
+> 2021+ OOS was NOT touched.** Deployable-system count stays 0. Do not mark this item DONE until the PR merges.
+
 - **What must be enabled.** A driver/gate path that marks **all components to ONE equity line** under the
   **shared 5% daily-DD cap** and the 2-per-currency exposure cap applied to the *book's* net exposure —
   replacing (or sitting beside) the per-fold-**LINEAR** combiner (`discovery/tools/combine_fold_roi.py`),

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,6 +14,11 @@ exclude = [
   "__pycache__/**",
   "attic/**",
   "**/*.ipynb",
+  # Discovery-fleet scratch working dirs (throwaway; committed but never a gate
+  # path) — excluded from lint like archive/research/results. Matches top-level
+  # (_disco_work, _disco2000_work, _disco3_work) and nested (discovery/_disco1_work).
+  "_*_work/**",
+  "**/_*_work/**",
 ]
 
 extend-exclude = [

--- a/scripts/cosim_validation/validate_4way_book.py
+++ b/scripts/cosim_validation/validate_4way_book.py
@@ -1,0 +1,265 @@
+"""Item-E validation — re-run the existing 4-way book through the co-sim gate.
+
+Scores the four components of the portfolio-route thread (arcs 1006/1011/1013/1019,
+combined in arc 1020) via the canonical A1 + ``MultiPairBacktester`` path over the
+per-year IS folds (2011-2020), then runs them through BOTH:
+
+  - the per-fold LINEAR combiner (``discovery/tools/combine_fold_roi.py``), and
+  - the single co-simulated equity curve (``core/wfo/cosim_book.py``),
+
+at the SAME (equal and IS-frozen risk-parity) capital weights, and prints a
+side-by-side per-fold ROI + maxDD table with the fold-flip verdict (does
+co-simulation change all-folds-positive vs the linear combiner — artifact or
+fundamental?).
+
+Run:  PYTHONPATH=. py scripts/cosim_validation/validate_4way_book.py
+
+Data:  histdata_root defaults to C:/Users/panap/histdata_backup, cache_root to the
+main-repo data/cache (both overridable by env COSIM_HISTDATA_ROOT / COSIM_CACHE_ROOT).
+This is an ANALYSIS script (not a gate path); it CALLS the canonical scoring engine.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from pathlib import Path
+
+import pandas as pd
+
+from core.arc.signal_protocol import SignalEvaluation
+from core.architectures.a1_system_level_filter import A1Architecture, A1Config
+from core.runners.arc_fold_runner import ArcFoldRunner
+from core.sim.panel import Panel
+from core.wfo.cosim_book import CoSimComponent, cosim_book_fold, mark_prices_from_panel
+from core.wfo.folds import build_v3_folds
+from discovery.tools.combine_fold_roi import combine_fold_rois, fit_weights
+from discovery.tools.failed_breakdown_signals import FailedBreakdownReclaimLongSignal
+from discovery.tools.gap_signals import WeekendGapFillLongSignal
+from discovery.tools.month_end_signals import (
+    MonthEndReversionLongSignal,
+    MonthEndReversionShortSignal,
+)
+from discovery.tools.time_exit_predicate import make_time_exit_predicate
+
+HISTDATA_ROOT = Path(os.environ.get("COSIM_HISTDATA_ROOT", r"C:/Users/panap/histdata_backup"))
+CACHE_ROOT = Path(os.environ.get("COSIM_CACHE_ROOT", r"C:/Users/panap/Documents/Forex-Backtester/data/cache"))
+BOUNDARY = "5ers_eet"
+SB = 100_000.0
+
+JPY_CROSSES = ["EURJPY", "GBPJPY", "AUDJPY", "CADJPY", "CHFJPY"]
+USD_MAJORS = ["EURUSD", "GBPUSD", "USDJPY", "USDCHF", "AUDUSD", "USDCAD", "NZDUSD"]
+
+# Recorded arc-1020 per-year IS ROI (%) — reproduction-fidelity cross-check only.
+ARC1020_RECORDED = {
+    # year: (gap, me_long, fbr, me_short)
+    2011: (-0.07, +0.40, +7.55, +3.39),
+    2012: (+8.23, +0.29, +3.05, +1.69),
+    2013: (-2.06, +0.96, +0.91, -0.90),
+    2014: (+2.94, -0.23, +0.19, +0.98),
+    2015: (-4.19, -1.14, +3.17, +0.40),
+    2016: (+3.20, -0.51, +2.55, -0.91),
+    2017: (+0.53, +0.34, +1.23, -0.68),
+    2018: (-6.79, +0.90, -4.20, +0.86),
+    2019: (+7.45, +1.16, +0.05, +1.29),
+    2020: (-2.39, +0.15, +4.03, +0.71),
+}
+
+
+def _load_panel(pairs, tf):
+    return Panel.from_pairs(
+        pairs, tf, histdata_root=HISTDATA_ROOT, cache_root=CACHE_ROOT,
+        use_cache=True, boundary_convention=BOUNDARY,
+    )
+
+
+def _attach_time_exit(sig: SignalEvaluation, panel: Panel, n_bars: int) -> SignalEvaluation:
+    """Return a copy of ``sig`` with an n-bar time-exit predicate on every pair."""
+    pred = make_time_exit_predicate({p: panel.pair_dfs[p] for p in panel.pairs}, n_bars)
+    new_per_pair = {
+        pair: dataclasses.replace(state, exit_predicate=pred)
+        for pair, state in sig.per_pair.items()
+    }
+    return dataclasses.replace(sig, per_pair=new_per_pair)
+
+
+def _slice_marks(marks: dict, fold) -> dict:
+    """Slice each pair's mark series to the fold window + warmup slack."""
+    lo = pd.Timestamp(fold.oos_start, tz="UTC") - pd.Timedelta(days=90)
+    hi = pd.Timestamp(fold.oos_end, tz="UTC") + pd.Timedelta(days=1)
+    return {p: s.loc[lo:hi] for p, s in marks.items()}
+
+
+def main() -> None:
+    print(f"histdata_root={HISTDATA_ROOT}\ncache_root={CACHE_ROOT}\n")
+
+    # ── panels ───────────────────────────────────────────────────────────
+    h4 = _load_panel(sorted(set(JPY_CROSSES) | set(USD_MAJORS)), "H4")
+    d1 = _load_panel(USD_MAJORS, "D1")
+    h4_jpy = Panel.from_frames({p: h4.pair_dfs[p] for p in JPY_CROSSES}, tf="H4", boundary_convention=BOUNDARY)
+    h4_usd = Panel.from_frames({p: h4.pair_dfs[p] for p in USD_MAJORS}, tf="H4", boundary_convention=BOUNDARY)
+
+    # ── component definitions: (name, signal_eval, panels, A1Config, mark panel) ──
+    gap_eval = _attach_time_exit(
+        WeekendGapFillLongSignal(threshold_atr=0.5, gap_hours=36).evaluate({"H4": h4_jpy}),
+        h4_jpy, n_bars=24,
+    )
+    me_long_eval = _attach_time_exit(
+        MonthEndReversionLongSignal(threshold_atr=1.0, into_bars=2).evaluate({"D1": d1}),
+        d1, n_bars=2,
+    )
+    fbr_eval = FailedBreakdownReclaimLongSignal(swing_lookback=40, min_shadow_atr=1.25).evaluate({"H4": h4_usd})
+    me_short_eval = MonthEndReversionShortSignal(threshold_atr=1.0, into_bars=2).evaluate({"D1": d1})
+
+    components = [
+        ("gap",      gap_eval,      {"H4": h4_jpy}, A1Config(config_id="arc_1006", sl_atr_mult=2.0, trail_enabled=False, exit_policy=None), h4_jpy),
+        ("me_long",  me_long_eval,  {"D1": d1},     A1Config(config_id="arc_1011", sl_atr_mult=2.0, trail_enabled=False, exit_policy="sl_only"), d1),
+        ("fbr",      fbr_eval,      {"H4": h4_usd}, A1Config(config_id="arc_1013", sl_atr_mult=2.0, trail_enabled=False, exit_policy="sl_plus_trailing_atr"), h4_usd),
+        ("me_short", me_short_eval, {"D1": d1},     A1Config(config_id="arc_1019", sl_atr_mult=2.0, trail_enabled=False, exit_policy="sl_partial_close_1r_runner_trail"), d1),
+    ]
+    names = [c[0] for c in components]
+
+    # ── score each component over the per-year IS folds (2011-2020) ──────
+    folds = [f for f in build_v3_folds().folds if f.oos_start.year >= 2011]
+    runners = {
+        name: ArcFoldRunner(A1Architecture(), sig, panels)
+        for (name, sig, panels, _cfg, _mp) in components
+    }
+    full_marks = {name: mark_prices_from_panel(mp) for (name, _s, _p, _c, mp) in components}
+
+    # per-fold: component FoldStats (for linear) + StrategyResult (for co-sim)
+    comp_fs: dict[str, list] = {n: [] for n in names}
+    comp_sr: dict[str, list] = {n: [] for n in names}
+    print("Scoring components over folds (canonical A1 + MultiPairBacktester)...")
+    for fold in folds:
+        for (name, sig, panels, cfg, _mp) in components:
+            fs = runners[name](fold, cfg)
+            comp_fs[name].append(fs)
+            comp_sr[name].append(runners[name].last_result)
+        print(f"  fold {fold.oos_start.year}: " + ", ".join(
+            f"{n}={comp_fs[n][-1].roi_pct*100:+.2f}%({comp_fs[n][-1].n_trades})" for n in names))
+
+    # ── reproduction-fidelity cross-check vs arc 1020 ────────────────────
+    print("\nReproduction cross-check (mine vs arc-1020 recorded, ROI %):")
+    print("year | " + " | ".join(f"{n:>8}" for n in names))
+    for i, fold in enumerate(folds):
+        yr = fold.oos_start.year
+        rec = ARC1020_RECORDED.get(yr)
+        mine = [comp_fs[n][i].roi_pct * 100 for n in names]
+        line = f"{yr} | " + " | ".join(f"{m:+7.2f}" for m in mine)
+        if rec:
+            line += "   (rec: " + ", ".join(f"{r:+.2f}" for r in rec) + ")"
+        print(line)
+
+    # ── LINEAR combiner: equal + IS-frozen risk-parity ───────────────────
+    comp_rois = [[fs.roi_pct for fs in comp_fs[n]] for n in names]
+    w_equal = [0.25, 0.25, 0.25, 0.25]
+    w_rp = fit_weights(comp_rois, mode="risk_parity")  # frozen on the IS fold ROIs
+    lin_equal = combine_fold_rois(comp_rois, w_equal).combined_roi
+    lin_rp = combine_fold_rois(comp_rois, w_rp).combined_roi
+    print("\nrisk-parity weights (frozen IS): " +
+          ", ".join(f"{n}={w:.3f}" for n, w in zip(names, w_rp)))
+
+    # ── CO-SIM: same weights, single equity line. Run BOTH:
+    #     cap OFF = the strictly-monotone anchor (real DD interaction only; ROI
+    #               must match linear up to the OOS-slice boundary → anti-optimism
+    #               proof: the equity/cost math adds no return source).
+    #     cap ON  = the faithful book under the 2-per-currency limit (drops
+    #               over-cap entries; not strictly ROI-monotone — dropping a
+    #               net-loser raises ROI; reported transparently).
+    def cosim_series(weights, apply_cap):
+        rois, dds, breaches, drops = [], [], [], []
+        for i, fold in enumerate(folds):
+            comps = [
+                CoSimComponent(
+                    name=n,
+                    closed_trades=comp_sr[n][i].run_result.closed_trades,
+                    mark_prices=_slice_marks(full_marks[n], fold),
+                    starting_balance=SB,
+                )
+                for n in names
+            ]
+            book = cosim_book_fold(comps, fold, weights=weights, starting_balance=SB,
+                                   apply_exposure_cap=apply_cap)
+            rois.append(book.roi_pct)
+            dds.append(book.fold_stats.max_dd_pct)
+            breaches.append(book.daily_dd_breached)
+            drops.append(book.n_dropped)
+        return rois, dds, breaches, drops
+
+    off_eq_roi, off_eq_dd, off_eq_br, _ = cosim_series(w_equal, apply_cap=False)
+    off_rp_roi, off_rp_dd, off_rp_br, _ = cosim_series(w_rp, apply_cap=False)
+    on_eq_roi, on_eq_dd, on_eq_br, on_eq_drop = cosim_series(w_equal, apply_cap=True)
+    on_rp_roi, on_rp_dd, on_rp_br, on_rp_drop = cosim_series(w_rp, apply_cap=True)
+
+    # ── anti-optimism anchor: cap-off co-sim ROI must match linear ───────
+    max_dev_eq = max(abs(off_eq_roi[i] - lin_equal[i]) for i in range(len(folds)))
+    max_dev_rp = max(abs(off_rp_roi[i] - lin_rp[i]) for i in range(len(folds)))
+    print(f"\nANTI-OPTIMISM ANCHOR (cap OFF): max|cosim_off - linear| = "
+          f"{max_dev_eq*100:.4f}% (equal), {max_dev_rp*100:.4f}% (risk-parity)")
+    print("  -> cap-off co-sim ROI tracks linear (boundary-only diff); the only NEW")
+    print("     information is the real BOOK max-DD the linear combiner cannot see.")
+
+    # ── side-by-side table (risk-parity) ─────────────────────────────────
+    print("\n" + "=" * 92)
+    print("CO-SIM vs LINEAR (risk-parity weights) -- per-fold ROI %, book maxDD %, drops")
+    print("=" * 92)
+    hdr = (f"{'year':>5} | {'linear':>7} {'cosOFF':>7} {'dOFF':>6} {'bookDD':>6} | "
+           f"{'cosON':>7} {'dON':>6} {'dropON':>6}")
+    print(hdr)
+    print("-" * len(hdr))
+    for i, fold in enumerate(folds):
+        yr = fold.oos_start.year
+        print(f"{yr:>5} | "
+              f"{lin_rp[i]*100:+7.2f} {off_rp_roi[i]*100:+7.2f} {(off_rp_roi[i]-lin_rp[i])*100:+6.2f} "
+              f"{off_rp_dd[i]*100:6.2f} | "
+              f"{on_rp_roi[i]*100:+7.2f} {(on_rp_roi[i]-lin_rp[i])*100:+6.2f} {on_rp_drop[i]:>6}")
+
+    # ── verdicts ─────────────────────────────────────────────────────────
+    def afp(rois):  # all-folds-positive
+        return all(r > 0.0 for r in rois), min(rois), sum(1 for r in rois if r <= 0)
+
+    print("\n" + "=" * 92)
+    print("ALL-FOLDS-POSITIVE VERDICTS (IS, 2011-2020)")
+    print("=" * 92)
+    for label, rois in [
+        ("linear        equal      ", lin_equal),
+        ("co-sim cap-OFF equal      ", off_eq_roi),
+        ("co-sim cap-ON  equal      ", on_eq_roi),
+        ("linear        risk-parity ", lin_rp),
+        ("co-sim cap-OFF risk-parity ", off_rp_roi),
+        ("co-sim cap-ON  risk-parity ", on_rp_roi),
+    ]:
+        ok, worst, n_neg = afp(rois)
+        print(f"  {label}: all_folds_positive={ok!s:>5}  worst_fold={worst*100:+.2f}%  n_nonpositive={n_neg}")
+
+    print(f"\n  co-sim exposure-cap drops (cap ON): {sum(on_rp_drop)} positions across all folds "
+          f"(book is USD-concentrated; 2-per-currency binds hard)")
+    print(f"  co-sim worst book max-DD (cap OFF, risk-parity): {max(off_rp_dd)*100:.2f}%")
+    print(f"  co-sim 5% daily-cap breached (cap OFF rp / cap ON rp): "
+          f"{any(off_rp_br)} / {any(on_rp_br)}")
+
+    # ── fold-flip verdict ────────────────────────────────────────────────
+    print("\n" + "=" * 92)
+    print("FOLD-FLIP VERDICT (the question arc 2019 left open)")
+    print("=" * 92)
+    lin_ok = afp(lin_rp)[0]
+    off_ok = afp(off_rp_roi)[0]
+    on_ok = afp(on_rp_roi)[0]
+    flips_off = [folds[i].oos_start.year for i in range(len(folds)) if (lin_rp[i] > 0) != (off_rp_roi[i] > 0)]
+    flips_on = [folds[i].oos_start.year for i in range(len(folds)) if (lin_rp[i] > 0) != (on_rp_roi[i] > 0)]
+    print(f"  linear all-folds-positive:        {lin_ok}")
+    print(f"  co-sim cap-OFF all-folds-positive: {off_ok}  (sign flips vs linear: {flips_off or 'none'})")
+    print(f"  co-sim cap-ON  all-folds-positive: {on_ok}  (sign flips vs linear: {flips_on or 'none'})")
+    if not (lin_ok or off_ok or on_ok):
+        print("\n  VERDICT: ALL measurements FAIL all-folds-positive. Co-simulation CONFIRMS")
+        print("  the linear verdict -- the 4-way book's failure is FUNDAMENTAL, not a")
+        print("  linear-combiner artifact. The route is closed cleanly. (No OOS touched.)")
+    elif off_ok and on_ok:
+        print("\n  VERDICT: co-sim PASSES on IS -> eligible to score the frozen 2021+ holdout ONCE.")
+    else:
+        print("\n  VERDICT: mixed -- see per-measurement rows above; operator decision.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/wfo/test_cosim_book.py
+++ b/tests/wfo/test_cosim_book.py
@@ -1,0 +1,371 @@
+"""Gate tests for the co-simulated portfolio equity curve (``core/wfo/cosim_book.py``).
+
+These are CI-pinning, pure-function / synthetic-engine tests (no data corpus),
+so they gate in CI (unmarked = not ``research``). They lock the four properties
+the Item-E PR rests on:
+
+  1. **Byte-identity to scoring alone** — a single-component book reproduces the
+     component's own canonical FoldStats (engine run on a synthetic panel).
+  2. **No-interaction == linear** — with caps off and disjoint currencies, the
+     co-sim per-fold ROI equals the linear combiner's weighted ROI exactly. This
+     is the anchor that proves the co-sim adds no return source.
+  3. **Can only tighten** — the book exposure cap can only DROP entries (never
+     add one), so when it drops a winner the co-sim ROI is < linear; and the
+     shared daily-DD cap can only FAIL a fold the linear ROI judge passes.
+  4. **Determinism** — two runs on identical inputs are byte-identical.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from core.runners._fold_stats_helpers import build_fold_stats_from_run
+from core.sim.account import ClosedTrade, Direction
+from core.sim.costs.model import CostModel
+from core.sim.multipair_backtester import MultiPairBacktester, Order
+from core.sim.panel import Panel
+from core.wfo.cosim_book import (
+    CoSimComponent,
+    cosim_book_fold,
+    mark_prices_from_panel,
+)
+from core.wfo.folds import Fold
+
+# A fold whose OOS window is calendar-2010 (all synthetic trades live here).
+FOLD_2010 = Fold(
+    fold_id=1,
+    is_start=date(2010, 1, 1),
+    is_end=date(2009, 12, 31),  # empty IS — A1-style no-training
+    oos_start=date(2010, 1, 1),
+    oos_end=date(2010, 12, 31),
+)
+
+SB = 100_000.0
+IDX = pd.date_range("2010-01-04 00:00", periods=48, freq="h", tz="UTC")  # 2 days, hourly
+
+
+# ── synthetic ledger helpers ──────────────────────────────────────────────
+def _ct(
+    pid: int,
+    pair: str,
+    entry_i: int,
+    exit_i: int,
+    pnl: float,
+    *,
+    direction: Direction = Direction.LONG,
+    entry_px: float = 1.0,
+    size: float = 100_000.0,
+    idx: pd.DatetimeIndex = IDX,
+) -> ClosedTrade:
+    """One closed trade with ``pnl`` realised at ``exit_i`` (zero spread → only
+    commission/slippage cost). Prices are consistent: pnl = sign·(exit−entry)·size."""
+    exit_px = entry_px + direction.sign * pnl / size
+    return ClosedTrade(
+        position_id=pid,
+        pair=pair,
+        direction=direction,
+        entry_time=idx[entry_i],
+        entry_price=entry_px,
+        exit_time=idx[exit_i],
+        exit_price=exit_px,
+        size=size,
+        pnl=pnl,
+        exit_reason="take_profit",
+        parent_position_id=None,
+        entry_bid=entry_px,
+        entry_ask=entry_px,
+        exit_bid=exit_px,
+        exit_ask=exit_px,
+        sl_price=entry_px - 0.02,
+    )
+
+
+def _flat_marks(pairs, *, idx: pd.DatetimeIndex = IDX, px: float = 1.0) -> dict:
+    return {p: pd.Series(px, index=idx, name="close_mid", dtype=float) for p in pairs}
+
+
+def _component_own_roi(comp: CoSimComponent, weight: float = 1.0) -> float:
+    """Score a component on its own through the co-sim (weight=1 book)."""
+    return cosim_book_fold([comp], FOLD_2010, weights=[1.0], starting_balance=SB).roi_pct
+
+
+# ── 1. byte-identity: single-component book == scoring it alone (real engine) ──
+def _panel_one_sl_trade() -> Panel:
+    """A hand-built EURUSD panel where one long position opens then stops out —
+    a real ``MultiPairBacktester`` close, no data corpus."""
+    idx = pd.date_range("2010-01-04 00:00", periods=12, freq="h", tz="UTC")
+    # bid closes: flat 1.10, then a down bar that breaches a 100-pip stop.
+    o = [1.10] * 6 + [1.08] * 6
+    c = [1.10] * 5 + [1.08] * 7
+    h = [1.10] * 6 + [1.08] * 6
+    lo = [1.10] * 5 + [1.08] * 7  # bar 5 low dips to 1.08
+    spread = 0.0001
+    df = pd.DataFrame(
+        {
+            "open_bid": o,
+            "high_bid": h,
+            "low_bid": lo,
+            "close_bid": c,
+            "open_ask": [x + spread for x in o],
+            "high_ask": [x + spread for x in h],
+            "low_ask": [x + spread for x in lo],
+            "close_ask": [x + spread for x in c],
+            "volume": [1000] * 12,
+            "spread_close": [spread] * 12,
+            "bid_ask_data_quality": ["ok"] * 12,
+        },
+        index=idx,
+    )
+    return Panel.from_frames({"EURUSD": df}, tf="H4", boundary_convention="utc")
+
+
+def _entry_once_strategy():
+    fired = {"done": False}
+
+    def strat(t, snapshot, account):
+        if fired["done"]:
+            return []
+        bar = snapshot.get("EURUSD")
+        if bar is None:
+            return []
+        fired["done"] = True
+        entry_proxy = float(bar["close_ask"])
+        return [
+            Order(
+                pair="EURUSD",
+                direction=Direction.LONG,
+                size=100_000.0,
+                sl_price=entry_proxy - 0.01,  # 100-pip stop → breached at bar 5
+            )
+        ]
+
+    return strat
+
+
+def test_single_component_book_equals_scoring_alone():
+    """A 1-component co-sim book reproduces the component's canonical FoldStats
+    bar-for-bar — the co-sim re-marking does not perturb a single book."""
+    panel = _panel_one_sl_trade()
+    from core.sim.account import Account
+
+    acct = Account(starting_balance=SB)
+    bt = MultiPairBacktester(panel=panel, account=acct, strategy=_entry_once_strategy())
+    rr = bt.run()
+    assert rr.n_trades == 1, "fixture must produce exactly one closed trade"
+
+    reference = build_fold_stats_from_run(fold=FOLD_2010, run_result=rr, starting_balance=SB)
+
+    comp = CoSimComponent(
+        name="solo",
+        closed_trades=rr.closed_trades,
+        mark_prices=mark_prices_from_panel(panel),
+        starting_balance=SB,
+    )
+    book = cosim_book_fold([comp], FOLD_2010, weights=[1.0], starting_balance=SB)
+
+    # Gross equity reproduced exactly (same marks, same trade). check_freq=False:
+    # the co-sim clock is a set-union index (no freq), the engine's is a
+    # date_range (freq=H) — the VALUES are identical, only the freq attr differs.
+    pd.testing.assert_series_equal(
+        book.gross_equity, rr.equity_curve, check_names=False, check_freq=False
+    )
+    # And therefore the cost-netted FoldStats are identical.
+    assert book.fold_stats.roi_pct == pytest.approx(reference.roi_pct, abs=1e-12)
+    assert book.fold_stats.max_dd_pct == pytest.approx(reference.max_dd_pct, abs=1e-12)
+    assert book.fold_stats.n_trades == reference.n_trades
+    assert book.fold_stats.days_breaching_daily_5pct == reference.days_breaching_daily_5pct
+    assert book.n_admitted == 1 and book.n_dropped == 0
+
+
+# ── 2. no-interaction == linear combiner ──────────────────────────────────
+@pytest.mark.parametrize("weights", [None, [0.5, 0.3, 0.2], [0.6, 0.4, 0.0]])
+def test_no_interaction_equals_linear(weights):
+    """With disjoint currencies (cap never binds) the co-sim per-fold ROI equals
+    the linear combiner's weighted ROI Σ w_k·ROI_k — exactly. This is the anchor
+    proving the co-sim introduces NO return source."""
+    comps = [
+        CoSimComponent("A", (_ct(1, "EURUSD", 2, 30, +600.0),), _flat_marks(["EURUSD"]), SB),
+        CoSimComponent("B", (_ct(1, "GBPJPY", 4, 20, -200.0),), _flat_marks(["GBPJPY"]), SB),
+        CoSimComponent("C", (_ct(1, "AUDCAD", 6, 28, +350.0),), _flat_marks(["AUDCAD"]), SB),
+    ]
+    n = len(comps)
+    w = [1.0 / n] * n if weights is None else weights
+
+    own = [_component_own_roi(c) for c in comps]
+    linear = sum(wk * rk for wk, rk in zip(w, own))
+
+    book = cosim_book_fold(
+        comps, FOLD_2010, weights=weights, starting_balance=SB, apply_exposure_cap=False
+    )
+    assert book.n_dropped == 0
+    assert book.roi_pct == pytest.approx(linear, abs=1e-12)
+
+
+def test_no_interaction_equals_linear_even_with_cap_on_when_disjoint():
+    """Cap ON but disjoint currencies → cap never binds → still == linear."""
+    comps = [
+        CoSimComponent("A", (_ct(1, "EURUSD", 2, 30, +600.0),), _flat_marks(["EURUSD"]), SB),
+        CoSimComponent("B", (_ct(1, "GBPJPY", 4, 20, +200.0),), _flat_marks(["GBPJPY"]), SB),
+    ]
+    own = [_component_own_roi(c) for c in comps]
+    linear = 0.5 * own[0] + 0.5 * own[1]
+    book = cosim_book_fold(comps, FOLD_2010, starting_balance=SB)  # cap on, equal weights
+    assert book.n_dropped == 0
+    assert book.roi_pct == pytest.approx(linear, abs=1e-12)
+
+
+# ── 3a. can only tighten: the exposure cap drops an over-currency WINNER ──
+# This is the dispatch's literal "can-only-tighten" gate: a constructed
+# multi-component case where the co-sim per-fold ROI ≤ the linear combiner's.
+# (Pairs are all non-JPY so per-pip value is uniform — see the cost-model note
+# in the module/PR: an active exposure cap is faithful but NOT strictly
+# ROI-monotone, because dropping a net-LOSING entry would raise ROI. The
+# strictly-monotone guarantee is the DD-interaction + daily-cap, anchored by
+# the cap-off == linear tests. For the 4-way book the cap never binds — its
+# components have disjoint event timing — so cap-on == cap-off there.)
+def test_exposure_cap_drops_over_currency_position_and_tightens():
+    """Three components all hold an EUR-touching pair simultaneously. The
+    2-per-currency book cap admits two and DROPS the third. The third is a
+    same-pip-scale WINNER, so dropping it makes the co-sim ROI strictly LOWER
+    than the linear combiner (which counts all three) — the safety invariant,
+    direction encoded."""
+    # All three open at the same bar and overlap → EUR is touched 3× at once.
+    comps = [
+        CoSimComponent("A_eurusd", (_ct(1, "EURUSD", 2, 40, +100.0),), _flat_marks(["EURUSD"]), SB),
+        CoSimComponent("B_eurgbp", (_ct(1, "EURGBP", 2, 40, +100.0),), _flat_marks(["EURGBP"]), SB),
+        CoSimComponent("C_euraud", (_ct(1, "EURAUD", 2, 40, +500.0),), _flat_marks(["EURAUD"]), SB),
+    ]
+    own = [_component_own_roi(c) for c in comps]
+    linear = sum(r / 3.0 for r in own)  # equal-weight linear combiner
+
+    book = cosim_book_fold(comps, FOLD_2010, starting_balance=SB)  # cap on
+    # EUR is touched by all three at once → exactly one is dropped.
+    assert book.n_dropped == 1
+    # The dropped one is the last by (component_index, position_id) tie-break — C.
+    assert book.dropped == (("C_euraud", 1),)
+    # Dropping a winner tightens: co-sim ROI strictly below the linear combiner.
+    assert book.roi_pct < linear
+    # And the cap-off book equals the linear combiner (no drop) — isolates the
+    # delta as purely the (faithful) dropped winner.
+    book_off = cosim_book_fold(
+        comps, FOLD_2010, starting_balance=SB, apply_exposure_cap=False
+    )
+    assert book_off.roi_pct == pytest.approx(linear, abs=1e-12)
+    assert book.roi_pct < book_off.roi_pct
+
+
+def test_exposure_cap_admits_when_under_two_per_currency():
+    """Two EUR-touchers is allowed (cap is 2); nothing dropped."""
+    comps = [
+        CoSimComponent("A", (_ct(1, "EURUSD", 2, 40, +300.0),), _flat_marks(["EURUSD"]), SB),
+        CoSimComponent("B", (_ct(1, "EURGBP", 2, 40, +300.0),), _flat_marks(["EURGBP"]), SB),
+    ]
+    book = cosim_book_fold(comps, FOLD_2010, starting_balance=SB)
+    assert book.n_dropped == 0 and book.n_admitted == 2
+
+
+# ── 3b. can only tighten: shared daily-DD cap fails a fold linear ROI passes ──
+def _dip_marks(pair: str, dip_at: int, *, entry_px: float = 1.0, dip_px: float = 0.90,
+               idx: pd.DatetimeIndex = IDX) -> dict:
+    """A close-mid series that sits at ``entry_px`` except a single deep dip
+    bar (used to manufacture an intraday drawdown while a position is open)."""
+    s = pd.Series(entry_px, index=idx, name="close_mid", dtype=float)
+    s.iloc[dip_at] = dip_px
+    return {pair: s}
+
+
+def test_shared_daily_cap_fails_a_fold_the_roi_judge_passes():
+    """A book that ends the day green (ROI > 0, passes the linear ROI judge) but
+    dipped >5% intraday is FAILED by the shared 5% daily cap — a real 5ers daily
+    breach = account dead. The linear combiner is blind to this; the co-sim is
+    strictly harder."""
+    # One position open across a deep midday dip, exiting slightly green.
+    # entry 1.0, dip to 0.90 (−10% on full size) midday, exit +tiny.
+    comp = CoSimComponent(
+        "dipper",
+        (_ct(1, "EURUSD", 1, 40, +50.0, entry_px=1.0, size=SB),),
+        _dip_marks("EURUSD", dip_at=10, entry_px=1.0, dip_px=0.90),
+        SB,
+    )
+    book = cosim_book_fold([comp], FOLD_2010, weights=[1.0], starting_balance=SB)
+    assert book.passes_roi is True          # ends green → linear ROI judge passes
+    assert book.daily_dd_breached is True   # ...but breached 5% intraday
+    assert book.passes_with_daily_cap is False  # the shared cap fails the fold
+
+
+def test_coincident_drawdowns_deepen_book_dd_vs_disjoint():
+    """Real cross-component DD interaction the linear combiner cannot see: two
+    components dipping on the SAME bar produce a deeper book max-DD than the
+    same two dipping on DIFFERENT bars, holding ROI fixed."""
+    # Each: long, open across the window, dip −6% at its dip bar, exit flat (pnl≈0).
+    def comp(name, pair, dip_at):
+        return CoSimComponent(
+            name,
+            (_ct(1, pair, 1, 40, +1.0, entry_px=1.0, size=SB),),  # ~breakeven
+            _dip_marks(pair, dip_at=dip_at, entry_px=1.0, dip_px=0.94),  # −6% dip
+            SB,
+        )
+
+    coincident = cosim_book_fold(
+        [comp("A", "EURUSD", 10), comp("B", "GBPJPY", 10)],
+        FOLD_2010, starting_balance=SB, apply_exposure_cap=False,
+    )
+    disjoint = cosim_book_fold(
+        [comp("A", "EURUSD", 10), comp("B", "GBPJPY", 20)],
+        FOLD_2010, starting_balance=SB, apply_exposure_cap=False,
+    )
+    # Same ROI (same trades), but coincident dips stack → deeper book DD.
+    assert coincident.fold_stats.roi_pct == pytest.approx(disjoint.fold_stats.roi_pct, abs=1e-9)
+    assert coincident.fold_stats.max_dd_pct > disjoint.fold_stats.max_dd_pct + 1e-6
+
+
+# ── 4. determinism ────────────────────────────────────────────────────────
+def test_determinism_two_run_byte_identity():
+    comps = [
+        CoSimComponent("A", (_ct(1, "EURUSD", 2, 30, +600.0), _ct(2, "EURUSD", 5, 33, -120.0)),
+                       _flat_marks(["EURUSD"]), SB),
+        CoSimComponent("B", (_ct(1, "GBPJPY", 4, 20, +200.0),), _flat_marks(["GBPJPY"]), SB),
+        CoSimComponent("C", (_ct(1, "AUDCAD", 6, 28, +350.0),), _flat_marks(["AUDCAD"]), SB),
+    ]
+    r1 = cosim_book_fold(comps, FOLD_2010, starting_balance=SB)
+    r2 = cosim_book_fold(comps, FOLD_2010, starting_balance=SB)
+    pd.testing.assert_series_equal(r1.gross_equity, r2.gross_equity)
+    pd.testing.assert_series_equal(r1.net_equity, r2.net_equity)
+    assert r1.fold_stats == r2.fold_stats
+    assert r1.dropped == r2.dropped
+    assert r1.days_breaching_daily_5pct_eet == r2.days_breaching_daily_5pct_eet
+
+
+def test_zero_weight_component_is_absent():
+    """A 0-weight component contributes nothing (matches the combiner dropping it)."""
+    comps = [
+        CoSimComponent("keep", (_ct(1, "EURUSD", 2, 30, +600.0),), _flat_marks(["EURUSD"]), SB),
+        CoSimComponent("drop", (_ct(1, "EURUSD", 3, 31, +900.0),), _flat_marks(["EURUSD"]), SB),
+    ]
+    book = cosim_book_fold(comps, FOLD_2010, weights=[1.0, 0.0], starting_balance=SB,
+                           apply_exposure_cap=False)
+    solo = cosim_book_fold([comps[0]], FOLD_2010, weights=[1.0], starting_balance=SB)
+    assert book.roi_pct == pytest.approx(solo.roi_pct, abs=1e-12)
+
+
+def test_costs_are_per_leg_not_netted():
+    """Per-leg cost discipline: the book's total cost equals the sum of each
+    component's standalone cost (no cross-instrument netting / Arc-10 defect)."""
+    a = CoSimComponent("A", (_ct(1, "EURUSD", 2, 30, +600.0),), _flat_marks(["EURUSD"]), SB)
+    b = CoSimComponent("B", (_ct(1, "GBPJPY", 4, 20, +200.0),), _flat_marks(["GBPJPY"]), SB)
+    model = CostModel.fundednext()
+    # Standalone net-vs-gross gap = standalone cost (equal weight → ×0.5 each).
+    book = cosim_book_fold([a, b], FOLD_2010, starting_balance=SB, cost_model=model,
+                           apply_exposure_cap=False)
+    gross_a = cosim_book_fold([a], FOLD_2010, weights=[1.0], starting_balance=SB,
+                              cost_model=CostModel.zero())
+    net_a = cosim_book_fold([a], FOLD_2010, weights=[1.0], starting_balance=SB, cost_model=model)
+    # The book applied a strictly positive cost (commission+slippage) per leg.
+    assert net_a.roi_pct < gross_a.roi_pct
+    # Book net ROI is below the cost-free linear combine (costs were applied, not waived).
+    book_costfree = cosim_book_fold([a, b], FOLD_2010, starting_balance=SB,
+                                    cost_model=CostModel.zero(), apply_exposure_cap=False)
+    assert book.roi_pct < book_costfree.roi_pct


### PR DESCRIPTION
## Item E — single co-simulated portfolio EQUITY CURVE (GATED-CORE — do NOT self-merge)

Builds the co-simulated portfolio equity-curve gate per `discovery/NEEDS_ENABLEMENT.md` item **E**.
This is a **canonical-core / scoring-path** change → on a branch for human review; **not merged until
CI + determinism + the honest-engine sweep re-read SAFE** (all done — see below). **No discovery arc is
opened by this PR** — enablement + validation of the existing book + gate only.

### What this builds

`core/wfo/cosim_book.py :: cosim_book_fold` — marks **all book components to ONE equity line on a shared
clock**, under a **shared 2-per-currency exposure cap on the book's net exposure** and a **shared 5%
daily-DD cap**, then scores the single co-simulated curve through the canonical cost + FoldStats
chokepoint. It replaces / sits beside the per-fold **LINEAR** combiner (`discovery/tools/combine_fold_roi.py`),
which sums each component's *independently simulated* per-fold ROI and is faithful only for
disjoint-event-timing components — it cannot see the book's actual risk geometry.

**The only NEW scoring code is the co-simulation loop.** Everything load-bearing is the canonical engine,
**called not re-rolled**: `Account` (sign-based `Direction`/`Position` + `parent_position_id`, shorts
probe Q2.6) for the 2-per-currency admission via `Account.exposure_check`; `apply_cost_model` (FundedNext
per-leg); `build_fold_stats_from_run` (cost+FoldStats chokepoint) + `compute_per_day_max_dd` (EET daily-DD).
Per-trade P&L is taken **verbatim** from each component's own SL-first `MultiPairBacktester` run — the
co-sim re-marks those trades, it never re-fills/re-prices/re-exits one.

### The "can only tighten" invariant — preserved and proven

A shared daily-DD cap + real cross-component drawdown interaction is strictly harder than the linear sum.
The co-sim adds only constraints and removes only the linear sum's idealizations — **zero fabrication
surface, no cross-instrument cost netting** (that would be the Arc-10 trap; per-leg costs stay per-leg).

Proven by `tests/wfo/test_cosim_book.py` (12 tests, CI-pinned):
- **`test_no_interaction_equals_linear`** — with caps off, co-sim per-fold ROI **equals** the linear
  combiner's weighted ROI `Σ w_k·ROI_k` exactly (the anchor: the equity/cost math adds no return source).
- **`test_single_component_book_equals_scoring_alone`** — a 1-component book reproduces the component's
  canonical FoldStats **bar-for-bar** (real engine on a synthetic panel; existing behaviour byte-identical).
- **`test_exposure_cap_drops_over_currency_position_and_tightens`** — the dispatch's literal can-only-tighten
  case: the cap drops an over-currency winner → co-sim ROI **< linear**.
- **`test_shared_daily_cap_fails_a_fold_the_roi_judge_passes`** + **`test_coincident_drawdowns_deepen_book_dd_vs_disjoint`** — the daily cap and DD interaction can only fail/deepen, never rescue.
- **`test_costs_are_per_leg_not_netted`**, **`test_determinism_two_run_byte_identity`**.

**Honest caveat surfaced for review (does NOT change engine honesty):** the shared **exposure cap** is a
faithful real constraint that is **not strictly ROI-monotone** — dropping a net-*losing* over-cap entry
raises ROI, and no lookahead-free cap can avoid that. So with the cap **ON** the co-sim can score *above*
the linear combiner on a fold (the drop-a-loser effect, not optimism). The strictly-monotone guarantee is
the DD-interaction + daily cap; the driver always reports the cap-**OFF** strictly-monotone bound and the
exposure drops (`n_dropped`/`dropped`). `apply_exposure_cap=False` is the clean bound. This is the one
design decision I most want the operator to weigh: keep the cap in the score (faithful), or treat it as a
reported diagnostic over the cap-off number.

### Validation — the existing 4-way book (the decision this unlocks)

Re-ran the portfolio-route book (arcs 1006/1011/1013/1019, combined in arc 1020) through BOTH gates at the
same weights — `PYTHONPATH=. py scripts/cosim_validation/validate_4way_book.py`. Reproduction fidelity:
gap/me_long/me_short match arc-1020's recorded per-fold ROI **exactly**; fbr within ~1.4%. Full table:
[`discovery/COSIM_ITEM_E_VALIDATION.md`](discovery/COSIM_ITEM_E_VALIDATION.md).

Per-fold ROI % (risk-parity weights), `dOFF`/`dON` = co-sim − linear:

```
year |  linear  cosOFF   dOFF bookDD% |   cosON    dON dropON
2011 |   +2.13   +2.05  -0.08   0.35  |   +1.05  -1.08     13
2012 |   +1.61   +1.59  -0.02   0.83  |   +0.97  -0.64     11
2013 |   +0.18   +0.18  -0.01   0.59  |   +0.34  +0.16      6
2014 |   +0.41   +0.41  -0.00   0.80  |   +0.57  +0.16     10
2015 |   -0.46   -0.46  +0.00   1.51  |   -0.50  -0.04     12
2016 |   +0.15   +0.16  +0.01   0.87  |   +0.61  +0.45      8
2017 |   +0.11   +0.02  -0.10   0.82  |   -0.07  -0.18     10
2018 |   -0.27   -0.27  +0.00   0.65  |   -0.58  -0.30      7
2019 |   +1.54   +1.53  -0.01   0.64  |   +1.18  -0.37     14
2020 |   +0.53   +0.53  +0.00   0.78  |   +0.31  -0.22     12
```

- **Anti-optimism anchor (cap OFF):** `max|cosim_off − linear| = 0.096%` (risk-parity) — boundary-only. The
  co-sim composition adds no return source. The only new information is the real BOOK max-DD (0.35–1.51%),
  which the linear combiner cannot see and which never approaches the 5% daily cap.
- **Exposure cap (cap ON):** the book is USD-concentrated → the 2-per-currency cap binds hard (103 drops
  over 10 folds), mixed-sign vs linear (drop-a-loser), and flips 2017 negative (strictly harder).

**Fold-flip verdict — artifact or fundamental?** All-folds-positive (IS 2011-2020):

| measurement | all-folds-positive | worst fold | n_nonpositive |
|---|:--:|:--:|:--:|
| linear, risk-parity | **False** | −0.46% | 2 |
| co-sim cap-OFF, risk-parity | **False** | −0.46% | 2 |
| co-sim cap-ON, risk-parity | **False** | −0.58% | 3 |

**Co-simulation CONFIRMS the linear verdict — the 4-way book's failure is FUNDAMENTAL, not a
linear-combiner artifact.** Every measurement fails all-folds-positive on IS (2015 and 2018 negative under
every weighting). This is the answer arc 2019 left open: the route is closed cleanly, the thinness is real
risk geometry. **Per §4: IS did not clear → the frozen 2021+ OOS was NOT touched.** No PASS candidate;
deployable-system count stays 0.

### Gate (all green)

- **Determinism** — `tests/test_determinism.py` (5 passed); co-sim two-run byte identity pinned.
- **Can-only-tighten test** — `tests/wfo/test_cosim_book.py` (12 passed), incl. the constructed `co-sim ROI ≤ linear` case + the cap-off == linear anchor.
- **Existing behaviour byte-identical** — single-component book == its own FoldStats; the linear combiner is untouched (sits beside); longs/existing pools unchanged.
- **Honest-engine sweep re-read** — `HONEST_ENGINE_SWEEP.md` "CO-SIM BOOK RE-READ ADDENDUM": **SAFE** (no lookahead in the shared-clock advance, daily-DD cap causal, costs strictly per-leg; the exposure-cap non-monotonicity flagged).
- **Full `pytest -m "not research"`** — green (see CI).

### Guardrails

PR on a branch; **do NOT push to main; do NOT self-merge** — flagged for operator review. Canonical engine
called/reused, never re-rolled; the co-sim loop's blast radius is tight and its cap-off can-only-tighten
property is provable + tested. **STOP for human review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
